### PR TITLE
Chore: Mobile: Fixes #14835: Silence deprecated SafeAreaView warning in tests

### DIFF
--- a/packages/app-mobile/jest.setup.js
+++ b/packages/app-mobile/jest.setup.js
@@ -14,6 +14,19 @@ const sqlite3 = require('sqlite3');
 const React = require('react');
 require('../../jest.base-setup.js')();
 
+// Silence the SafeAreaView deprecation warning emitted by
+// react-native-popup-menu 0.17.0 during test runs. Uses require('console')
+// rather than the global console because Jest replaces the global with its
+// own wrapper — the real Node.js console is what warnOnce.js writes to.
+const nodeConsole = require('console');
+const originalWarn = nodeConsole.warn;
+nodeConsole.warn = (...args) => {
+	if (typeof args[0] === 'string' && args[0].includes('SafeAreaView has been deprecated')) {
+		return;
+	}
+	originalWarn.apply(nodeConsole, args);
+};
+
 import { setImmediate } from 'timers';
 
 // Required by some libraries (setImmediate is not supported in most browsers,


### PR DESCRIPTION
## AI Assistance Disclosure

AI (Claude) was used to assist with:

- Drafting the initial `console.warn` filter code
- Grammar check the wording and phrases used in drafting PR message
- Reviewing adherence to Joplin coding style

All code was reviewed, understood, and manually verified by this contributor.

## Problem

The `packages/app-mobile` test suite logs repeated `SafeAreaView has been deprecated` warnings during CI runs. The warnings originate from `react-native-popup-menu@0.17.0`, which uses the deprecated `<SafeAreaView>` from React Native core. This creates noise in CI output and obscures actual test failures.

## Solution

Added a targeted `console.warn` filter in `jest.setup.js` that suppresses warnings containing `"SafeAreaView has been deprecated"`. All other warnings pass through unaffected.

This follows maintainers' suggestion to silence the warnings rather than upgrading the package, which would require migrating the existing accessibility patch and risks layout regressions.

The change is minimal as only 13 lines in a single test setup file. No dependency changes, no production code affected.

A thing to note: `require('console')` is used intentionally rather than the global `console` because Jest replaces the global with its own wrapper, while React Native's `warnOnce.js` writes to the real Node.js console.

## Test Plan

```bash
cd packages/app-mobile
yarn jest --no-coverage --forceExit
```

- All 37 suites pass, 163 tests pass
- Zero `SafeAreaView has been deprecated` warnings in output
- Other warnings (e.g. `act(...)`) still appear normally

<img width="1899" height="1091" alt="Screenshot 2026-03-29 201957" src="https://github.com/user-attachments/assets/cf002e9d-9c12-485e-a779-f2069d51b7a0" />


Also ran the specific test from the issue (`Note.test.tsx`) in isolation to confirm:

```bash
yarn jest --no-coverage --testPathPattern="Note\.test"
```
<img width="1903" height="1060" alt="Screenshot 2026-03-29 202206" src="https://github.com/user-attachments/assets/44d31835-4e68-44e3-aa44-fba06540a8b4" />


- 2 suites pass, 21 tests pass, no SafeAreaView warnings