### PR TITLE
Desktop Fix: #14890 Disable "Expand all notebooks" button when no sub-notebooks exist

### DIFF
--- a/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
+++ b/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { AppState } from '../../app.reducer';
 import { FolderEntity, TagsWithNoteCountEntity } from '@joplin/lib/services/database/types';
 import areAllFoldersCollapsed from '@joplin/lib/models/utils/areAllFoldersCollapsed';
+import getCanBeCollapsedFolderIds from '@joplin/lib/models/utils/getCanBeCollapsedFolderIds';
 import { PluginStates } from '@joplin/lib/services/plugins/reducer';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
@@ -48,6 +49,11 @@ const FolderAndTagList: React.FC<Props> = props => {
 		return areAllFoldersCollapsed(props.folders, props.collapsedFolderIds);
 	}, [props.collapsedFolderIds, props.folders]);
 
+	const hasSubFolders = useMemo(() => {
+		return getCanBeCollapsedFolderIds(props.folders).length > 0;
+	}, [props.folders]);
+
+
 	const listContainerRef = useRef<HTMLDivElement|null>(null);
 	const onRenderItem = useOnRenderItem({
 		...props,
@@ -76,7 +82,7 @@ const FolderAndTagList: React.FC<Props> = props => {
 	const listHeight = useElementHeight(itemListContainer);
 	const listStyle = useMemo(() => ({ height: listHeight }), [listHeight]);
 
-	const onRenderContentWrapper = useOnRenderListWrapper({ allFoldersCollapsed, selectedIndex, onKeyDown: onKeyEventHandler });
+	const onRenderContentWrapper = useOnRenderListWrapper({ allFoldersCollapsed, selectedIndex, onKeyDown: onKeyEventHandler, hasSubFolders });
 
 	return (
 		<div

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx
@@ -7,6 +7,7 @@ interface Props {
 	selectedIndex: number;
 	onKeyDown: React.KeyboardEventHandler;
 	allFoldersCollapsed: boolean;
+	hasSubFolders: boolean;
 }
 
 const onAddFolderButtonClick = () => {
@@ -19,6 +20,7 @@ const onToggleAllFolders = (allFoldersCollapsed: boolean) => {
 
 interface CollapseExpandAllButtonProps {
 	allFoldersCollapsed: boolean;
+	hasSubFolders: boolean;
 }
 
 const CollapseExpandAllButton = (props: CollapseExpandAllButtonProps) => {
@@ -27,7 +29,12 @@ const CollapseExpandAllButton = (props: CollapseExpandAllButtonProps) => {
 	const icon = props.allFoldersCollapsed ? 'far fa-caret-square-right' : 'far fa-caret-square-down';
 	const label = props.allFoldersCollapsed ? _('Expand all notebooks') : _('Collapse all notebooks');
 
-	return <button onClick={() => onToggleAllFolders(props.allFoldersCollapsed)} className='sidebar-header-button -collapseall' title={label}>
+	return <button
+		onClick={() => onToggleAllFolders(props.allFoldersCollapsed)}
+		className={`sidebar-header-button -collapseall ${props.hasSubFolders ? '' : '-disabled'}`}
+		title={label}
+		disabled={!props.hasSubFolders}
+	>
 		<i
 			aria-label={label}
 			role='img'
@@ -55,7 +62,7 @@ const useOnRenderListWrapper = (props: Props) => {
 		const listHasValidSelection = props.selectedIndex >= 0;
 		const allowContainerFocus = !listHasValidSelection;
 		return <>
-			<CollapseExpandAllButton allFoldersCollapsed={props.allFoldersCollapsed}/>
+			<CollapseExpandAllButton allFoldersCollapsed={props.allFoldersCollapsed} hasSubFolders={props.hasSubFolders}/>
 			<NewFolderButton/>
 			<div
 				role='tree'
@@ -66,7 +73,7 @@ const useOnRenderListWrapper = (props: Props) => {
 				{...listItems}
 			</div>
 		</>;
-	}, [props.selectedIndex, props.onKeyDown, props.allFoldersCollapsed]);
+	}, [props.selectedIndex, props.onKeyDown, props.allFoldersCollapsed, props.hasSubFolders]);
 };
 
 export default useOnRenderListWrapper;

--- a/packages/app-desktop/gui/Sidebar/styles/sidebar-header-button.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/sidebar-header-button.scss
@@ -13,12 +13,12 @@
 	font-size: var(--joplin-toolbar-icon-size);
 	color: var(--joplin-color2);
 
-	&:hover {
+	&:hover:not(:disabled) {
 		color: var(--joplin-color-hover2);
 		background: none;
 	}
 
-	&:active {
+	&:active:not(:disabled) {
 		color: var(--joplin-color-active2);
 		background: none;
 	}

--- a/packages/app-desktop/gui/Sidebar/styles/sidebar-header-button.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/sidebar-header-button.scss
@@ -26,4 +26,9 @@
 	&.-collapseall {
 		right: 25px;
 	}
+
+	&:disabled {
+		opacity: 0.3;
+		pointer-events: none;
+	}
 }

--- a/packages/app-desktop/gui/Sidebar/styles/sidebar-header-button.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/sidebar-header-button.scss
@@ -29,6 +29,5 @@
 
 	&:disabled {
 		opacity: 0.3;
-		pointer-events: none;
 	}
 }


### PR DESCRIPTION
## Description
### Problem
As reported in #14890, the "Expand all notebooks" button in the sidebar header remains active (Highlighted) even when the current profile contains no sub-notebooks (folders with children). This UX, especially for new users with only the default "Welcome" notebook, gives the impression that the button is broken when clicked.

### Solution
I have implemented Option 2 from the issue proposal: Disable the button when no sub-notebooks exist.

Before, the "Expand all notebooks" (not working) highlighted even after no sub-notebooks  : 


https://github.com/user-attachments/assets/184f73bd-8ef8-4d4b-b4a1-370462ca5ef3


After, the "Expand all notebooks" is dimmed when there are no sub-notebooks and only gets highlighted when a subnotebook is added: 




https://github.com/user-attachments/assets/00fd2323-76c0-4cd8-92f4-729fa566a742




### Changes
- Logic: Updated ``FolderAndTagList.tsx`` to calculate hasSubFolders using the existing ``getCanBeCollapsedFolderIds`` utility from the Joplin library.
- UI: Passed the hasSubFolders flag to the CollapseExpandAllButton component.
- Accessibility: Added the disabled attribute to the button element.
- Styling: Modified sidebar-header-button.scss to add a :disabled state that drapes the button in opacity: 0.3 and disables pointer events, providing clear visual feedback.

### Testing / Verification

- Without sub-notebooks: The "Expand/Collapse all" button (square icon next to the + button) is now dimmed and does not respond to clicks/hover.
- With sub-notebooks: As soon as a notebook is nested inside another, the button becomes fully opaque and functional.
- Trash: The logic also correctly accounts for expandable notebooks within the trash, as per the issue requirement.