### PR TITLE
Fix: upgrade react-native-popup-menu to remove deprecated SafeAreaView warning

### DIFF
--- a/.yarn/patches/react-native-popup-menu-npm-0.19.0-c75418add4.patch
+++ b/.yarn/patches/react-native-popup-menu-npm-0.19.0-c75418add4.patch
@@ -1,10 +1,8 @@
-# This patch improves the note actions menu (the kebab menu)'s accessibility
-# by labelling its dismiss button.
 diff --git a/build/rnpm.js b/build/rnpm.js
-index 47bc91a88b9e2246a0ce4295f9f932da6a572461..75b5a22bdcbc2594238bcf953df6d54e18cc7793 100644
+index d609e53d6146093ef0fabecfce33b21d7b0ea28f..acf932f1b819b04e549c8036bde28400301c73ef 100644
 --- a/build/rnpm.js
 +++ b/build/rnpm.js
-@@ -1267,7 +1267,9 @@
+@@ -1265,7 +1265,10 @@
              onPress = _this$props.onPress,
              style = _this$props.style;
          return React__default.createElement(reactNative.TouchableWithoutFeedback, {
@@ -12,10 +10,11 @@ index 47bc91a88b9e2246a0ce4295f9f932da6a572461..75b5a22bdcbc2594238bcf953df6d54e
 +          onPress: onPress,
 +          accessibilityLabel: _this$props.accessibilityLabel,
 +          accessibilityRole: 'button',
++
          }, React__default.createElement(reactNative.Animated.View, {
            style: [styles.fullscreen, {
              opacity: this.fadeAnim
-@@ -1282,7 +1284,8 @@
+@@ -1280,7 +1283,8 @@
    }(React.Component);
  
    Backdrop.propTypes = {
@@ -25,7 +24,7 @@ index 47bc91a88b9e2246a0ce4295f9f932da6a572461..75b5a22bdcbc2594238bcf953df6d54e
    };
    var styles = reactNative.StyleSheet.create({
      fullscreen: {
-@@ -1352,6 +1355,7 @@
+@@ -1350,6 +1354,7 @@
            style: styles$1.placeholder
          }, React__default.createElement(Backdrop, {
            onPress: ctx._onBackdropPress,
@@ -33,7 +32,7 @@ index 47bc91a88b9e2246a0ce4295f9f932da6a572461..75b5a22bdcbc2594238bcf953df6d54e
            style: backdropStyles,
            ref: ctx.onBackdropRef
          }), ctx._makeOptions());
-@@ -1784,6 +1788,7 @@
+@@ -1981,6 +1986,7 @@
          }), React__default.createElement(MenuPlaceholder, {
            ctx: this,
            backdropStyles: customStyles.backdrop,
@@ -41,24 +40,15 @@ index 47bc91a88b9e2246a0ce4295f9f932da6a572461..75b5a22bdcbc2594238bcf953df6d54e
            ref: this._onPlaceholderRef
          }))));
        }
-@@ -1854,7 +1859,7 @@
-         var _options$props = options.props,
-             optionsContainerStyle = _options$props.optionsContainerStyle,
-             renderOptionsContainer = _options$props.renderOptionsContainer,
--            customStyles = _options$props.customStyles;
-+            customStyles = _options$props.customStyles || {};
-         var optionsRenderer = renderOptionsContainer || defaultOptionsContainerRenderer;
-         var isOutside = !triggerLayout || !optionsLayout;
- 
 diff --git a/src/index.d.ts b/src/index.d.ts
-index 7e1ef2e441a665e97c304984080399f9646395df..673c4f713757abfb1851cba0d4560020c83e5f50 100644
+index 6a9917ffea268379985f70e10221bf52efe865be..81a647ca7570727c99e969e6210479ae05f1af0a 100644
 --- a/src/index.d.ts
 +++ b/src/index.d.ts
