### PR TITLE
fix(desktop):14940: added correct selectedIds restoration for tag navig

### DIFF
--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -791,7 +791,7 @@ const getContextFromHistory = (ctx: any) => {
 		result.selectedFolderIds = [result.selectedFolderId];
 	} else if (result.notesParentType === 'Tag') {
 		result.selectedTagId = ctx.selectedTagId;
-		result.selectedTagIds = [result.selectedTagIds];
+		result.selectedTagIds = result.selectedTagId ? [result.selectedTagId] : [];
 	} else if (result.notesParentType === 'Search') {
 		result.selectedSearchId = ctx.selectedSearchId;
 		result.searches = ctx.searches;


### PR DESCRIPTION
Issue:Incorrect assignment of selectedTagIds in getContextFromHistory #14940

Fixed incorrect assignment of selectedTagIds in history restoration.

Before:
result.selectedTagIds = [result.selectedTagIds];

This produced [undefined] or nested arrays, breaking tag selection when navigating back/forward.

After:
result.selectedTagIds = result.selectedTagId ? [result.selectedTagId] : [];

Matches folder handling and restores correct tag state.