### PR TITLE
Clipper: Make the styling of dialogues consistent

### DIFF
--- a/packages/app-clipper/popup/src/App.js
+++ b/packages/app-clipper/popup/src/App.js
@@ -297,7 +297,11 @@ class AppComponent extends Component {
 		if (!this.state.contentScriptLoaded) {
 			let msg = 'Loading...';
 			if (this.state.contentScriptError) msg = `The Joplin extension is not available on this tab due to: ${this.state.contentScriptError}`;
-			return <div style={{ padding: 10, fontSize: 12, maxWidth: 200 }}>{msg}</div>;
+			return (
+				<div className="App Startup">
+					{msg}
+				</div>
+			);
 		}
 
 		const warningComponent = !this.props.warning ? null : <div className="Warning">{ this.props.warning }</div>;


### PR DESCRIPTION
# Problem
- The styling of the dialogue of web clipper extension is not consisten at the url / at any browser.
- the styling of all dialogues of web clipper has the background light dark blue but for url / at any browser it has the white background and vertical dialogue instead of horizontal one
<img width="112" height="387" alt="image" src="https://github.com/user-attachments/assets/674a796f-c36f-45ec-ab34-fa7dc2ec8fe9" />



# Solution
Make the styling consisten similar to the other dialogues
<img width="516" height="116" alt="image" src="https://github.com/user-attachments/assets/e945afc7-7762-4b93-b599-1a7e9e8f52d1" />
 
# Testing
Open the web clipper extension at the home page of browser and you will notice the consistent styling of dialogue similar to other ones 