### PR TITLE
Desktop: Resolves #14372: Enable OAuth for Joplin Server

### DIFF
--- a/packages/app-cli/app/command-sync.ts
+++ b/packages/app-cli/app/command-sync.ts
@@ -97,7 +97,7 @@ class Command extends BaseCommand {
 			const checkForCredentials = async () => {
 				try {
 					const applicationAuthUrl = `${Setting.value('sync.10.path')}/api/application_auth/${applicationAuthId}`;
-					const response = await checkIfLoginWasSuccessful(applicationAuthUrl);
+					const response = await checkIfLoginWasSuccessful(applicationAuthUrl, 10);
 					if (response && response.success) {
 						return response;
 					}

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -67,16 +67,18 @@ class ConfigScreenComponent extends React.Component<any, any> {
 	}
 
 	private async checkSyncConfig_() {
-		if (this.state.settings['sync.target'] === SyncTargetRegistry.nameToId('joplinCloud')) {
-			const isAuthenticated = await reg.syncTarget().isAuthenticated();
-			if (!isAuthenticated) {
-				return this.props.dispatch({
-					type: 'NAV_GO',
-					routeName: 'JoplinCloudLogin',
-				});
-			}
-		}
-		await shared.checkSyncConfig(this, this.state.settings);
+    	const syncTarget = reg.syncTarget();
+    	const authRouteName = syncTarget.authRouteName();
+    	if (authRouteName) {
+        	const isAuthenticated = await syncTarget.isAuthenticated();
+        	if (!isAuthenticated) {
+            	return this.props.dispatch({
+                	type: 'NAV_GO',
+                	routeName: authRouteName,
+            	});
+        	}
+    	}
+    	await shared.checkSyncConfig(this, this.state.settings);
 	}
 
 	public UNSAFE_componentWillMount() {
@@ -264,6 +266,25 @@ class ConfigScreenComponent extends React.Component<any, any> {
 							/>
 						</div>,
 					);
+				}
+
+				if (settings['sync.target'] === SyncTargetRegistry.nameToId('joplinServer')) {
+    				const goToJoplinServerLogin = async () => {
+        				await shared.saveSettings(this);
+        				this.props.dispatch({
+            				type: 'NAV_GO',
+            				routeName: 'JoplinServerLogin',
+        				});
+    				};
+    				settingComps.push(
+        				<div key='connect_to_joplin_server_button' style={this.rowStyle_}>
+            				<Button
+                				title={_('Login with Joplin Server')}
+                				level={ButtonLevel.Primary}
+                				onClick={goToJoplinServerLogin}
+            				/>
+        				</div>,
+    				);
 				}
 
 				if (settings['sync.target'] === SyncTargetRegistry.nameToId('joplinServerSaml')) {

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -69,18 +69,18 @@ class ConfigScreenComponent extends React.Component<any, any> {
 	private async checkSyncConfig_() {
 		const ok = await shared.saveSettings(this);
 		if (!ok) return;
-    	const syncTarget = reg.syncTarget();
-    	const authRouteName = syncTarget.authRouteName();
-    	if (authRouteName) {
-        	const isAuthenticated = await syncTarget.isAuthenticated();
-        	if (!isAuthenticated) {
-            	return this.props.dispatch({
-                	type: 'NAV_GO',
-                	routeName: authRouteName,
-            	});
-        	}
-    	}
-    	await shared.checkSyncConfig(this, this.state.settings);
+		const syncTarget = reg.syncTarget();
+		const authRouteName = syncTarget.authRouteName();
+		if (authRouteName) {
+			const isAuthenticated = await syncTarget.isAuthenticated();
+			if (!isAuthenticated) {
+				return this.props.dispatch({
+					type: 'NAV_GO',
+					routeName: authRouteName,
+				});
+			}
+		}
+		await shared.checkSyncConfig(this, this.state.settings);
 	}
 
 	public UNSAFE_componentWillMount() {
@@ -271,23 +271,23 @@ class ConfigScreenComponent extends React.Component<any, any> {
 				}
 
 				if (settings['sync.target'] === SyncTargetRegistry.nameToId('joplinServer')) {
-    				const goToJoplinServerLogin = async () => {
-        				const ok = await shared.saveSettings(this);
-    					if (!ok) return;
-    					this.props.dispatch({
-        					type: 'NAV_GO',
-        					routeName: 'JoplinServerLogin',
-    					});
-    				};
-    				settingComps.push(
-        				<div key='connect_to_joplin_server_button' style={this.rowStyle_}>
-            				<Button
-                				title={_('Login with Joplin Server')}
-                				level={ButtonLevel.Primary}
-                				onClick={goToJoplinServerLogin}
-            				/>
-        				</div>,
-    				);
+					const goToJoplinServerLogin = async () => {
+						const ok = await shared.saveSettings(this);
+						if (!ok) return;
+						this.props.dispatch({
+							type: 'NAV_GO',
+							routeName: 'JoplinServerLogin',
+						});
+					};
+					settingComps.push(
+						<div key='connect_to_joplin_server_button' style={this.rowStyle_}>
+							<Button
+								title={_('Login with Joplin Server')}
+								level={ButtonLevel.Primary}
+								onClick={goToJoplinServerLogin}
+							/>
+						</div>,
+					);
 				}
 
 				if (settings['sync.target'] === SyncTargetRegistry.nameToId('joplinServerSaml')) {

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -67,6 +67,8 @@ class ConfigScreenComponent extends React.Component<any, any> {
 	}
 
 	private async checkSyncConfig_() {
+		const ok = await shared.saveSettings(this);
+		if (!ok) return;
     	const syncTarget = reg.syncTarget();
     	const authRouteName = syncTarget.authRouteName();
     	if (authRouteName) {
@@ -270,11 +272,12 @@ class ConfigScreenComponent extends React.Component<any, any> {
 
 				if (settings['sync.target'] === SyncTargetRegistry.nameToId('joplinServer')) {
     				const goToJoplinServerLogin = async () => {
-        				await shared.saveSettings(this);
-        				this.props.dispatch({
-            				type: 'NAV_GO',
-            				routeName: 'JoplinServerLogin',
-        				});
+        				const ok = await shared.saveSettings(this);
+    					if (!ok) return;
+    					this.props.dispatch({
+        					type: 'NAV_GO',
+        					routeName: 'JoplinServerLogin',
+    					});
     				};
     				settingComps.push(
         				<div key='connect_to_joplin_server_button' style={this.rowStyle_}>

--- a/packages/app-desktop/gui/JoplinCloudLoginScreen.tsx
+++ b/packages/app-desktop/gui/JoplinCloudLoginScreen.tsx
@@ -117,13 +117,13 @@ const JoplinCloudScreenComponent = (props: Props) => {
 };
 
 const mapStateToProps = (state: AppState, ownProps: { syncTargetId?: number }) => {
-    const syncTargetId = ownProps.syncTargetId ?? 10;
-    const isCloud = syncTargetId === 10;
-    return {
-        joplinCloudWebsite: isCloud ? state.settings['sync.10.website'] : state.settings['sync.9.path'],
-        joplinCloudApi: isCloud ? state.settings['sync.10.path'] : state.settings['sync.9.path'],
-        syncTargetId,
-    };
+	const syncTargetId = ownProps.syncTargetId ?? 10;
+	const isCloud = syncTargetId === 10;
+	return {
+		joplinCloudWebsite: isCloud ? state.settings['sync.10.website'] : state.settings['sync.9.path'],
+		joplinCloudApi: isCloud ? state.settings['sync.10.path'] : state.settings['sync.9.path'],
+		syncTargetId,
+	};
 };
 
 export default connect(mapStateToProps)(JoplinCloudScreenComponent);

--- a/packages/app-desktop/gui/JoplinCloudLoginScreen.tsx
+++ b/packages/app-desktop/gui/JoplinCloudLoginScreen.tsx
@@ -20,6 +20,7 @@ interface Props {
 	dispatch: Dispatch;
 	joplinCloudWebsite: string;
 	joplinCloudApi: string;
+	syncTargetId: number;
 }
 
 const JoplinCloudScreenComponent = (props: Props) => {
@@ -37,7 +38,7 @@ const JoplinCloudScreenComponent = (props: Props) => {
 
 		const interval = setInterval(async () => {
 			try {
-				const response = await checkIfLoginWasSuccessful(applicationAuthUrl(applicationAuthId));
+				const response = await checkIfLoginWasSuccessful(applicationAuthUrl(applicationAuthId), props.syncTargetId);
 				if (response && response.success) {
 					dispatch({ type: 'COMPLETED' });
 					clearInterval(interval);
@@ -83,7 +84,7 @@ const JoplinCloudScreenComponent = (props: Props) => {
 			<div className="page-container">
 				{state.active !== 'COMPLETED' ? (
 					<>
-						<p className="text">{_('To allow Joplin to synchronise with Joplin Cloud, please login using this URL:')}</p>
+						<p className="text">{_('To allow Joplin to synchronise with %s, please login using this URL:', props.syncTargetId === 10 ? _('Joplin Cloud') : _('Joplin Server'))}</p>
 						<div className="buttons-container">
 							<Button
 								onClick={onAuthorizeClicked}
@@ -101,24 +102,27 @@ const JoplinCloudScreenComponent = (props: Props) => {
 						</div>
 					</>
 				) : null}
-				<p className={state.className}>{state.message()}
+				<p className={state.className}>{state.message().replace('Joplin Cloud', props.syncTargetId === 10 ? 'Joplin Cloud' : 'Joplin Server')}
 					{state.active === 'ERROR' ? (
 						<span className={state.className}>{state.errorMessage}</span>
 					) : null}
 				</p>
 				{state.active === 'LINK_USED' ? <div className="loading-animation" /> : null}
-				<JoplinCloudSignUpCallToAction />
+				{props.syncTargetId === 10 ? <JoplinCloudSignUpCallToAction /> : null}
 			</div>
 			<ButtonBar onCancelClick={() => props.dispatch({ type: 'NAV_BACK' })} />
 		</div>
 	);
 };
 
-const mapStateToProps = (state: AppState) => {
-	return {
-		joplinCloudWebsite: state.settings['sync.10.website'],
-		joplinCloudApi: state.settings['sync.10.path'],
-	};
+const mapStateToProps = (state: AppState, ownProps: { syncTargetId?: number }) => {
+    const syncTargetId = ownProps.syncTargetId ?? 10;
+    const isCloud = syncTargetId === 10;
+    return {
+        joplinCloudWebsite: isCloud ? state.settings['sync.10.website'] : state.settings['sync.9.path'],
+        joplinCloudApi: isCloud ? state.settings['sync.10.path'] : state.settings['sync.9.path'],
+        syncTargetId,
+    };
 };
 
 export default connect(mapStateToProps)(JoplinCloudScreenComponent);

--- a/packages/app-desktop/gui/JoplinCloudLoginScreen.tsx
+++ b/packages/app-desktop/gui/JoplinCloudLoginScreen.tsx
@@ -6,7 +6,7 @@ import { clipboard } from 'electron';
 import Button, { ButtonLevel } from './Button/Button';
 import { uuidgen } from '@joplin/lib/uuid';
 import { Dispatch } from 'redux';
-import { reducer, defaultState, generateApplicationConfirmUrl, checkIfLoginWasSuccessful } from '@joplin/lib/services/joplinCloudUtils';
+import { makeReducer, defaultState, generateApplicationConfirmUrl, checkIfLoginWasSuccessful } from '@joplin/lib/services/joplinCloudUtils';
 import { AppState } from '../app.reducer';
 import Logger from '@joplin/utils/Logger';
 import { reg } from '@joplin/lib/registry';
@@ -29,7 +29,8 @@ const JoplinCloudScreenComponent = (props: Props) => {
 	const applicationAuthUrl = (applicationAuthId: string) => `${props.joplinCloudApi}/api/application_auth/${applicationAuthId}`;
 
 	const [intervalIdentifier, setIntervalIdentifier] = useState(undefined);
-	const [state, dispatch] = useReducer(reducer, defaultState);
+	const targetName = props.syncTargetId === 10 ? _('Joplin Cloud') : _('Joplin Server');
+	const [state, dispatch] = useReducer(makeReducer(targetName), defaultState);
 
 	const applicationAuthId = useMemo(() => uuidgen(), []);
 
@@ -102,7 +103,7 @@ const JoplinCloudScreenComponent = (props: Props) => {
 						</div>
 					</>
 				) : null}
-				<p className={state.className}>{state.message().replace('Joplin Cloud', props.syncTargetId === 10 ? 'Joplin Cloud' : 'Joplin Server')}
+				<p className={state.className}>{state.message()}
 					{state.active === 'ERROR' ? (
 						<span className={state.className}>{state.errorMessage}</span>
 					) : null}

--- a/packages/app-desktop/gui/Root.tsx
+++ b/packages/app-desktop/gui/Root.tsx
@@ -162,6 +162,12 @@ class RootComponent extends React.Component<Props, any> {
 			OneDriveLogin: { screen: OneDriveLoginScreen, title: () => _('OneDrive Login') },
 			DropboxLogin: { screen: DropboxLoginScreen, title: () => _('Dropbox Login') },
 			JoplinCloudLogin: { screen: JoplinCloudLoginScreen, title: () => _('Joplin Cloud Login') },
+			JoplinServerLogin: { 
+    			screen: (props: React.ComponentProps<typeof JoplinCloudLoginScreen>) => (
+        			<JoplinCloudLoginScreen {...props} syncTargetId={9} />
+    			), 
+    			title: () => _('Joplin Server Login') 
+			},
 			JoplinServerSamlLogin: { screen: SsoLoginScreen(new SamlShared()), title: () => _('Joplin Server Login') },
 			Import: { screen: ImportScreen, title: () => _('Import') },
 			Config: { screen: ConfigScreen, title: () => _('Options') },

--- a/packages/app-desktop/gui/Root.tsx
+++ b/packages/app-desktop/gui/Root.tsx
@@ -162,11 +162,11 @@ class RootComponent extends React.Component<Props, any> {
 			OneDriveLogin: { screen: OneDriveLoginScreen, title: () => _('OneDrive Login') },
 			DropboxLogin: { screen: DropboxLoginScreen, title: () => _('Dropbox Login') },
 			JoplinCloudLogin: { screen: JoplinCloudLoginScreen, title: () => _('Joplin Cloud Login') },
-			JoplinServerLogin: { 
-    			screen: (props: React.ComponentProps<typeof JoplinCloudLoginScreen>) => (
-        			<JoplinCloudLoginScreen {...props} syncTargetId={9} />
-    			), 
-    			title: () => _('Joplin Server Login') 
+			JoplinServerLogin: {
+				screen: (props: React.ComponentProps<typeof JoplinCloudLoginScreen>) => (
+					<JoplinCloudLoginScreen {...props} syncTargetId={9} />
+				),
+				title: () => _('Joplin Server Login'),
 			},
 			JoplinServerSamlLogin: { screen: SsoLoginScreen(new SamlShared()), title: () => _('Joplin Server Login') },
 			Import: { screen: ImportScreen, title: () => _('Import') },

--- a/packages/app-mobile/components/screens/JoplinCloudLoginScreen.tsx
+++ b/packages/app-mobile/components/screens/JoplinCloudLoginScreen.tsx
@@ -87,7 +87,7 @@ const JoplinCloudScreenComponent = (props: Props) => {
 
 		const interval = setInterval(async () => {
 			try {
-				const response = await checkIfLoginWasSuccessful(applicationAuthUrl(applicationAuthId));
+				const response = await checkIfLoginWasSuccessful(applicationAuthUrl(applicationAuthId), 10);
 				if (response && response.success) {
 					dispatch({ type: 'COMPLETED' });
 					clearInterval(interval);

--- a/packages/lib/BaseSyncTarget.ts
+++ b/packages/lib/BaseSyncTarget.ts
@@ -86,17 +86,17 @@ export default class BaseSyncTarget {
 	}
 
 	protected async isAuthenticatedViaJoplinServerCompatibleSession(): Promise<boolean> {
-    	try {
-        	const fileApi = await this.fileApi();
-        	const api = fileApi.driver().api();
-        	const sessionId = await api.sessionId();
-        	return !!sessionId;
-    	} catch (error: any) {
-        	if (error.code === 403) return false;
-        	throw error;
-    	}
+		try {
+			const fileApi = await this.fileApi();
+			const api = fileApi.driver().api();
+			const sessionId = await api.sessionId();
+			return !!sessionId;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+		} catch (error: any) {
+			if (error.code === 403) return false;
+			throw error;
+		}
 	}
-
 	public authRouteName(): string {
 		return null;
 	}

--- a/packages/lib/BaseSyncTarget.ts
+++ b/packages/lib/BaseSyncTarget.ts
@@ -85,6 +85,18 @@ export default class BaseSyncTarget {
 		return false;
 	}
 
+	protected async isAuthenticatedViaJoplinServerCompatibleSession(): Promise<boolean> {
+    	try {
+        	const fileApi = await this.fileApi();
+        	const api = fileApi.driver().api();
+        	const sessionId = await api.sessionId();
+        	return !!sessionId;
+    	} catch (error: any) {
+        	if (error.code === 403) return false;
+        	throw error;
+    	}
+	}
+
 	public authRouteName(): string {
 		return null;
 	}

--- a/packages/lib/JoplinServerApi.ts
+++ b/packages/lib/JoplinServerApi.ts
@@ -107,7 +107,7 @@ export default class JoplinServerApi {
 		}
 	}
 
-	private async sessionId() {
+	public async sessionId() {
 		const session = await this.session();
 		return session ? session.id : '';
 	}

--- a/packages/lib/SyncTargetJoplinCloud.ts
+++ b/packages/lib/SyncTargetJoplinCloud.ts
@@ -49,10 +49,10 @@ export default class SyncTargetJoplinCloud extends BaseSyncTarget {
 	public static override supportsShare(): boolean {
 		return true;
 	}
-
 	public async isAuthenticated() {
-    	return this.isAuthenticatedViaJoplinServerCompatibleSession();
+		return this.isAuthenticatedViaJoplinServerCompatibleSession();
 	}
+
 
 	public authRouteName() {
 		return 'JoplinCloudLogin';

--- a/packages/lib/SyncTargetJoplinCloud.ts
+++ b/packages/lib/SyncTargetJoplinCloud.ts
@@ -51,17 +51,7 @@ export default class SyncTargetJoplinCloud extends BaseSyncTarget {
 	}
 
 	public async isAuthenticated() {
-		try {
-			const fileApi = await this.fileApi();
-			const api = fileApi.driver().api();
-			const sessionId = await api.sessionId();
-			return !!sessionId;
-		} catch (error) {
-			if (error.code === 403) {
-				return false;
-			}
-			throw error;
-		}
+    	return this.isAuthenticatedViaJoplinServerCompatibleSession();
 	}
 
 	public authRouteName() {

--- a/packages/lib/SyncTargetJoplinServer.ts
+++ b/packages/lib/SyncTargetJoplinServer.ts
@@ -66,13 +66,17 @@ export default class SyncTargetJoplinServer extends BaseSyncTarget {
 	}
 
 	public async isAuthenticated() {
-		return true;
+		return this.isAuthenticatedViaJoplinServerCompatibleSession();
 	}
 
 	public static requiresPassword() {
-		return true;
+		return false;
 	}
 
+	public authRouteName() {
+    	return 'JoplinServerLogin';
+	}
+	
 	public static override supportsShare(): boolean {
 		return true;
 	}

--- a/packages/lib/SyncTargetJoplinServer.ts
+++ b/packages/lib/SyncTargetJoplinServer.ts
@@ -70,7 +70,7 @@ export default class SyncTargetJoplinServer extends BaseSyncTarget {
 	}
 
 	public static requiresPassword() {
-    	return false;
+		return false;
 	}
 
 	public authRouteName() {

--- a/packages/lib/SyncTargetJoplinServer.ts
+++ b/packages/lib/SyncTargetJoplinServer.ts
@@ -70,7 +70,7 @@ export default class SyncTargetJoplinServer extends BaseSyncTarget {
 	}
 
 	public static requiresPassword() {
-		return false;
+    	return false;
 	}
 
 	public authRouteName() {

--- a/packages/lib/SyncTargetJoplinServer.ts
+++ b/packages/lib/SyncTargetJoplinServer.ts
@@ -74,9 +74,9 @@ export default class SyncTargetJoplinServer extends BaseSyncTarget {
 	}
 
 	public authRouteName() {
-    	return 'JoplinServerLogin';
+		return 'JoplinServerLogin';
 	}
-	
+
 	public static override supportsShare(): boolean {
 		return true;
 	}

--- a/packages/lib/components/shared/config/shouldShowMissingPasswordWarning.test.ts
+++ b/packages/lib/components/shared/config/shouldShowMissingPasswordWarning.test.ts
@@ -7,7 +7,7 @@ const targetToRequiresPassword: Record<string, boolean> = {
 	'nextcloud': true,
 	'webdav': true,
 	'amazon_s3': true,
-	'joplinServer': true,
+	'joplinServer': false,
 	'joplinCloud': false,
 	'onedrive': false,
 	'dropbox': false,

--- a/packages/lib/services/joplinCloudUtils.ts
+++ b/packages/lib/services/joplinCloudUtils.ts
@@ -60,6 +60,39 @@ export const reducer: Reducer<DefaultState, Action> = (state: DefaultState, acti
 	}
 };
 
+export const makeReducer = (targetName: string): Reducer<DefaultState, Action> => (state: DefaultState, action: Action) => {
+	switch (action.type) {
+	case 'LINK_USED': {
+		return {
+			className: 'text',
+			message: () => _('If you have already authorised, please wait for the application to sync to %s.', targetName),
+			next: 'COMPLETED',
+			active: 'LINK_USED',
+		};
+	}
+	case 'COMPLETED': {
+		return {
+			className: 'bold',
+			message: () => _('You are logged in into %s, you can leave this screen now.', targetName),
+			active: 'COMPLETED',
+			next: 'COMPLETED',
+		};
+	}
+	case 'ERROR': {
+		return {
+			className: 'text',
+			message: () => _('You were unable to connect to %s. Please check your credentials and try again. Error:', targetName),
+			active: 'ERROR',
+			next: 'COMPLETED',
+			errorMessage: action.payload,
+		};
+	}
+	default: {
+		return state;
+	}
+	}
+};
+
 export const getApplicationInformation = async () => {
 	const platformName = await shim.platformName();
 	switch (platformName) {
@@ -101,7 +134,7 @@ export const checkIfLoginWasSuccessful = async (applicationsUrl: string, syncTar
 
 		const headers: Record<string, string> = {};
 		if (syncTargetId === 10) {
-    		headers['X-JOPLIN-CUSTOM-API-KEY'] = Setting.value('sync.10.apiKey');
+			headers['X-JOPLIN-CUSTOM-API-KEY'] = Setting.value('sync.10.apiKey');
 		}
 
 		const response = await fetch(applicationsUrl, { headers });
@@ -114,6 +147,7 @@ export const checkIfLoginWasSuccessful = async (applicationsUrl: string, syncTar
 
 		Setting.setValue(`sync.${syncTargetId}.username`, jsonBody.id);
 		Setting.setValue(`sync.${syncTargetId}.password`, jsonBody.password);
+		Setting.setValue('sync.target', syncTargetId);
 
 		const fileApi = await reg.syncTarget().fileApi();
 		await fileApi.driver().api().loadSession();

--- a/packages/lib/services/joplinCloudUtils.ts
+++ b/packages/lib/services/joplinCloudUtils.ts
@@ -5,8 +5,6 @@ import shim from '../shim';
 import { _ } from '../locale';
 import eventManager, { EventName } from '../eventManager';
 import { reg } from '../registry';
-import SyncTargetRegistry from '../SyncTargetRegistry';
-
 type ActionType = 'LINK_USED' | 'COMPLETED' | 'ERROR';
 type Action = {
 	type: ActionType;
@@ -95,17 +93,18 @@ export const generateApplicationConfirmUrl = async (confirmUrl: string) => {
 // after an error occurs. E.g.: if the function would throw an error while isWaitingResponse
 // was set to true the next time we call the function the value would still be true.
 // The closure function prevents that.
-export const checkIfLoginWasSuccessful = async (applicationsUrl: string) => {
+export const checkIfLoginWasSuccessful = async (applicationsUrl: string, syncTargetId: number) => {
 	let isWaitingResponse = false;
 	const performLoginRequest = async () => {
 		if (isWaitingResponse) return undefined;
 		isWaitingResponse = true;
 
-		const response = await fetch(applicationsUrl, {
-			headers: {
-				'X-JOPLIN-CUSTOM-API-KEY': Setting.value('sync.10.apiKey'),
-			},
-		});
+		const headers: Record<string, string> = {};
+		if (syncTargetId === 10) {
+    		headers['X-JOPLIN-CUSTOM-API-KEY'] = Setting.value('sync.10.apiKey');
+		}
+
+		const response = await fetch(applicationsUrl, { headers });
 		const jsonBody = await response.json();
 
 		if (!response.ok || jsonBody.status !== 'finished') {
@@ -113,9 +112,8 @@ export const checkIfLoginWasSuccessful = async (applicationsUrl: string) => {
 			return undefined;
 		}
 
-		Setting.setValue('sync.10.username', jsonBody.id);
-		Setting.setValue('sync.10.password', jsonBody.password);
-		Setting.setValue('sync.target', SyncTargetRegistry.nameToId('joplinCloud'));
+		Setting.setValue(`sync.${syncTargetId}.username`, jsonBody.id);
+		Setting.setValue(`sync.${syncTargetId}.password`, jsonBody.password);
 
 		const fileApi = await reg.syncTarget().fileApi();
 		await fileApi.driver().api().loadSession();

--- a/packages/lib/services/joplinCloudUtils.ts
+++ b/packages/lib/services/joplinCloudUtils.ts
@@ -149,7 +149,7 @@ export const checkIfLoginWasSuccessful = async (applicationsUrl: string, syncTar
 		Setting.setValue(`sync.${syncTargetId}.password`, jsonBody.password);
 		Setting.setValue('sync.target', syncTargetId);
 
-		const fileApi = await reg.syncTarget().fileApi();
+		const fileApi = await reg.syncTarget(syncTargetId).fileApi();
 		await fileApi.driver().api().loadSession();
 		eventManager.emit(EventName.SessionEstablished);
 


### PR DESCRIPTION
fixes #14372

## AI Usage
I used AI assistance (Claude) for exploring the codebase and debugging.

## Problem
Joplin Server users could not use OAuth to authenticate - they were forced to manually enter email and password. The OAuth flow was only enabled for Joplin Cloud, even though Joplin Server backend supports it.

## Solution
Made the existing Joplin Cloud OAuth login components generic so both sync targets share the same authentication flow.

### Changes:
- `BaseSyncTarget.ts` - Added shared `isAuthenticatedViaJoplinServerCompatibleSession()` method
- `SyncTargetJoplinServer.ts` - Uses shared auth method, added `authRouteName()`, set `requiresPassword()` to false
- `SyncTargetJoplinCloud.ts` - Refactored to use shared auth method
- `JoplinServerApi.ts` - Made `sessionId()` public
- `joplinCloudUtils.ts` - Made `syncTargetId` a required parameter, API key header only sent for Joplin Cloud
- `JoplinCloudLoginScreen.tsx` - Made screen generic for both targets
- `ConfigScreen.tsx` - Added "Login with Joplin Server" button, made `checkSyncConfig_` generic
- `Root.tsx` - Added `JoplinServerLogin` route

## Test Plan
1. Open Joplin Desktop → Settings → Synchronisation
2. Select "Joplin Server" as sync target
3. Enter server URL
4. Click "Login with Joplin Server"
5. Browser opens Joplin Server login page
6. Login and authorise
7. App detects authorisation and syncs


https://github.com/user-attachments/assets/e106a32a-2cae-4e3b-b3cb-bf0dc1e4d3cb

