### PR TITLE
Desktop: Accessibility: Rich Text Editor: Pre-populate search dialog with global search query

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1604,7 +1604,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 	}, [props.searchMarkers]);
 
 	useEffect(() => {
-		if (!editor) return;
+		if (!editor) return () => {};
 
 		const onKeyDown = (e: KeyboardEvent) => {
 			const isCtrlF = (e.ctrlKey || e.metaKey) && e.key === 'f';

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1598,18 +1598,17 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 		if (!props.searchMarkers) return;
 
 		const keywords = props.searchMarkers.keywords;
-		if (!keywords || keywords.length === 0) {
+		const searchTerm = (keywords && keywords.length > 0) ? (keywords[0]?.value ?? '') : '';
+
+		if (!searchTerm) {
 			if (editor.plugins?.searchreplace) {
 				editor.plugins.searchreplace.done(false);
 			}
 			return;
 		}
 
-		const searchTerm = keywords[0]?.value ?? '';
-		if (!searchTerm) return;
-
 		if (editor.plugins?.searchreplace) {
-			editor.plugins.searchreplace.find(searchTerm, false, false, true);
+			editor.plugins.searchreplace.find(searchTerm, false, false, false);
 		}
 	}, [editor, props.searchMarkers]);
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1591,6 +1591,29 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 	// editor in their clean up function will get an invalid reference.
 	// -----------------------------------------------------------------------------------------
 
+	// Pre-populate the RTE search dialog with the global search query (WCAG SC 3.3.7)
+	// Search-entry pre-population is currently only done in the Markdown editor.
+	useEffect(() => {
+		if (!editor) return;
+		if (!props.searchMarkers) return;
+
+		const keywords = props.searchMarkers.keywords;
+		if (!keywords || keywords.length === 0) {
+			if (editor.plugins?.searchreplace) {
+				editor.plugins.searchreplace.done(false);
+			}
+			return;
+		}
+
+		const searchTerm = keywords[0]?.value ?? '';
+		if (!searchTerm) return;
+
+		if (editor.plugins?.searchreplace) {
+			editor.plugins.searchreplace.find(searchTerm, false, false, true);
+		}
+	}, [editor, props.searchMarkers]);
+
+
 	useEffect(() => {
 		return () => {
 			if (!editorRef.current) return;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1593,25 +1593,63 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 
 	// Pre-populate the RTE search dialog with the global search query (WCAG SC 3.3.7)
 	// Search-entry pre-population is currently only done in the Markdown editor.
+	const globalSearchTermRef = useRef<string>('');
+
+	useEffect(() => {
+		if (!props.searchMarkers) return;
+		const keywords = props.searchMarkers.keywords;
+		globalSearchTermRef.current = (keywords && keywords.length > 0)
+			? (keywords[0]?.value ?? '')
+			: '';
+	}, [props.searchMarkers]);
+
 	useEffect(() => {
 		if (!editor) return;
-		if (!props.searchMarkers) return;
 
-		const keywords = props.searchMarkers.keywords;
-		const searchTerm = (keywords && keywords.length > 0) ? (keywords[0]?.value ?? '') : '';
+		const onKeyDown = (e: KeyboardEvent) => {
+			const isCtrlF = (e.ctrlKey || e.metaKey) && e.key === 'f';
+			if (!isCtrlF) return;
 
-		if (!searchTerm) {
-			if (editor.plugins?.searchreplace) {
-				editor.plugins.searchreplace.done(false);
-			}
-			return;
-		}
+			const searchTerm = globalSearchTermRef.current;
+			if (!searchTerm) return;
 
-		if (editor.plugins?.searchreplace) {
-			editor.plugins.searchreplace.find(searchTerm, false, false, false);
-		}
-	}, [editor, props.searchMarkers, props.noteId]);
+			const maxAttempts = 20;
+			let attempts = 0;
 
+			const tryFill = () => {
+				const input = document.querySelector<HTMLInputElement>(
+					'.tox-textfield[placeholder="Find"]',
+				);
+
+				if (!input) {
+					attempts++;
+					if (attempts < maxAttempts) {
+						shim.setTimeout(tryFill, 50);
+					}
+					return;
+				}
+				shim.setTimeout(() => {
+					const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+						window.HTMLInputElement.prototype, 'value',
+					)?.set;
+					nativeInputValueSetter?.call(input, searchTerm);
+					input.dispatchEvent(new Event('input', { bubbles: true }));
+					input.dispatchEvent(new Event('change', { bubbles: true }));
+					focus('TinyMCE::searchDialog', input);
+				}, 50);
+			};
+
+			shim.setTimeout(tryFill, 50);
+		};
+
+		document.addEventListener('keydown', onKeyDown);
+		editor.getDoc()?.addEventListener('keydown', onKeyDown);
+
+		return () => {
+			document.removeEventListener('keydown', onKeyDown);
+			editor.getDoc()?.removeEventListener('keydown', onKeyDown);
+		};
+	}, [editor]);
 
 	useEffect(() => {
 		return () => {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1610,7 +1610,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 		if (editor.plugins?.searchreplace) {
 			editor.plugins.searchreplace.find(searchTerm, false, false, false);
 		}
-	}, [editor, props.searchMarkers]);
+	}, [editor, props.searchMarkers, props.noteId]);
 
 
 	useEffect(() => {


### PR DESCRIPTION
## Summary

When a user performs a global search in Joplin and then opens the 
Find/Replace dialog in the Rich Text Editor (Ctrl+F), the search 
dialog would open empty. This is inconsistent with the Markdown 
editor, which already pre-populates the local search with the 
global search term.

This PR fixes that by pre-populating the RTE's built-in 
`searchreplace` plugin with the current global search query 
whenever `props.searchMarkers` changes.

## WCAG Reference

Fixes part of #10795 — SC 3.3.7 Redundant Entry (Level A):
> Pre-populate the Rich Text editor search dialog with the global 
> search content. Search-entry pre-population is currently only 
> done in the Markdown editor.

## What changed
Added two useEffect hooks in TinyMCE.tsx:

1.)The first passively stores the current global search term in a ref whenever props.searchMarkers changes — this never opens or interacts with the dialog

2.)The second listens for keydown Ctrl+F on both document and the editor's iframe document, then polls for the Find input (.tox-textfield[placeholder="Find"]) every 50ms once Ctrl+F is detected, and once found waits one additional tick to ensure TinyMCE has fully finished its own dialog initialization before injecting the global search term

How to test-

1.Create a note with some text (e.g. "testing")
2.Type that word in the global search bar
3.Click on the matching note to open it
4.Switch to Rich Text Editor (click the toggle editors button in the toolbar)
5.Press Ctrl+F to open the Find and Replace dialog

**Before:** Search dialog opens empty  
**After:** Search dialog opens with the global search term 
      pre-filled and matches highlighted