### PR TITLE
Improve web clipper connection feedback and retry flow

### DIFF
--- a/packages/app-clipper/popup/src/App.css
+++ b/packages/app-clipper/popup/src/App.css
@@ -175,3 +175,8 @@ body {
 .App .StatusBar .ServerStatus .Help {
 	margin-left: 5px;
 }
+
+.App.Startup a.Retry {
+	margin-top: 15px;
+	align-self: center;
+}

--- a/packages/app-clipper/popup/src/App.js
+++ b/packages/app-clipper/popup/src/App.js
@@ -142,6 +142,10 @@ class AppComponent extends Component {
 			bridge().tabsCreate({ url: 'https://joplinapp.org/help/apps/clipper' });
 		};
 
+		this.retry_click = async () => {
+			await bridge().findClipperServerPort();
+		};
+
 		this.folderSelect_change = (event) => {
 			this.props.dispatch({
 				type: 'SELECTED_FOLDER_SET',
@@ -259,6 +263,7 @@ class AppComponent extends Component {
 				// when clicking on the extension button.
 				'searching': 'Connecting to the Joplin application...',
 				'not_found': 'Error: Could not connect to the Joplin application. Please ensure that it is started and that the clipper service is enabled in the configuration.',
+				'app_not_running': 'The Joplin application is not running. Please open Joplin and then click "Retry" below.',
 			},
 			authState: {
 				'starting': 'Starting...',
@@ -271,9 +276,13 @@ class AppComponent extends Component {
 
 		let msg = '';
 		let title = '';
+		let button = null;
 
 		if (messages.serverFoundState[foundState]) {
 			msg = messages.serverFoundState[foundState];
+			if (foundState === 'app_not_running') {
+				button = <a className={'Retry Button'} href="#" onClick={this.retry_click}>Retry</a>;
+			}
 		} else {
 			msg = messages.authState[this.props.authStatus];
 			title = <h1>{'Permission needed'}</h1>;
@@ -285,6 +294,7 @@ class AppComponent extends Component {
 			<div className="App Startup">
 				{title}
 				{msg}
+				{button}
 			</div>
 		);
 	}
@@ -341,6 +351,7 @@ class AppComponent extends Component {
 
 			const stateToString = function(state) {
 				if (state === 'not_found') return 'Not found';
+				if (state === 'app_not_running') return 'Not running';
 				return state.charAt(0).toUpperCase() + state.slice(1);
 			};
 
@@ -356,7 +367,7 @@ class AppComponent extends Component {
 			} else {
 				msg = stateToString(foundState);
 				led = foundState === 'searching' ? led_orange : led_red;
-				if (foundState === 'not_found') helpLink = <a className="Help" onClick={this.clipperServerHelpLink_click} href="help">[Help]</a>;
+				if (foundState === 'not_found' || foundState === 'app_not_running') helpLink = <a className="Help" onClick={this.clipperServerHelpLink_click} href="help">[Help]</a>;
 			}
 
 			msg = `Service status: ${msg}`;

--- a/packages/app-clipper/popup/src/App.js
+++ b/packages/app-clipper/popup/src/App.js
@@ -261,7 +261,7 @@ class AppComponent extends Component {
 				// ports and it takes time before failing. So if we don't
 				// display any message, it looks like it's not doing anything
 				// when clicking on the extension button.
-				'searching': 'Connecting to the Joplin application...',
+				'searching': 'Connecting to the Joplin. Please ensure that it is running...',
 				'not_found': 'Error: Could not connect to the Joplin application. Please ensure that it is started and that the clipper service is enabled in the configuration.',
 				'app_not_running': 'The Joplin application is not running. Please open Joplin and then click "Retry" below.',
 			},

--- a/packages/app-clipper/popup/src/bridge.js
+++ b/packages/app-clipper/popup/src/bridge.js
@@ -231,10 +231,22 @@ class Bridge {
 	}
 
 	async findClipperServerPort() {
-		this.dispatch({ type: 'CLIPPER_SERVER_SET', foundState: 'searching' });
+		this.dispatch({ type: 'CLIPPER_SERVER_SET', foundState: 'searching', searchStartTime: Date.now() });
+
+		const timeout = 8000; // 8 seconds before showing "app not running" message
+		const startTime = Date.now();
 
 		let state = null;
 		for (let i = 0; i < 10; i++) {
+			const elapsedTime = Date.now() - startTime;
+
+			// If we've exceeded the timeout, show the "app not running" message
+			if (elapsedTime > timeout) {
+				this.clipperServerPortStatus_ = 'app_not_running';
+				this.dispatch({ type: 'CLIPPER_SERVER_SET', foundState: 'app_not_running' });
+				return null;
+			}
+
 			state = randomClipperPort(state, this.env());
 
 			try {
@@ -263,7 +275,7 @@ class Bridge {
 	async clipperServerPort() {
 		return new Promise((resolve, reject) => {
 			const checkStatus = () => {
-				if (this.clipperServerPortStatus_ === 'not_found') {
+				if (this.clipperServerPortStatus_ === 'not_found' || this.clipperServerPortStatus_ === 'app_not_running') {
 					reject(new Error('Could not find clipper service. Please make sure that Joplin is running and that the clipper server is enabled.'));
 					return true;
 				} else if (this.clipperServerPortStatus_ === 'found') {


### PR DESCRIPTION
fixes #14785
## Summary (Problem)

This PR improves Web Clipper connection feedback in the extension popup when the desktop app/service is unavailable.

## What changed

- Added clearer connection state handling for when Joplin is not running.
- Introduced an app_not_running state after connection timeout.
- Updated startup/status messages to be more actionable.
- Added a Retry action in the popup to re-check connectivity without reopening the extension.
- Kept existing Help link behavior and extended it to the new unavailable state.

## Why (Solution)

Previously, users could remain on a generic “Connecting…” message and only discover issues later through troubleshooting.
This change makes connection problems visible earlier and reduces repeated failed clipping attempts.

## Testing

- Verified normal flow when Joplin is running (status becomes ready).
- Verified app-not-running flow shows clear message and retry option.
- Verified Help link is available for unavailable states.
- Verified behavior on restricted browser tabs remains unchanged (expected browser limitation).


https://github.com/user-attachments/assets/7f61c8d3-18db-4d8d-8a6d-d1334591782b

