### PR TITLE
Desktop: Fixes #14628: Fix crash when closing secondary windows

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -482,7 +482,8 @@ export default class ElectronAppWrapper {
 						event.preventDefault();
 
 						// As of March 2026, Electron crashes with "Assertion failed: (Environment::GetCurrent(isolate)) == (env)" if the native 'close'
-						// event is allowed to close a secondary window. As a workaround, briefly hide the window and programmatically close it later.
+						// event is allowed to close a secondary window. As a workaround, briefly hide the window and .close() it later.
+						// See https://github.com/laurent22/joplin/issues/14628.
 						window.hide();
 						setTimeout(() => {
 							if (!window.isDestroyed()) {

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -471,8 +471,21 @@ export default class ElectronAppWrapper {
 			// Match the main window's zoom:
 			window.webContents.setZoomFactor(this.mainWindow().webContents.getZoomFactor());
 
-			window.once('close', () => {
-				this.secondaryWindows_.delete(windowId);
+			window.once('close', (event) => {
+				if (this.secondaryWindows_.has(windowId)) {
+					this.secondaryWindows_.delete(windowId);
+
+					event.preventDefault();
+
+					// As of March 2026, Electron crashes with "Assertion failed: (Environment::GetCurrent(isolate)) == (env)" if the native 'close'
+					// event is allowed to close a secondary window. As a workaround, briefly hide the window and programmatically close it later.
+					window.hide();
+					setTimeout(() => {
+						if (!window.isDestroyed()) {
+							window.close();
+						}
+					}, 100);
+				}
 
 				const allSecondaryWindowsClosed = this.secondaryWindows_.size === 0;
 				const mainWindowVisuallyClosed = this.mainWindowHidden_;

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -475,16 +475,21 @@ export default class ElectronAppWrapper {
 				if (this.secondaryWindows_.has(windowId)) {
 					this.secondaryWindows_.delete(windowId);
 
-					event.preventDefault();
+					// Avoid closing a destroyed window. Closing a destroyed window results in the following error:
+					//   Error: Render frame was disposed before WebFrameMain could be accessed
+					const stillOpen = !window.isDestroyed();
+					if (stillOpen) {
+						event.preventDefault();
 
-					// As of March 2026, Electron crashes with "Assertion failed: (Environment::GetCurrent(isolate)) == (env)" if the native 'close'
-					// event is allowed to close a secondary window. As a workaround, briefly hide the window and programmatically close it later.
-					window.hide();
-					setTimeout(() => {
-						if (!window.isDestroyed()) {
-							window.close();
-						}
-					}, 100);
+						// As of March 2026, Electron crashes with "Assertion failed: (Environment::GetCurrent(isolate)) == (env)" if the native 'close'
+						// event is allowed to close a secondary window. As a workaround, briefly hide the window and programmatically close it later.
+						window.hide();
+						setTimeout(() => {
+							if (!window.isDestroyed()) {
+								window.close();
+							}
+						}, 100);
+					}
 				}
 
 				const allSecondaryWindowsClosed = this.secondaryWindows_.size === 0;


### PR DESCRIPTION
# Problem

When closing secondary windows, the desktop app can crash with an `(Environment::GetCurrent(isolate)) == (env)` assertion failure.

# Solution

This pull request delays closing secondary windows by about 100ms. Interestingly, this seems to fix #14628, or at least make it much less frequent.

There are already two places in the codebase where window closing behavior is deferred to prevent a crash:
https://github.com/laurent22/joplin/blob/dfdc0f3c354c20420cd76e3fa4f9231d229dbf8a/packages/app-desktop/gui/NewWindowOrIFrame.tsx#L68
https://github.com/laurent22/joplin/blob/dfdc0f3c354c20420cd76e3fa4f9231d229dbf8a/packages/app-desktop/InteropServiceHelper.ts#L140

Partially resolves #14628.

# Testing

**Screen recordings**:
| Case | Before | After|
|------|---------|--------|
| One window | <video src="https://github.com/user-attachments/assets/6c7248a1-95c5-4fae-8952-0121cbd84a57"/> | <video src="https://github.com/user-attachments/assets/b6911266-73c3-4ec8-8245-b37d1e9aea82"/> |
| Many windows | <video src="https://github.com/user-attachments/assets/052b7bce-78df-4ef1-a38b-f89ac1afae73"/> | <video src="https://github.com/user-attachments/assets/34d688e7-f79a-4867-83d0-964a461c6ff0"/> |


Testing was done on a MacOS 26 computer, where the crash previously occurred consistently in the one-window case, but only **sometimes** occurred in the multi-window case.

Test plan:
1. Open 10 secondary windows.
2. Close them all quickly.
3. Verify that the app doesn't crash.
4. Restart the app.
5. Open 1 secondary window.
6. Close the secondary window.
7. Verify that the app doesn't crash.

Note: The `multiWindow.spec.ts` window-closing test still fails with this pull request. However, it also seems to fail with Joplin 3.5.x (see [comment](https://github.com/laurent22/joplin/pull/14849#issuecomment-4099388654)).

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->



