### PR TITLE
Chore: Windows: Run tests in CI

### DIFF
--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -101,9 +101,7 @@ jobs:
         run: |
           yarn install && cd packages/app-desktop && yarn dist
 
-      # Build and package the Windows app, without publishing it, just to
-      # verify that the build process hasn't been broken.
-      - name: Build Windows app (no publishing)
+      - name: Windows build and test (no publishing)
         if: runner.os == 'Windows' && !startsWith(github.ref, 'refs/tags/v')
         env:
           IS_CONTINUOUS_INTEGRATION: 1
@@ -111,7 +109,12 @@ jobs:
           SERVER_REPOSITORY: joplin/server
           SERVER_TAG_PREFIX: server
         run: |
-          yarn install && cd packages/app-desktop && yarn dist --publish=never
+          yarn install &&
+            # Run tests on Windows to detect Windows-specific test failures
+            yarn test &&
+            # Build and package the Windows app, without publishing it, just to verify build still works:
+            cd packages/app-desktop &&
+            yarn dist --publish=never
 
       - name: Publish Docker manifest
         if: runner.os == 'Linux'


### PR DESCRIPTION
# Problem

Windows-specific regressions often aren't caught by tests that run in CI.

# Solution

Run Windows-specific tests in CI. These tests are expected to fail until https://github.com/laurent22/joplin/pull/14904 is merged.

See https://github.com/laurent22/joplin/issues/14903#issuecomment-4127476409.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->