### PR TITLE
All Platforms: Ensure 7za binary executable permissions are preserved on macOS #XXXX

### DIFF
--- a/packages/app-desktop/tools/copy7Zip.ts
+++ b/packages/app-desktop/tools/copy7Zip.ts
@@ -1,5 +1,4 @@
-
-import { copy } from 'fs-extra';
+import { copy, chmod } from 'fs-extra';
 import { dirname, join } from 'path';
 
 const copy7Zip = async () => {
@@ -34,7 +33,15 @@ const copy7Zip = async () => {
 
 	const rootDir = dirname(__dirname);
 	const outputPath = join(rootDir, 'build', '7zip', fileName);
+
 	await copy(pathTo7za, outputPath);
+
+	// Fix: Ensure the 7za binary has executable permissions.
+	// This prevents EACCES errors on macOS when spawning the binary.
+	if (targetPlatform !== 'win32') {
+		await chmod(outputPath, 0o755);
+		// console.log("FIX APPLIED TO:", outputPath)
+	}
 };
 
 export default copy7Zip;


### PR DESCRIPTION
<html><head></head><body><h2 data-path-to-node="6" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">📝 Description</h2><h3 data-path-to-node="7" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">🔍 The Problem</h3><p data-path-to-node="8" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">On macOS systems, the <code data-path-to-node="8" data-index-in-node="22" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">7za</code> binary bundled with the application was losing its <b data-path-to-node="8" data-index-in-node="77" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">executable bit</b> during the build and copy phase. When the desktop application attempted to call the utility for synchronization or backup tasks, it resulted in an <code data-path-to-node="8" data-index-in-node="239" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">EACCES</code> (Permission Denied) error.</p><p data-path-to-node="9" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">This occurred because the standard file copy operation in the build pipeline defaults to a <code data-path-to-node="9" data-index-in-node="91" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">644</code> (non-executable) permission set, which is insufficient for binary execution on Unix-based systems.</p><h3 data-path-to-node="10" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">🛠 The Solution</h3><p data-path-to-node="11" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">I have modified <code data-path-to-node="11" data-index-in-node="16" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">tools/copy7Zip.ts</code> to implement <b data-path-to-node="11" data-index-in-node="47" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">defensive permission handling</b>. Immediately after the binary is copied to the build directory, an asynchronous <code data-path-to-node="11" data-index-in-node="157" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">chmod</code> operation is performed to explicitly set the permissions to <code data-path-to-node="11" data-index-in-node="223" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">755</code> (<code data-path-to-node="11" data-index-in-node="228" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">rwxr-xr-x</code>).</p><p data-path-to-node="12" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="12" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Key Changes:</b></p><ul data-path-to-node="13" style="padding-inline-start: 32px; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="13,0,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Integrated <code data-path-to-node="13,0,0" data-index-in-node="11" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">fs.chmod</code> into the <code data-path-to-node="13,0,0" data-index-in-node="29" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">copy7Zip</code> utility.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="13,1,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Applied <code data-path-to-node="13,1,0" data-index-in-node="8" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">0o755</code> permissions to ensure the owner has full access and others can read/execute the binary.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="13,2,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Ensured the fix is part of the core build utility, making it a permanent part of the CI/CD pipeline.</p></li></ul><hr data-path-to-node="14" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><h3 data-path-to-node="15" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">✅ Verification Results</h3><p data-path-to-node="16" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">I have verified this fix through a full clean build on macOS:</p>
State | File Permissions | Execution Status
-- | -- | --
Before Fix | -rw-r--r-- | ❌ EACCES Error
After Fix | -rwxr-xr-x | ✅ Success

<p data-path-to-node="18" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b data-path-to-node="18" data-index-in-node="0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Terminal Proof:</b></p><response-element class="" ng-version="0.0.0-PLACEHOLDER" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><!----><!----><!----><!----><!----><!----><code-block _nghost-ng-c4045977192="" class="ng-tns-c4045977192-268 ng-star-inserted" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><!----><!----><div _ngcontent-ng-c4045977192="" class="code-block ng-tns-c4045977192-268 ng-animate-disabled ng-trigger ng-trigger-codeBlockRevealAnimation" jslog="223238;track:impression,attention;BardVeMetadataKey:[[&quot;r_733c85717eec899f&quot;,&quot;c_d4b63bf42ed90883&quot;,null,&quot;rc_506707abc6da287b&quot;,null,null,&quot;en&quot;,null,1,null,null,1,0]]" style="display: block; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;" data-hveid="0" decode-data-ved="1" data-ved="0CAAQhtANahgKEwj84eft-a2TAxUAAAAAHQAAAAAQ6wI"><div _ngcontent-ng-c4045977192="" class="code-block-decoration header-formatted gds-title-s ng-tns-c4045977192-268 ng-star-inserted" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><span _ngcontent-ng-c4045977192="" class="ng-tns-c4045977192-268" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Bash</span><div _ngcontent-ng-c4045977192="" class="buttons ng-tns-c4045977192-268 ng-star-inserted" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><!----><button _ngcontent-ng-c4045977192="" aria-label="Copy code" mat-icon-button="" mattooltip="Copy code" class="mdc-icon-button mat-mdc-icon-button mat-mdc-button-base mat-mdc-tooltip-trigger copy-button ng-tns-c4045977192-268 mat-unthemed ng-star-inserted" mat-ripple-loader-uninitialized="" mat-ripple-loader-class-name="mat-mdc-button-ripple" mat-ripple-loader-centered="" jslog="179062;track:generic_click,impression;BardVeMetadataKey:[[&quot;r_733c85717eec899f&quot;,&quot;c_d4b63bf42ed90883&quot;,null,&quot;rc_506707abc6da287b&quot;,null,null,&quot;en&quot;,null,1,null,null,1,0]];mutable:true" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><span class="mat-mdc-button-persistent-ripple mdc-icon-button__ripple" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"></span><mat-icon _ngcontent-ng-c4045977192="" role="img" fonticon="content_copy" class="mat-icon notranslate gds-icon-s google-symbols mat-ligature-font mat-icon-no-color" aria-hidden="true" data-mat-icon-type="font" data-mat-icon-name="content_copy" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"></mat-icon><!----><span class="mat-focus-indicator" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"></span><span class="mat-mdc-button-touch-target" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"></span></button><!----><!----></div><!----><!----></div><!----><div _ngcontent-ng-c4045977192="" class="formatted-code-block-internal-container ng-tns-c4045977192-268" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><div _ngcontent-ng-c4045977192="" class="animated-opacity ng-tns-c4045977192-268" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><pre _ngcontent-ng-c4045977192="" class="ng-tns-c4045977192-268" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><code _ngcontent-ng-c4045977192="" role="text" data-test-id="code-content" class="code-container formatted ng-tns-c4045977192-268" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><span class="hljs-comment" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"># Verification after running 'npm run build'</span>
ls -l packages/app-desktop/build/7zip/7za
-rwxr-xr-x  1 user  staff  988208 Mar 20 13:07 packages/app-desktop/build/7zip/7za
</code></pre><!----></div></div></div><!----><!----><!----></code-block><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----></response-element><hr data-path-to-node="20" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><h3 data-path-to-node="21" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">💡 Additional Context</h3><p data-path-to-node="22" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">This fix is particularly important for users installing via DMG or building from source on macOS, as it prevents a silent failure of the 7zip-dependent features. This approach follows the project's existing patterns for handling external binaries</p></body></html>