### PR TITLE
Chore: Fixes #14832: CI: Update handleAnchorClick tests to use dispatchEvent for click simulation

### DIFF
--- a/packages/app-mobile/contentScripts/rendererBundle/contentScript/index.handleAnchorClick.test.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/contentScript/index.handleAnchorClick.test.ts
@@ -28,26 +28,32 @@ describe('index.handleAnchorClick', () => {
 	test('scrollIntoView is called even when the same link is clicked twice', () => {
 		const linkA = document.getElementById('link-a')!;
 
-		linkA.click();
+		linkA.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
 		expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
 
-		linkA.click();
+		linkA.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
 		expect(scrollIntoViewMock).toHaveBeenCalledTimes(2);
 	});
 
 	test('scrollIntoView is called for each click when different links are clicked alternately', () => {
-		document.getElementById('link-a')!.click();
-		document.getElementById('link-b')!.click();
-		document.getElementById('link-a')!.click();
+		document.getElementById('link-a')!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+		document.getElementById('link-b')!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+		document.getElementById('link-a')!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
 
 		expect(scrollIntoViewMock).toHaveBeenCalledTimes(3);
 	});
 
 	test('does not intercept external links (http://...#hash)', () => {
 		const linkExt = document.getElementById('link-ext')!;
-		linkExt.click();
+
+		const preventNavigation = (e: Event) => e.preventDefault();
+		window.addEventListener('click', preventNavigation);
+
+		linkExt.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
 
 		expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+		window.removeEventListener('click', preventNavigation);
 	});
 
 	test('works with URL-encoded Japanese anchors', () => {
@@ -55,14 +61,14 @@ describe('index.handleAnchorClick', () => {
             <h2 id="セクション">日本語セクション</h2>
             <a id="link-ja" href="#%E3%82%BB%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3">日本語リンク</a>
         `;
-		document.getElementById('link-ja')!.click();
+		document.getElementById('link-ja')!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
 		expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
 	});
 
 	test('does not throw when clicking a link to a missing anchor', () => {
 		document.body.innerHTML += '<a id="link-dead" href="#missing-section">dead link</a>';
 		expect(() => {
-			document.getElementById('link-dead')!.click();
+			document.getElementById('link-dead')!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
 		}).not.toThrow();
 	});
 });

--- a/packages/app-mobile/contentScripts/rendererBundle/contentScript/index.handleAnchorClick.test.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/contentScript/index.handleAnchorClick.test.ts
@@ -5,6 +5,26 @@ describe('index.handleAnchorClick', () => {
 	let document: Document;
 	let scrollIntoViewMock: jest.Mock;
 
+	// Helper function to replace .click() and avoid code duplication.
+	// We dispatch a cancelable event so e.preventDefault() can actually stop the navigation.
+	const simulateClick = (element: HTMLElement) => {
+		element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+	};
+
+	const preventNavigation = (e: Event) => e.preventDefault();
+
+	beforeAll(() => {
+		// JSDOM intentionally does not support full-page navigation.
+		// When our logic correctly ignores an external link, the click event bubbles up
+		// and triggers the native browser navigation, causing a "Not implemented: navigation" error.
+		// This global listener stops the native navigation attempt for the entire test suite.
+		window.addEventListener('click', preventNavigation);
+	});
+
+	afterAll(() => {
+		window.removeEventListener('click', preventNavigation);
+	});
+
 	beforeEach(() => {
 		document = window.document;
 		document.body.innerHTML = `
@@ -28,17 +48,17 @@ describe('index.handleAnchorClick', () => {
 	test('scrollIntoView is called even when the same link is clicked twice', () => {
 		const linkA = document.getElementById('link-a')!;
 
-		linkA.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+		simulateClick(linkA);
 		expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
 
-		linkA.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+		simulateClick(linkA);
 		expect(scrollIntoViewMock).toHaveBeenCalledTimes(2);
 	});
 
 	test('scrollIntoView is called for each click when different links are clicked alternately', () => {
-		document.getElementById('link-a')!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
-		document.getElementById('link-b')!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
-		document.getElementById('link-a')!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+		simulateClick(document.getElementById('link-a')!);
+		simulateClick(document.getElementById('link-b')!);
+		simulateClick(document.getElementById('link-a')!);
 
 		expect(scrollIntoViewMock).toHaveBeenCalledTimes(3);
 	});
@@ -46,15 +66,9 @@ describe('index.handleAnchorClick', () => {
 	test('does not intercept external links (http://...#hash)', () => {
 		const linkExt = document.getElementById('link-ext')!;
 
-		const preventNavigation = (e: Event) => e.preventDefault();
-		window.addEventListener('click', preventNavigation);
+		simulateClick(linkExt);
 
-		try {
-			linkExt.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
-		} finally {
-			window.removeEventListener('click', preventNavigation);
-		}
+		expect(scrollIntoViewMock).not.toHaveBeenCalled();
 	});
 
 	test('works with URL-encoded Japanese anchors', () => {
@@ -62,14 +76,14 @@ describe('index.handleAnchorClick', () => {
             <h2 id="セクション">日本語セクション</h2>
             <a id="link-ja" href="#%E3%82%BB%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3">日本語リンク</a>
         `;
-		document.getElementById('link-ja')!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+		simulateClick(document.getElementById('link-ja')!);
 		expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
 	});
 
 	test('does not throw when clicking a link to a missing anchor', () => {
 		document.body.innerHTML += '<a id="link-dead" href="#missing-section">dead link</a>';
 		expect(() => {
-			document.getElementById('link-dead')!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+			simulateClick(document.getElementById('link-dead')!);
 		}).not.toThrow();
 	});
 });

--- a/packages/app-mobile/contentScripts/rendererBundle/contentScript/index.handleAnchorClick.test.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/contentScript/index.handleAnchorClick.test.ts
@@ -49,11 +49,12 @@ describe('index.handleAnchorClick', () => {
 		const preventNavigation = (e: Event) => e.preventDefault();
 		window.addEventListener('click', preventNavigation);
 
-		linkExt.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
-
-		expect(scrollIntoViewMock).not.toHaveBeenCalled();
-
-		window.removeEventListener('click', preventNavigation);
+		try {
+			linkExt.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+		} finally {
+			window.removeEventListener('click', preventNavigation);
+		}
 	});
 
 	test('works with URL-encoded Japanese anchors', () => {


### PR DESCRIPTION
Fixes: #14832

**Description**
This PR resolves the warning "Error: Not implemented: navigation" that was being logged to the console during the `rendererBundle/contentScript/index.handleAnchorClick.test.ts` test suite.

In the test "does not intercept external links", an external link is clicked. Because our handleAnchorClick logic correctly identifies it as external, it does not call e.preventDefault(). This allows the click event to bubble up and trigger the browser's default navigation behavior. Since JSDOM does not support full-page navigation, it intercepts the attempt and throws the "Not implemented" error.

**Changes**
- Prevented JSDOM navigation: added a temporary window event listener during the external link test to explicitly call `e.preventDefault()`. This stops JSDOM from attempting the navigation, fixing the root cause of the warning.
- Standardized "click" events: replaced standard `.click()` calls with `dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))`, this ensures that the simulated events accurately simulate real user interactions and that `preventDefault()` actually works.

### Before
<img width="1404" height="587" alt="before" src="https://github.com/user-attachments/assets/3f2090c9-853d-46e3-ab4d-5f1d53be972d" />

### After
<img width="1040" height="327" alt="after" src="https://github.com/user-attachments/assets/8a35b8a0-9cb5-4a9b-825b-5183ff82f5cf" />

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->