### PR TITLE
Desktop: Fixes #14878: Prevent focusing undefined titleInputRef in dialog

### DIFF
--- a/packages/app-desktop/gui/EditFolderDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/EditFolderDialog/Dialog.tsx
@@ -47,10 +47,13 @@ export default function(props: Props) {
 	}, [props.dispatch]);
 
 	useEffect(() => {
+		if (!titleInputRef.current) return;
 		focus('Dialog::titleInputRef', titleInputRef.current);
 
 		setTimeout(() => {
-			titleInputRef.current.select();
+			if (titleInputRef.current) {
+				titleInputRef.current.select();
+			}
 		}, 100);
 	}, []);
 


### PR DESCRIPTION
Problem
While working with the desktop app in development mode, I noticed a warning in the console when opening the “Edit notebook” dialog:
focusHandler: tried action "focus" on an undefined element: Dialog::titleInputRef

it seems the dialog tries to focus the title input before the ref is actually available. This is reproducible consistently and is tracked in #14878

Solution
So i just added:
1. a simple guard to check that titleInputRef.current is defined before calling focus and 
2. also added a similar check before calling .select() to avoid any potential runtime errors

I have also tested this after the change by opening the dialog multiple times creating a new notebook and adding an existing one

Impact:
this change helped reduce noisy console warnings and prevents invalid focus calls
there are no functional changes to the UI or behavior