### PR TITLE
Web Clipper: Allow appending clipped selection to an existing note

### DIFF
--- a/packages/app-clipper/popup/src/App.js
+++ b/packages/app-clipper/popup/src/App.js
@@ -42,10 +42,16 @@ class PreviewComponent extends React.PureComponent {
 	}
 
 	render() {
-		return (
-			<div className="Preview">
+		const titleComp = !this.props.showTitle ? null : (
+			<React.Fragment>
 				<h2>Title:</h2>
 				<input className={'Title'} value={this.props.title} onChange={this.props.onTitleChange}/>
+			</React.Fragment>
+		);
+
+		return (
+			<div className="Preview">
+				{ titleComp }
 				<p><span>Type:</span> {commandUserString(this.props.command)}</p>
 				<a className={'Confirm Button'} href="#" onClick={this.props.onConfirmClick}>Confirm</a>
 			</div>
@@ -70,6 +76,7 @@ class AppComponent extends Component {
 			const content = { ...this.props.clippedContent };
 			content.tags = this.state.selectedTags.join(',');
 			content.parent_id = this.props.selectedFolderId;
+			if (this.props.selectedNoteId) content.target_note_id = this.props.selectedNoteId;
 			const response = await bridge().sendContentToJoplin(content);
 			this.setState({ newNoteId: response.id });
 		};
@@ -145,6 +152,13 @@ class AppComponent extends Component {
 		this.folderSelect_change = (event) => {
 			this.props.dispatch({
 				type: 'SELECTED_FOLDER_SET',
+				id: event.target.value,
+			});
+		};
+
+		this.noteSelect_change = (event) => {
+			this.props.dispatch({
+				type: 'SELECTED_NOTE_SET',
 				id: event.target.value,
 			});
 		};
@@ -305,6 +319,8 @@ class AppComponent extends Component {
 		const hasContent = !!this.props.clippedContent;
 		const content = this.props.clippedContent;
 
+		const showNotesComp = hasContent && content.source_command && content.source_command.name === 'selectedHtml';
+
 		let previewComponent = null;
 
 		const operation = this.props.contentUploadOperation;
@@ -334,6 +350,7 @@ class AppComponent extends Component {
 				body_html={content.body_html}
 				onTitleChange={this.contentTitle_change}
 				command={content.source_command}
+				showTitle={!this.props.selectedNoteId}
 			/>;
 		}
 
@@ -386,6 +403,25 @@ class AppComponent extends Component {
 				<div className="Folders">
 					<label>In notebook: </label>
 					<select value={this.props.selectedFolderId || ''} onChange={this.folderSelect_change}>
+						{ optionComps }
+					</select>
+				</div>
+			);
+		};
+
+		const notesComp = () => {
+			const optionComps = [];
+			optionComps.push(<option key="new" value="">--- New Note ---</option>);
+
+			for (let i = 0; i < this.props.notes.length; i++) {
+				const note = this.props.notes[i];
+				optionComps.push(<option key={note.id} value={note.id}>{note.title}</option>);
+			}
+
+			return (
+				<div className="Notes">
+					<label>To note: </label>
+					<select value={this.props.selectedNoteId || ''} onChange={this.noteSelect_change}>
 						{ optionComps }
 					</select>
 				</div>
@@ -460,6 +496,7 @@ class AppComponent extends Component {
 					</ul>
 				</div>
 				{ foldersComp() }
+				{ showNotesComp ? notesComp() : null }
 				<div className="Tags">
 					<label>Tags:</label>
 					{tagsComp()}
@@ -485,7 +522,9 @@ const mapStateToProps = (state) => {
 		clipperServer: state.clipperServer,
 		folders: state.folders,
 		tags: state.tags,
+		notes: state.notes,
 		selectedFolderId: state.selectedFolderId,
+		selectedNoteId: state.selectedNoteId,
 		isProbablyReaderable: state.isProbablyReaderable,
 		authStatus: state.authStatus,
 	};

--- a/packages/app-clipper/popup/src/bridge.js
+++ b/packages/app-clipper/popup/src/bridge.js
@@ -317,7 +317,7 @@ class Bridge {
 	}
 
 	async notes(folderId) {
-		return this.clipperApiExec('GET', 'notes', { parent_id: folderId, fields: 'id,title', order_by: 'title', order_dir: 'ASC', limit: 100 });
+		return this.clipperApiExec('GET', 'notes', { parent_id: folderId, fields: 'id,title', order_by: 'updated_time', order_dir: 'DESC', limit: 200 });
 	}
 
 	async storageSet(keys) {

--- a/packages/app-clipper/popup/src/bridge.js
+++ b/packages/app-clipper/popup/src/bridge.js
@@ -316,6 +316,10 @@ class Bridge {
 		return this.clipperApiExec('GET', 'folders', { as_tree: 1 });
 	}
 
+	async notes(folderId) {
+		return this.clipperApiExec('GET', 'notes', { parent_id: folderId, fields: 'id,title', order_by: 'title', order_dir: 'ASC', limit: 100 });
+	}
+
 	async storageSet(keys) {
 		return this.browser().storage.local.set(keys);
 	}

--- a/packages/app-clipper/popup/src/bridge.js
+++ b/packages/app-clipper/popup/src/bridge.js
@@ -317,7 +317,7 @@ class Bridge {
 	}
 
 	async notes(folderId) {
-		return this.clipperApiExec('GET', 'notes', { parent_id: folderId, fields: 'id,title', order_by: 'updated_time', order_dir: 'DESC', limit: 200 });
+		return this.clipperApiExec('GET', 'notes', { parent_id: folderId, fields: 'id,title', order_by: 'updated_time', order_dir: 'DESC', limit: 100 });
 	}
 
 	async storageSet(keys) {

--- a/packages/app-clipper/popup/src/index.js
+++ b/packages/app-clipper/popup/src/index.js
@@ -18,7 +18,9 @@ const defaultState = {
 	},
 	folders: [],
 	tags: [],
+	notes: [],
 	selectedFolderId: null,
+	selectedNoteId: null,
 	env: 'prod',
 	isProbablyReaderable: true,
 	authStatus: 'starting',
@@ -28,8 +30,16 @@ const reduxMiddleware = store => next => async (action) => {
 	const result = next(action);
 	const newState = store.getState();
 
-	if (['SELECTED_FOLDER_SET'].indexOf(action.type) >= 0) {
-		bridge().scheduleStateSave(newState);
+	if (['SELECTED_FOLDER_SET', 'FOLDERS_SET'].indexOf(action.type) >= 0) {
+		if (['SELECTED_FOLDER_SET'].indexOf(action.type) >= 0) {
+			bridge().scheduleStateSave(newState);
+		}
+
+		const folderId = action.type === 'SELECTED_FOLDER_SET' ? action.id : newState.selectedFolderId;
+		if (folderId) {
+			const notes = await bridge().notes(folderId);
+			store.dispatch({ type: 'NOTES_SET', notes: notes.items || [] });
+		}
 	}
 
 	return result;
@@ -79,10 +89,21 @@ function reducer(state = defaultState, action) {
 		newState = { ...state };
 		newState.tags = action.tags;
 
+	} else if (action.type === 'NOTES_SET') {
+
+		newState = { ...state };
+		newState.notes = action.notes;
+		newState.selectedNoteId = null;
+
 	} else if (action.type === 'SELECTED_FOLDER_SET') {
 
 		newState = { ...state };
 		newState.selectedFolderId = action.id;
+
+	} else if (action.type === 'SELECTED_NOTE_SET') {
+
+		newState = { ...state };
+		newState.selectedNoteId = action.id;
 
 	} else if (action.type === 'CLIPPER_SERVER_SET') {
 

--- a/packages/lib/services/rest/routes/notes.ts
+++ b/packages/lib/services/rest/routes/notes.ts
@@ -507,7 +507,24 @@ export default async function(request: Request, id: string = null, link: string 
 			allowedProtocolsForDownloadMediaFiles,
 		);
 
-		let note = await Note.save(extracted.note, extracted.saveOptions);
+		let noteToSave = extracted.note;
+		let saveOptions = extracted.saveOptions;
+
+		if (requestNote.target_note_id) {
+			const existingNote = await Note.load(requestNote.target_note_id);
+			if (existingNote) {
+				noteToSave = {
+					...existingNote,
+					body: (existingNote.body ? `${existingNote.body}\n\n` : '') + extracted.note.body,
+				};
+				saveOptions = {
+					...defaultSaveOptions('PUT', existingNote.id),
+					autoTimestamp: true,
+				};
+			}
+		}
+
+		let note = await Note.save(noteToSave, saveOptions);
 
 		if (requestNote.tags) {
 			const tagTitles = requestNote.tags.split(',');


### PR DESCRIPTION
# Problem
Currently, the Joplin Web Clipper always creates a new note for every "Clip Selection" action. This forces users to manually merge multiple snippets from the same source into a single note afterwards, which is an inefficient workflow for researchers and students. There is no way to choose a specific existing note as a target for a new clip.

# Solution
This PR introduces a "To note" selection field in the Web Clipper popup, only for the "Clip selection" command.

- **Dynamic Selection:** Users can now pick an existing note from the currently selected notebook.
- **Appending Logic:** If a target note is selected, the clipped content is appended to the bottom of that note (separated by two newlines) instead of creating a new one.
- **Smart UI**: When a target note is selected, the "Title" field is automatically hidden to streamline the UI, as the existing note's title is preserved.
- **Backward Compatibility:** The "--- New Note ---" option remains the default, ensuring the existing workflow is not disrupted.


https://github.com/user-attachments/assets/2b336669-0d0f-4688-80ee-a74d784f3dca



## Technical Changes:

**REST API:** Modified the POST /notes route in @joplin/lib to handle target_note_id. If present, it performs a load-append-save cycle.
**Clipper Bridge:** Added a notes() method to fetch note headers (id and title) for the selected folder.
**Clipper Popup:** Updated the Redux store to manage note lists and implemented conditional rendering based on the selected command.

# Test PLan
## Manual Steps:
- Open the Web Clipper in your browser.
- Select a notebook in the "In notebook" dropdown.
- Select "Clip selection".
- Observe the new "To note" dropdown. Select an existing note from the list.
- Notice that the "Title" field disappears to keep the UI clean.
- Click Confirm.
- Open the Joplin Desktop app and verify that the selection has been appended to the end of the chosen note.
- Verify that selecting "--- New Note ---" still results in a new note being created with the provided title.