### PR TITLE
Testing: Improve search subsystem unit test coverage and edge cases

### DIFF
--- a/packages/lib/services/search/SearchEngine.test.ts
+++ b/packages/lib/services/search/SearchEngine.test.ts
@@ -614,4 +614,71 @@ describe('services/SearchEngine', () => {
 			expect(rows.length).toBe(resourcesFound);
 		});
 
+	it('should return empty results for empty search string', (async () => {
+		await Note.save({ title: 'hello world' });
+		await engine.syncTables();
+
+		const rows = await engine.search('');
+		expect(rows.length).toBe(0);
+	}));
+
+	it('should return empty results for whitespace-only search string', (async () => {
+		await Note.save({ title: 'hello world' });
+		await engine.syncTables();
+
+		// '   ' is truthy so it passes the !searchString guard,
+		// but produces zero parsed terms
+		const rows = await engine.search('   ');
+		expect(rows.length).toBe(0);
+	}));
+
+	it('should remove wildcard-only terms from parsed query', (async () => {
+		// SQLite FTS doesn't allow '*' queries
+		const mixed = await engine.parseQuery('hello *');
+		expect(mixed.termCount).toBe(1);
+
+		const starOnly = await engine.parseQuery('*');
+		expect(starOnly.termCount).toBe(0);
+	}));
+
+	it('should convert query terms to regex correctly', (() => {
+		expect(engine.queryTermToRegex('hello')).toBe('hello');
+		expect(engine.queryTermToRegex('hello.world')).toBe('hello\\.world');
+
+		// Leading wildcards should be stripped
+		expect(engine.queryTermToRegex('***hello')).toBe('hello');
+
+		// Trailing wildcard should produce a character class match
+		const result = engine.queryTermToRegex('hello*');
+		expect(result).toMatch(/^hello/);
+		expect(result).not.toBe('hello\\*');
+		expect(result.length).toBeGreaterThan(5);
+	}));
+
+	it('should aggregate all parsed query terms across columns', (async () => {
+		const parsedQuery = await engine.parseQuery('hello title:world');
+		const allTerms = engine.allParsedQueryTerms(parsedQuery);
+		expect(allTerms.length).toBe(2);
+	}));
+
+	it('should return empty array from allParsedQueryTerms for null input', (() => {
+		expect(engine.allParsedQueryTerms(null)).toEqual([]);
+	}));
+
+	it('should search notes containing mixed CJK and Latin text', (async () => {
+		await Note.save({
+			title: 'Meeting notes 会議の記録',
+			body: 'Discuss project プロジェクトについて',
+		});
+		await engine.syncTables();
+
+		// Latin - uses FTS
+		expect((await engine.search('Meeting')).length).toBe(1);
+		expect((await engine.search('project')).length).toBe(1);
+		// CJK - uses NONLATIN_SCRIPT (LIKE)
+		expect((await engine.search('会議')).length).toBe(1);
+		expect((await engine.search('プロジェクト')).length).toBe(1);
+	}));
+
+
 });

--- a/packages/lib/services/search/filterParser.test.ts
+++ b/packages/lib/services/search/filterParser.test.ts
@@ -168,4 +168,42 @@ describe('filterParser should be correct filter for keyword', () => {
 		expect(filterParser(searchString)).toContainEqual(makeTerm('text', '"hello"', false, true));
 		expect(filterParser(searchString)).toContainEqual(makeTerm('text', '"you"', false, true));
 	});
+
+	it('id filter', () => {
+		const searchString = 'id:abcd1234';
+		expect(filterParser(searchString)).toContainEqual(makeTerm('id', 'abcd1234', false));
+	});
+
+	it('negated id filter', () => {
+		const searchString = '-id:abcd1234';
+		expect(filterParser(searchString)).toContainEqual(makeTerm('id', 'abcd1234', true));
+	});
+
+	it('due filter', () => {
+		const searchString = 'due:20210427';
+		expect(filterParser(searchString)).toContainEqual(makeTerm('due', '20210427', false));
+	});
+
+	it('negated due filter', () => {
+		const searchString = '-due:20210427';
+		expect(filterParser(searchString)).toContainEqual(makeTerm('due', '20210427', true));
+	});
+
+	it('empty query string', () => {
+		expect(filterParser('')).toEqual([]);
+	});
+
+	it('wildcard in text search term', () => {
+		const searchString = 'hello*';
+		expect(filterParser(searchString)).toContainEqual(
+			makeTerm('text', '"hello*"', false, false, true),
+		);
+	});
+
+	it('sourceurl with port number (multiple colons)', () => {
+		const searchString = 'sourceurl:https://example.com:8080/path';
+		expect(filterParser(searchString)).toContainEqual(
+			makeTerm('sourceurl', 'https://example.com:8080/path', false),
+		);
+	});
 });


### PR DESCRIPTION
## Summary

This PR improves test coverage for the search subsystem by adding unit tests for previously untested functions and edge cases in `SearchEngine.ts` and `filterParser.ts`.

## Motivation

As part of preparing for GSoC 2026, I explored the search system in depth and identified several areas with missing or limited test coverage. Since search is a core feature of Joplin and directly related to AI-supported search improvements, strengthening its reliability is important.

## Changes

### SearchEngine.test.ts

* Added tests for empty and whitespace queries
* Covered `queryTermToRegex` behavior
* Covered `allParsedQueryTerms`
* Added mixed-script test cases (Latin + non-Latin)
* Tested wildcard-only query handling

### filterParser.test.ts

* Added tests for `id:` and `-id:` filters
* Added tests for `due:` and `-due:` filters
* Covered empty query parsing
* Covered wildcard text handling
* Tested URLs with multiple colons

## Notes

* All tests pass locally (`yarn test`)
* Changes follow existing test structure and style
* No production code was modified

## GSoC Context

This contribution is part of my preparation for working on the **AI-supported search for notes** project. It helped me understand the current search pipeline and identify areas for future improvement.

I would appreciate any feedback or suggestions.
