### PR TITLE
Desktop: Resolves #14801: Fix Shift+Tab keyboard navigation in sideba…

### DIFF
--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -74,7 +74,13 @@ const focusListItem = (item: HTMLElement|null) => {
 		// If the currently focused element is a tree item inside the same list,
 		// the user is navigating with the keyboard — always allow focus to move
 		// to the newly selected item so arrow-key scrolling is not interrupted.
-		const isKeyboardNavigating = !!activeTreeItem && itemList?.contains(activeTreeItem);
+		// Also treat any focused element that is contained inside the same
+		// sidebar list as keyboard navigation (this handles cases such as
+		// Shift+Tab or when focus is on a nested control that isn't a treeitem).
+		const isKeyboardNavigating = (
+			(!!activeTreeItem && itemList?.contains(activeTreeItem)) ||
+			(activeElement instanceof HTMLElement && itemList?.contains(activeElement))
+		);
 
 		// Avoid disturbing scroll while user is manually scrolling through the list.
 		// However, if focus was lost (activeElement -> <body>), or the user is


### PR DESCRIPTION
## Problem
When the notebook list in the sidebar is scrolled down, users cannot reach the "New notebook" button via Shift+Tab keyboard navigation. This is a regression that breaks keyboard accessibility.

## Root Cause
The focus management logic in `useOnRenderItem.tsx` was too restrictive. It only recognized tree items (`role="treeitem"`) as keyboard navigation, so when focus was on other elements (like the "New notebook" button), the scroll-avoidance logic would prevent focus from moving back into the list.

## Solution
Expanded the `isKeyboardNavigating` condition to recognize **any** focused element within the same sidebar list container, not just tree items. This allows Shift+Tab to work correctly regardless of what element has focus or where the list is scrolled.

**Changes:**
- Modified the `isKeyboardNavigating` heuristic in `useOnRenderItem.tsx` to check:
  1. If active element is a tree item in the same list (existing behavior)
  2. OR if active element is ANY element in the same list container (new behavior)
- Added explanatory comments with concrete examples

**Code:**
```typescript
const isKeyboardNavigating = (
  (!!activeTreeItem && itemList?.contains(activeTreeItem)) ||
  (activeElement instanceof HTMLElement && itemList?.contains(activeElement))
);
```

## Testing
Steps to verify the fix:

- Create enough notebooks to make the sidebar scrollable
- Scroll down so the "Notebooks" header is out of view
- Focus on a notebook item
- Press Shift+Tab
- Focus should move to the "New notebook" button and scroll into view

## AI Disclosure
- I used AI to help refine the PR description and explore possible solutions.

