### PR TITLE
Chore: Server: Remove auto-generated explicit any in `types.ts`

### DIFF
--- a/packages/server/src/services/database/types.ts
+++ b/packages/server/src/services/database/types.ts
@@ -153,8 +153,7 @@ export interface File {
 	id?: Uuid;
 	owner_id?: Uuid;
 	name?: string;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	content?: any;
+	content?: Buffer;
 	mime_type?: string;
 	size?: number;
 	is_directory?: number;

--- a/packages/server/src/tools/generateTypes.ts
+++ b/packages/server/src/tools/generateTypes.ts
@@ -54,6 +54,7 @@ const propertyTypes: Record<string, string> = {
 	'events.created_time': 'number',
 	'events.type': 'EventType',
 	'items.content': 'Buffer',
+	'files.content': 'Buffer',
 	'items.jop_updated_time': 'number',
 	'notifications.level': 'NotificationLevel',
 	'share_users.status': 'ShareUserStatus',


### PR DESCRIPTION
# Problem

Running `yarn generateTypes` created a file that failed the precommit linter. Previously, [`database/types.ts` included](https://github.com/laurent22/joplin/blob/05fc3e91048e46de0223bbc3f4f36bf9ee39e2cb/packages/server/src/services/database/types.ts#L157):
```ts
content?: any;
```
In `dev`, a `// eslint-disable-next-line @typescript-eslint/no-explicit-any` comment is present. Regenerating `types.ts` removed this comment.

> [!NOTE]
>
> It might also be safe to drop the `files` table entirely: The `files` table seems to currently be unused, with the exception of `testing/fileApiUtils.ts`. However, the functions in `fileApiUtils.ts` that interact with the `files` table also seem to be unused.

# Solution

Replace `any` with `Buffer`.

# Validation

`PRAGMA table_info(files);` indicates that `files.content` has type `BLOB` in SQLite. This matches the type of `items.content`, which also has TypeScript type `Buffer`.
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->