### PR TITLE
Desktop: Resolves #14791: Add warning dialog before JEX import to prevent note duplication

### DIFF
--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts
@@ -14,7 +14,7 @@ import Logger from '@joplin/utils/Logger';
 const packageInfo: PackageInfo = require('../../../packageInfo.js');
 
 const logger = Logger.create('importFrom');
-let jexImportWarningAcceptedForCurrentSession = false;
+const jexImportWarningAcceptedSetting = 'jexImportWarningAccepted';
 
 export const declaration: CommandDeclaration = {
 	name: 'importFrom',
@@ -79,9 +79,9 @@ const promptForSourcePath = async (module: ImportModule, sourceType: FileSystemI
 
 const shouldContinueWithImport = async (module: ImportModule) => {
 	if (module.format !== 'jex') return true;
-	if (jexImportWarningAcceptedForCurrentSession) return true;
+	if (Setting.value(jexImportWarningAcceptedSetting)) return true;
 
-	const message = _('Importing is intended for adding or restoring notes. If you import and then sync with existing notes on another device, duplicates will be created. To transfer notes, use sync instead. Do you want to continue?');
+	const message = _('Importing is intended for adding or restoring notes. After importing notes, if you enable sync with the same notes already on another device, duplicates will be created. To transfer notes between devices, please use sync instead. Do you want to continue with the import?');
 	const buttonIndex = await bridge().showMessageBox(message, {
 		buttons: [_('Yes'), _('No')],
 		defaultId: 1,
@@ -90,7 +90,7 @@ const shouldContinueWithImport = async (module: ImportModule) => {
 
 	if (buttonIndex !== 0) return false;
 
-	jexImportWarningAcceptedForCurrentSession = true;
+	Setting.setValue(jexImportWarningAcceptedSetting, true);
 	return true;
 };
 

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts
@@ -83,6 +83,7 @@ const shouldContinueWithImport = async (module: ImportModule) => {
 
 	const message = _('Importing is intended for adding or restoring notes. After importing notes, if you enable sync with the same notes already on another device, duplicates will be created. To transfer notes between devices, please use sync instead. Do you want to continue with the import?');
 	const buttonIndex = await bridge().showMessageBox(message, {
+		title: _('Warning'),
 		buttons: [_('Yes'), _('No')],
 		defaultId: 1,
 		cancelId: 1,

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts
@@ -77,12 +77,12 @@ const promptForSourcePath = async (module: ImportModule, sourceType: FileSystemI
 	}
 };
 
-const shouldContinueWithImport = async (module: ImportModule) => {
+const shouldContinueWithImport = (module: ImportModule) => {
 	if (module.format !== 'jex') return true;
 	if (Setting.value(jexImportWarningAcceptedSetting)) return true;
 
 	const message = _('Importing is intended for adding or restoring notes. After importing notes, if you enable sync with the same notes already on another device, duplicates will be created. To transfer notes between devices, please use sync instead. Do you want to continue with the import?');
-	const buttonIndex = await bridge().showMessageBox(message, {
+	const buttonIndex = bridge().showMessageBox(message, {
 		title: _('Warning'),
 		buttons: [_('Yes'), _('No')],
 		defaultId: 1,
@@ -102,7 +102,7 @@ export const runtime = (control: WindowControl): CommandRuntime => {
 			const importModule = await findImportModule(options, control);
 			if (!importModule) return null; // E.g. if cancelled
 
-			if (!await shouldContinueWithImport(importModule)) return null;
+			if (!shouldContinueWithImport(importModule)) return null;
 
 			let sourcePath = options?.sourcePath ?? await promptForSourcePath(importModule, options?.sourceType);
 			if (Array.isArray(sourcePath)) {

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts
@@ -14,6 +14,7 @@ import Logger from '@joplin/utils/Logger';
 const packageInfo: PackageInfo = require('../../../packageInfo.js');
 
 const logger = Logger.create('importFrom');
+let jexImportWarningAcceptedForCurrentSession = false;
 
 export const declaration: CommandDeclaration = {
 	name: 'importFrom',
@@ -76,12 +77,31 @@ const promptForSourcePath = async (module: ImportModule, sourceType: FileSystemI
 	}
 };
 
+const shouldContinueWithImport = async (module: ImportModule) => {
+	if (module.format !== 'jex') return true;
+	if (jexImportWarningAcceptedForCurrentSession) return true;
+
+	const message = _('Importing is intended for adding or restoring notes. If you import and then sync with existing notes on another device, duplicates will be created. To transfer notes, use sync instead. Do you want to continue?');
+	const buttonIndex = await bridge().showMessageBox(message, {
+		buttons: [_('Yes'), _('No')],
+		defaultId: 1,
+		cancelId: 1,
+	});
+
+	if (buttonIndex !== 0) return false;
+
+	jexImportWarningAcceptedForCurrentSession = true;
+	return true;
+};
+
 export const runtime = (control: WindowControl): CommandRuntime => {
 	return {
 		// Since this can be run from "go to anything", partialOptions needs to support being null or empty.
 		execute: async (context: CommandContext, options: ImportCommandOptions|undefined) => {
 			const importModule = await findImportModule(options, control);
 			if (!importModule) return null; // E.g. if cancelled
+
+			if (!await shouldContinueWithImport(importModule)) return null;
 
 			let sourcePath = options?.sourcePath ?? await promptForSourcePath(importModule, options?.sourceType);
 			if (Array.isArray(sourcePath)) {

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -595,13 +595,19 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 		}
 
 		if (section.name === 'importOrExport') {
+			// Duplicated from desktop import warning in packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts.
 			const importSyncWarning = _('Importing is intended for adding or restoring notes. After importing notes, if you enable sync with the same notes already on another device, duplicates will be created. To transfer notes between devices, please use sync instead.');
 			addSettingComponent(
 				<View key='import_sync_warning' style={{
 					backgroundColor: theme.warningBackgroundColor,
+					paddingTop: 5,
+					paddingBottom: 5,
+					paddingLeft: 10,
+					paddingRight: 10,
 					marginLeft: theme.margin,
 					marginRight: theme.margin,
 					marginTop: theme.marginTop,
+					marginBottom: theme.marginBottom,
 				}}>
 					<Text style={styleSheet.settingText}>{importSyncWarning}</Text>
 				</View>,

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -41,6 +41,7 @@ import { UpdateSettingValueCallback } from './types';
 import Folder from '@joplin/lib/models/Folder';
 import { FolderEntity } from '@joplin/lib/services/database/types';
 import { substrWithEllipsis } from '@joplin/lib/string-utils';
+import { themeStyle } from '../../global-style';
 
 interface ConfigScreenState {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -437,6 +438,7 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 		};
 
 		const styleSheet = this.styles().styleSheet;
+		const theme = themeStyle(this.props.themeId);
 		const addSettingLink = (key: string, title: string, target: string) => {
 			const component = (
 				<View key={key} style={styleSheet.settingContainer}>
@@ -596,8 +598,10 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 			const importSyncWarning = _('Importing is intended for adding or restoring notes. After importing notes, if you enable sync with the same notes already on another device, duplicates will be created. To transfer notes between devices, please use sync instead.');
 			addSettingComponent(
 				<View key='import_sync_warning' style={{
-					...styleSheet.settingContainer,
-					backgroundColor: '#FFCF8D',
+					backgroundColor: theme.warningBackgroundColor,
+					marginLeft: theme.margin,
+					marginRight: theme.margin,
+					marginTop: theme.marginTop,
 				}}>
 					<Text style={styleSheet.settingText}>{importSyncWarning}</Text>
 				</View>,

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -593,6 +593,9 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 		}
 
 		if (section.name === 'importOrExport') {
+			const importSyncWarning = _('Warning: Importing is intended for adding or restoring notes. After importing notes, if you enable sync with the same notes already on another device, duplicates will be created. To transfer notes between devices, please use sync instead.');
+			addSettingText('import_sync_warning', importSyncWarning);
+
 			addSettingComponent(
 				<NoteExportButton key='export_as_jex_button' styles={this.styles()} />,
 				[exportButtonDefaultTitle(), exportButtonDescription()],

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -593,8 +593,16 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 		}
 
 		if (section.name === 'importOrExport') {
-			const importSyncWarning = _('Warning: Importing is intended for adding or restoring notes. After importing notes, if you enable sync with the same notes already on another device, duplicates will be created. To transfer notes between devices, please use sync instead.');
-			addSettingText('import_sync_warning', importSyncWarning);
+			const importSyncWarning = _('Importing is intended for adding or restoring notes. After importing notes, if you enable sync with the same notes already on another device, duplicates will be created. To transfer notes between devices, please use sync instead.');
+			addSettingComponent(
+				<View key='import_sync_warning' style={{
+					...styleSheet.settingContainer,
+					backgroundColor: '#FFCF8D',
+				}}>
+					<Text style={styleSheet.settingText}>{importSyncWarning}</Text>
+				</View>,
+				importSyncWarning,
+			);
 
 			addSettingComponent(
 				<NoteExportButton key='export_as_jex_button' styles={this.styles()} />,

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -505,6 +505,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		notesParent: { value: '', type: SettingItemType.String, public: false },
 
 		richTextBannerDismissed: { value: false, type: SettingItemType.Bool, storage: SettingStorage.File, isGlobal: true, public: false },
+		jexImportWarningAccepted: { value: false, type: SettingItemType.Bool, storage: SettingStorage.File, isGlobal: false, public: false, appTypes: [AppType.Desktop] },
 		'editor.pluginCompatibilityBannerDismissedFor': {
 			value: [] as string[], // List of plugin IDs
 			type: SettingItemType.Array,

--- a/readme/welcome/2_importing_and_exporting_notes.md
+++ b/readme/welcome/2_importing_and_exporting_notes.md
@@ -1,5 +1,9 @@
 # Importing and exporting notes
 
+## Importing and sync
+
+Importing is intended for adding or restoring notes. After importing notes, if you enable sync with the same notes already on another device, duplicates will be created. To transfer notes between devices, please use sync instead.
+
 ## Importing from Evernote
 
 Joplin can import complete Evernote notebooks, as well as notes, tags, images, attached files and note metadata (such as author, geo-location, etc.) via ENEX files.


### PR DESCRIPTION
**Fixes: #14791**

## Summary:

Importing a .jex file currently adds notes instead of replacing existing ones. When users later sync with another device that already contains those notes, duplicates are created. This behavior is not واضح to users, leading to unintended duplication.

## Fix:

Adds a confirmation dialog before opening the file picker when importing JEX files.
The dialog:
- Warns about duplicate note creation when syncing
- Suggests using sync instead of import for transferring notes
- Allows users to continue or cancel the import
- The warning is session-based: once accepted, it won’t appear again until the app restarts.

### Changes made:
`importFrom.ts`:
1. Added session flag: `jexImportWarningAcceptedForCurrentSession`
2. Added helper: `shouldContinueWithImport(module)`
3. Integrated warning check before triggering the file picker for JEX imports only

## Testing:
I manually tested all the changes made and made a demo video for the same.

https://github.com/user-attachments/assets/3403f4ec-efd5-44cf-a609-1242b2d5e183


## AI Disclosure:
I used AI to help refine the PR description and structure the solution.