### PR TITLE
All: Fix: replace native alert() with shim.showMessageBox in encryption config

### DIFF
--- a/packages/lib/components/EncryptionConfigScreen/utils.ts
+++ b/packages/lib/components/EncryptionConfigScreen/utils.ts
@@ -116,7 +116,7 @@ export const useInputMasterPassword = (masterKeys: MasterKeyEntity[], activeMast
 		Setting.setValue('encryption.masterPassword', inputMasterPassword);
 
 		if (!(await masterPasswordIsValid(inputMasterPassword, masterKeys.find(mk => mk.id === activeMasterKeyId)))) {
-			alert('Password is invalid. Please try again.');
+			await shim.showMessageBox(_('Password is invalid. Please try again.'));
 		}
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied
 	}, [inputMasterPassword]);


### PR DESCRIPTION
## Problem

`useInputMasterPassword` in `EncryptionConfigScreen/utils.ts` uses the
native browser `alert()` to show an invalid password message. This is
inconsistent with the rest of the codebase which uses `shim.showMessageBox`
for all dialogs, and will not render correctly on all platforms.

## Solution

Replaced `alert(...)` with `await shim.showMessageBox(_(...))` to use
Joplin's cross-platform dialog API consistently.

## Test Plan

Manually verify that entering an incorrect master password in the
encryption config screen shows the error dialog correctly on desktop.
Existing tests continue to pass.