### PR TITLE
Chore: Fixes #14834: Mobile: Fix JSDOM scrollIntoView error in tests

### DIFF
--- a/packages/app-mobile/components/ExtendedWebView/index.jest.tsx
+++ b/packages/app-mobile/components/ExtendedWebView/index.jest.tsx
@@ -16,7 +16,28 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 	const dom = useMemo(() => {
 		// Note: Adding `runScripts: 'dangerously'` to allow running inline <script></script>s.
 		// Use with caution -- don't load untrusted WebView HTML while testing.
-		return new JSDOM(props.html, { runScripts: 'dangerously', pretendToBeVisual: true });
+		
+		// Create an empty JSDOM instance first, so we can patch it BEFORE any scripts run.
+		const d = new JSDOM('', { runScripts: 'dangerously', pretendToBeVisual: true });
+
+		// JSDOM does not support scrollIntoView, so we polyfill it to prevent crashes.
+		const polyfillScroll = (win: any) => {
+			if (!win.Element) return;
+			const noop = () => { };
+			win.Element.prototype.scrollIntoView = noop;
+			win.HTMLElement.prototype.scrollIntoView = noop;
+			if (win.SVGElement) win.SVGElement.prototype.scrollIntoView = noop;
+			win.scrollBy = noop;
+			win.scrollTo = noop;
+			win.scroll = noop;
+		};
+
+		polyfillScroll(d.window);
+
+		// Now that it's patched, we can safely load the HTML content.
+		d.window.document.write(props.html);
+
+		return d;
 	}, [props.html]);
 
 	const injectJs = useCallback((js: string) => {
@@ -56,7 +77,10 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 	useEffect(() => {
 		// JSDOM polyfills
 		dom.window.eval(`
-			window.scrollBy = (_amount) => { };
+			Element.prototype.scrollIntoView = () => {};
+			HTMLElement.prototype.scrollIntoView = () => {};
+			window.scrollBy = () => {};
+			window.scrollTo = () => {};
 
 			// JSDOM iframes are missing certain functionality required by Joplin,
 			// including:
@@ -82,15 +106,23 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 						source: contentWindow,
 					}));
 				};
+
+				if (contentWindow.Element) {
+					const noop = () => { };
+					contentWindow.Element.prototype.scrollIntoView = noop;
+					contentWindow.HTMLElement.prototype.scrollIntoView = noop;
+					if (contentWindow.SVGElement) contentWindow.SVGElement.prototype.scrollIntoView = noop;
+				}
 			};
 
 			Object.defineProperty(HTMLIFrameElement.prototype, 'srcdoc', {
 				set(value) {
 					this.src = 'about:blank';
 					setTimeout(() => {
-						this.contentDocument.write(value);
-
+						// We must polyfill BEFORE writing to the document, because document.write
+						// can trigger script execution immediately.
 						polyfillIframeContentWindow(this.contentWindow);
+						this.contentDocument.write(value);
 					}, 0);
 				},
 			});

--- a/packages/app-mobile/jest.setup.js
+++ b/packages/app-mobile/jest.setup.js
@@ -65,7 +65,7 @@ jest.doMock('react-native-version-info', () => {
 
 // react-native-webview expects native iOS/Android code so needs to be mocked.
 jest.mock('./components/ExtendedWebView', () => {
-	return require('./components/ExtendedWebView/index.jest.js');
+	return require('./components/ExtendedWebView/index.jest');
 });
 
 jest.mock('./components/CameraView/Camera', () => {
@@ -90,6 +90,14 @@ for (const packageName of emptyMockPackages) {
 	jest.doMock(packageName, () => {
 		return { default: { } };
 	});
+}
+
+// JSDOM does not implement scrollIntoView, which causes some tests to log errors
+// after they have finished. We polyfill it here to prevent those errors.
+if (global.Element) {
+	const noop = () => {};
+	global.Element.prototype.scrollIntoView = noop;
+	if (global.HTMLElement) global.HTMLElement.prototype.scrollIntoView = noop;
 }
 
 jest.mock('react-native-file-viewer', () => {


### PR DESCRIPTION
### Description

Fixes #14834
This PR resolves the persistent `TypeError: a.scrollIntoView is not a function` and the subsequent `Cannot log after tests are done` warning that appeared during the [Note.test.tsx](cci:7://file:///c:/Users/BIT/Desktop/joplin/packages/app-mobile/components/screens/Note/Note.test.tsx:0:0-0:0) test suite in CI.

### The Problem:
JSDOM (the mock browser environment) does not implement `scrollIntoView`, `scrollTo`, or `scrollBy` on its element prototypes. In the [ExtendedWebView](cci:1://file:///c:/Users/BIT/Desktop/joplin/packages/app-mobile/components/ExtendedWebView/index.jest.tsx:14:0-166:2) mock, content scripts (specifically the [afterFullPageRender.ts](cci:7://file:///c:/Users/BIT/Desktop/joplin/packages/app-mobile/contentScripts/rendererBundle/contentScript/utils/afterFullPageRender.ts:0:0-0:0) script used for scrolling to hashes) were attempting to call these methods. 
Additionally, a race condition existed in the mock where scripts inside the note HTML (or within iframes) would execute before the mock's polyfills were finished setting up, leading to unhandled exceptions after the tests had officially completed.

### The Solution:
1.  **Global Polyfill**: Added a project-wide safety mock to [packages/app-mobile/jest.setup.js](cci:7://file:///c:/Users/BIT/Desktop/joplin/packages/app-mobile/jest.setup.js:0:0-0:0) to ensure the global `Element` prototype is patched for all tests.
2.  **Race Condition Prevention**: Refactored [packages/app-mobile/components/ExtendedWebView/index.jest.tsx](cci:7://file:///c:/Users/BIT/Desktop/joplin/packages/app-mobile/components/ExtendedWebView/index.jest.tsx:0:0-0:0) to create the JSDOM instance, apply prototype patches **before** loading any HTML content, and then finally load the content. This ensures no script can "sneak" a call in before the fix is ready.
3.  **Comprehensive Coverage**: Extended the polyfill to cover `HTMLElement`, `SVGElement`, `scroll`, `scrollTo`, and `scrollBy` for both the main window and any internal iframe windows.
4.  **Mock Path Update**: Updated the Jest require path to allow it to resolve the [.tsx](cci:7://file:///c:/Users/BIT/Desktop/joplin/packages/app-mobile/components/ExtendedWebView/index.tsx:0:0-0:0) mock directly, avoiding reliance on stale pre-compiled [.js](cci:7://file:///c:/Users/BIT/Desktop/joplin/packages/app-mobile/jest.setup.js:0:0-0:0) files.

### Testing:
Verified locally by running:
`yarn jest components/screens/Note/Note.test.tsx`
Confirmed that the test suite now finishes with a **100% clean terminal output** and zero stray error logs.