### PR TITLE
Desktop: Fixes #12994: Share owner sees "Leave notebook" instead of "Share notebook" when server is offline

### DIFF
--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -627,6 +627,12 @@ export default class BaseApplication {
 		DecryptionWorker.instance().dispatch = this.store().dispatch;
 		ResourceFetcher.instance().dispatch = this.store().dispatch;
 		ShareService.instance().initialize(this.store(), EncryptionService.instance());
+
+		const cached = parseShareCache(Setting.value('sync.shareCache'));
+		if (cached.shares.length) {
+			this.store().dispatch({ type: 'SHARE_SET', shares: cached.shares });
+		}
+
 	}
 
 	public deinitRedux() {

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -629,10 +629,15 @@ export default class BaseApplication {
 		ShareService.instance().initialize(this.store(), EncryptionService.instance());
 
 		const cached = parseShareCache(Setting.value('sync.shareCache'));
-		if (cached.shares.length) {
-			this.store().dispatch({ type: 'SHARE_SET', shares: cached.shares });
+		const hasCachedShareData = cached.shares.length || Object.keys(cached.shareUsers).length || cached.shareInvitations.length;
+		if (hasCachedShareData) {
+			this.store().dispatch({
+				type: 'SHARE_CACHE_RESTORE',
+				shares: cached.shares,
+				shareUsers: cached.shareUsers,
+				shareInvitations: cached.shareInvitations,
+			});
 		}
-
 	}
 
 	public deinitRedux() {

--- a/packages/lib/components/shared/reduxSharedMiddleware.ts
+++ b/packages/lib/components/shared/reduxSharedMiddleware.ts
@@ -130,7 +130,7 @@ export default async (store: any, _next: any, action: any, dispatch: Dispatch) =
 		}
 	}
 
-	if (action.type.startsWith('SHARE_')) {
+	if (action.type.startsWith('SHARE_') && action.type !== 'SHARE_CACHE_RESTORE') {
 		const serialized = JSON.stringify(newState.shareService);
 		Setting.setValue('sync.shareCache', serialized);
 		BaseItem.syncShareCache = JSON.parse(serialized);

--- a/packages/lib/services/share/reducer.ts
+++ b/packages/lib/services/share/reducer.ts
@@ -136,6 +136,13 @@ const reducer = (draftRoot: Draft<RootState>, action: any) => {
 			draft.shareInvitations = action.shareInvitations;
 			break;
 
+		case 'SHARE_CACHE_RESTORE':
+
+			draft.shares = action.shares;
+			draft.shareUsers = action.shareUsers;
+			draft.shareInvitations = action.shareInvitations;
+			break;
+
 		case 'SHARE_INVITATION_RESPONSE_PROCESSING':
 
 			draft.processingShareInvitationResponse = action.value;


### PR DESCRIPTION
The Redux store wasn't loaded with share data when the server was unreachable at startup, as it wasn't falling back to the local cache.


How to test
Configure Joplin desktop to sync with Joplin Server
Share a notebook with another user
Quit Joplin desktop
Stop Joplin Server
Start Joplin desktop and right-click the shared notebook
As the owner, "Share notebook" should show — not "Leave notebook"


https://github.com/user-attachments/assets/3a3c426a-9d55-4116-b946-a0f75721b509

