### PR TITLE
Chore: Editor: Strengthen compatibility layer event types

### DIFF
--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
@@ -14,8 +14,21 @@ const { pregQuote } = require('@joplin/lib/string-utils-common');
 
 type CodeMirror5Command = (codeMirror: CodeMirror5Emulation)=> void;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-type EditorEventCallback = (editor: CodeMirror5Emulation, ...args: any[])=> void;
+type BuiltInEventArgs = {
+	'paste': [ClipboardEvent];
+	'mousedown': [MouseEvent];
+	'blur': [];
+	'focus': [];
+	'scroll': [];
+	'update': [];
+	'viewportChange': [number, number];
+	'beforeSelectionChange': [];
+};
+// Fall back to `unknown[]` for unknown events (e.g. plugin events)
+type EventArgs<T> = T extends keyof BuiltInEventArgs ? BuiltInEventArgs[T] : unknown[];
+type EventType = (keyof BuiltInEventArgs)|string;
+
+type EditorEventCallback<T extends EventType> = (editor: CodeMirror5Emulation, ...args: EventArgs<T>)=> void;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 type OptionUpdateCallback = (editor: CodeMirror5Emulation, newVal: any, oldVal: any)=> void;
 
@@ -60,8 +73,12 @@ const posFromDocumentPosition = (doc: Text, pos: DocumentPosition) => {
 	return result;
 };
 
+type EventMap = {
+	[Key in EventType]?: EditorEventCallback<Key>[]
+};
+
 export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
-	private _events: Record<string, EditorEventCallback[]> = {};
+	private _events: EventMap = {};
 	private _options: Record<string, CodeMirror5OptionRecord> = Object.create(null);
 	private _decorator: Decorator;
 	private _decoratorExtension: Extension;
@@ -163,15 +180,15 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 		return ['beforeSelectionChange'].includes(eventName);
 	}
 
-	public on(eventName: string, callback: EditorEventCallback) {
+	public on<T extends EventType>(eventName: T, callback: EditorEventCallback<T>) {
 		if (this.isEventHandledBySuperclass(eventName)) {
 			return super.on(eventName, callback);
 		}
 		this._events[eventName] ??= [];
-		this._events[eventName].push(callback);
+		this._events[eventName].push(callback as EditorEventCallback<EventType>);
 	}
 
-	public off(eventName: string, callback: EditorEventCallback) {
+	public off<T extends EventType>(eventName: T, callback: EditorEventCallback<T>) {
 		if (!(eventName in this._events)) {
 			return;
 		}
@@ -182,7 +199,7 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public static signal(target: CodeMirror5Emulation, eventName: string, ...args: any[]) {
+	public static signal<T extends EventType>(target: CodeMirror5Emulation, eventName: T, ...args: EventArgs<T>) {
 		const listeners = target._events[eventName] ?? [];
 
 		for (const listener of listeners) {

--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
@@ -14,6 +14,14 @@ const { pregQuote } = require('@joplin/lib/string-utils-common');
 
 type CodeMirror5Command = (codeMirror: CodeMirror5Emulation)=> void;
 
+interface ChangeRecord {
+	from: DocumentPosition;
+	to: DocumentPosition;
+	text: string[];
+	removed: string[];
+	transaction: Transaction;
+}
+
 type BuiltInEventArgs = {
 	'paste': [ClipboardEvent];
 	'mousedown': [MouseEvent];
@@ -21,11 +29,17 @@ type BuiltInEventArgs = {
 	'focus': [];
 	'scroll': [];
 	'update': [];
+	'change': [ChangeRecord];
+	'changes': [ChangeRecord[]];
+	'inputRead': [ChangeRecord];
 	'viewportChange': [number, number];
 	'beforeSelectionChange': [];
 };
 // Fall back to `unknown[]` for unknown events (e.g. plugin events)
-type EventArgs<T> = T extends keyof BuiltInEventArgs ? BuiltInEventArgs[T] : unknown[];
+type EventArgs<EventName> =
+	EventName extends keyof BuiltInEventArgs
+		? BuiltInEventArgs[EventName]
+		: unknown[];
 type EventType = (keyof BuiltInEventArgs)|string;
 
 type EditorEventCallback<T extends EventType> = (editor: CodeMirror5Emulation, ...args: EventArgs<T>)=> void;
@@ -198,7 +212,6 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 		);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public static signal<T extends EventType>(target: CodeMirror5Emulation, eventName: T, ...args: EventArgs<T>) {
 		const listeners = target._events[eventName] ?? [];
 
@@ -210,13 +223,6 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 	}
 
 	private fireChangeEvents(update: ViewUpdate) {
-		type ChangeRecord = {
-			from: DocumentPosition;
-			to: DocumentPosition;
-			text: string[];
-			removed: string[];
-			transaction: Transaction;
-		};
 		const changes: ChangeRecord[] = [];
 		const origDoc = update.startState.doc;
 


### PR DESCRIPTION
Ref: https://github.com/laurent22/joplin/pull/14825#discussion_r2960221073

# Problem

The CodeMirror5 compatibility layer used explicit `any` types in its event handler logic.

# Solution

Use mapped types.

# Validation

I have verified that the only change in the generated `CodeMirror5Emulation.js` file is a now-removed `// eslint-disable-next-line` comment.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->