### PR TITLE
Desktop: Enable Copy and Select All in viewer and read-only modes

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.test.ts
@@ -6,6 +6,7 @@ const baseContext: Record<string, any> = {
 	modalDialogVisible: false,
 	gotoAnythingVisible: false,
 	markdownEditorPaneVisible: true,
+	markdownViewerPaneVisible: false,
 	oneNoteSelected: true,
 	noteIsMarkdown: true,
 	noteIsReadOnly: false,
@@ -98,9 +99,38 @@ describe('editorCommandDeclarations', () => {
 			{
 				textBold: false,
 				textPaste: false,
-
-				// TODO: textCopy should be enabled in read-only notes:
-				// textCopy: false,
+				textCopy: true,
+				textSelectAll: true,
+			},
+		],
+		[
+			// Viewer-only mode (no editor pane visible, only the rendered viewer)
+			{
+				markdownEditorPaneVisible: false,
+				richTextEditorVisible: false,
+				markdownViewerPaneVisible: true,
+			},
+			{
+				textCopy: true,
+				textSelectAll: true,
+				textCut: false,
+				textPaste: false,
+				textBold: false,
+			},
+		],
+		[
+			// Viewer-only mode with a read-only note
+			{
+				markdownEditorPaneVisible: false,
+				richTextEditorVisible: false,
+				markdownViewerPaneVisible: true,
+				noteIsReadOnly: true,
+			},
+			{
+				textCopy: true,
+				textSelectAll: true,
+				textCut: false,
+				textPaste: false,
 			},
 		],
 	])('should correctly determine whether command is enabled (case %#)', (context, expectedStates) => {

--- a/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts
+++ b/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts
@@ -10,14 +10,8 @@ const workWithHtmlNotes = [
 	'textSelectAll',
 ];
 
-// Commands that should remain enabled when only the viewer pane is visible (no editor pane).
-const worksInViewerMode = [
-	'textCopy',
-	'textSelectAll',
-];
-
-// Commands that should remain enabled even when the note is read-only.
-const worksInReadOnlyMode = [
+// Commands that should remain enabled in viewer mode and when the note is read-only.
+const worksInViewerAndReadOnlyMode = [
 	'textCopy',
 	'textSelectAll',
 ];
@@ -25,12 +19,11 @@ const worksInReadOnlyMode = [
 export const enabledCondition = (commandName: string) => {
 	const markdownEditorOnly = !Object.keys(joplinCommandToTinyMceCommands).includes(commandName);
 	const noteMustBeMarkdown = !workWithHtmlNotes.includes(commandName);
-	const allowInViewer = worksInViewerMode.includes(commandName);
-	const allowInReadOnly = worksInReadOnlyMode.includes(commandName);
+	const allowInViewerAndReadOnlyMode = worksInViewerAndReadOnlyMode.includes(commandName);
 
 	const editorPaneCondition = markdownEditorOnly
 		? 'markdownEditorPaneVisible'
-		: allowInViewer
+		: allowInViewerAndReadOnlyMode
 			? '(markdownEditorPaneVisible || richTextEditorVisible || markdownViewerPaneVisible)'
 			: '(markdownEditorPaneVisible || richTextEditorVisible)';
 
@@ -41,7 +34,7 @@ export const enabledCondition = (commandName: string) => {
 		editorPaneCondition,
 		'oneNoteSelected',
 		noteMustBeMarkdown ? 'noteIsMarkdown' : '',
-		allowInReadOnly ? '' : '!noteIsReadOnly',
+		allowInViewerAndReadOnlyMode ? '' : '!noteIsReadOnly',
 	];
 
 	return output.filter(c => !!c).join(' && ');

--- a/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts
+++ b/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts
@@ -10,18 +10,38 @@ const workWithHtmlNotes = [
 	'textSelectAll',
 ];
 
+// Commands that should remain enabled when only the viewer pane is visible (no editor pane).
+const worksInViewerMode = [
+	'textCopy',
+	'textSelectAll',
+];
+
+// Commands that should remain enabled even when the note is read-only.
+const worksInReadOnlyMode = [
+	'textCopy',
+	'textSelectAll',
+];
+
 export const enabledCondition = (commandName: string) => {
 	const markdownEditorOnly = !Object.keys(joplinCommandToTinyMceCommands).includes(commandName);
 	const noteMustBeMarkdown = !workWithHtmlNotes.includes(commandName);
+	const allowInViewer = worksInViewerMode.includes(commandName);
+	const allowInReadOnly = worksInReadOnlyMode.includes(commandName);
+
+	const editorPaneCondition = markdownEditorOnly
+		? 'markdownEditorPaneVisible'
+		: allowInViewer
+			? '(markdownEditorPaneVisible || richTextEditorVisible || markdownViewerPaneVisible)'
+			: '(markdownEditorPaneVisible || richTextEditorVisible)';
 
 	const output = [
 		// gotoAnythingVisible: Enable if the command palette (which is a modal dialog) is visible
 		'(!modalDialogVisible || gotoAnythingVisible)',
 
-		markdownEditorOnly ? 'markdownEditorPaneVisible' : '(markdownEditorPaneVisible || richTextEditorVisible)',
+		editorPaneCondition,
 		'oneNoteSelected',
 		noteMustBeMarkdown ? 'noteIsMarkdown' : '',
-		'!noteIsReadOnly',
+		allowInReadOnly ? '' : '!noteIsReadOnly',
 	];
 
 	return output.filter(c => !!c).join(' && ');


### PR DESCRIPTION
This is a replacement for #14732, which could not be merged due to CLA issues (the original PR contained commits co-authored by Copilot, which is not 
covered by the CLA agreement).
 
 ## Problem
 
 On macOS, when the note editor is in viewer-only mode (editor pane hidden) or when a note is read-only, the **Copy** and **Select All** items in the Edit 
menu are greyed out. Since macOS relies on menu item enabled state for keyboard shortcuts, this causes `Cmd+C` and `Cmd+A` to stop working entirely in these
 modes.
 
 ## Solution
 
 Introduced `worksInViewerMode` and `worksInReadOnlyMode` allowance lists in `editorCommandDeclarations.ts`. Commands in these lists (`textCopy` and 
`textSelectAll`) remain enabled when:
 - Only the markdown viewer pane is visible (viewer-only mode)
 - The note is read-only
 
 Editing commands (`textCut`, `textPaste`, `textBold`, etc.) correctly remain disabled in these modes.
 
 This PR also extends the original fix from #14732 by additionally enabling the **Select All** (`Cmd+A`) command in viewer and read-only modes, which 
suffered from the same issue.
 