### PR TITLE
Desktop: Fixes #11235: Fix "Leave notebook" disabled when notebook isn't currently open

### DIFF
--- a/packages/lib/services/commands/stateToWhenClauseContext.ts
+++ b/packages/lib/services/commands/stateToWhenClauseContext.ts
@@ -66,7 +66,7 @@ export default function stateToWhenClauseContext(state: State, options: WhenClau
 	const selectedNotes = BaseModel.modelsByIds(windowState.notes ?? [], selectedNoteIds);
 
 	const selectedFolderIds = windowState.selectedFolderIds || [];
-	const commandFolderIds = state.notesParentType === 'Folder' ? (options.commandFolderIds || selectedFolderIds) : [];
+	const commandFolderIds = options.commandFolderIds ? options.commandFolderIds : (state.notesParentType === 'Folder' ? selectedFolderIds : []);
 	const commandFolders = commandFolderIds.length ? BaseModel.modelsByIds(state.folders, commandFolderIds) : [];
 	const commandFolder = commandFolders.length ? commandFolders[0] : null;
 


### PR DESCRIPTION
Fixes #11235

## Problem

The "Leave notebook" command can be incorrectly disabled when invoked from a notebook context menu while the current note list is not scoped to a folder, such as in tag views or All notes. In that case, `notesParentType` is not `Folder`, so `commandFolderIds` becomes empty even when the command received an explicit folder id.

## Solution

Prefer `options.commandFolderIds` whenever it is provided, and only fall back to `selectedFolderIds` when no explicit command folder id was passed. This allows the when-clause context to resolve the target shared notebook correctly for right-click actions outside the currently open notebook.

## Test Plan

Not run.

## AI Assistance Disclosure
AI tools were not used to write this code. The fix was identified
through manual code review of stateToWhenClauseContext.ts.