### PR TITLE
Desktop: Fixes #14644: Convert raw file path to file URL in loadPdf

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -619,6 +619,7 @@ packages/app-desktop/services/plugins/hooks/useWebviewToPluginMessages.js
 packages/app-desktop/services/plugins/types.js
 packages/app-desktop/services/restart.js
 packages/app-desktop/services/spellChecker/SpellCheckerServiceDriverNative.js
+packages/app-desktop/services/windowStateTracker.test.js
 packages/app-desktop/tools/bundleJs.js
 packages/app-desktop/tools/copy7Zip.js
 packages/app-desktop/tools/generateLatestArm64Yml.js

--- a/.gitignore
+++ b/.gitignore
@@ -592,6 +592,7 @@ packages/app-desktop/services/plugins/hooks/useWebviewToPluginMessages.js
 packages/app-desktop/services/plugins/types.js
 packages/app-desktop/services/restart.js
 packages/app-desktop/services/spellChecker/SpellCheckerServiceDriverNative.js
+packages/app-desktop/services/windowStateTracker.test.js
 packages/app-desktop/tools/bundleJs.js
 packages/app-desktop/tools/copy7Zip.js
 packages/app-desktop/tools/generateLatestArm64Yml.js

--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -805,7 +805,7 @@ function shimInit(options: ShimInitOptions = null) {
 
 	const loadPdf = async (path: string) => {
 		const loadingTask = pdfJs.getDocument({
-			url: path,
+			url: pathToFileURL(path).href,
 			// https://github.com/mozilla/pdf.js/issues/4244#issuecomment-1479534301
 			useSystemFonts: true,
 			// IMPORTANT: Set to false to mitigate CVE-2024-4367.


### PR DESCRIPTION
AI Assistance Disclosure
AI Assistance Disclosure
I did not use AI to write this fix. AI was used to help structure and word this PR description.
Problem
When a user sets a local file path for OCR and tries to create an accessible PDF, it fails. The issue is that pdfJs.getDocument() expects a file URL but is getting a raw Windows file path instead.
Solution
I changed url: path to url: pathToFileURL(path).href in the loadPdf function in packages/lib/shim-init-node.ts. The pathToFileURL function is already imported and used the same way on line 241 for images, so this just makes loadPdf consistent with the rest of the file.
Test Plan
Multiple contributors on the issue were unable to reproduce the bug in the dev build. I could not reproduce it either. However the fix is logically correct. Passing a raw file path where a URL is expected is wrong. All existing tests in packages/lib pass.