### PR TITLE
CLI: Add `clear` command to clear console output

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -103,6 +103,7 @@ packages/app-cli/app/command-apidoc.js
 packages/app-cli/app/command-attach.js
 packages/app-cli/app/command-batch.js
 packages/app-cli/app/command-cat.js
+packages/app-cli/app/command-clear.js
 packages/app-cli/app/command-config.js
 packages/app-cli/app/command-cp.js
 packages/app-cli/app/command-done.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ packages/app-cli/app/command-apidoc.js
 packages/app-cli/app/command-attach.js
 packages/app-cli/app/command-batch.js
 packages/app-cli/app/command-cat.js
+packages/app-cli/app/command-clear.js
 packages/app-cli/app/command-config.js
 packages/app-cli/app/command-cp.js
 packages/app-cli/app/command-done.test.js

--- a/packages/app-cli/app/command-clear.ts
+++ b/packages/app-cli/app/command-clear.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './base-command';
 import app from './app';
+import { _ } from '@joplin/lib/locale';
 
 class Command extends BaseCommand {
 	public override usage() {
@@ -7,7 +8,7 @@ class Command extends BaseCommand {
 	}
 
 	public override description() {
-		return ('Clears the console output.');
+		return _('Clears the console output.');
 	}
 
 	public override async action() {

--- a/packages/app-cli/app/command-clear.ts
+++ b/packages/app-cli/app/command-clear.ts
@@ -1,0 +1,18 @@
+import BaseCommand from './base-command';
+import app from './app';
+
+class Command extends BaseCommand {
+	public override usage() {
+		return 'clear';
+	}
+
+	public override description() {
+		return ('Clears the console output.');
+	}
+
+	public override async action() {
+		app().gui().widget('console').clear();
+	}
+}
+
+module.exports = Command;

--- a/packages/app-cli/app/gui/ConsoleWidget.js
+++ b/packages/app-cli/app/gui/ConsoleWidget.js
@@ -34,6 +34,12 @@ class ConsoleWidget extends TextWidget {
 		super.onBlur();
 	}
 
+	clear() {
+		this.lines_ = [];
+		this.updateText_ = true;
+		this.invalidate();
+	}
+
 	render() {
 		if (this.updateText_) {
 			if (this.lines_.length > this.maxLines_) {


### PR DESCRIPTION
This PR adds a `clear` command to the CLI application.

Currently the console output accumulates and the only way to remove
previous output is by scrolling. This command clears the console pane,
making the CLI easier to use during interactive sessions.

Implementation details:
- added a new CLI command `clear` inside the  packages/app-cli/app/command-clear.ts
- added a `clear()` method to packages/app-cli/app/gui/ConsoleWidget.js to reset the console buffer 

Example usage:

### Test Plan

1. Start the Joplin CLI.
2. Execute several commands so that console output appears.
3. Run `:clear`.
4. Verify that the console output is cleared.
5. Verify that new commands continue to work after clearing.