### PR TITLE
Fix disabled desktop button interaction styles issue #14934

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -195,6 +195,7 @@ packages/app-desktop/commands/switchProfile3.js
 packages/app-desktop/commands/toggleExternalEditing.js
 packages/app-desktop/commands/toggleSafeMode.js
 packages/app-desktop/commands/toggleTabMovesFocus.js
+packages/app-desktop/gui/Button/Button.test.js
 packages/app-desktop/gui/Button/Button.js
 packages/app-desktop/gui/ClipperConfigScreen.js
 packages/app-desktop/gui/ConfigScreen/ButtonBar.js

--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,7 @@ packages/app-desktop/commands/switchProfile3.js
 packages/app-desktop/commands/toggleExternalEditing.js
 packages/app-desktop/commands/toggleSafeMode.js
 packages/app-desktop/commands/toggleTabMovesFocus.js
+packages/app-desktop/gui/Button/Button.test.js
 packages/app-desktop/gui/Button/Button.js
 packages/app-desktop/gui/ClipperConfigScreen.js
 packages/app-desktop/gui/ConfigScreen/ButtonBar.js

--- a/packages/app-desktop/gui/Button/Button.test.tsx
+++ b/packages/app-desktop/gui/Button/Button.test.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { renderToString } from 'react-dom/server';
+import Button, { ButtonLevel } from './Button';
+
+const { ServerStyleSheet, ThemeProvider } = require('styled-components');
+
+const theme = {
+	toolbarIconSize: 16,
+	backgroundColor3: '#111111',
+	backgroundColor4: '#222222',
+	backgroundColor5: '#333333',
+	backgroundColorHover4: '#444444',
+	backgroundColorHover5: '#555555',
+	backgroundColorHoverDim3: '#666666',
+	backgroundColorActive3: '#777777',
+	backgroundColorActive4: '#888888',
+	backgroundColorActive5: '#999999',
+	borderColor4: '#aaaaaa',
+	color: '#bbbbbb',
+	color2: '#cccccc',
+	color3: '#dddddd',
+	color4: '#eeeeee',
+	color5: '#ffffff',
+	colorHover2: '#121212',
+	colorActive2: '#232323',
+};
+
+describe('Button styles', () => {
+	it('limits hover and active states to enabled buttons', () => {
+		const sheet = new ServerStyleSheet();
+
+		renderToString(sheet.collectStyles(
+			<ThemeProvider theme={theme}>
+				<div>
+					<Button level={ButtonLevel.Primary} title='Primary' />
+					<Button level={ButtonLevel.Secondary} title='Secondary' />
+					<Button level={ButtonLevel.Tertiary} title='Tertiary' />
+					<Button level={ButtonLevel.SidebarSecondary} title='Sidebar secondary' />
+				</div>
+			</ThemeProvider>,
+		));
+
+		const styles = sheet.getStyleTags();
+		const enabledHoverMatches = styles.match(/:enabled:hover/g) ?? [];
+		const enabledActiveMatches = styles.match(/:enabled:active/g) ?? [];
+
+		expect(enabledHoverMatches).toHaveLength(4);
+		expect(enabledActiveMatches).toHaveLength(4);
+		expect(styles).not.toContain('true{');
+		expect(styles).not.toContain('false{');
+	});
+});

--- a/packages/app-desktop/gui/Button/Button.tsx
+++ b/packages/app-desktop/gui/Button/Button.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 const styled = require('styled-components').default;
+const { css } = require('styled-components');
 const { space } = require('styled-system');
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied;
@@ -77,19 +78,27 @@ const StyledIcon = styled(styled.span(space))`
 	${(props: StyleProps) => props.animation ? `animation: ${props.animation}` : ''};
 `;
 
+const interactiveStates = (hoverStyles: string, activeStyles: string) => css`
+	&:enabled:hover {
+		${hoverStyles}
+	}
+
+	&:enabled:active {
+		${activeStyles}
+	}
+`;
+
 const StyledButtonPrimary = styled(StyledButtonBase)`
 	border: none;
 	background-color: ${(props: StyleProps) => props.theme.backgroundColor5};
 
-	${(props: StyleProps) => props.disabled} {
-		&:hover {
-			background-color: ${(props: StyleProps) => props.theme.backgroundColorHover5};
-		}
+	${interactiveStates(
+		'background-color: var(--button-hover-background-color);',
+		'background-color: var(--button-active-background-color);',
+	)}
 
-		&:active {
-			background-color: ${(props: StyleProps) => props.theme.backgroundColorActive5};
-		}
-	}
+	--button-hover-background-color: ${(props: StyleProps) => props.theme.backgroundColorHover5};
+	--button-active-background-color: ${(props: StyleProps) => props.theme.backgroundColorActive5};
 
 	${StyledIcon} {
 		color: ${(props: StyleProps) => props.theme.color5};
@@ -104,15 +113,13 @@ const StyledButtonSecondary = styled(StyledButtonBase)`
 	border: 1px solid ${(props: StyleProps) => props.theme.borderColor4};
 	background-color: ${(props: StyleProps) => props.theme.backgroundColor4};
 
