### PR TITLE
Chore: CI: Fix test warnings

### DIFF
--- a/packages/app-mobile/components/screens/SearchScreen/SearchResults.test.tsx
+++ b/packages/app-mobile/components/screens/SearchScreen/SearchResults.test.tsx
@@ -5,7 +5,7 @@ import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/
 import createMockReduxStore from '../../../utils/testing/createMockReduxStore';
 import setupGlobalStore from '../../../utils/testing/setupGlobalStore';
 import Note from '@joplin/lib/models/Note';
-import { render, screen } from '../../../utils/testing/testingLibrary';
+import { act, render, screen } from '../../../utils/testing/testingLibrary';
 import SearchResults from './SearchResults';
 import SearchEngine from '@joplin/lib/services/search/SearchEngine';
 import Folder from '@joplin/lib/models/Folder';
@@ -44,7 +44,9 @@ describe('SearchResult', () => {
 		await createNotes(noteCount);
 
 		render(<WrappedSearchResults query='abcd' paused={false}/>);
-		const items = await screen.findAllByText(/abcd \d\d?\d?/);
-		expect(items.length).toBe(noteCount);
+		await act(async () => {
+			const items = await screen.findAllByText(/abcd \d\d?\d?/);
+			expect(items.length).toBe(noteCount);
+		});
 	});
 });

--- a/packages/app-mobile/components/screens/SearchScreen/SearchResults.test.tsx
+++ b/packages/app-mobile/components/screens/SearchScreen/SearchResults.test.tsx
@@ -5,7 +5,7 @@ import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/
 import createMockReduxStore from '../../../utils/testing/createMockReduxStore';
 import setupGlobalStore from '../../../utils/testing/setupGlobalStore';
 import Note from '@joplin/lib/models/Note';
-import { act, render, screen } from '../../../utils/testing/testingLibrary';
+import { render, screen } from '../../../utils/testing/testingLibrary';
 import SearchResults from './SearchResults';
 import SearchEngine from '@joplin/lib/services/search/SearchEngine';
 import Folder from '@joplin/lib/models/Folder';
@@ -43,10 +43,12 @@ describe('SearchResult', () => {
 		const noteCount = 8;
 		await createNotes(noteCount);
 
-		render(<WrappedSearchResults query='abcd' paused={false}/>);
-		await act(async () => {
-			const items = await screen.findAllByText(/abcd \d\d?\d?/);
-			expect(items.length).toBe(noteCount);
-		});
+		const { unmount } = render(<WrappedSearchResults query='abcd' paused={false}/>);
+
+		const items = await screen.findAllByText(/abcd \d\d?\d?/);
+		expect(items.length).toBe(noteCount);
+
+		// Unmount early to prevent state changes after the test finishes.
+		unmount();
 	});
 });

--- a/packages/lib/services/plugins/loadPlugins.test.ts
+++ b/packages/lib/services/plugins/loadPlugins.test.ts
@@ -1,6 +1,6 @@
 import Setting from '../../models/Setting';
 import PluginService from '../../services/plugins/PluginService';
-import { setupDatabaseAndSynchronizer, switchClient } from '../../testing/test-utils';
+import { setupDatabaseAndSynchronizer, switchClient, withWarningSilenced } from '../../testing/test-utils';
 import loadPlugins, { Props as LoadPluginsProps } from './loadPlugins';
 import MockPluginRunner from './testing/MockPluginRunner';
 import reducer, { State, defaultState } from '../../reducer';
@@ -172,7 +172,9 @@ describe('loadPlugins', () => {
 		const service = PluginService.instance();
 		service.initialize('2.3.4', platformImplementation, failingPluginRunner, store);
 
-		await service.loadAndRunPlugins(Setting.value('pluginDir'), Setting.value('plugins.states'));
+		await withWarningSilenced(/Plugin "joplin.test.bad.plugin" failed to start: Error: Simulated plugin crash/, async () => {
+			await service.loadAndRunPlugins(Setting.value('pluginDir'), Setting.value('plugins.states'));
+		});
 
 		// The bad plugin failed, but allPluginsStarted should still be true
 		// because the fix marks failed plugins as "started".


### PR DESCRIPTION
# Problem

Warnings were logged while running the `SearchResults` and `loadPlugins` tests.

# Solution

- In `loadPlugins.test.ts`, hide the expected plugin load-related warning.
- In `SearchResults.test.tsx`, explicitly unmount the component to prevent warnings related to state updates that occur after the test finishes.

# Testing

- In `packages/app-mobile`, `yarn test SearchResults` no longer emits warnings.
- In `packages/lib`, `yarn test loadPlugins` no longer emits warnings.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->