### PR TITLE
Chore: OneNote importer: Remove unused callback

### DIFF
--- a/packages/onenote-converter/parser/src/one/property_set/page_metadata.rs
+++ b/packages/onenote-converter/parser/src/one/property_set/page_metadata.rs
@@ -31,10 +31,6 @@ pub(crate) fn parse(object: &Object) -> Result<Data> {
         .ok_or_else(|| ErrorKind::MalformedOneNoteFileData("page metadata has no guid".into()))?;
     // The page might not have a title but we can use the first Section outline from the body as the fallback later
     let cached_title = simple::parse_string(PropertyType::CachedTitleString, object)?
-        .ok_or_else(|| {
-            let guid = simple::parse_guid(PropertyType::NotebookManagementEntityGuid, object);
-            return guid.map(|g| g.unwrap().to_string());
-        })
         .unwrap_or("Untitled Page".to_string());
     let schema_revision_in_order_to_read =
         simple::parse_u32(PropertyType::SchemaRevisionInOrderToRead, object)?;


### PR DESCRIPTION
# Problem

The `onenote-converter` package includes a confusing `ok_or_else` callback:
- This callback *looks* like it should set the imported page title to a GUID (e.g. `{10100300-0400-0500-0600-008000900A00}`) when no title can be found.
- However, because of how `ok_or_else` works, the callback's results were always discarded in favor of "Untitled Page" when a title could not be found.

This was flagged during a @coderabbitai review of https://github.com/laurent22/joplin/pull/14858#discussion_r2968149876.

# Solution

Remove the `ok_or_else` callback.

## Why this is okay

The previous code looked roughly like this (pseudocode)
```rust
let cached_title = something_that_returns_an_option()
  .ok_or_else(|| {
      // return the page GUID
  })
  .unwrap_or("Untitled Page".to_string());
```

`ok_or_else` is documented as:
> Transforms the `Option<T>` into a `Result<T, E>`, mapping `Some(v)` to `Ok(v)` and `None` to `Err(err())`.
> — https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or_else

As such, the page GUID was always returned as an `Err(guid)`. The [`unwrap_or`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap_or) would then unwrap this `Err`, ignore its contents, and return `"Untitled Page"`. As a result, the `Err` was always ignored.

The `ok_or_else` logic was originally added in https://github.com/laurent22/joplin/pull/11598.

# Validation

On Linux:
- [x] `cargo test` Rust-native tests pass
- [x] `InteropService_Importer_OneNote.test.ts` tests in `packages/lib` pass

These tests are also run in CI.
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->