### PR TITLE
Desktop: Fixes #14890: Disable Expand all notebooks button if no sub-notebooks exist

### DIFF
--- a/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
+++ b/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { AppState } from '../../app.reducer';
 import { FolderEntity, TagsWithNoteCountEntity } from '@joplin/lib/services/database/types';
 import areAllFoldersCollapsed from '@joplin/lib/models/utils/areAllFoldersCollapsed';
+import getCanBeCollapsedFolderIds from '@joplin/lib/models/utils/getCanBeCollapsedFolderIds';
 import { PluginStates } from '@joplin/lib/services/plugins/reducer';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
@@ -48,6 +49,10 @@ const FolderAndTagList: React.FC<Props> = props => {
 		return areAllFoldersCollapsed(props.folders, props.collapsedFolderIds);
 	}, [props.collapsedFolderIds, props.folders]);
 
+	const hasCollapsableFolders = useMemo(() => {
+		return getCanBeCollapsedFolderIds(props.folders).length > 0;
+	}, [props.folders]);
+
 	const listContainerRef = useRef<HTMLDivElement|null>(null);
 	const onRenderItem = useOnRenderItem({
 		...props,
@@ -76,7 +81,7 @@ const FolderAndTagList: React.FC<Props> = props => {
 	const listHeight = useElementHeight(itemListContainer);
 	const listStyle = useMemo(() => ({ height: listHeight }), [listHeight]);
 
-	const onRenderContentWrapper = useOnRenderListWrapper({ allFoldersCollapsed, selectedIndex, onKeyDown: onKeyEventHandler });
+	const onRenderContentWrapper = useOnRenderListWrapper({ allFoldersCollapsed, hasCollapsableFolders, selectedIndex, onKeyDown: onKeyEventHandler });
 
 	return (
 		<div

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx
@@ -7,6 +7,7 @@ interface Props {
 	selectedIndex: number;
 	onKeyDown: React.KeyboardEventHandler;
 	allFoldersCollapsed: boolean;
+	hasCollapsableFolders: boolean;
 }
 
 const onAddFolderButtonClick = () => {
@@ -19,6 +20,7 @@ const onToggleAllFolders = (allFoldersCollapsed: boolean) => {
 
 interface CollapseExpandAllButtonProps {
 	allFoldersCollapsed: boolean;
+	disabled: boolean;
 }
 
 const CollapseExpandAllButton = (props: CollapseExpandAllButtonProps) => {
@@ -26,8 +28,9 @@ const CollapseExpandAllButton = (props: CollapseExpandAllButtonProps) => {
 	// is not included in the portion of the list with role='tree'.
 	const icon = props.allFoldersCollapsed ? 'far fa-caret-square-right' : 'far fa-caret-square-down';
 	const label = props.allFoldersCollapsed ? _('Expand all notebooks') : _('Collapse all notebooks');
+	const className = `sidebar-header-button -collapseall${props.disabled ? ' disabled' : ''}`;
 
-	return <button onClick={() => onToggleAllFolders(props.allFoldersCollapsed)} className='sidebar-header-button -collapseall' title={label}>
+	return <button disabled={props.disabled} onClick={() => onToggleAllFolders(props.allFoldersCollapsed)} className={className} title={label}>
 		<i
 			aria-label={label}
 			role='img'
@@ -55,7 +58,7 @@ const useOnRenderListWrapper = (props: Props) => {
 		const listHasValidSelection = props.selectedIndex >= 0;
 		const allowContainerFocus = !listHasValidSelection;
 		return <>
-			<CollapseExpandAllButton allFoldersCollapsed={props.allFoldersCollapsed}/>
+			<CollapseExpandAllButton disabled={!props.hasCollapsableFolders} allFoldersCollapsed={props.allFoldersCollapsed}/>
 			<NewFolderButton/>
 			<div
 				role='tree'
@@ -66,7 +69,7 @@ const useOnRenderListWrapper = (props: Props) => {
 				{...listItems}
 			</div>
 		</>;
-	}, [props.selectedIndex, props.onKeyDown, props.allFoldersCollapsed]);
+	}, [props.selectedIndex, props.onKeyDown, props.allFoldersCollapsed, props.hasCollapsableFolders]);
 };
 
 export default useOnRenderListWrapper;


### PR DESCRIPTION
This PR fixes issue #14890. It disables the 'Expand all notebooks' button visually and functionally when there are no sub-notebooks available in the current profile (to avoid user confusion as reported in the issue) by passing down a disabled prop to the Expand component.