### PR TITLE
MacOS: Fixes #9637: Fix broken fullscreen shortcut (Ctrl + Cmd + F)

### DIFF
--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -823,6 +823,12 @@ function useMenu(props: Props) {
 								Setting.incValue('windowContentZoomFactor', -10);
 							},
 							accelerator: 'CommandOrControl+-',
+						}, {
+							type: 'separator',
+							visible: shim.isMac(),
+						}, {
+							role: 'togglefullscreen',
+							visible: shim.isMac(),
 						}],
 				},
 				go: {


### PR DESCRIPTION
## **Fix: Ctrl+Cmd+F fullscreen shortcut not working on macOS**

### Problem

On macOS (Sonoma 14.2.1 and later, including Tahoe 26.3.1), pressing **Ctrl+Cmd+F** to toggle fullscreen mode has no effect. The standard macOS fullscreen shortcut is mapped in Electron to the `togglefullscreen` role, but Joplin's View menu did not expose this role, leaving the native shortcut unmapped and non-functional.

This prevents users from using the expected macOS fullscreen keyboard shortcut, requiring them to find an alternative method or menu item.

### Solution

Added a native Electron menu item with the `togglefullscreen` role to the View menu on macOS. This exposes the standard Electron fullscreen behavior and binds it to the OS-level Ctrl+Cmd+F shortcut.

**Changes:**
- Added a separator in the View menu (macOS only)
- Added a fullscreen menu item using `role: 'togglefullscreen'` (macOS only)
- Both items are conditionally visible only on macOS via `visible: shim.isMac()`

This is a low-risk change that:
- Only affects macOS users
- Uses Electron's built-in fullscreen role (no custom implementation)
- Does not affect other platforms or existing functionality
- Follows the existing pattern of platform-specific menu items

### Test Plan

**macOS (Tahoe 26.3.1 or Sonoma 14.2.1+):**
   - Open Joplin desktop app
   - Press **Ctrl+Cmd+F**
   - Expected: Window enters fullscreen mode
   - Press **Ctrl+Cmd+F** again
   - Expected: Window exits fullscreen mode

#### AI Disclosure

- Used AI to pinpoint the issue and suggest solution.

Fixes: #9637