-@@ -18,6 +18,7 @@ declare module "react-native-popup-menu" {
-       menuProviderWrapper?: StyleProp<ViewStyle>;
+@@ -19,6 +19,7 @@ declare module "react-native-popup-menu" {
        backdrop?: StyleProp<ViewStyle>;
+       safeArea?: StyleProp<ViewStyle>;
      };
 +    closeButtonLabel: string;
      backHandler?: boolean | Function;
      skipInstanceCheck?: boolean;
-     children: React.ReactNode;
+     SafeAreaComponent?: React.ComponentType<any>;

--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -70,7 +70,7 @@
     "react-native-modal-datetime-picker": "18.0.0",
     "react-native-nitro-modules": "0.33.2",
     "react-native-paper": "5.14.5",
-    "react-native-popup-menu": "0.17.0",
+    "react-native-popup-menu": "patch:react-native-popup-menu@npm%3A0.19.0#~/.yarn/patches/react-native-popup-menu-npm-0.19.0-c75418add4.patch",
     "react-native-quick-actions": "0.3.13",
     "react-native-quick-base64": "2.2.2",
     "react-native-quick-crypto": "0.7.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10675,7 +10675,7 @@ __metadata:
     react-native-modal-datetime-picker: "npm:18.0.0"
     react-native-nitro-modules: "npm:0.33.2"
     react-native-paper: "npm:5.14.5"
-    react-native-popup-menu: "npm:0.17.0"
+    react-native-popup-menu: "patch:react-native-popup-menu@npm%3A0.19.0#~/.yarn/patches/react-native-popup-menu-npm-0.19.0-c75418add4.patch"
     react-native-quick-actions: "npm:0.3.13"
     react-native-quick-base64: "npm:2.2.2"
     react-native-quick-crypto: "npm:0.7.17"
@@ -44310,17 +44310,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-popup-menu@npm:0.17.0":
-  version: 0.17.0
-  resolution: "react-native-popup-menu@npm:0.17.0"
-  checksum: 10/7b78285979c754cfb40ac4b8571c69a42d3b76820b9d814edea6b752307e8b5a3c9cee9cc0ff054f5c820f265761e84f2b49fdfded7b5ff9f8c1f8a675ba6f0a
+"react-native-popup-menu@npm:0.19.0":
+  version: 0.19.0
+  resolution: "react-native-popup-menu@npm:0.19.0"
+  checksum: 10/96e88d60331c40d11bf74f540bcdfef78c89d5f661a8fc5c31982626d8c0c8e3dd28c58761bd8f02dc4f111e6dbcc52e23e025bd56394e6db3fbe7592a3f6182
   languageName: node
   linkType: hard
 
-"react-native-popup-menu@patch:react-native-popup-menu@npm%3A0.17.0#./.yarn/patches/react-native-popup-menu-npm-0.17.0-8b745d88dd.patch::locator=root%40workspace%3A.":
-  version: 0.17.0
-  resolution: "react-native-popup-menu@patch:react-native-popup-menu@npm%3A0.17.0#./.yarn/patches/react-native-popup-menu-npm-0.17.0-8b745d88dd.patch::version=0.17.0&hash=906a51&locator=root%40workspace%3A."
-  checksum: 10/3f7659f14a6291b866669596c3c66ef1a5c27ea1f621fb7be7a4fe61d146066f2bb36f575a1b9e90f3ecf71e1a906659e90e72d9e683c04899b1f9e15224dd34
+"react-native-popup-menu@patch:react-native-popup-menu@npm%3A0.19.0#~/.yarn/patches/react-native-popup-menu-npm-0.19.0-c75418add4.patch":
+  version: 0.19.0
+  resolution: "react-native-popup-menu@patch:react-native-popup-menu@npm%3A0.19.0#~/.yarn/patches/react-native-popup-menu-npm-0.19.0-c75418add4.patch::version=0.19.0&hash=ad7775"
+  checksum: 10/9672038e499ad1f955c36163d74668dcf6ddb75d85f36fe4ecf79d7da1aef13a23ffa513d97ff3738be6f5b9adf6a7d6f524414e8cf91e725c2719ced5207f4d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What does this PR do?

Upgrades `react-native-popup-menu` from `0.17.0` to `0.19.0` to fix 
deprecated `<SafeAreaView>` warnings logged during CI test runs.

## Why?

Closes #14835

The old version used the deprecated `<SafeAreaView>` component from 
`react-native` core. The newer version removes this in favour of 
`react-native-safe-area-context`.

## Changes

- Upgraded `react-native-popup-menu` from `0.17.0` to `0.19.0`
- Migrated the existing accessibility patch (which adds `closeButtonLabel` 
  and `accessibilityRole` to the backdrop dismiss button) to the new version
- Removed the old `0.17.0` patch file

## How to test

1. Run `yarn workspace @joplin/app-mobile jest --forceExit`
2. Verify no `SafeAreaView has been deprecated` warnings appear in the output
3. Verify all tests pass

## Test results
Test Suites: 2 passed, 2 total
Tests:       21 passed, 21 total
No SafeAreaView warnings in output.