### PR TITLE
Desktop: Refactored TagList.tsx to enforce strict TypeScript interfaces

### DIFF
--- a/packages/app-desktop/gui/TagList.tsx
+++ b/packages/app-desktop/gui/TagList.tsx
@@ -7,12 +7,15 @@ import { getCollator, getCollatorLocale } from '@joplin/lib/models/utils/getColl
 const { connect } = require('react-redux');
 const { themeStyle } = require('@joplin/lib/theme');
 
+interface Tag {
+	id: string;
+	title: string;
+}
+
 interface Props {
 	themeId: number;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	style: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	items: any[];
+	style: React.CSSProperties;
+	items: Tag[];
 }
 
 function TagList(props: Props) {
@@ -34,8 +37,7 @@ function TagList(props: Props) {
 	const tags = useMemo(() => {
 		const output = props.items.slice();
 		const collator = getCollator(collatorLocale);
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		output.sort((a: any, b: any) => {
+		output.sort((a: Tag, b: Tag) => {
 			return collator.compare(a.title, b.title);
 		});
 


### PR DESCRIPTION
Resolves legacy technical debt in `packages/app-desktop/gui/TagList.tsx` by enforcing compile-time type safety. 

- Replaced `any` types in the items array with a strict `Tag` interface.
- Typed the `style` prop as `React.CSSProperties`.
- Updated the `sort` callback to use the typed interface.
- Cleaned up the obsolete `eslint-disable` comments.

**Testing:**
Passed `yarn tsc` and `yarn linter` locally. Verified no UI regressions in the desktop app (tags still render, assign, and sort correctly).