### PR TITLE
Desktop: Resolves #10933: Prevent generated index.ts files from being rewritten on Windows

### DIFF
--- a/packages/tools/gulp/utils.js
+++ b/packages/tools/gulp/utils.js
@@ -187,18 +187,33 @@ utils.setPackagePrivateField = async function(filePath, value) {
 
 utils.insertContentIntoFile = async (filePath, marker, contentToInsert, createIfNotExist = false) => {
 	const fs = require('fs-extra');
+
+	const normalizeEol = content => {
+		return content.replace(/\r\n/g, '\n');
+	};
+
 	const fileExists = await fs.pathExists(filePath);
+	const insertedBlock = `${marker}\n${contentToInsert}\n${marker}`;
 
 	if (!fileExists) {
 		if (!createIfNotExist) throw new Error(`File not found: ${filePath}`);
-		await fs.writeFile(filePath, `${marker}\n${contentToInsert}\n${marker}`);
-	} else {
-		let content = await fs.readFile(filePath, 'utf-8');
-		// [^]* matches any character including new lines
-		const regex = new RegExp(`${marker}[^]*?${marker}`);
-		content = content.replace(regex, `${marker}\n${contentToInsert}\n${marker}`);
-		await fs.writeFile(filePath, content);
+
+		const newContent = normalizeEol(`${insertedBlock}\n`);
+		await fs.writeFile(filePath, newContent, 'utf8');
+		return;
 	}
+
+	const existingContent = await fs.readFile(filePath, 'utf8');
+
+	const regex = new RegExp(`${marker}[^]*?${marker}`);
+	const replacedContent = existingContent.replace(regex, insertedBlock);
+
+	const normalizedExistingContent = normalizeEol(existingContent).replace(/\n?$/, '\n');
+	const normalizedNewContent = normalizeEol(replacedContent).replace(/\n?$/, '\n');
+
+	if (normalizedExistingContent === normalizedNewContent) return;
+
+	await fs.writeFile(filePath, normalizedNewContent, 'utf8');
 };
 
 utils.getFilename = (path) => {


### PR DESCRIPTION
**Problem**
On Windows, running:

corepack yarn postinstall

It can leave the working tree dirty by rewriting generated index.ts files, even when their logical content has not changed.

The issue is caused by generated content being written back without normalizing line endings and without checking whether the final content is actually different.

**Solution:**
This PR updates insertContentIntoFile in packages/tools/gulp/utils.js to:

normalize line endings before comparing content
avoid rewriting files when the normalized content is unchanged
write normalized content using UTF-8

This fixes the generated index.ts files used by buildScriptIndexes, so they are no longer rewritten unnecessarily on Windows.

**Test Plan**

Tested on Windows.

1. Start from a clean checkout.

2. Run: corepack yarn postinstall

3. Run: git status

4. Verify that generated index.ts files such as these are no longer marked as modified:
packages/app-desktop/commands/index.ts
packages/app-desktop/gui/NoteEditor/commands/index.ts
packages/app-mobile/commands/index.ts
packages/lib/commands/index.ts
packages/lib/services/database/migrations/index.ts

AI disclosure

I used ChatGPT to help draft parts of this PR description and to reason about the likely source of the issue. I reviewed and validated the final code changes and test results manually.

<img width="1916" height="1138" alt="Screenshot 2026-03-29 181605" src="https://github.com/user-attachments/assets/9bf22178-e15f-41dc-842a-6ec11295e4b7" />
<img width="1919" height="1142" alt="Screenshot 2026-03-29 181652" src="https://github.com/user-attachments/assets/b3ee8d1b-bd50-4776-a393-620ed6653d7c" />

