### PR TITLE
Desktop: Fixes #14919: Prevent Plugin API callback registry memory leak

### DIFF
--- a/packages/app-desktop/services/plugins/PluginRunner.ts
+++ b/packages/app-desktop/services/plugins/PluginRunner.ts
@@ -155,12 +155,15 @@ export default class PluginRunner extends BasePluginRunner {
 			if (message.pluginId !== plugin.id) return;
 
 			if (message.mainWindowCallbackId) {
-				const promise = callbackPromises[message.mainWindowCallbackId];
+				const callbackId = message.mainWindowCallbackId;
+				const promise = callbackPromises[callbackId];
 
 				if (!promise) {
 					console.error('Got a callback without matching promise: ', message);
 					return;
 				}
+
+				delete callbackPromises[callbackId];
 
 				if (message.error) {
 					promise.reject(message.error);

--- a/packages/app-desktop/services/plugins/plugin_index.js
+++ b/packages/app-desktop/services/plugins/plugin_index.js
@@ -113,11 +113,14 @@
 		}
 
 		if (message.pluginCallbackId) {
-			const promise = callbackPromises[message.pluginCallbackId];
+			const callbackId = message.pluginCallbackId;
+			const promise = callbackPromises[callbackId];
 			if (!promise) {
 				console.error('Got a callback without matching promise: ', message);
 				return;
 			}
+
+			delete callbackPromises[callbackId];
 
 			if (message.error) {
 				promise.reject(message.error);


### PR DESCRIPTION
## Summary

This PR fixes a memory leak in the desktop plugin IPC bridge where callback registry entries (`cb_*`) were retained after Promise resolution or rejection.

## Problem

Plugins making frequent async API calls such as `joplin.data.get`, `joplin.settings.value`, and `joplin.views.panels.visible` could gradually increase memory usage because entries in `callbackPromises` were never removed after completion.

## Root cause

There were two callback resolution paths where Promises were resolved or rejected, but the corresponding callback registry entries were not deleted:

- plugin sandbox callback handling (`plugin_index.js`)
- main-window callback handling (`PluginRunner.ts`)

## What changed

- added callback cleanup in the plugin sandbox callback resolution path
- added callback cleanup in the main-window callback resolution path
- deleted `callbackPromises[callbackId]` before resolving or rejecting
- kept the TypeScript and runtime JavaScript paths aligned

## Scope

This change is limited to callback lifecycle cleanup in the desktop plugin IPC flow. It does not change API contracts or callback routing behavior.

## Validation

- TypeScript compile:
  - `yarn --cwd "c:\GSOC_26\joplin-clean\packages\app-desktop" tsc`
- full desktop Jest suite:
  - `yarn --cwd "c:\GSOC_26\joplin-clean\packages\app-desktop" test`
  - `33 passed, 33 total`
- focused smoke test:
  - `yarn --cwd "c:\GSOC_26\joplin-clean\packages\app-desktop" test --runTestsByPath "gui/NoteEditor/NoteBody/TinyMCE/utils/shouldPasteResources.test.ts"`

Fixes #14919