### PR TITLE
Desktop: Fixes #14914: RTE checklists should create unchecked items on Enter

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1493,6 +1493,23 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 			}
 		}
 
+		const clearInheritedCheckedStateOnChecklistEnter = () => {
+			const currentNode = editor.selection.getStart();
+			const currentListItem = editor.dom.getParent(currentNode, 'li') as HTMLLIElement;
+			if (!currentListItem) return;
+
+			const parentChecklist = editor.dom.getParent(currentListItem, 'ul.joplin-checklist');
+			if (!parentChecklist) return;
+
+			if (!currentListItem.classList.contains('checked')) return;
+
+			const textContent = (currentListItem.textContent ?? '').replace(/\u200B/g, '').trim();
+			if (textContent !== '') return;
+
+			currentListItem.classList.remove('checked');
+			onChangeHandler();
+		};
+
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		async function onKeyDown(event: any) {
 			// It seems "paste as text" is handled automatically on Windows and Linux,
@@ -1507,6 +1524,13 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 			if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.code === 'KeyV') {
 				event.preventDefault();
 				pasteAsPlainText(null);
+			}
+
+			if (event.key === 'Enter' && !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey && !event.isComposing) {
+				shim.setTimeout(() => {
+					if (!editor || !editor.getDoc()) return;
+					clearInheritedCheckedStateOnChecklistEnter();
+				}, 0);
 			}
 		}
 


### PR DESCRIPTION
## Summary

Fixes the Rich Text Editor checklist behavior where pressing Enter after a checked item creates the next item as checked.

## Root cause

TinyMCE can carry over checklist state from the previous item, and there was no normalization step for newly created Joplin checklist items.

## What changed

- normalize newly created checklist items after Enter
- remove inherited checked state from empty checklist items
- keep the change limited to Joplin checklist lists
- preserve existing toggle behavior

## Testing

1. Create a checklist in the Rich Text Editor.
2. Check an item.
3. Press Enter at the end of that item.
4. Verify the new item is unchecked.
5. Verify normal checklist toggle behavior still works.
6. Verify bullet and numbered lists are unaffected.

## Before 
A new checklist item is created, but it is already checked.

https://github.com/user-attachments/assets/3ee4fa3b-92a3-4f91-8cc7-a171cfbe195e

## After
A new checklist item should be created as unchecked.

https://github.com/user-attachments/assets/321be6c4-3572-4d40-af73-1bade0b94832

---
Fixes #14914 