### PR TITLE
Desktop: Fixes #14788: Prevent sync panel from jumping (v2 with startup fix)

### DIFF
--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -81,7 +81,7 @@ const SidebarComponent = (props: Props) => {
 			aria-label={syncReportExpanded ? _('Hide sync log') : _('Show sync log')}
 			title={syncReportExpanded ? _('Hide sync log') : _('Show sync log')}
 		>
-			<i className={`fas fa-caret-${syncReportExpanded ? 'down' : 'up'}`} />
+			<i className={`fas fa-caret-${syncReportExpanded ? 'down' : 'right'}`} />
 			{(completedTime || props.syncStarted) ? (
 				<span className="timestamp">
 					{props.syncStarted ? _('Last sync: In progress...') : _('Last sync: %s', completedTime)}

--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -72,11 +72,8 @@ const SidebarComponent = (props: Props) => {
 
 	const syncButton = renderSynchronizeButton(props.syncStarted ? 'cancel' : 'sync');
 
-	// Show toggle when there are log lines, a completed timestamp, OR a sync is in progress
-	const hasContent = lines.length > 0 || completedTime || props.syncStarted;
-
 	// Toggle to show/hide sync log output
-	const toggleButton = hasContent ? (
+	const toggleButton = (
 		<button
 			className="sidebar-sync-toggle"
 			onClick={toggleSyncReport}
@@ -85,13 +82,13 @@ const SidebarComponent = (props: Props) => {
 			title={syncReportExpanded ? _('Hide sync log') : _('Show sync log')}
 		>
 			<i className={`fas fa-caret-${syncReportExpanded ? 'down' : 'up'}`} />
-			{!syncReportExpanded && (completedTime || props.syncStarted) ? (
+			{(completedTime || props.syncStarted) ? (
 				<span className="timestamp">
-					{props.syncStarted ? _('Synchronising...') : _('Last sync: %s', completedTime)}
+					{props.syncStarted ? _('Last sync: In progress...') : _('Last sync: %s', completedTime)}
 				</span>
 			) : ''}
 		</button>
-	) : null;
+	);
 
 	// Sync log output, only visible when expanded
 	const syncReportComp = (syncReportExpanded && lines.length > 0) ? (

--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -105,7 +105,7 @@ const SidebarComponent = (props: Props) => {
 		<StyledRoot className='sidebar _scrollbar2' role='navigation' aria-label={_('Sidebar')}>
 			<div style={{ flex: 1 }}><FolderAndTagList /></div>
 			<div style={{ flex: 0, padding: theme.mainPadding }}>
-				{toggleButton}
+				{(completedTime || props.syncStarted) ? toggleButton : null}
 				{syncReportComp}
 				{syncButton}
 			</div>

--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -72,8 +72,8 @@ const SidebarComponent = (props: Props) => {
 
 	const syncButton = renderSynchronizeButton(props.syncStarted ? 'cancel' : 'sync');
 
-	// Show toggle when there are log lines or a completed timestamp
-	const hasContent = lines.length > 0 || completedTime;
+	// Show toggle when there are log lines, a completed timestamp, OR a sync is in progress
+	const hasContent = lines.length > 0 || completedTime || props.syncStarted;
 
 	// Toggle to show/hide sync log output
 	const toggleButton = hasContent ? (
@@ -85,7 +85,11 @@ const SidebarComponent = (props: Props) => {
 			title={syncReportExpanded ? _('Hide sync log') : _('Show sync log')}
 		>
 			<i className={`fas fa-caret-${syncReportExpanded ? 'down' : 'up'}`} />
-			{!syncReportExpanded && completedTime ? <span className="timestamp">{_('Last sync: %s', completedTime)}</span> : ''}
+			{!syncReportExpanded && (completedTime || props.syncStarted) ? (
+				<span className="timestamp">
+					{props.syncStarted ? _('Synchronising...') : _('Last sync: %s', completedTime)}
+				</span>
+			) : ''}
 		</button>
 	) : null;
 

--- a/packages/app-desktop/gui/Sidebar/styles/index.ts
+++ b/packages/app-desktop/gui/Sidebar/styles/index.ts
@@ -120,7 +120,7 @@ export const StyledSyncReport = styled.div`
 	opacity: 0.5;
 	display: flex;
 	flex-direction: column;
-	margin-left: 5px;
+	margin-left: 25px;
 	margin-right: 5px;
 	margin-bottom: 10px;
 	word-wrap: break-word;

--- a/packages/app-desktop/gui/Sidebar/styles/sidebar-sync-toggle.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/sidebar-sync-toggle.scss
@@ -1,7 +1,8 @@
 .sidebar-sync-toggle {
 	display: flex;
 	align-items: center;
-	justify-content: center;
+	justify-content: flex-start;
+	padding-left: 5px;
 	background: none;
 	border: none;
 	color: var(--joplin-color2);

--- a/packages/app-desktop/gui/Sidebar/styles/sidebar-sync-toggle.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/sidebar-sync-toggle.scss
@@ -2,13 +2,12 @@
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
-	padding-left: 5px;
+	padding: 4px 5px 4px 5px;
 	background: none;
 	border: none;
 	color: var(--joplin-color2);
 	opacity: 0.5;
 	cursor: pointer;
-	padding: 4px 0;
 	width: 100%;
 	font-size: calc(var(--joplin-font-size) * 1.6);
 	transition: opacity 0.2s;
@@ -17,8 +16,16 @@
 		opacity: 1;
 	}
 
+	i {
+		width: 16px;
+		display: inline-flex;
+		justify-content: center;
+		font-size: calc(var(--joplin-toolbar-icon-size) * 0.8);
+	}
+
 	>.timestamp {
 		font-size: 0.6em;
-		margin-left: 6px;
+		margin-left: 4px;
 	}
 }
+


### PR DESCRIPTION
This is a re-submission of the previously merged PR #14792. It includes a fix for the regression that caused the revert: the sync toggle is now hidden during the app setup phase (first 5-10 seconds) to prevent an empty arrow from appearing.

The sync toggle is now hidden until sync timing data is available or a sync has started, matching the behavior of the `dev` branch. I have also retained the CSS improvements that prevent horizontal jumps and align the sync report text with the toggle status.


https://github.com/user-attachments/assets/100edf46-8810-4425-8717-70e7fde9b594

