### PR TITLE
Desktop, Mobile: Fixes #13660: Clear deleted_items entries when apply…

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -1116,6 +1116,11 @@ export default class Synchronizer {
 									sourceDescription: 'sync: deleteLocal',
 								},
 							);
+
+							// If there's a pending deleted_items entry for this item
+							// (e.g., from the local revision cleaner), remove it since
+							// the remote deletion has already been done by another client.
+							await BaseItem.remoteDeletedItem(syncTargetId, local.id);
 						}
 					}
 
@@ -1168,6 +1173,10 @@ export default class Synchronizer {
 							sourceDescription: 'Sync',
 						};
 						await Folder.delete(folderId, deletionOptions);
+
+						// Clear any pending deleted_items entry, since the
+						// remote deletion has already been done.
+						await BaseItem.remoteDeletedItem(syncTargetId, folderId);
 					}
 				}
 


### PR DESCRIPTION
Fixes: #13660

Problem
When multiple clients run the revision cleaner, each one queues the same expired revisions for remote deletion via deleted_items. The first client to sync pushes the deletion to the server — but all other clients still have stale deleted_items entries and redundantly push the same deletions again. This causes a large "deleted remote items" count when reopening a client that hasn't synced in a while.

Solution
When the delta step applies a DeleteLocal action (item already deleted on server), also clear any matching deleted_items entry. This way, stale entries from the local revision cleaner are cleaned up as soon as the delta step confirms the remote deletion already happened.

How This Works With PR #14394
PR #14394 (already merged) defers the revision cleaner's first run until after the initial sync. This PR complements that by handling cases where deleted_items entries were created before the delta step ran — e.g. between syncs, or if the initial sync failed/timed out.
