### PR TITLE
Desktop: fix layout overlap when resizing the editor to the left

### DIFF
--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -118,9 +118,9 @@ const StyledUserWebviewDialogContainer = styled.div`
 const defaultLayout: LayoutItem = {
 	key: 'root',
 	children: [
-		{ key: 'sideBar', width: 250 },
-		{ key: 'noteList', width: 250 },
-		{ key: 'editor' },
+		{ key: 'sideBar', width: 250, minWidth: 180 },
+		{ key: 'noteList', width: 250, minWidth: 150 },
+		{ key: 'editor', minWidth: 200 },
 	],
 };
 

--- a/packages/app-desktop/gui/ResizableLayout/utils/persist.test.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/persist.test.ts
@@ -75,4 +75,36 @@ describe('persist', () => {
 		expect(loaded.children[1].direction).toBe(LayoutItemDirection.Column);
 	});
 
+	test('should backfill min-width from defaultLayout for existing layouts', () => {
+		const persistedLayout: LayoutItem = {
+			key: 'root',
+			children: [
+				{
+					key: 'sideBar', width: 170,
+				},
+				{
+					key: 'noteList', width: 140,
+				},
+				{
+					key: 'editor', width: 180,
+				},
+			],
+		};
+
+		const defaultLayout: LayoutItem = {
+			key: 'root',
+			children: [
+				{ key: 'sideBar', minWidth: 180 },
+				{ key: 'noteList', minWidth: 150 },
+				{ key: 'editor', minWidth: 200 },
+			],
+		};
+
+		const result = loadLayout(persistedLayout, defaultLayout, { width: 100, height: 300 });
+
+		expect(result.key).toBe('root');
+		expect(result.children[0].minWidth).toBe(180);
+		expect(result.children[1].minWidth).toBe(150);
+		expect(result.children[2].minWidth).toBe(200);
+	});
 });

--- a/packages/app-desktop/gui/ResizableLayout/utils/persist.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/persist.ts
@@ -9,6 +9,8 @@ export function saveLayout(layout: LayoutItem): any {
 		'visible',
 		'width',
 		'height',
+		'minWidth',
+		'minHeight',
 		'children',
 		'key',
 		'context',
@@ -28,12 +30,33 @@ export function saveLayout(layout: LayoutItem): any {
 	});
 }
 
+function backfillMinWidth(persisted: LayoutItem, defaultLayout: LayoutItem): LayoutItem {
+	if (!persisted || !defaultLayout) return persisted;
+
+	const result = { ...persisted };
+
+	if (result.minWidth === undefined && defaultLayout.minWidth !== undefined) {
+		result.minWidth = defaultLayout.minWidth;
+	}
+
+	if (Array.isArray(result.children) && Array.isArray(defaultLayout.children)) {
+		result.children = result.children.map((child: LayoutItem) => {
+			const matchingDefault = defaultLayout.children.find(
+				(d: LayoutItem) => d.key === child.key,
+			);
+			return matchingDefault ? backfillMinWidth(child, matchingDefault) : child;
+		});
+	}
+
+	return result;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 export function loadLayout(layout: any, defaultLayout: LayoutItem, rootSize: Size): LayoutItem {
 	let output: LayoutItem = null;
 
 	if (layout) {
-		output = { ...layout };
+		output = backfillMinWidth(layout, defaultLayout);
 	} else {
 		output = { ...defaultLayout };
 	}

--- a/packages/app-desktop/gui/ResizableLayout/utils/persist.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/persist.ts
@@ -42,7 +42,7 @@ function backfillMinWidth(persisted: LayoutItem, defaultLayout: LayoutItem): Lay
 	if (Array.isArray(result.children) && Array.isArray(defaultLayout.children)) {
 		result.children = result.children.map((child: LayoutItem) => {
 			const matchingDefault = defaultLayout.children.find(
-				(d: LayoutItem) => d.key === child.key,
+				(d: LayoutItem) => d.key === child?.key,
 			);
 			return matchingDefault ? backfillMinWidth(child, matchingDefault) : child;
 		});


### PR DESCRIPTION
## summary

when resizing the editor panel towards the left side, the layout seems misaligned some ui elements in the sidebar and note list overlap or become misaligned.

this happens because some layout panels can shrink to very small widths (fallback minimum ~40px), which breaks the layout when dragging the divider.

## changes

- added minimum width constraints for the sidebar, note list and editor panels

## before

when dragging the editor divider to the extreme left, the sidebar and other ui elements overlap.

<img width="434" height="689" alt="Screenshot 2026-03-26 204438" src="https://github.com/user-attachments/assets/a5326f42-9fc5-4d6b-825b-67a75ad6811b" />

<img width="651" height="816" alt="Screenshot 2026-03-26 213407" src="https://github.com/user-attachments/assets/11e097d5-2e45-49dd-b68f-01885b4bb08f" />


## after

panels stop resizing before reaching the layout-breaking width.

<img width="1916" height="1022" alt="Screenshot 2026-03-26 233334" src="https://github.com/user-attachments/assets/5d9dccda-ea9b-4cf1-9e5f-be1a4c245f38" />

