### PR TITLE
Desktop: Fixes #14940: Restore correct selectedTagIds during tag navigation

### DIFF
--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -791,7 +791,7 @@ const getContextFromHistory = (ctx: any) => {
 		result.selectedFolderIds = [result.selectedFolderId];
 	} else if (result.notesParentType === 'Tag') {
 		result.selectedTagId = ctx.selectedTagId;
-		result.selectedTagIds = [result.selectedTagIds];
+		result.selectedTagIds = result.selectedTagId ? [result.selectedTagId] : [];
 	} else if (result.notesParentType === 'Search') {
 		result.selectedSearchId = ctx.selectedSearchId;
 		result.searches = ctx.searches;


### PR DESCRIPTION
Problem

When navigating back or forward to a tag view, the selected tag state is not restored correctly.

Observed behavior:
- The tag is not properly selected in the sidebar
- The notes list may not reflect the selected tag
- Internally, `selectedTagIds` becomes `[undefined]`

This leads to inconsistent UI state after navigation.

Root Cause

In `getContextFromHistory`, `selectedTagIds` is incorrectly assigned:

result.selectedTagIds = [result.selectedTagIds];

This wraps an already incorrect or undefined value, producing `[undefined]` or nested arrays.

Solution

Use `selectedTagId` as the source of truth and align behavior with folder restoration logic:

result.selectedTagIds = result.selectedTagId ? [result.selectedTagId] : [];

This ensures that the selected tag is restored correctly after navigation.

Test Plan

1. Create a note and assign a tag
2. Open the tag view
3. Navigate to another folder or note
4. Use back navigation (Alt + Left Arrow)
5. Verify:
   - The correct tag is selected
   - Notes under the tag are displayed
   - No inconsistent state or empty view occurs