### PR TITLE
Desktop: Fixes #14946: Auto-generated note title retains inline markdown due to incomplete filtering

### DIFF
--- a/packages/lib/markdownUtils.ts
+++ b/packages/lib/markdownUtils.ts
@@ -236,7 +236,7 @@ const markdownUtils = {
 		}
 
 		title = title.replace(/<\/?(ins|del|mark|sub|sup)>/g, ' ');
-		title = title.replace(/!?\[([^\]]*)\]\(([^)]*)\)/g, (_match, text, url) => {
+		title = title.replace(/!?\[([^\]]*)\]\((.+?)\)/g, (_match, text, url) => {
 			return text || url;
 		});
 		const formattingPatterns = [
@@ -256,8 +256,8 @@ const markdownUtils = {
 			}
 		} while (title !== prev);
 
+		title = title.replace(/^(\s*([-*+]|\d+[.)])\s+(\[[ xX]\]\s+)?)/, '');
 		title = title.replace(/^(~{2,}|={2,})$/, '');
-		title = title.replace(/[*_=`^]+/g, '');
 		title = title.replace(/^[#>\-*`\s=]+/, '');
 		title = title.replace(/[#>\-*`\s=]+$/, '');
 		title = title.trim();

--- a/packages/lib/markdownUtils.ts
+++ b/packages/lib/markdownUtils.ts
@@ -224,17 +224,45 @@ const markdownUtils = {
 		if (!body) return '';
 		const spaceEntities = /&nbsp;/g;
 		body = body.replace(spaceEntities, ' ');
-		const lines = body.trim().split('\n');
-		const title = lines[0].trim();
+		const lines = body.split('\n');
+		let title = '';
 
-		const mdLinkRegex = /!?\[([^\]]+?)\]\(.+?\)/g;
-		const emptyMdLinkRegex = /!?\[\]\((.+?)\)/g;
-		const filterRegex = /^[#\s\n\t*`_\-~]+|[*_~`]+$/g;
-		return title
-			.replace(filterRegex, '')
-			.replace(mdLinkRegex, '$1')
-			.replace(emptyMdLinkRegex, '$1')
-			.substring(0, 80);
+		for (const line of lines) {
+			const trimmed = line.trim();
+			if (trimmed) {
+				title = trimmed;
+				break;
+			}
+		}
+
+		title = title.replace(/<\/?(ins|del|mark|sub|sup)>/g, ' ');
+		title = title.replace(/!?\[([^\]]*)\]\(([^\)]*)\)/g, (_match, text, url) => {
+			return text || url;
+		});
+		
+		const formattingPatterns = [
+			/(\*\*\*|___)(.*?)\1/g,
+			/(\*\*|__)(.*?)\1/g,
+			/(\*|_)(.*?)\1/g,
+			/(~~)(.*?)\1/g,
+			/(==)(.*?)\1/g,
+			/(\^)(.*?)\1/g,
+		];
+
+		let prev;
+		do {
+			prev = title;
+			for (const pattern of formattingPatterns) {
+				title = title.replace(pattern, '$2');
+			}
+		} while (title !== prev);
+
+		title = title.replace(/^(~{2,}|={2,})$/, '');
+		title = title.replace(/[*_=`^]+/g, '');
+		title = title.replace(/^[#>\-*`\s=]+/, '');
+		title = title.replace(/[#>\-*`\s=]+$/, '');
+		title = title.trim();
+		return title.substring(0, 80);
 	},
 };
 

--- a/packages/lib/markdownUtils.ts
+++ b/packages/lib/markdownUtils.ts
@@ -229,7 +229,7 @@ const markdownUtils = {
 
 		const mdLinkRegex = /!?\[([^\]]+?)\]\(.+?\)/g;
 		const emptyMdLinkRegex = /!?\[\]\((.+?)\)/g;
-		const filterRegex = /^[# \n\t*`-]*/;
+		const filterRegex = /^[#\s\n\t*`_\-~]+|[*_~`]+$/g;
 		return title
 			.replace(filterRegex, '')
 			.replace(mdLinkRegex, '$1')

--- a/packages/lib/markdownUtils.ts
+++ b/packages/lib/markdownUtils.ts
@@ -239,7 +239,6 @@ const markdownUtils = {
 		title = title.replace(/!?\[([^\]]*)\]\(([^)]*)\)/g, (_match, text, url) => {
 			return text || url;
 		});
-		
 		const formattingPatterns = [
 			/(\*\*\*|___)(.*?)\1/g,
 			/(\*\*|__)(.*?)\1/g,

--- a/packages/lib/markdownUtils.ts
+++ b/packages/lib/markdownUtils.ts
@@ -235,8 +235,8 @@ const markdownUtils = {
 			}
 		}
 
-		title = title.replace(/<\/?(ins|del|mark|sub|sup)>/g, ' ');
-		title = title.replace(/!?\[([^\]]*)\]\((.+?)\)/g, (_match, text, url) => {
+		title = title.replace(/<\/?(ins|del|mark|sub|sup)>/g, '');
+		title = title.replace(/!?\[([^\]]*)\]\(([^()\n]+(?:\([^()\n]*\)[^()\n]*)*)\)/g, (_match, text, url) => {
 			return text || url;
 		});
 		const formattingPatterns = [
@@ -256,7 +256,7 @@ const markdownUtils = {
 			}
 		} while (title !== prev);
 
-		title = title.replace(/^(\s*([-*+]|\d+[.)])\s+(\[[ xX]\]\s+)?)/, '');
+		title = title.replace(/^\s*([-*+]|\d+[.)])\s+(\[[ xX]\]\s+)?/, '');
 		title = title.replace(/^(~{2,}|={2,})$/, '');
 		title = title.replace(/^[#>\-*`\s=]+/, '');
 		title = title.replace(/[#>\-*`\s=]+$/, '');

--- a/packages/lib/markdownUtils.ts
+++ b/packages/lib/markdownUtils.ts
@@ -236,7 +236,7 @@ const markdownUtils = {
 		}
 
 		title = title.replace(/<\/?(ins|del|mark|sub|sup)>/g, ' ');
-		title = title.replace(/!?\[([^\]]*)\]\(([^\)]*)\)/g, (_match, text, url) => {
+		title = title.replace(/!?\[([^\]]*)\]\(([^)]*)\)/g, (_match, text, url) => {
 			return text || url;
 		});
 		

--- a/packages/lib/markdownUtils2.test.ts
+++ b/packages/lib/markdownUtils2.test.ts
@@ -115,6 +115,15 @@ describe('markdownUtils', () => {
 		['These are [link1](one), [link2](two) and ![link3](three)', 'These are link1, link2 and link3'],
 		['No description link to [](https://joplinapp.org)', 'No description link to https://joplinapp.org'],
 		['&nbsp;\n\nThis is a test &nbsp; test.', 'This is a test   test.'],
+		['***Example title***', 'Example title'],
+		['==~~Formatted title~~==', 'Formatted title'],
+		['<ins>Important note title</ins>', 'Important note title'],
+		['`Inline code title`', 'Inline code title'],
+		['<ins>~~==***Deeply formatted title***==~~</ins>', 'Deeply formatted title'],
+		['C++ <vector> usage guide', 'C++ <vector> usage guide'],
+		['C# programming basics', 'C# programming basics'],
+		['Understanding a ~ b relationship', 'Understanding a ~ b relationship'],
+		['***~~***', ''],
 	])('should create a default note title from the note body (%j -> %j)', (body, expectedTitle) => {
 		expect(markdownUtils.titleFromBody(body)).toBe(expectedTitle);
 	});


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/14946

Problem

Auto-generated note titles may include markdown formatting characters when derived from the first line of the note body.


Ex:
Input:
hi

Generated title:
hi**

Expected title:
hi


Root Cause

In `markdownUtils.titleFromBody`, the existing regex:

only removes leading markdown characters it does not handle trailing formatting symbols


Solution

Update the existing `filterRegex` to handle both leading and trailing markdown symbols


Before:
<img width="2559" height="1565" alt="Screenshot 2026-03-29 183639" src="https://github.com/user-attachments/assets/a5b3a595-732b-410f-a420-fb631c0ed0e4" />


After:
<img width="2556" height="1566" alt="Screenshot 2026-03-29 190346" src="https://github.com/user-attachments/assets/e666a49e-33d3-4c26-b7df-459149a6c8df" />


