### PR TITLE
All: Fixed potential TypeError in syncedCount, deletedItemCount, and itemType when no rows are found

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1573,6 +1573,7 @@ packages/lib/services/ocr/utils/types.js
 packages/lib/services/plugins/BasePlatformImplementation.js
 packages/lib/services/plugins/BasePluginRunner.js
 packages/lib/services/plugins/EditorPluginHandler.js
+packages/lib/services/plugins/JoplinData.test.js
 packages/lib/services/plugins/MenuController.js
 packages/lib/services/plugins/MenuItemController.js
 packages/lib/services/plugins/Plugin.js
@@ -1586,7 +1587,6 @@ packages/lib/services/plugins/api/Joplin.js
 packages/lib/services/plugins/api/JoplinClipboard.js
 packages/lib/services/plugins/api/JoplinCommands.js
 packages/lib/services/plugins/api/JoplinContentScripts.js
-packages/lib/services/plugins/api/JoplinData.test.js
 packages/lib/services/plugins/api/JoplinData.js
 packages/lib/services/plugins/api/JoplinFilters.js
 packages/lib/services/plugins/api/JoplinFs.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1586,6 +1586,7 @@ packages/lib/services/plugins/api/Joplin.js
 packages/lib/services/plugins/api/JoplinClipboard.js
 packages/lib/services/plugins/api/JoplinCommands.js
 packages/lib/services/plugins/api/JoplinContentScripts.js
+packages/lib/services/plugins/api/JoplinData.test.js
 packages/lib/services/plugins/api/JoplinData.js
 packages/lib/services/plugins/api/JoplinFilters.js
 packages/lib/services/plugins/api/JoplinFs.js

--- a/.gitignore
+++ b/.gitignore
@@ -1559,6 +1559,7 @@ packages/lib/services/plugins/api/Joplin.js
 packages/lib/services/plugins/api/JoplinClipboard.js
 packages/lib/services/plugins/api/JoplinCommands.js
 packages/lib/services/plugins/api/JoplinContentScripts.js
+packages/lib/services/plugins/api/JoplinData.test.js
 packages/lib/services/plugins/api/JoplinData.js
 packages/lib/services/plugins/api/JoplinFilters.js
 packages/lib/services/plugins/api/JoplinFs.js

--- a/.gitignore
+++ b/.gitignore
@@ -1546,6 +1546,7 @@ packages/lib/services/ocr/utils/types.js
 packages/lib/services/plugins/BasePlatformImplementation.js
 packages/lib/services/plugins/BasePluginRunner.js
 packages/lib/services/plugins/EditorPluginHandler.js
+packages/lib/services/plugins/JoplinData.test.js
 packages/lib/services/plugins/MenuController.js
 packages/lib/services/plugins/MenuItemController.js
 packages/lib/services/plugins/Plugin.js
@@ -1559,7 +1560,6 @@ packages/lib/services/plugins/api/Joplin.js
 packages/lib/services/plugins/api/JoplinClipboard.js
 packages/lib/services/plugins/api/JoplinCommands.js
 packages/lib/services/plugins/api/JoplinContentScripts.js
-packages/lib/services/plugins/api/JoplinData.test.js
 packages/lib/services/plugins/api/JoplinData.js
 packages/lib/services/plugins/api/JoplinFilters.js
 packages/lib/services/plugins/api/JoplinFs.js

