### PR TITLE
Mobile: Fixes #11122: Tag's note list fails to update after removing the tag from a note

### DIFF
--- a/packages/lib/models/Tag.ts
+++ b/packages/lib/models/Tag.ts
@@ -114,6 +114,7 @@ export default class Tag extends BaseItem {
 		this.dispatch({
 			type: 'NOTE_TAG_REMOVE',
 			item: tag,
+			noteId: noteId,
 		});
 	}
 

--- a/packages/lib/reducer.test.ts
+++ b/packages/lib/reducer.test.ts
@@ -391,6 +391,26 @@ describe('reducer', () => {
 		expect(state.selectedTagId).toEqual(expected.selectedIds[0]);
 	}));
 
+	it('should remove note from list when tag is removed', (async () => {
+		const folders = await createNTestFolders(1);
+		const notes = await createNTestNotes(3, folders[0]);
+		const tags = await createNTestTags(1);
+
+		// Current view is the tag we're about to remove from a note
+		let state = initTestState(folders, 0, notes, [0], tags, 0);
+
+		expect(state.notes.length).toBe(3);
+		expect(state.notesParentType).toBe('Tag');
+		expect(state.selectedTagId).toBe(tags[0].id);
+
+		// Remove tag from the first note
+		state = reducer(state, { type: 'NOTE_TAG_REMOVE', item: tags[0], noteId: notes[0].id });
+
+		// Expect the note to be removed from state.notes
+		expect(state.notes.length).toBe(2);
+		expect(state.notes.map(n => n.id)).not.toContain(notes[0].id);
+	}));
+
 	it.each([false, true])('should select multiple folders (extend:%j)', async (extendSelection) => {
 		const folders = await createNTestFolders(3);
 		let state = initTestState(folders, 0, [], []);

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -1356,8 +1356,13 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 			{
 				updateOneItem(draft, action, 'tags');
 				const tagRemoved = action.item;
+				const noteId = action.noteId;
 				for (const windowStateDraft of stateUtils.allWindowStates(draft)) {
 					windowStateDraft.selectedNoteTags = removeItemFromArray(windowStateDraft.selectedNoteTags, 'id', tagRemoved.id);
+
+					if (windowStateDraft.notesParentType === 'Tag' && windowStateDraft.selectedTagId === tagRemoved.id) {
+						windowStateDraft.notes = windowStateDraft.notes.filter(note => note.id !== noteId);
+					}
 				}
 			}
 			break;


### PR DESCRIPTION
This PR fixes the bug where a note remains visible in a tag's note list after the tag has been removed from that note on mobile.

## Problem

When browsing notes under a tag and removing that tag from one of the notes, the note continues to appear in the list until the user navigates away and back. The list should update immediately upon returning from the tag editor.

This was reported in [#11122](https://github.com/laurent22/joplin/issues/11122).

## Investigation

Tracing the tag removal flow revealed the missing link:

When a tag is removed, `Tag.removeNote` correctly deletes the record from the `note_tags` table and dispatches a `NOTE_TAG_REMOVE` Redux action. However, the action payload only carried the tag itself — not the `noteId` of the note it was removed from.

As a result, the Redux reducer updated `draft.tags` and `selectedNoteTags` as expected, but had no way to filter `draft.notes` — the list of notes shown when user navigates back. 

## Solution

After reviewing the data flow through `TagEditor.tsx` → `NoteTagsDialog.tsx` → `Tag.setNoteTagsByTitles` → `Tag.removeNote` → Redux, the fix was applied in two places:

1. `Tag.removeNote` now includes `noteId` in the `NOTE_TAG_REMOVE` dispatch payload.
2. The `NOTE_TAG_REMOVE` case in `reducer.ts` now filters `draft.notes` when the current selected folder/tag matches the removed tag.

## Changes Made

* `Tag.ts`: Pass `noteId` in the `NOTE_TAG_REMOVE` dispatch inside `removeNote`
* `reducer.ts`: In the `NOTE_TAG_REMOVE` case, filter `draft.notes` to remove the note that had its tag unlinked, if the active view is the affected tag
* `reducer.test.js`: Added a test case verifying that a note is removed from `state.notes` when `NOTE_TAG_REMOVE` is dispatched with a matching `noteId` while the active view is that tag
## Testing

### Automated Tests

* Added a new test case to `reducer.test.js` verifying that a note is removed from `state.notes` when `NOTE_TAG_REMOVE` is dispatched with a matching `noteId` while the active view is that tag
* Ran `yarn test models/Tag.test.js reducer.test.js` — all tests pass ✅

### Manual Testing Steps

1. **Create a tag** with 3 or more notes assigned to it
2. **Open the tag** from the sidebar — verify all notes appear
3. **Open one of the notes**, go to its tag editor, and **remove the tag**
4. **Go back to the tag's note list**
5. ✅ Verify: The note no longer appears in the list
6. **Repeat for all remaining notes**
7. ✅ Verify: The list correctly empties out as tags are removed

### Related Functionality Verification

* Adding tags to notes still works as expected
* Switching between tags reflects correct note lists
* Redux `selectedNoteTags` still updates correctly alongside `draft.notes`
* Notes not under the active tag are unaffected

## Benefits

* ✅ Tag note list updates correctly without requiring navigation away and back
* ✅ No additional network or database calls — fix is purely in the Redux layer

## Screenshots/Videos


https://github.com/user-attachments/assets/f643f7c7-6452-4c7a-92c1-4683356bf921


## Related Issue

Fixes [#11122](https://github.com/laurent22/joplin/issues/11122)