### PR TITLE
fix: show correct notebook context menu options when server is offline

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -24,6 +24,7 @@ import ExternalEditWatcher from '@joplin/lib/services/ExternalEditWatcher';
 import appReducer, { createAppDefaultState } from './app.reducer';
 import Folder from '@joplin/lib/models/Folder';
 import Tag from '@joplin/lib/models/Tag';
+import BaseItem from '@joplin/lib/models/BaseItem';
 import { reg } from '@joplin/lib/registry';
 const packageInfo: PackageInfo = require('./packageInfo.js');
 import DecryptionWorker from '@joplin/lib/services/DecryptionWorker';
@@ -500,6 +501,12 @@ class Application extends BaseApplication {
 
 			this.initRedux();
 
+			if (BaseItem.syncShareCache) {
+				this.dispatch({
+					type: 'SHARE_STATE_SET',
+					...BaseItem.syncShareCache,
+				});
+			}
 			initializeCommandService(this.store(), Setting.value('env') === 'dev');
 
 			const keymapService = KeymapService.instance();

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -270,6 +270,12 @@ const buildStartupTasks = (
 
 		BaseItem.syncShareCache = parseShareCache(Setting.value('sync.shareCache'));
 
+		if (BaseItem.syncShareCache) {
+			dispatch({
+				type: 'SHARE_STATE_SET',
+				...BaseItem.syncShareCache,
+			});
+		}
 		if (Setting.value('firstStart')) {
 			const detectedLocale = shim.detectAndSetLocale(Setting);
 			reg.logger().info(`First start: detected locale as ${detectedLocale}`);

--- a/packages/lib/services/share/reducer.ts
+++ b/packages/lib/services/share/reducer.ts
@@ -108,6 +108,12 @@ const reducer = (draftRoot: Draft<RootState>, action: any) => {
 	try {
 		switch (action.type) {
 
+		case 'SHARE_STATE_SET':
+			draft.shares = action.shares || [];
+			draft.shareUsers = action.shareUsers || {};
+			draft.shareInvitations = action.shareInvitations || [];
+			break;
+
 		case 'SHARE_SET':
 
 			draft.shares = action.shares;


### PR DESCRIPTION
## Problem
When a user owns a shared notebook and the Joplin Server is unreachable,the right-click context menu incorrectly shows "Leave notebook..." even though the current user is the owner. Owners should never see this option.

This is because the shareService redux starts completely empty on boot and as the server is offline it cannot populate state.shareService.shares and this causes `isSharedFolderOwner()` to return false. Because of this the menu behave as if the current user is a guest rather than the owner.

The cache is stored but not dispatched to the Redux store

## Solution

Added a new reducer action `SHARE_STATE_SET` that seeds `state.shareService`  with the cached shares immediately after the Redux store is initialized, before any sync attempt. This is done in both the desktop (`app.ts`) and mobile (`buildStartupTasks.ts`) boot paths.

This is a low risk change — it only affects the initial state of the share service and does not touch any sync or sharing logic.

## Test Plan

1. Configure Joplin Desktop to sync with Joplin Server
2. Share a notebook with another user and sync
3. Quit Joplin Desktop and stop the server
4. Reopen Joplin Desktop and right-click the shared notebook
5. Confirm "Leave notebook..." is gone and "Share notebook..." is visible


##Demo
https://github.com/user-attachments/assets/a18c292b-6844-4d82-917f-4b9c2d793bac

Fixes #12994
