### PR TITLE
Improve 'New version' popup window with release notes (#14251)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -471,6 +471,8 @@ packages/app-desktop/gui/ToolbarSpace.js
 packages/app-desktop/gui/TrashNotification/TrashNotification.js
 packages/app-desktop/gui/TrashNotification/TrashNotificationMessage.js
 packages/app-desktop/gui/UpdateNotification/UpdateNotification.js
+packages/app-desktop/gui/UpdateNotification/releaseNotesUtils.test.js
+packages/app-desktop/gui/UpdateNotification/releaseNotesUtils.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/AppDialogs.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/ModalMessageOverlay.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/PluginDialogs.js

--- a/.gitignore
+++ b/.gitignore
@@ -444,6 +444,8 @@ packages/app-desktop/gui/ToolbarSpace.js
 packages/app-desktop/gui/TrashNotification/TrashNotification.js
 packages/app-desktop/gui/TrashNotification/TrashNotificationMessage.js
 packages/app-desktop/gui/UpdateNotification/UpdateNotification.js
+packages/app-desktop/gui/UpdateNotification/releaseNotesUtils.test.js
+packages/app-desktop/gui/UpdateNotification/releaseNotesUtils.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/AppDialogs.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/ModalMessageOverlay.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/PluginDialogs.js

--- a/packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx
+++ b/packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx
@@ -7,6 +7,7 @@ import shim from '@joplin/lib/shim';
 import { PopupNotificationContext } from '../PopupNotification/PopupNotificationProvider';
 import Button, { ButtonLevel } from '../Button/Button';
 import { NotificationType } from '../PopupNotification/types';
+import { releaseNotesToHtml } from './releaseNotesUtils';
 
 interface Props {
 }
@@ -19,66 +20,6 @@ export enum UpdateNotificationEvents {
 
 const handleApplyUpdate = () => {
 	ipcRenderer.send('apply-update-now');
-};
-
-// Converts basic Markdown release notes to simple HTML for display.
-// Handles headers, bold, list items, and horizontal rules.
-const releaseNotesToHtml = (notes: string): string => {
-	if (!notes) return '';
-
-	const lines = notes.split('\n');
-	const htmlLines: string[] = [];
-
-	for (const line of lines) {
-		let trimmed = line.trim();
-		if (!trimmed) continue;
-
-		// Skip horizontal rules
-		if (/^(\*\s*\*\s*\*|---+|___+)\s*$/.test(trimmed)) {
-			htmlLines.push('<hr/>');
-			continue;
-		}
-
-		// Headers
-		const headerMatch = trimmed.match(/^(#{1,6})\s+(.*)/);
-		if (headerMatch) {
-			const level = headerMatch[1].length;
-			const text = escapeHtml(headerMatch[2]);
-			htmlLines.push(`<h${level}>${text}</h${level}>`);
-			continue;
-		}
-
-		// List items
-		if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
-			trimmed = trimmed.substring(2);
-			htmlLines.push(`<li>${formatInlineMarkdown(trimmed)}</li>`);
-			continue;
-		}
-
-		htmlLines.push(`<p>${formatInlineMarkdown(trimmed)}</p>`);
-	}
-
-	return htmlLines.join('\n');
-};
-
-const escapeHtml = (text: string): string => {
-	return text
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;')
-		.replace(/'/g, '&#039;');
-};
-
-const formatInlineMarkdown = (text: string): string => {
-	let escaped = escapeHtml(text);
-	// Bold
-	escaped = escaped.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
-	// Inline code
-	escaped = escaped.replace(/`(.+?)`/g, '<code>$1</code>');
-	// Links: [text](url)
-	escaped = escaped.replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank">$1</a>');
-	return escaped;
 };
 
 const UpdateNotification: React.FC<Props> = () => {

--- a/packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx
+++ b/packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { useCallback, useContext, useEffect } from 'react';
-import { UpdateInfo } from 'electron-updater';
 import { ipcRenderer, IpcRendererEvent } from 'electron';
-import { AutoUpdaterEvents } from '../../services/autoUpdater/AutoUpdaterService';
+import { AutoUpdaterEvents, UpdateDownloadedInfo } from '../../services/autoUpdater/AutoUpdaterService';
 import { _ } from '@joplin/lib/locale';
 import shim from '@joplin/lib/shim';
 import { PopupNotificationContext } from '../PopupNotification/PopupNotificationProvider';
@@ -18,26 +17,100 @@ export enum UpdateNotificationEvents {
 	Dismiss = 'dismiss-update-notification',
 }
 
-const changelogLink = 'https://github.com/laurent22/joplin/releases';
-
-const openChangelogLink = () => {
-	shim.openUrl(changelogLink);
-};
-
 const handleApplyUpdate = () => {
 	ipcRenderer.send('apply-update-now');
+};
+
+// Converts basic Markdown release notes to simple HTML for display.
+// Handles headers, bold, list items, and horizontal rules.
+const releaseNotesToHtml = (notes: string): string => {
+	if (!notes) return '';
+
+	const lines = notes.split('\n');
+	const htmlLines: string[] = [];
+
+	for (const line of lines) {
+		let trimmed = line.trim();
+		if (!trimmed) continue;
+
+		// Skip horizontal rules
+		if (/^(\*\s*\*\s*\*|---+|___+)\s*$/.test(trimmed)) {
+			htmlLines.push('<hr/>');
+			continue;
+		}
+
+		// Headers
+		const headerMatch = trimmed.match(/^(#{1,6})\s+(.*)/);
+		if (headerMatch) {
+			const level = headerMatch[1].length;
+			const text = escapeHtml(headerMatch[2]);
+			htmlLines.push(`<h${level}>${text}</h${level}>`);
+			continue;
+		}
+
+		// List items
+		if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
+			trimmed = trimmed.substring(2);
+			htmlLines.push(`<li>${formatInlineMarkdown(trimmed)}</li>`);
+			continue;
+		}
+
+		htmlLines.push(`<p>${formatInlineMarkdown(trimmed)}</p>`);
+	}
+
+	return htmlLines.join('\n');
+};
+
+const escapeHtml = (text: string): string => {
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#039;');
+};
+
+const formatInlineMarkdown = (text: string): string => {
+	let escaped = escapeHtml(text);
+	// Bold
+	escaped = escaped.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+	// Inline code
+	escaped = escaped.replace(/`(.+?)`/g, '<code>$1</code>');
+	// Links: [text](url)
+	escaped = escaped.replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank">$1</a>');
+	return escaped;
 };
 
 const UpdateNotification: React.FC<Props> = () => {
 	const popupManager = useContext(PopupNotificationContext);
 
-	const handleUpdateDownloaded = useCallback((_event: IpcRendererEvent, info: UpdateInfo) => {
+	const handleUpdateDownloaded = useCallback((_event: IpcRendererEvent, info: UpdateDownloadedInfo) => {
+		const openReleasePage = () => {
+			if (info.pageUrl) {
+				shim.openUrl(info.pageUrl);
+			}
+		};
+
+		const releaseNotesHtml = releaseNotesToHtml(info.releaseNotes);
+
 		const notification = popupManager.createPopup(() => (
 			<div className='update-notification'>
-				{_('A new update (%s) is available', info.version)}
-				<button className='link-button' onClick={openChangelogLink}>{
-					_('See changelog')
-				}</button>
+				<div className='update-notification-header'>
+					<span className='update-notification-title'>
+						{_('A new update (%s) is available', info.version)}
+					</span>
+					{info.pageUrl && (
+						<button className='link-button' onClick={openReleasePage}>
+							{_('Full release notes')}
+						</button>
+					)}
+				</div>
+				{releaseNotesHtml && (
+					<div
+						className='update-notification-release-notes'
+						dangerouslySetInnerHTML={{ __html: releaseNotesHtml }}
+					/>
+				)}
 				<div className='buttons'>
 					<Button
 						level={ButtonLevel.Tertiary}

--- a/packages/app-desktop/gui/UpdateNotification/releaseNotesUtils.test.ts
+++ b/packages/app-desktop/gui/UpdateNotification/releaseNotesUtils.test.ts
@@ -1,0 +1,147 @@
+import { escapeHtml, formatInlineMarkdown, releaseNotesToHtml } from './releaseNotesUtils';
+
+describe('releaseNotesUtils', () => {
+
+	describe('escapeHtml', () => {
+		it('should escape ampersands', () => {
+			expect(escapeHtml('a & b')).toBe('a &amp; b');
+		});
+
+		it('should escape angle brackets', () => {
+			expect(escapeHtml('<div>')).toBe('&lt;div&gt;');
+		});
+
+		it('should escape quotes', () => {
+			expect(escapeHtml('"hello" & \'world\'')).toBe('&quot;hello&quot; &amp; &#039;world&#039;');
+		});
+
+		it('should return empty string for empty input', () => {
+			expect(escapeHtml('')).toBe('');
+		});
+
+		it('should not modify plain text', () => {
+			expect(escapeHtml('hello world')).toBe('hello world');
+		});
+	});
+
+	describe('formatInlineMarkdown', () => {
+		it('should convert bold text', () => {
+			expect(formatInlineMarkdown('this is **bold** text')).toBe('this is <strong>bold</strong> text');
+		});
+
+		it('should convert inline code', () => {
+			expect(formatInlineMarkdown('use `console.log`')).toBe('use <code>console.log</code>');
+		});
+
+		it('should convert markdown links', () => {
+			expect(formatInlineMarkdown('[Joplin](https://joplinapp.org)')).toBe(
+				'<a href="https://joplinapp.org" target="_blank">Joplin</a>',
+			);
+		});
+
+		it('should handle multiple inline formats together', () => {
+			const input = '**bold** and `code` and [link](http://example.com)';
+			const result = formatInlineMarkdown(input);
+			expect(result).toContain('<strong>bold</strong>');
+			expect(result).toContain('<code>code</code>');
+			expect(result).toContain('<a href="http://example.com" target="_blank">link</a>');
+		});
+
+		it('should escape HTML before formatting', () => {
+			expect(formatInlineMarkdown('**<script>**')).toBe('<strong>&lt;script&gt;</strong>');
+		});
+
+		it('should return plain escaped text when no markdown is present', () => {
+			expect(formatInlineMarkdown('plain text')).toBe('plain text');
+		});
+	});
+
+	describe('releaseNotesToHtml', () => {
+		it('should return empty string for empty input', () => {
+			expect(releaseNotesToHtml('')).toBe('');
+		});
+
+		it('should return empty string for null input', () => {
+			expect(releaseNotesToHtml(null)).toBe('');
+		});
+
+		it('should return empty string for undefined input', () => {
+			expect(releaseNotesToHtml(undefined)).toBe('');
+		});
+
+		it('should convert headers', () => {
+			const result = releaseNotesToHtml('## What is new');
+			expect(result).toBe('<h2>What is new</h2>');
+		});
+
+		it('should convert different header levels', () => {
+			const input = '# H1\n## H2\n### H3';
+			const result = releaseNotesToHtml(input);
+			expect(result).toContain('<h1>H1</h1>');
+			expect(result).toContain('<h2>H2</h2>');
+			expect(result).toContain('<h3>H3</h3>');
+		});
+
+		it('should convert dash list items', () => {
+			const result = releaseNotesToHtml('- First item\n- Second item');
+			expect(result).toContain('<li>First item</li>');
+			expect(result).toContain('<li>Second item</li>');
+		});
+
+		it('should convert asterisk list items', () => {
+			const result = releaseNotesToHtml('* First item\n* Second item');
+			expect(result).toContain('<li>First item</li>');
+			expect(result).toContain('<li>Second item</li>');
+		});
+
+		it('should convert horizontal rules', () => {
+			expect(releaseNotesToHtml('---')).toBe('<hr/>');
+			expect(releaseNotesToHtml('___')).toBe('<hr/>');
+			expect(releaseNotesToHtml('* * *')).toBe('<hr/>');
+		});
+
+		it('should wrap plain text in paragraphs', () => {
+			const result = releaseNotesToHtml('Some plain text');
+			expect(result).toBe('<p>Some plain text</p>');
+		});
+
+		it('should skip blank lines', () => {
+			const result = releaseNotesToHtml('Line 1\n\n\nLine 2');
+			expect(result).toBe('<p>Line 1</p>\n<p>Line 2</p>');
+		});
+
+		it('should handle a realistic release note', () => {
+			const input = [
+				'## New features',
+				'',
+				'- Added **dark mode** support',
+				'- New `search` command',
+				'',
+				'## Bug fixes',
+				'',
+				'- Fixed crash on startup',
+				'- Fixed [issue #123](https://github.com/example/issues/123)',
+			].join('\n');
+
+			const result = releaseNotesToHtml(input);
+			expect(result).toContain('<h2>New features</h2>');
+			expect(result).toContain('<li>Added <strong>dark mode</strong> support</li>');
+			expect(result).toContain('<li>New <code>search</code> command</li>');
+			expect(result).toContain('<h2>Bug fixes</h2>');
+			expect(result).toContain('<li>Fixed crash on startup</li>');
+			expect(result).toContain('<a href="https://github.com/example/issues/123" target="_blank">issue #123</a>');
+		});
+
+		it('should escape HTML in release notes to prevent XSS', () => {
+			const input = '- <script>alert("xss")</script>';
+			const result = releaseNotesToHtml(input);
+			expect(result).not.toContain('<script>');
+			expect(result).toContain('&lt;script&gt;');
+		});
+
+		it('should handle headers with special characters', () => {
+			const result = releaseNotesToHtml('## Version 3.2.1 & "Improvements"');
+			expect(result).toBe('<h2>Version 3.2.1 &amp; &quot;Improvements&quot;</h2>');
+		});
+	});
+});

--- a/packages/app-desktop/gui/UpdateNotification/releaseNotesUtils.ts
+++ b/packages/app-desktop/gui/UpdateNotification/releaseNotesUtils.ts
@@ -1,0 +1,60 @@
+// Converts basic Markdown release notes to simple HTML for display.
+// Handles headers, bold, list items, and horizontal rules.
+
+export const escapeHtml = (text: string): string => {
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#039;');
+};
+
+export const formatInlineMarkdown = (text: string): string => {
+	let escaped = escapeHtml(text);
+	// Bold
+	escaped = escaped.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+	// Inline code
+	escaped = escaped.replace(/`(.+?)`/g, '<code>$1</code>');
+	// Links: [text](url)
+	escaped = escaped.replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank">$1</a>');
+	return escaped;
+};
+
+export const releaseNotesToHtml = (notes: string): string => {
+	if (!notes) return '';
+
+	const lines = notes.split('\n');
+	const htmlLines: string[] = [];
+
+	for (const line of lines) {
+		let trimmed = line.trim();
+		if (!trimmed) continue;
+
+		// Horizontal rules
+		if (/^(\*\s*\*\s*\*|---+|___+)\s*$/.test(trimmed)) {
+			htmlLines.push('<hr/>');
+			continue;
+		}
+
+		// Headers
+		const headerMatch = trimmed.match(/^(#{1,6})\s+(.*)/);
+		if (headerMatch) {
+			const level = headerMatch[1].length;
+			const text = escapeHtml(headerMatch[2]);
+			htmlLines.push(`<h${level}>${text}</h${level}>`);
+			continue;
+		}
+
+		// List items
+		if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
+			trimmed = trimmed.substring(2);
+			htmlLines.push(`<li>${formatInlineMarkdown(trimmed)}</li>`);
+			continue;
+		}
+
+		htmlLines.push(`<p>${formatInlineMarkdown(trimmed)}</p>`);
+	}
+
+	return htmlLines.join('\n');
+};

--- a/packages/app-desktop/gui/UpdateNotification/style.scss
+++ b/packages/app-desktop/gui/UpdateNotification/style.scss
@@ -2,6 +2,68 @@
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
+	max-width: 450px;
+
+	> .update-notification-header {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 4px;
+		width: 100%;
+
+		> .update-notification-title {
+			font-weight: bold;
+		}
+
+		> .link-button {
+			font-size: 0.9em;
+		}
+	}
+
+	> .update-notification-release-notes {
+		max-height: 200px;
+		overflow-y: auto;
+		width: 100%;
+		margin-top: 8px;
+		padding: 8px;
+		border-radius: 4px;
+		background-color: rgba(0, 0, 0, 0.05);
+		font-size: 0.9em;
+		line-height: 1.4;
+
+		h1, h2, h3, h4, h5, h6 {
+			margin: 4px 0 2px 0;
+			font-size: 1em;
+			font-weight: bold;
+		}
+
+		p {
+			margin: 2px 0;
+		}
+
+		li {
+			margin-left: 16px;
+			list-style-type: disc;
+		}
+
+		hr {
+			border: none;
+			border-top: 1px solid rgba(0, 0, 0, 0.1);
+			margin: 8px 0;
+		}
+
+		code {
+			background-color: rgba(0, 0, 0, 0.08);
+			padding: 1px 4px;
+			border-radius: 3px;
+			font-size: 0.9em;
+		}
+
+		a {
+			color: inherit;
+			text-decoration: underline;
+		}
+	}
 
 	> .buttons {
 		display: flex;

--- a/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
+++ b/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
@@ -7,6 +7,12 @@ const shim: typeof ShimType = require('@joplin/lib/shim').default;
 import { GitHubRelease, GitHubReleaseAsset, handleReleaseResponseError } from '../../utils/checkForUpdatesUtils';
 import * as semver from 'semver';
 
+export interface UpdateDownloadedInfo {
+	version: string;
+	releaseNotes: string;
+	pageUrl: string;
+}
+
 export enum AutoUpdaterEvents {
 	CheckingForUpdate = 'checking-for-update',
 	UpdateAvailable = 'update-available',
@@ -54,6 +60,7 @@ export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
 	private allowDowngrade = false;
 	private isManualCheckInProgress = false;
 	private isUpdateInProgress = false;
+	private latestRelease_: GitHubRelease = null;
 
 	public constructor(mainWindow: BrowserWindow, logger: LoggerWrapper, devMode: boolean, includePreReleases: boolean) {
 		this.window_ = mainWindow;
@@ -135,6 +142,7 @@ export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
 
 		try {
 			const release: GitHubRelease = await this.fetchLatestRelease(this.includePreReleases_);
+			this.latestRelease_ = release;
 
 			try {
 				let assetUrl = this.getDownloadUrlForPlatform(release, shim.platformName(), process.arch);
@@ -203,7 +211,7 @@ export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
 	private onUpdateDownloaded = (info: UpdateInfo): void => {
 		this.logger_.info('Update downloaded.');
 		this.isUpdateInProgress = false;
-		void this.promptUserToUpdate(info);
+		void this.promptUserToUpdate(info, this.latestRelease_);
 	};
 
 	private onError = (error: Error): void => {
@@ -211,7 +219,14 @@ export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
 		this.isUpdateInProgress = false;
 	};
 
-	private promptUserToUpdate = async (info: UpdateInfo): Promise<void> => {
-		this.window_.webContents.send(AutoUpdaterEvents.UpdateDownloaded, info);
+	private promptUserToUpdate = async (info: UpdateInfo, release: GitHubRelease): Promise<void> => {
+		const releaseNotes = release?.body ?? '';
+		const pageUrl = release?.html_url ?? '';
+		const updateInfo: UpdateDownloadedInfo = {
+			version: info.version,
+			releaseNotes,
+			pageUrl,
+		};
+		this.window_.webContents.send(AutoUpdaterEvents.UpdateDownloaded, updateInfo);
 	};
 }


### PR DESCRIPTION
## Problem

When a new version of Joplin is available, the desktop app displays a minimal popup notification that only shows the version number and a generic link to the full releases page (`https://github.com/laurent22/joplin/releases`). Users have no way to see what changed in the new version without navigating away from the app. This makes the update experience less informative and less user-friendly.

Closes https://github.com/laurent22/joplin/issues/14251

## Solution

The update notification popup now displays the release notes for the new version directly inline, along with a link to the specific release page on GitHub.

### Changes:

**`AutoUpdaterService.ts` (main process):**
- Added a new `UpdateDownloadedInfo` interface containing `version`, `releaseNotes`, and `pageUrl`
- The service now stores the fetched `GitHubRelease` object (which already contains the release body and URL) when checking for updates
- `promptUserToUpdate` sends this richer `UpdateDownloadedInfo` over IPC instead of the raw `UpdateInfo` from electron-updater (which only contains the version number)

**`UpdateNotification.tsx` (renderer):**
- Replaced the generic "See changelog" link (pointing to the releases index) with a "Full release notes" link pointing to the specific GitHub release page for the new version
- Added a scrollable release notes area that renders the Markdown release notes as simple HTML
- Added lightweight Markdown-to-HTML helpers (`releaseNotesToHtml`, `escapeHtml`, `formatInlineMarkdown`) that handle headers, lists, bold, inline code, links, and horizontal rules. A full Markdown library was avoided to keep the change minimal
- Removed the dependency on `UpdateInfo` from `electron-updater` in the renderer

**`style.scss`:**
- Styled the release notes area with max-height scrolling, background, and inner element formatting

### Behavioural changes:

- The "See changelog" button is replaced by "Full release notes" which links to the specific release (e.g. `https://github.com/laurent22/joplin/releases/tag/v3.2.1`) instead of the generic releases page
- Release notes are shown inline in the popup. If no release notes are available, the popup gracefully falls back to the previous behaviour (title + buttons only)
- No changes to the "No updates available" notification

This is a low-risk, UI-only change in the renderer and a small data-passing change in the main process. The auto-updater download/install logic is untouched.

## Test Plan

1. **Update available scenario:** Trigger an update notification (or simulate by calling the IPC event with test data). Verify that:
   - The popup shows the version number in bold at the top
   - A "Full release notes" link appears and opens the correct GitHub release page
   - Release notes are displayed in a scrollable area below the header
   - Markdown formatting (headers, bullet lists, bold, code) renders correctly
   - "Restart now" button applies the update
   - "Update later" button dismisses the popup
2. **No release notes:** Send an update event with an empty `releaseNotes` string. Verify the release notes area is hidden and the popup still shows the version and buttons correctly
3. **No update available:** Trigger a manual check when no update is available. Verify the "No updates available" notification still appears and auto-dismisses
4. **Long release notes:** Test with very long release notes to verify the scrollable area works correctly and doesn't overflow the popup
5. **Existing tests:** Run `yarn test` in `packages/app-desktop` to ensure the existing `AutoUpdaterService.test.ts` tests still pass (they test `fetchLatestRelease` and `getDownloadUrlForPlatform`, which are unchanged)

## AI Disclosure

I used AI to help refine the PR description and explore possible solutions.
