### PR TITLE
Chore: Fixes #14834: Mobile: JSDOM scroll polyfill in ExtendedWebView

### DIFF
--- a/packages/app-mobile/components/ExtendedWebView/index.jest.tsx
+++ b/packages/app-mobile/components/ExtendedWebView/index.jest.tsx
@@ -62,9 +62,10 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 					if (!win) return;
 					for (const Ctor of [win.Element, win.HTMLElement, win.SVGElement]) {
 						if (!Ctor || !Ctor.prototype) continue;
-						Ctor.prototype.scrollIntoView = scrollNoop;
-						if (!Ctor.prototype.scrollTo) Ctor.prototype.scrollTo = scrollNoop;
-						if (!Ctor.prototype.scrollBy) Ctor.prototype.scrollBy = scrollNoop;
+						// Only polyfill when the method is missing, so we don't clobber test spies/mocks.
+						if (typeof Ctor.prototype.scrollIntoView !== 'function') Ctor.prototype.scrollIntoView = scrollNoop;
+						if (typeof Ctor.prototype.scrollTo !== 'function') Ctor.prototype.scrollTo = scrollNoop;
+						if (typeof Ctor.prototype.scrollBy !== 'function') Ctor.prototype.scrollBy = scrollNoop;
 					}
 				};
 				window.__joplinJestPolyfillScroll(window);

--- a/packages/app-mobile/components/ExtendedWebView/index.jest.tsx
+++ b/packages/app-mobile/components/ExtendedWebView/index.jest.tsx
@@ -56,6 +56,20 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 	useEffect(() => {
 		// JSDOM polyfills
 		dom.window.eval(`
+			(function() {
+				const scrollNoop = () => {};
+				window.__joplinJestPolyfillScroll = (win) => {
+					if (!win) return;
+					for (const Ctor of [win.Element, win.HTMLElement, win.SVGElement]) {
+						if (!Ctor || !Ctor.prototype) continue;
+						Ctor.prototype.scrollIntoView = scrollNoop;
+						if (!Ctor.prototype.scrollTo) Ctor.prototype.scrollTo = scrollNoop;
+						if (!Ctor.prototype.scrollBy) Ctor.prototype.scrollBy = scrollNoop;
+					}
+				};
+				window.__joplinJestPolyfillScroll(window);
+			})();
+
 			window.scrollBy = (_amount) => { };
 
 			// JSDOM iframes are missing certain functionality required by Joplin,
@@ -64,6 +78,7 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 			//   Joplin uses this to determine the source of messages in iframe-related IPC.
 			// - iframe.srcdoc: Used by Joplin to create plugin windows.
 			const polyfillIframeContentWindow = (contentWindow) => {
+				window.__joplinJestPolyfillScroll(contentWindow);
 				contentWindow.addEventListener('message', event => {
 					// Work around a missing ".source" property on events.
 					// See https://github.com/jsdom/jsdom/issues/2745#issuecomment-1207414024

--- a/packages/app-mobile/components/ExtendedWebView/index.jest.tsx
+++ b/packages/app-mobile/components/ExtendedWebView/index.jest.tsx
@@ -61,11 +61,9 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 				window.__joplinJestPolyfillScroll = (win) => {
 					if (!win) return;
 					for (const Ctor of [win.Element, win.HTMLElement, win.SVGElement]) {
-						if (!Ctor || !Ctor.prototype) continue;
-						// Only polyfill when the method is missing, so we don't clobber test spies/mocks.
-						if (typeof Ctor.prototype.scrollIntoView !== 'function') Ctor.prototype.scrollIntoView = scrollNoop;
-						if (typeof Ctor.prototype.scrollTo !== 'function') Ctor.prototype.scrollTo = scrollNoop;
-						if (typeof Ctor.prototype.scrollBy !== 'function') Ctor.prototype.scrollBy = scrollNoop;
+						Ctor.prototype.scrollIntoView ??= scrollNoop;
+						Ctor.prototype.scrollTo ??= scrollNoop;
+						Ctor.prototype.scrollBy ??= scrollNoop;
 					}
 				};
 				window.__joplinJestPolyfillScroll(window);

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -753,6 +753,11 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	}
 
 	public componentWillUnmount() {
+		if (this.focusUpdateIID_) {
+			shim.clearInterval(this.focusUpdateIID_);
+			this.focusUpdateIID_ = null;
+		}
+
 		BackButtonService.removeHandler(this.backHandler);
 		NavService.removeHandler(this.navHandler);
 


### PR DESCRIPTION
Fixes #14834

Problem
Running the mobile test suite could finish with Jest reporting “Cannot log after tests are done” after Note.test.tsx. The underlying error was TypeError: scrollIntoView is not a function inside the ExtendedWebView Jest mock’s nested JSDOM: renderer code schedules scrolling (e.g. hash / afterFullPageRender) on a timer, but JSDOM does not implement layout APIs like scrollIntoView. That led to uncaught errors after the test had already completed.

Separately, the Note screen could leave a focus polling interval running briefly after unmount in tests, which contributed to stray logging / teardown issues.

Solution
Scoped polyfill, not global: scrollIntoView / scrollTo / scrollBy are polyfilled only on the nested JSDOM window used by the ExtendedWebView test mock (and again for iframe contentWindows when the existing iframe polyfill runs). This fixes the renderer timers without patching the global Jest/jsdom Element prototype, which would break tests that assign their own scrollIntoView mock (e.g. index.handleAnchorClick.test.ts).

Lifecycle: clear the Note editor focus update interval in componentWillUnmount so it cannot keep firing after the screen is torn down in tests.

No change to production mobile behaviour; test / mock behaviour only (plus safe unmount cleanup).

Test Plan
yarn workspace @joplin/app-mobile test components/screens/Note/Note.test.tsx
yarn workspace @joplin/app-mobile test contentScripts/rendererBundle/contentScript/index.handleAnchorClick.test.ts

