### PR TITLE
Server: Move deletion of objects outside of transaction block

### DIFF
--- a/packages/server/src/models/ItemModel.ts
+++ b/packages/server/src/models/ItemModel.ts
@@ -955,13 +955,16 @@ export default class ItemModel extends BaseModel<Item> {
 			await this.models().share().delete(shares.map(s => s.id));
 			await this.models().userItem().deleteByItemIds(ids, { recordChanges: !options.deleteChanges });
 			await this.models().itemResource().deleteByItemIds(ids);
-			await storageDriver.delete(ids, { models: this.models() });
-			if (storageDriverFallback) await storageDriverFallback.delete(ids, { models: this.models() });
-
 			await super.delete(ids, options);
-
 			if (options.deleteChanges) await this.models().change().deleteByItemIds(ids);
 		}, 'ItemModel::delete');
+
+		// Storage operations are done outside the transaction to avoid holding database locks
+		// during potentially slow I/O operations (e.g., S3). If storage delete fails, the database
+		// records are already gone, which is acceptable - orphaned storage files can be cleaned up
+		// separately.
+		await storageDriver.delete(ids, { models: this.models() });
+		if (storageDriverFallback) await storageDriverFallback.delete(ids, { models: this.models() });
 	}
 
 	public async deleteForUser(userId: Uuid, item: Item, options: DeleteOptions = {}): Promise<void> {

--- a/packages/server/src/models/UserItemModel.ts
+++ b/packages/server/src/models/UserItemModel.ts
@@ -238,7 +238,7 @@ export default class UserItemModel extends BaseModel<UserItem> {
 			}
 
 			await this.db(this.tableName).whereIn('id', userItems.map(ui => ui.id)).delete();
-		}, 'ItemModel::delete');
+		}, 'UserItemModel::delete');
 	}
 
 }


### PR DESCRIPTION
Previously objects in S3 or other storage where being deleted as part of the `withTransaction` block which could cause the database to lock for longer than needed on busy instances.

The deletion is now moved outside the `withTransaction` block.

It means we may have to implement a cleanup job to delete orphaned items.