--- a/packages/app-cli/tests/support/plugins/clipboard/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/clipboard/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/codemirror5-and-codemirror6/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/codemirror5-and-codemirror6/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/codemirror6/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/codemirror6/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/codemirror_content_script/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/codemirror_content_script/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/content_script/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/content_script/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/dialog/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/dialog/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/editor_context_menu/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/editor_context_menu/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/events/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/events/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/external_assets/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/external_assets/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/imaging/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/imaging/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/jpl_test/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/jpl_test/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/json_export/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/json_export/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/load_css/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/load_css/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/menu/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/menu/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/multi_selection/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/multi_selection/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/nativeModule/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/nativeModule/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/note_list_renderer/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/note_list_renderer/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/post_messages/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/post_messages/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/register_command/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/register_command/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/selected_text/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/selected_text/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/settings/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/settings/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/toast/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/toast/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/toc/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/toc/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/user_data/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/user_data/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/withExternalModules/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/withExternalModules/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/app-cli/tests/support/plugins/worker/api/JoplinData.d.ts
+++ b/packages/app-cli/tests/support/plugins/worker/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/generator-joplin/generators/app/templates/api/JoplinData.d.ts
+++ b/packages/generator-joplin/generators/app/templates/api/JoplinData.d.ts
@@ -48,7 +48,7 @@ export default class JoplinData {
     post(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     put(path: Path, query?: any, body?: any, files?: any[]): Promise<any>;
     delete(path: Path, query?: any): Promise<any>;
-    itemType(itemId: string): Promise<ModelType>;
+    itemType(itemId: string): Promise<ModelType | null>;
     resourcePath(resourceId: string): Promise<string>;
     /**
      * Gets an item user data. User data are key/value pairs. The `key` can be any

--- a/packages/lib/models/BaseItem.test.ts
+++ b/packages/lib/models/BaseItem.test.ts
@@ -191,4 +191,16 @@ three line \\n no escape`)).toBe(0);
 		const note = await Note.save({ id }, { isNew: true });
 		expect(await BaseItem.loadItemById(note.id)).toMatchObject({ id });
 	});
+
+	it('syncedCount should return 0 when no sync items exist for the given sync target', async () => {
+		// Use a sync target that has never been used so the sync_items table has no matching rows
+		const result = await Note.syncedCount(999);
+		expect(result).toBe(0);
+	});
+
+	it('deletedItemCount should return 0 when no deleted items exist for the given sync target', async () => {
+		// Use a sync target that has never been used so the deleted_items table has no matching rows
+		const result = await Note.deletedItemCount(999);
+		expect(result).toBe(0);
+	});
 });

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -160,7 +160,7 @@ export default class BaseItem extends BaseModel {
 		// that the returned number might be inaccurate (for example if a sync operation was cancelled)
 		const sql = 'SELECT count(*) as total FROM sync_items WHERE sync_target = ? AND item_type = ?';
 		const r = await this.db().selectOne(sql, [syncTarget, itemType]);
-		return r.total;
+		return r ? r.total : 0;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -381,7 +381,7 @@ export default class BaseItem extends BaseModel {
 
 	public static async deletedItemCount(syncTarget: number) {
 		const r = await this.db().selectOne('SELECT count(*) as total FROM deleted_items WHERE sync_target = ?', [syncTarget]);
-		return r['total'];
+		return r ? r.total : 0;
 	}
 
 	public static async allItemsInTrash() {

--- a/packages/lib/services/plugins/JoplinData.test.ts
+++ b/packages/lib/services/plugins/JoplinData.test.ts
@@ -1,9 +1,9 @@
-import { afterAllCleanUp, setupDatabaseAndSynchronizer, switchClient } from '../../../testing/test-utils';
-import JoplinData from './JoplinData';
-import Note from '../../../models/Note';
-import Folder from '../../../models/Folder';
-import { ModelType } from '../../../BaseModel';
-import Plugin from '../Plugin';
+import { afterAllCleanUp, setupDatabaseAndSynchronizer, switchClient } from '../../testing/test-utils';
+import JoplinData from './api/JoplinData';
+import Note from '../../models/Note';
+import Folder from '../../models/Folder';
+import { ModelType } from '../../BaseModel';
+import Plugin from './Plugin';
 
 const newJoplinData = () => {
 	// JoplinData only uses plugin.id for userDataGet/Set/Delete, not for itemType

--- a/packages/lib/services/plugins/api/JoplinData.test.ts
+++ b/packages/lib/services/plugins/api/JoplinData.test.ts
@@ -1,0 +1,50 @@
+import { afterAllCleanUp, setupDatabaseAndSynchronizer, switchClient } from '../../../testing/test-utils';
+import JoplinData from './JoplinData';
+import Note from '../../../models/Note';
+import Folder from '../../../models/Folder';
+import { ModelType } from '../../../BaseModel';
+import Plugin from '../Plugin';
+
+const newJoplinData = () => {
+	// JoplinData only uses plugin.id for userDataGet/Set/Delete, not for itemType
+	return new JoplinData({ id: 'test-plugin' } as Plugin);
+};
+
+describe('JoplinData', () => {
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+	});
+
+	afterAll(async () => {
+		await afterAllCleanUp();
+	});
+
+	it('itemType should return the correct ModelType for an existing note', async () => {
+		const folder = await Folder.save({ title: 'folder' });
+		const note = await Note.save({ title: 'note', parent_id: folder.id });
+
+		const joplinData = newJoplinData();
+		const result = await joplinData.itemType(note.id);
+
+		expect(result).toBe(ModelType.Note);
+	});
+
+	it('itemType should return the correct ModelType for an existing folder', async () => {
+		const folder = await Folder.save({ title: 'folder' });
+
+		const joplinData = newJoplinData();
+		const result = await joplinData.itemType(folder.id);
+
+		expect(result).toBe(ModelType.Folder);
+	});
+
+	it('itemType should return null when the item does not exist', async () => {
+		const joplinData = newJoplinData();
+		const result = await joplinData.itemType('non_existent_id_000000000000000000000');
+
+		expect(result).toBeNull();
+	});
+
+});

--- a/packages/lib/services/plugins/api/JoplinData.ts
+++ b/packages/lib/services/plugins/api/JoplinData.ts
@@ -97,7 +97,7 @@ export default class JoplinData {
 		return this.api_.route('DELETE', this.pathToString(path), query);
 	}
 
-	public async itemType(itemId: string): Promise<ModelType> {
+	public async itemType(itemId: string): Promise<ModelType | null> {
 		const item = await BaseItem.loadItemById(itemId);
 		if (!item) return null;
 		return item.type_;


### PR DESCRIPTION
## Problem

Three methods access the result of `selectOne()` without checking for null first. `selectOne()` returns `null` when no rows match the query, which causes a `TypeError` at runtime:

- `BaseItem.syncedCount()` — accesses `r.total` directly; throws for sync targets with no history
- `BaseItem.deletedItemCount()` — accesses `r['total']` directly; throws for sync targets with no deletions
- `JoplinData.itemType()` — declared return type is `Promise<ModelType>` but the method returns `null` when the item is not found, misleading plugin developers into skipping a null check

## Solution

Applied the existing null-safe pattern `r ? r.total : 0` already used in `BaseItem.ts` (line 874) to `syncedCount` and `deletedItemCount`. No logic was changed in either method.

For `itemType`, updated the return type from `Promise<ModelType>` to `Promise<ModelType | null>` to accurately reflect the existing behaviour. No logic was changed.

## Test Plan

Added tests to `BaseItem.test.ts` verifying that `syncedCount` and `deletedItemCount` return `0` when no rows exist for the given sync target, instead of throwing.

Added `JoplinData.test.ts` covering three cases for `itemType`: returns `ModelType.Note` for an existing note, returns `ModelType.Folder` for an existing folder, and returns `null` for a non-existent ID.

## AI Assistance Disclosure

AI tools were used to help identify the affected methods. All fixes and tests were written and reviewed by me.
