### PR TITLE
All: Fix missing await in crypto.decrypt for decryptRaw call

### DIFF
--- a/packages/lib/services/e2ee/crypto.ts
+++ b/packages/lib/services/e2ee/crypto.ts
@@ -94,7 +94,7 @@ const crypto: Crypto = {
 		const iv = Buffer.from(data.iv, 'base64');
 
 		const key = await pbkdf2Raw(password, salt, encryptionParameters.iterationCount, encryptionParameters.keyLength, encryptionParameters.digestAlgorithm);
-		const decrypted = decryptRaw(Buffer.from(data.ct, 'base64'), key, iv, encryptionParameters.authTagLength, encryptionParameters.associatedData);
+		const decrypted = await decryptRaw(Buffer.from(data.ct, 'base64'), key, iv, encryptionParameters.authTagLength, encryptionParameters.associatedData);
 
 		return decrypted;
 	},


### PR DESCRIPTION
## Problem

`decryptRaw` is an `async` function but was called without `await` in the
`decrypt` method of `crypto.ts` (line 97). This causes the function to
return a `Promise<Buffer>` instead of a resolved `Buffer`, which is a
latent correctness bug in the decryption path.

## Solution

Added the missing `await` before the `decryptRaw(...)` call in
`packages/lib/services/e2ee/crypto.ts`.

## Test Plan

Existing tests in `EncryptionService.test.ts` cover the decrypt path,
including tampered ciphertext and wrong password scenarios. All existing
tests pass with this change. No new tests required for this one-line fix.