-	${(props: StyleProps) => props.disabled} {
-		&:hover {
-			background-color: ${(props: StyleProps) => props.theme.backgroundColorHover4};
-		}
+	${interactiveStates(
+		'background-color: var(--button-hover-background-color);',
+		'background-color: var(--button-active-background-color);',
+	)}
 
-		&:active {
-			background-color: ${(props: StyleProps) => props.theme.backgroundColorActive4};
-		}
-	}
+	--button-hover-background-color: ${(props: StyleProps) => props.theme.backgroundColorHover4};
+	--button-active-background-color: ${(props: StyleProps) => props.theme.backgroundColorActive4};
 
 	${StyledIcon} {
 		color: ${(props: StyleProps) => props.theme.color4};
@@ -127,13 +134,13 @@ const StyledButtonTertiary = styled(StyledButtonBase)`
 	border: 1px solid ${(props: StyleProps) => props.theme.color3};
 	background-color: ${(props: StyleProps) => props.theme.backgroundColor3};
 
-	&:hover {
-		background-color: ${(props: StyleProps) => props.theme.backgroundColorHoverDim3};
-	}
+	${interactiveStates(
+		'background-color: var(--button-hover-background-color);',
+		'background-color: var(--button-active-background-color);',
+	)}
 
-	&:active {
-		background-color: ${(props: StyleProps) => props.theme.backgroundColorActive3};
-	}
+	--button-hover-background-color: ${(props: StyleProps) => props.theme.backgroundColorHoverDim3};
+	--button-active-background-color: ${(props: StyleProps) => props.theme.backgroundColorActive3};
 
 	${StyledIcon} {
 		color: ${(props: StyleProps) => props.theme.color};
@@ -164,7 +171,7 @@ const StyledButtonSidebarSecondary = styled(StyledButtonBase)`
 	border-color: ${(props: StyleProps) => props.theme.color2};
 	color: ${(props: StyleProps) => props.theme.color2};
 
-	&:hover {
+	&:enabled:hover {
 		color: ${(props: StyleProps) => props.theme.colorHover2};
 		border-color: ${(props: StyleProps) => props.theme.colorHover2};
 		background: none;
@@ -178,7 +185,7 @@ const StyledButtonSidebarSecondary = styled(StyledButtonBase)`
 		}
 	}
 
-	&:active {
+	&:enabled:active {
 		color: ${(props: StyleProps) => props.theme.colorActive2};
 		border-color: ${(props: StyleProps) => props.theme.colorActive2};
 		background: none;


### PR DESCRIPTION
## Problem

Disabled desktop buttons were still picking up hover and active styling in some variants, while primary and secondary buttons were not applying their interactive feedback consistently. This made button behaviour feel uneven across the desktop UI and caused disabled buttons to still look interactive in places like settings and sidebar-related actions.

From a user perspective, this is confusing because disabled controls should appear non-interactive, and enabled controls should respond consistently to hover and click states.

## Solution

This change updates the shared desktop button styles so interactive states are only applied when a button is enabled.

At a high level:
- primary and secondary button variants now use explicit enabled-only hover and active selectors
- tertiary and sidebar-secondary variants no longer apply hover or active styles when disabled
- a focused regression test was added around the shared button component styling so this behaviour stays consistent across variants

This is a low-risk change because it is scoped to the desktop shared button component and only affects how interaction states are styled.

## Test Plan

Verified with:
- `yarn workspace @joplin/app-desktop tsc --noEmit`

Added a regression test in:
- `packages/app-desktop/gui/Button/Button.test.tsx`

Manual review of the updated shared button styling confirms that:
- hover and active styles are gated behind enabled state
- disabled buttons no longer receive interactive styling
- button variants now behave consistently

Note:
- A focused Jest run was attempted for the new test, but the desktop test bootstrap currently fails before the test executes because of an existing module-resolution issue in `jest.setup.js` (`Cannot find module '@joplin/utils/Logger'`).
