### PR TITLE
Desktop: Fixes #14628: Fix renderer crashes still occuring due to incorrect merge

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -486,8 +486,31 @@ export default class ElectronAppWrapper {
 			// Match the main window's zoom:
 			window.webContents.setZoomFactor(this.mainWindow().webContents.getZoomFactor());
 
-			window.once('close', () => {
-				this.secondaryWindows_.delete(windowId);
+			window.once('close', (event) => {
+				// Check both: BrowserWindow and webContents can be destroyed independently
+				if (this.win_ && !this.win_.isDestroyed() && !this.win_.webContents.isDestroyed()) {
+					this.win_.webContents.send('secondary-window-closing', windowId);
+				}
+				if (this.secondaryWindows_.has(windowId)) {
+					this.secondaryWindows_.delete(windowId);
+
+					// Avoid closing a destroyed window. Closing a destroyed window results in the following error:
+					//   Error: Render frame was disposed before WebFrameMain could be accessed
+					const stillOpen = !window.isDestroyed();
+					if (stillOpen) {
+						event.preventDefault();
+
+						// As of March 2026, Electron crashes with "Assertion failed: (Environment::GetCurrent(isolate)) == (env)" if the native 'close'
+						// event is allowed to close a secondary window. As a workaround, briefly hide the window and .close() it later.
+						// See https://github.com/laurent22/joplin/issues/14628.
+						window.hide();
+						setTimeout(() => {
+							if (!window.isDestroyed()) {
+								window.close();
+							}
+						}, 100);
+					}
+				}
 
 				const allSecondaryWindowsClosed = this.secondaryWindows_.size === 0;
 				const mainWindowVisuallyClosed = this.mainWindowHidden_;

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -749,6 +749,9 @@ class Application extends BaseApplication {
 
 			ipcRenderer.on('main-window-focused', scheduleResumeSync);
 			ipcRenderer.on('system-resumed', scheduleResumeSync);
+			ipcRenderer.on('secondary-window-closing', (_event, windowId: string) => {
+				this.dispatch({ type: 'WINDOW_CLOSE', windowId });
+			});
 		});
 
 		addTask('app/initPluginService', () => this.initPluginService());


### PR DESCRIPTION
When conflicts were resolved in PR https://github.com/laurent22/joplin/pull/14849, the conflict resolution was done incorrectly, resulting is some of the original changes to be removed, and also removing the change in PR https://github.com/laurent22/joplin/pull/14892/changes

This PR re-instates all of the changes which were incorrectly removed.

### Testing

I have verified that for the 2 issues which each PR were previously verified to have fixed, both scenarios causing renderer crashes are now correctly fixed