### PR TITLE
Desktop: Fixes #12877: Viewer word count includes CSS-hidden text causing editor/viewer count mismatch

### DIFF
--- a/packages/renderer/htmlUtils.test.ts
+++ b/packages/renderer/htmlUtils.test.ts
@@ -86,6 +86,76 @@ describe('htmlUtils', () => {
 		}
 	});
 
+	test('should not count hidden text', () => {
+		const testCases = [
+			// visibility: hidden
+			[
+				'<span style="visibility: hidden">hidden text</span>',
+				'',
+			],
+			// display: none
+			[
+				'<span style="display: none">hidden text</span>',
+				'',
+			],
+			// opacity: 0
+			[
+				'<span style="opacity: 0">hidden text</span>',
+				'',
+			],
+			// font-size: 0
+			[
+				'<span style="font-size: 0">hidden text</span>',
+				'',
+			],
+			// color: transparent
+			[
+				'<span style="color: transparent">hidden text</span>',
+				'',
+			],
+			// text-indent off-screen
+			[
+				'<span style="text-indent: -9999px">hidden text</span>',
+				'',
+			],
+			// overflow hidden with zero height
+			[
+				'<span style="overflow: hidden; height: 0">hidden text</span>',
+				'',
+			],
+			// transform scale 0
+			[
+				'<span style="transform: scale(0)">hidden text</span>',
+				'',
+			],
+			// clip-path fully hidden
+			[
+				'<span style="clip-path: inset(100%)">hidden text</span>',
+				'',
+			],
+			// visible text should still be counted
+			[
+				'Note! <span style="visibility: hidden">hidden text</span>',
+				'Note! ',
+			],
+			// nested hidden — child inside hidden parent should also be excluded
+			[
+				'<div style="display: none"><span>still hidden</span></div>',
+				'',
+			],
+			// whitespace variations in style value
+			[
+				'<span style="visibility:   hidden">hidden text</span>',
+				'',
+			],
+		];
+		for (const t of testCases) {
+			const [input, expected] = t;
+			const actual = htmlUtils.stripHtml(input);
+			expect(actual).toBe(expected);
+		}
+	});
+
 	it.each([
 		['<p>Test</p><div></div>', 'Test'],
 		['<p>Testing</p><p>A test</p>', '<p>Testing</p><p>A test</p>'],

--- a/packages/renderer/htmlUtils.test.ts
+++ b/packages/renderer/htmlUtils.test.ts
@@ -148,6 +148,31 @@ describe('htmlUtils', () => {
 				'<span style="visibility:   hidden">hidden text</span>',
 				'',
 			],
+			// nested hidden — multiple children inside hidden parent should all be excluded
+			[
+				'<div style="display: none"><span>still hidden</span><p>also hidden</p></div>',
+				'',
+			],
+			// opacity: 0.5 should NOT be treated as hidden
+			[
+				'<span style="opacity: 0.5">visible text</span>',
+				'visible text',
+			],
+			// height: 0.5px should NOT be treated as hidden
+			[
+				'<span style="overflow: hidden; height: 0.5px">visible text</span>',
+				'visible text',
+			],
+			// text-indent: -99999px should NOT match -9999 rule
+			[
+				'<span style="text-indent: -99999px">visible text</span>',
+				'visible text',
+			],
+			// font-size: 0.5 should NOT be treated as hidden
+			[
+				'<span style="font-size: 0.5em">visible text</span>',
+				'visible text',
+			],
 		];
 		for (const t of testCases) {
 			const [input, expected] = t;

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -48,12 +48,33 @@ export const attributesHtml = (attr: Record<string, string>) => {
 			output.push(`${n}="${htmlentities(attr[n])}"`);
 		}
 	}
-
 	return output.join(' ');
 };
 
 export const isSelfClosingTag = (tagName: string) => {
 	return selfClosingElements.includes(tagName.toLowerCase());
+};
+
+const isHiddenByStyle = (style: string): boolean => {
+	if (!style) return false;
+	const s = style.replace(/\s/g, '').toLowerCase();
+
+	return (
+		s.includes('visibility:hidden') ||
+        s.includes('display:none') ||
+        s.includes('opacity:0') ||
+        s.includes('font-size:0') ||
+        s.includes('color:transparent') ||
+        s.includes('color:rgba(0,0,0,0)') ||
+        // Moves element far off-screen
+        s.includes('text-indent:-9999') ||
+        s.includes('text-indent:-999') ||
+        // Zero dimensions with hidden overflow
+        (s.includes('overflow:hidden') && (s.includes('height:0') || s.includes('width:0') || s.includes('max-height:0'))) ||
+        // Clip path fully hidden
+        s.includes('clip-path:inset(100%)') ||
+        s.includes('transform:scale(0)')
+	);
 };
 
 type ProcessImageResult = {
@@ -139,6 +160,8 @@ class HtmlUtils {
 
 		const tagStack: string[] = [];
 
+		let hiddenDepth = 0;
+
 		const currentTag = () => {
 			if (!tagStack.length) return '';
 			return tagStack[tagStack.length - 1];
@@ -148,17 +171,22 @@ class HtmlUtils {
 
 		const parser = new htmlparser2.Parser({
 
-			onopentag: (name: string) => {
+			onopentag: (name: string, attrs: Record<string, string>) => {
 				tagStack.push(name.toLowerCase());
+				if (isHiddenByStyle(attrs['style'])) {
+					hiddenDepth++;
+				}
 			},
 
 			ontext: (decodedText: string) => {
+				if (hiddenDepth > 0) return;
 				if (disallowedTags.includes(currentTag())) return;
 				output.push(decodedText);
 			},
 
 			onclosetag: (name: string) => {
 				if (currentTag() === name.toLowerCase()) tagStack.pop();
+				if (hiddenDepth > 0) hiddenDepth--;
 			},
 
 		}, { decodeEntities: true });

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -60,30 +60,36 @@ const isHiddenByStyle = (style: string): boolean => {
 	const s = style.replace(/\s/g, '').toLowerCase();
 
 	return (
-		s.includes('visibility:hidden') ||
-        s.includes('display:none') ||
-        s.includes('opacity:0') ||
-        s.includes('font-size:0') ||
-        s.includes('color:transparent') ||
-        s.includes('color:rgba(0,0,0,0)') ||
-        // Moves element far off-screen
-        s.includes('text-indent:-9999') ||
-        s.includes('text-indent:-999') ||
-        // Zero dimensions with hidden overflow
-        (s.includes('overflow:hidden') && (s.includes('height:0') || s.includes('width:0') || s.includes('max-height:0'))) ||
-        // Clip path fully hidden
-        s.includes('clip-path:inset(100%)') ||
-        s.includes('transform:scale(0)')
+		/visibility:hidden(?:;|$)/.test(s) ||
+		/display:none(?:;|$)/.test(s) ||
+		/opacity:0(?:;|$)/.test(s) ||
+		/font-size:0(?:px|em|rem|%)?(?:;|$)/.test(s) ||
+		/color:transparent(?:;|$)/.test(s) ||
+		/color:rgba\(0,0,0,0\)(?:;|$)/.test(s) ||
+		// Moves element far off-screen
+		/text-indent:-9999(?:px)?(?:;|$)/.test(s) ||
+		/text-indent:-999(?:px)?(?:;|$)/.test(s) ||
+		// Zero dimensions with hidden overflow
+		(
+			/overflow:hidden(?:;|$)/.test(s) && (
+				/(?:^|;)height:0(?:px|em|rem|%)?(?:;|$)/.test(s) ||
+				/(?:^|;)width:0(?:px|em|rem|%)?(?:;|$)/.test(s) ||
+				/(?:^|;)max-height:0(?:px|em|rem|%)?(?:;|$)/.test(s)
+			)
+		) ||
+		// Clip path fully hidden
+		/clip-path:inset\(100%\)(?:;|$)/.test(s) ||
+		/transform:scale\(0\)(?:;|$)/.test(s)
 	);
 };
 
 type ProcessImageResult = {
 	type: 'replaceElement';
 	html: string;
-}|{
+} | {
 	type: 'replaceSource';
 	src: string;
-}|{
+} | {
 	type: 'setAttributes';
 	attrs: Record<string, string>;
 };
@@ -161,6 +167,7 @@ class HtmlUtils {
 		const tagStack: string[] = [];
 
 		let hiddenDepth = 0;
+		const hiddenTagStack: boolean[] = [];
 
 		const currentTag = () => {
 			if (!tagStack.length) return '';
@@ -173,9 +180,9 @@ class HtmlUtils {
 
 			onopentag: (name: string, attrs: Record<string, string>) => {
 				tagStack.push(name.toLowerCase());
-				if (isHiddenByStyle(attrs['style'])) {
-					hiddenDepth++;
-				}
+				const isHidden = isHiddenByStyle(attrs['style']);
+				hiddenTagStack.push(isHidden);
+				if (isHidden) hiddenDepth++;
 			},
 
 			ontext: (decodedText: string) => {
@@ -185,8 +192,11 @@ class HtmlUtils {
 			},
 
 			onclosetag: (name: string) => {
-				if (currentTag() === name.toLowerCase()) tagStack.pop();
-				if (hiddenDepth > 0) hiddenDepth--;
+				if (currentTag() === name.toLowerCase()) {
+					tagStack.pop();
+					const wasHidden = hiddenTagStack.pop() ?? false;
+					if (wasHidden) hiddenDepth--;
+				}
 			},
 
 		}, { decodeEntities: true });

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -86,13 +86,14 @@ const isHiddenByStyle = (style: string): boolean => {
 type ProcessImageResult = {
 	type: 'replaceElement';
 	html: string;
-} | {
+}|{
 	type: 'replaceSource';
 	src: string;
-} | {
+}|{
 	type: 'setAttributes';
 	attrs: Record<string, string>;
 };
+
 interface ProcessImageEvent {
 	src: string;
 	before: string;


### PR DESCRIPTION
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->


This PR fixes #12877.

When a note contains HTML elements hidden via CSS (e.g. `visibility: hidden`, `display: none`), the Viewer word count was incorrectly including that hidden text in its total — causing a mismatch with what the user actually sees in the preview.

The Editor count is intentionally unaffected, as it reflects everything the user has typed regardless of styling.

**Fix:** `stripHtml` now detects and skips CSS-hidden elements during text 
extraction, so the Viewer count only reflects visible, rendered content.

**Tests:** Added test cases to `htmlUtils.test.ts` covering all supported 
CSS hiding methods (`visibility: hidden`, `display: none`, etc.), 
nested hidden elements, and mixed visible/hidden content.

**Before**

Joplin 3.5.13 (prod, linux)
Device: linux, Intel(R) Core(TM) i3-8100 CPU @ 3.60GHz
Client ID: e3dcf4bbb98c4873b7229cd3a859a4aa
Sync Version: 3
Profile Version: 49
Keychain Supported: No
Alternative instance ID: -
Revision: 0c1511f
Backup: 1.5.1
Freehand Drawing: 4.2.0

https://github.com/user-attachments/assets/d79b3286-65e1-4451-8e67-2296ee5637dd

**After**
Joplin 3.6.6 (dev, linux)
Device: linux, Intel(R) Core(TM) i3-8100 CPU @ 3.60GHz
Client ID: 463bfd1c6f0e487298782bdebf4a6d09
Sync Version: 3
Profile Version: 49
Keychain Supported: No
Alternative instance ID: -
Sync target: (None)
Editor: Markdown
Revision: dfdc0f3c3 (dev)
Backup: 1.5.1
Freehand Drawing: 4.3.0

https://github.com/user-attachments/assets/11e83d2c-2650-4830-abc8-99097f1ca0d3


