### PR TITLE
Chore: Mobile: Fixes #14834: Fix JSDOM scrollIntoView error in tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -701,6 +701,7 @@ packages/app-mobile/components/ExtendedWebView/index.jest.js
 packages/app-mobile/components/ExtendedWebView/index.js
 packages/app-mobile/components/ExtendedWebView/index.web.js
 packages/app-mobile/components/ExtendedWebView/types.js
+packages/app-mobile/components/ExtendedWebView/utils/polyfillScrollFunctions.js
 packages/app-mobile/components/ExtendedWebView/utils/useCss.js
 packages/app-mobile/components/FolderPicker.js
 packages/app-mobile/components/Icon.js

--- a/.gitignore
+++ b/.gitignore
@@ -674,6 +674,7 @@ packages/app-mobile/components/ExtendedWebView/index.jest.js
 packages/app-mobile/components/ExtendedWebView/index.js
 packages/app-mobile/components/ExtendedWebView/index.web.js
 packages/app-mobile/components/ExtendedWebView/types.js
+packages/app-mobile/components/ExtendedWebView/utils/polyfillScrollFunctions.js
 packages/app-mobile/components/ExtendedWebView/utils/useCss.js
 packages/app-mobile/components/FolderPicker.js
 packages/app-mobile/components/Icon.js

--- a/packages/app-mobile/components/ExtendedWebView/index.jest.tsx
+++ b/packages/app-mobile/components/ExtendedWebView/index.jest.tsx
@@ -9,6 +9,7 @@ import Logger from '@joplin/utils/Logger';
 import { Props, WebViewControl } from './types';
 import { JSDOM } from 'jsdom';
 import useCss from './utils/useCss';
+import polyfillScrollFunctions from './utils/polyfillScrollFunctions';
 
 const logger = Logger.create('ExtendedWebView');
 
@@ -55,9 +56,9 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 
 	useEffect(() => {
 		// JSDOM polyfills
-		dom.window.eval(`
-			window.scrollBy = (_amount) => { };
+		dom.window.eval(polyfillScrollFunctions);
 
+		dom.window.eval(`
 			// JSDOM iframes are missing certain functionality required by Joplin,
 			// including:
 			// - MessageEvent.source: Should point to the window that created a message.

--- a/packages/app-mobile/components/ExtendedWebView/utils/polyfillScrollFunctions.ts
+++ b/packages/app-mobile/components/ExtendedWebView/utils/polyfillScrollFunctions.ts
@@ -1,0 +1,10 @@
+const polyfillScrollFunctions = `
+	if (!window.scrollBy) {
+		window.scrollBy = (_amount) => { };
+	}
+	if (!Element.prototype.scrollIntoView) {
+		Element.prototype.scrollIntoView = function() { };
+	}
+`;
+
+export default polyfillScrollFunctions;


### PR DESCRIPTION
## AI Assistance Disclosure

This PR was developed with AI assistance (Claude). AI was used for:

- Drafting the polyfill implementation
- Grammar check the wording and phrases used in drafting PR message
- Reviewing adherence to Joplin coding style

All generated code was reviewed, understood, and validated with local test runs.

## Problem

After `Note.test.tsx` tests complete, a deferred `setTimeout` in `afterFullPageRender.ts` calls `element.scrollIntoView()`. JSDOM does not implement `Element.prototype.scrollIntoView`, so this throws a `TypeError` that surfaces as a "Cannot log after tests are done" warning. The existing JSDOM mock (`ExtendedWebView/index.jest.tsx`) already polyfilled `window.scrollBy` but not `scrollIntoView`.

## Solution

Extracted the inline `scrollBy` polyfill from `index.jest.tsx` into a shared polyfill string (`polyfillScrollFunctions.ts`) and added a guarded no-op for `Element.prototype.scrollIntoView`. The polyfill runs inside the isolated JSDOM context via `dom.window.eval()`, so it does not affect Jest's global jsdom environment or other test files.

This is a low-risk change as it only adds a no-op function to an isolated test mock. No production code is modified.

## Test plan

- `yarn test Note.test` - 21/21 pass
- `yarn test handleAnchorClick` - 5/5 pass (file not modified, unaffected by change)
- 'yarn test-ci' - 36/37 suites pass (1 pre-existing flaky failure in `NoteEditor.test.tsx`, unrelated to the change in the PR)

<img width="1860" height="602" alt="Screenshot 2026-03-23 132418" src="https://github.com/user-attachments/assets/1882bde6-fc5d-4523-bd6a-7e49b3578843" />
<img width="597" height="141" alt="Screenshot 2026-03-23 135537" src="https://github.com/user-attachments/assets/4fd9804a-8dbd-48e8-b49c-ee31a245f2a5" />

Additional things to note: we recognized one failing test (NoteEditor.test.tsx) in the full suite and identified that the failing test is a pre-existing flaky test that is unrelated to the changes in this PR. It fails intermittently due to timing issues in the editor component tests and was already failing prior to the changes made in this PR.