### PR TITLE
Desktop,Cli: Fixes #14954: Fix changes made in an external editor are sometimes ignored

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1446,6 +1446,7 @@ packages/lib/services/CommandService.test.js
 packages/lib/services/CommandService.js
 packages/lib/services/DecryptionWorker.test.js
 packages/lib/services/DecryptionWorker.js
+packages/lib/services/ExternalEditWatcher.test.js
 packages/lib/services/ExternalEditWatcher.js
 packages/lib/services/ExternalEditWatcher/utils.js
 packages/lib/services/ItemChangeUtils.js

--- a/.gitignore
+++ b/.gitignore
@@ -1419,6 +1419,7 @@ packages/lib/services/CommandService.test.js
 packages/lib/services/CommandService.js
 packages/lib/services/DecryptionWorker.test.js
 packages/lib/services/DecryptionWorker.js
+packages/lib/services/ExternalEditWatcher.test.js
 packages/lib/services/ExternalEditWatcher.js
 packages/lib/services/ExternalEditWatcher/utils.js
 packages/lib/services/ItemChangeUtils.js

--- a/packages/lib/services/ExternalEditWatcher.test.ts
+++ b/packages/lib/services/ExternalEditWatcher.test.ts
@@ -1,0 +1,47 @@
+import { setupDatabaseAndSynchronizer } from '../testing/test-utils';
+import ExternalEditWatcher from './ExternalEditWatcher';
+import { appendFile } from 'fs/promises';
+import Note from '../models/Note';
+import { msleep } from '@joplin/utils/time';
+import waitFor from '../testing/waitFor';
+
+describe('ExternalEditWatcher', () => {
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(0);
+		ExternalEditWatcher
+			.instance()
+			.initialize(jest.fn(), jest.fn());
+		jest.useRealTimers();
+	});
+
+	test('should handle rapid changes to a file', async () => {
+		const watcher = new ExternalEditWatcher();
+		const openedItems: string[] = [];
+		watcher.initialize(jest.fn(() => ({
+			openItem: (filePath: string)=>{
+				openedItems.push(filePath);
+			},
+		})), jest.fn());
+
+		const note = await Note.save({ title: 'Testing', body: 'test' });
+		await watcher.openAndWatch(note);
+
+		const filePath = openedItems[0];
+		expect(filePath).toBeTruthy();
+
+		await appendFile(filePath, '...');
+		// After a brief delay, change the note again.
+		await msleep(20);
+		await appendFile(filePath, '...');
+
+		// Should detect both changes
+		await waitFor(async () => {
+			expect(await Note.load(note.id)).toMatchObject({
+				title: 'Testing',
+				body: 'test......',
+			});
+		});
+
+		await watcher.stopWatchingAll();
+	});
+});

--- a/packages/lib/services/ExternalEditWatcher.test.ts
+++ b/packages/lib/services/ExternalEditWatcher.test.ts
@@ -4,44 +4,74 @@ import { appendFile } from 'fs/promises';
 import Note from '../models/Note';
 import { msleep } from '@joplin/utils/time';
 import waitFor from '../testing/waitFor';
+import { NoteEntity } from './database/types';
+
+const createAndWatchNote = async (note: NoteEntity) => {
+	const watcher = new ExternalEditWatcher();
+	const openedItems: string[] = [];
+	watcher.initialize(jest.fn(() => ({
+		openItem: (filePath: string)=>{
+			openedItems.push(filePath);
+		},
+	})), jest.fn());
+
+	note = await Note.save(note);
+	await watcher.openAndWatch(note);
+
+	const filePath = openedItems[0];
+	expect(filePath).toBeTruthy();
+
+	return { note, watcher, filePath };
+};
 
 describe('ExternalEditWatcher', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(0);
-		ExternalEditWatcher
-			.instance()
-			.initialize(jest.fn(), jest.fn());
 		jest.useRealTimers();
 	});
 
 	test('should handle rapid changes to a file', async () => {
-		const watcher = new ExternalEditWatcher();
-		const openedItems: string[] = [];
-		watcher.initialize(jest.fn(() => ({
-			openItem: (filePath: string)=>{
-				openedItems.push(filePath);
-			},
-		})), jest.fn());
+		const { filePath, watcher, note } = await createAndWatchNote({
+			title: 'Testing',
+			body: 'test',
+		});
 
-		const note = await Note.save({ title: 'Testing', body: 'test' });
-		await watcher.openAndWatch(note);
+		try {
+			await appendFile(filePath, '1');
+			// Change the note several times, with a brief delay between each:
+			await msleep(10);
+			await appendFile(filePath, '2');
+			await msleep(10);
+			await appendFile(filePath, '3');
+			await msleep(10);
+			await appendFile(filePath, '4');
 
-		const filePath = openedItems[0];
-		expect(filePath).toBeTruthy();
+			// Should detect both changes
+			await waitFor(async () => {
+				expect(await Note.load(note.id)).toMatchObject({
+					title: 'Testing',
+					body: 'test1234',
+				});
+			});
+		} finally {
+			await watcher.stopWatchingAll();
+		}
+	});
 
-		await appendFile(filePath, '...');
-		// After a brief delay, change the note again.
-		await msleep(20);
-		await appendFile(filePath, '...');
+	test('should detect a change made just before watching stops', async () => {
+		const { filePath, watcher, note } = await createAndWatchNote({
+			title: 'Testing', body: 'Test',
+		});
 
-		// Should detect both changes
+		await appendFile(filePath, '!');
+		await appendFile(filePath, '!!');
+		await watcher.stopWatchingAll();
+
 		await waitFor(async () => {
 			expect(await Note.load(note.id)).toMatchObject({
 				title: 'Testing',
-				body: 'test......',
+				body: 'Test!!!',
 			});
 		});
-
-		await watcher.stopWatchingAll();
 	});
 });

--- a/packages/lib/services/ExternalEditWatcher.test.ts
+++ b/packages/lib/services/ExternalEditWatcher.test.ts
@@ -76,23 +76,6 @@ describe('ExternalEditWatcher', () => {
 		}
 	});
 
-	test('should detect a change made just before watching stops', async () => {
-		const { filePath, watcher, note } = await createAndWatchNote({
-			title: 'Testing', body: 'Test',
-		});
-
-		await appendFile(filePath, '!');
-		await appendFile(filePath, '!!');
-		await watcher.stopWatchingAll();
-
-		await waitFor(async () => {
-			expect(await Note.load(note.id)).toMatchObject({
-				title: 'Testing',
-				body: 'Test!!!',
-			});
-		});
-	});
-
 	test('should detect changes made to different files', async () => {
 		const { filePaths, watcher, notes } = await createAndWatchNotes([
 			{ title: 'Test 1', body: 'Test' },

--- a/packages/lib/services/ExternalEditWatcher.test.ts
+++ b/packages/lib/services/ExternalEditWatcher.test.ts
@@ -1,4 +1,4 @@
-import { setupDatabaseAndSynchronizer } from '../testing/test-utils';
+import { setupDatabaseAndSynchronizer, switchClient } from '../testing/test-utils';
 import ExternalEditWatcher from './ExternalEditWatcher';
 import { appendFile } from 'fs/promises';
 import Note from '../models/Note';
@@ -44,6 +44,7 @@ const createAndWatchNote = async (note: NoteEntity) => {
 describe('ExternalEditWatcher', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(0);
+		await switchClient(0);
 		jest.useRealTimers();
 	});
 

--- a/packages/lib/services/ExternalEditWatcher.test.ts
+++ b/packages/lib/services/ExternalEditWatcher.test.ts
@@ -6,22 +6,39 @@ import { msleep } from '@joplin/utils/time';
 import waitFor from '../testing/waitFor';
 import { NoteEntity } from './database/types';
 
-const createAndWatchNote = async (note: NoteEntity) => {
+const createAndWatchNotes = async (notes: NoteEntity[]) => {
 	const watcher = new ExternalEditWatcher();
-	const openedItems: string[] = [];
+	const openedPaths: string[] = [];
 	watcher.initialize(jest.fn(() => ({
 		openItem: (filePath: string)=>{
-			openedItems.push(filePath);
+			openedPaths.push(filePath);
 		},
 	})), jest.fn());
 
-	note = await Note.save(note);
-	await watcher.openAndWatch(note);
+	const savedNotes = [];
+	for (const note of notes) {
+		const savedNote = await Note.save(note);
+		await watcher.openAndWatch(savedNote);
+		savedNotes.push(savedNote);
+	}
 
-	const filePath = openedItems[0];
-	expect(filePath).toBeTruthy();
+	expect(openedPaths).toHaveLength(savedNotes.length);
 
-	return { note, watcher, filePath };
+	return {
+		notes: savedNotes,
+		filePaths: openedPaths,
+		watcher,
+	};
+};
+
+const createAndWatchNote = async (note: NoteEntity) => {
+	const { notes, filePaths, watcher } = await createAndWatchNotes([note]);
+
+	return {
+		note: notes[0],
+		filePath: filePaths[0],
+		watcher,
+	};
 };
 
 describe('ExternalEditWatcher', () => {
@@ -73,5 +90,30 @@ describe('ExternalEditWatcher', () => {
 				body: 'Test!!!',
 			});
 		});
+	});
+
+	test('should detect changes made to different files', async () => {
+		const { filePaths, watcher, notes } = await createAndWatchNotes([
+			{ title: 'Test 1', body: 'Test' },
+			{ title: 'Test 2', body: 'Test' },
+		]);
+
+		try {
+			await appendFile(filePaths[0], ' (updated 1)');
+			await appendFile(filePaths[1], ' (updated 2)');
+
+			await waitFor(async () => {
+				expect(await Note.load(notes[0].id)).toMatchObject({
+					title: 'Test 1',
+					body: 'Test (updated 1)',
+				});
+				expect(await Note.load(notes[1].id)).toMatchObject({
+					title: 'Test 2',
+					body: 'Test (updated 2)',
+				});
+			});
+		} finally {
+			await watcher.stopWatchingAll();
+		}
 	});
 });

--- a/packages/lib/services/ExternalEditWatcher.ts
+++ b/packages/lib/services/ExternalEditWatcher.ts
@@ -6,9 +6,14 @@ import time from '../time';
 import { NoteEntity } from './database/types';
 import Note from '../models/Note';
 import { openFileWithExternalEditor } from './ExternalEditWatcher/utils';
+import AsyncActionQueue from '../AsyncActionQueue';
 const EventEmitter = require('events');
 const chokidar = require('chokidar');
 const { ErrorNotFound } = require('./rest/utils/errors');
+
+interface ChangeEventContext {
+	path: string;
+}
 
 export default class ExternalEditWatcher {
 
@@ -19,6 +24,7 @@ export default class ExternalEditWatcher {
 	private logger_: Logger = new Logger();
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private watcher_: any = null;
+	private changeEventQueue_: AsyncActionQueue<ChangeEventContext>;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private eventEmitter_: any = new EventEmitter();
 	private skipNextChangeEvent_: Record<string, boolean> = {};
@@ -37,6 +43,29 @@ export default class ExternalEditWatcher {
 	public initialize(bridge: Function, dispatch: Function) {
 		this.bridge_ = bridge;
 		this.dispatch = dispatch;
+
+		// Chokidar skips repeated events for the same file.
+		// As a result, it may be possible for something similar to the following to happen:
+		// 1. A user makes a change to a file in an external editor.
+		// 2. The external editor truncates the file to just before the change.
+		// 3. Joplin receives an event from Chokidar and reads the truncated file.
+		// 4. The external editor writes the remainder of the file (with the user's change).
+		// 5. The change event is ignored (throttled by Chokidar) since it happened within
+		//    50 ms of the change from step 2.
+		// 6. The note remains truncated in Joplin.
+		//
+		// To avoid this, we use an AsyncActionQueue to delay processing change events received
+		// from Chokidar.
+		// The timeout must be at least the throttling delay used internally by chokidar.
+		// https://github.com/laurent22/joplin/issues/14954
+		const timeout = 50;
+		this.changeEventQueue_ = new AsyncActionQueue<ChangeEventContext>(timeout);
+		this.changeEventQueue_.setCanSkipTaskHandler((task1, task2) => {
+			// Only skip change events for the same path
+			const context1 = task1.context;
+			const context2 = task2.context;
+			return context1.path === context2.path;
+		});
 	}
 
 	public externalApi() {
@@ -102,55 +131,7 @@ export default class ExternalEditWatcher {
 					// See: https://github.com/laurent22/joplin/issues/710#issuecomment-420997167
 					// this.watcher_.unwatch(path);
 				} else if (event === 'change') {
-					const id = this.noteFilePathToId_(path);
-
-					if (!this.skipNextChangeEvent_[id]) {
-						const note = await Note.load(id);
-
-						if (!note) {
-							this.logger().warn(`ExternalEditWatcher: Watched note has been deleted: ${id}`);
-							void this.stopWatching(id);
-							return;
-						}
-
-						let noteContent = await shim.fsDriver().readFile(path, 'utf-8');
-
-						// In some very rare cases, the "change" event is going to be emitted but the file will be empty.
-						// This is likely to be the editor that first clears the file, then writes the content to it, so if
-						// the file content is read very quickly after the change event, we'll get empty content.
-						// Usually, re-reading the content again will fix the issue and give back the file content.
-						// To replicate on Windows: associate Typora as external editor, and leave Ctrl+S pressed -
-						// it will keep on saving very fast and the bug should happen at some point.
-						// Below we re-read the file multiple times until we get the content, but in my tests it always
-						// work in the first try anyway. The loop is just for extra safety.
-						// https://github.com/laurent22/joplin/issues/1854
-						if (!noteContent) {
-							this.logger().warn(`ExternalEditWatcher: Watched note is empty - this is likely to be a bug and re-reading the note should fix it. Trying again... ${id}`);
-
-							for (let i = 0; i < 10; i++) {
-								noteContent = await shim.fsDriver().readFile(path, 'utf-8');
-								if (noteContent) {
-									this.logger().info(`ExternalEditWatcher: Note is now readable: ${id}`);
-									break;
-								}
-								await time.msleep(100);
-							}
-
-							if (!noteContent) this.logger().warn(`ExternalEditWatcher: Could not re-read note - user might have purposely deleted note content: ${id}`);
-						}
-
-						this.logger().debug('ExternalEditWatcher: Updating note object.');
-
-						const updatedNote = await Note.unserializeForEdit(noteContent);
-						updatedNote.id = id;
-						updatedNote.parent_id = note.parent_id;
-						await Note.save(updatedNote);
-						this.eventEmitter_.emit('noteChange', { id: updatedNote.id, note: updatedNote });
-					} else {
-						this.logger().debug('ExternalEditWatcher: Skipping this event.');
-					}
-
-					this.skipNextChangeEvent_ = {};
+					this.changeEventQueue_.push(() => this.onNoteChange_(path), { path });
 				} else if (event === 'error') {
 					this.logger().error('ExternalEditWatcher: error');
 				}
@@ -160,6 +141,58 @@ export default class ExternalEditWatcher {
 		}
 
 		return this.watcher_;
+	}
+
+	private async onNoteChange_(path: string) {
+		const id = this.noteFilePathToId_(path);
+
+		if (!this.skipNextChangeEvent_[id]) {
+			const note = await Note.load(id);
+
+			if (!note) {
+				this.logger().warn(`ExternalEditWatcher: Watched note has been deleted: ${id}`);
+				void this.stopWatching(id);
+				return;
+			}
+
+			let noteContent = await shim.fsDriver().readFile(path, 'utf-8');
+
+			// In some very rare cases, the "change" event is going to be emitted but the file will be empty.
+			// This is likely to be the editor that first clears the file, then writes the content to it, so if
+			// the file content is read very quickly after the change event, we'll get empty content.
+			// Usually, re-reading the content again will fix the issue and give back the file content.
+			// To replicate on Windows: associate Typora as external editor, and leave Ctrl+S pressed -
+			// it will keep on saving very fast and the bug should happen at some point.
+			// Below we re-read the file multiple times until we get the content, but in my tests it always
+			// work in the first try anyway. The loop is just for extra safety.
+			// https://github.com/laurent22/joplin/issues/1854
+			if (!noteContent) {
+				this.logger().warn(`ExternalEditWatcher: Watched note is empty - this is likely to be a bug and re-reading the note should fix it. Trying again... ${id}`);
+
+				for (let i = 0; i < 10; i++) {
+					noteContent = await shim.fsDriver().readFile(path, 'utf-8');
+					if (noteContent) {
+						this.logger().info(`ExternalEditWatcher: Note is now readable: ${id}`);
+						break;
+					}
+					await time.msleep(100);
+				}
+
+				if (!noteContent) this.logger().warn(`ExternalEditWatcher: Could not re-read note - user might have purposely deleted note content: ${id}`);
+			}
+
+			this.logger().debug('ExternalEditWatcher: Updating note object.');
+
+			const updatedNote = await Note.unserializeForEdit(noteContent);
+			updatedNote.id = id;
+			updatedNote.parent_id = note.parent_id;
+			await Note.save(updatedNote);
+			this.eventEmitter_.emit('noteChange', { id: updatedNote.id, note: updatedNote });
+		} else {
+			this.logger().debug('ExternalEditWatcher: Skipping this event.');
+		}
+
+		this.skipNextChangeEvent_ = {};
 	}
 
 	private noteIdToFilePath_(noteId: string) {
@@ -236,6 +269,8 @@ export default class ExternalEditWatcher {
 	public async stopWatching(noteId: string) {
 		if (!noteId) return;
 
+		await this.changeEventQueue_.processAllNow();
+
 		const filePath = this.noteIdToFilePath_(noteId);
 		if (this.watcher_) this.watcher_.unwatch(filePath);
 		await shim.fsDriver().remove(filePath);
@@ -247,6 +282,8 @@ export default class ExternalEditWatcher {
 	}
 
 	public async stopWatchingAll() {
+		await this.changeEventQueue_.processAllNow();
+
 		const filePaths = this.watchedFiles();
 		for (let i = 0; i < filePaths.length; i++) {
 			await shim.fsDriver().remove(filePaths[i]);

--- a/packages/lib/services/ExternalEditWatcher.ts
+++ b/packages/lib/services/ExternalEditWatcher.ts
@@ -132,7 +132,13 @@ export default class ExternalEditWatcher {
 					// See: https://github.com/laurent22/joplin/issues/710#issuecomment-420997167
 					// this.watcher_.unwatch(path);
 				} else if (event === 'change') {
-					this.changeEventQueue_.push(() => this.onNoteChange_(path), { path });
+					const id = this.noteFilePathToId_(path);
+					if (!this.skipNextChangeEvent_[id]) {
+						this.changeEventQueue_.push(() => this.onNoteChange_(path), { path });
+					} else {
+						this.logger().debug('ExternalEditWatcher: Skipping this event.');
+					}
+					this.skipNextChangeEvent_ = {};
 				} else if (event === 'error') {
 					this.logger().error('ExternalEditWatcher: error');
 				}
@@ -146,54 +152,47 @@ export default class ExternalEditWatcher {
 
 	private async onNoteChange_(path: string) {
 		const id = this.noteFilePathToId_(path);
+		const note = await Note.load(id);
 
-		if (!this.skipNextChangeEvent_[id]) {
-			const note = await Note.load(id);
-
-			if (!note) {
-				this.logger().warn(`ExternalEditWatcher: Watched note has been deleted: ${id}`);
-				void this.stopWatching(id);
-				return;
-			}
-
-			let noteContent = await shim.fsDriver().readFile(path, 'utf-8');
-
-			// In some very rare cases, the "change" event is going to be emitted but the file will be empty.
-			// This is likely to be the editor that first clears the file, then writes the content to it, so if
-			// the file content is read very quickly after the change event, we'll get empty content.
-			// Usually, re-reading the content again will fix the issue and give back the file content.
-			// To replicate on Windows: associate Typora as external editor, and leave Ctrl+S pressed -
-			// it will keep on saving very fast and the bug should happen at some point.
-			// Below we re-read the file multiple times until we get the content, but in my tests it always
-			// work in the first try anyway. The loop is just for extra safety.
-			// https://github.com/laurent22/joplin/issues/1854
-			if (!noteContent) {
-				this.logger().warn(`ExternalEditWatcher: Watched note is empty - this is likely to be a bug and re-reading the note should fix it. Trying again... ${id}`);
-
-				for (let i = 0; i < 10; i++) {
-					noteContent = await shim.fsDriver().readFile(path, 'utf-8');
-					if (noteContent) {
-						this.logger().info(`ExternalEditWatcher: Note is now readable: ${id}`);
-						break;
-					}
-					await time.msleep(100);
-				}
-
-				if (!noteContent) this.logger().warn(`ExternalEditWatcher: Could not re-read note - user might have purposely deleted note content: ${id}`);
-			}
-
-			this.logger().debug('ExternalEditWatcher: Updating note object.');
-
-			const updatedNote = await Note.unserializeForEdit(noteContent);
-			updatedNote.id = id;
-			updatedNote.parent_id = note.parent_id;
-			await Note.save(updatedNote);
-			this.eventEmitter_.emit('noteChange', { id: updatedNote.id, note: updatedNote });
-		} else {
-			this.logger().debug('ExternalEditWatcher: Skipping this event.');
+		if (!note) {
+			this.logger().warn(`ExternalEditWatcher: Watched note has been deleted: ${id}`);
+			void this.stopWatching(id);
+			return;
 		}
 
-		this.skipNextChangeEvent_ = {};
+		let noteContent = await shim.fsDriver().readFile(path, 'utf-8');
+
+		// In some very rare cases, the "change" event is going to be emitted but the file will be empty.
+		// This is likely to be the editor that first clears the file, then writes the content to it, so if
+		// the file content is read very quickly after the change event, we'll get empty content.
+		// Usually, re-reading the content again will fix the issue and give back the file content.
+		// To replicate on Windows: associate Typora as external editor, and leave Ctrl+S pressed -
+		// it will keep on saving very fast and the bug should happen at some point.
+		// Below we re-read the file multiple times until we get the content, but in my tests it always
+		// work in the first try anyway. The loop is just for extra safety.
+		// https://github.com/laurent22/joplin/issues/1854
+		if (!noteContent) {
+			this.logger().warn(`ExternalEditWatcher: Watched note is empty - this is likely to be a bug and re-reading the note should fix it. Trying again... ${id}`);
+
+			for (let i = 0; i < 10; i++) {
+				noteContent = await shim.fsDriver().readFile(path, 'utf-8');
+				if (noteContent) {
+					this.logger().info(`ExternalEditWatcher: Note is now readable: ${id}`);
+					break;
+				}
+				await time.msleep(100);
+			}
+
+			if (!noteContent) this.logger().warn(`ExternalEditWatcher: Could not re-read note - user might have purposely deleted note content: ${id}`);
+		}
+
+		this.logger().debug('ExternalEditWatcher: Updating note object.');
+
+		const updatedNote = await Note.unserializeForEdit(noteContent);
+		updatedNote.id = id;
+		updatedNote.parent_id = note.parent_id;
+		await Note.save(updatedNote);
+		this.eventEmitter_.emit('noteChange', { id: updatedNote.id, note: updatedNote });
 	}
 
 	private noteIdToFilePath_(noteId: string) {

--- a/packages/lib/services/ExternalEditWatcher.ts
+++ b/packages/lib/services/ExternalEditWatcher.ts
@@ -57,6 +57,7 @@ export default class ExternalEditWatcher {
 		// To avoid this, we use an AsyncActionQueue to delay processing change events received
 		// from Chokidar.
 		// The timeout must be at least the throttling delay used internally by chokidar.
+		// With Chokidar 3.6.0, this throttling delay is 50ms.
 		// https://github.com/laurent22/joplin/issues/14954
 		const timeout = 55;
 		this.changeEventQueue_ = new AsyncActionQueue<ChangeEventContext>(timeout);

--- a/packages/lib/services/ExternalEditWatcher.ts
+++ b/packages/lib/services/ExternalEditWatcher.ts
@@ -58,7 +58,7 @@ export default class ExternalEditWatcher {
 		// from Chokidar.
 		// The timeout must be at least the throttling delay used internally by chokidar.
 		// https://github.com/laurent22/joplin/issues/14954
-		const timeout = 50;
+		const timeout = 55;
 		this.changeEventQueue_ = new AsyncActionQueue<ChangeEventContext>(timeout);
 		this.changeEventQueue_.setCanSkipTaskHandler((task1, task2) => {
 			// Only skip change events for the same path

--- a/packages/lib/services/ExternalEditWatcher.ts
+++ b/packages/lib/services/ExternalEditWatcher.ts
@@ -133,11 +133,13 @@ export default class ExternalEditWatcher {
 					// this.watcher_.unwatch(path);
 				} else if (event === 'change') {
 					const id = this.noteFilePathToId_(path);
+
 					if (!this.skipNextChangeEvent_[id]) {
 						this.changeEventQueue_.push(() => this.onNoteChange_(path), { path });
 					} else {
 						this.logger().debug('ExternalEditWatcher: Skipping this event.');
 					}
+
 					this.skipNextChangeEvent_ = {};
 				} else if (event === 'error') {
 					this.logger().error('ExternalEditWatcher: error');

--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -503,8 +503,6 @@ async function setupDatabaseAndSynchronizer(id: number, options: any = null) {
 	resourceFetchers_[id] = new ResourceFetcher(() => { return synchronizers_[id].api(); });
 	kvStores_[id] = new KvStore();
 
-	BaseItem.revisionService_ = revisionServices_[id];
-
 	setRSA(RSA);
 
 	await fileApi().initialize();

--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -503,6 +503,8 @@ async function setupDatabaseAndSynchronizer(id: number, options: any = null) {
 	resourceFetchers_[id] = new ResourceFetcher(() => { return synchronizers_[id].api(); });
 	kvStores_[id] = new KvStore();
 
+	BaseItem.revisionService_ = revisionServices_[id];
+
 	setRSA(RSA);
 
 	await fileApi().initialize();


### PR DESCRIPTION
# Problem

The external edit watcher could miss changes in a rapidly-changing file.

Joplin uses [Chokidar](https://github.com/paulmillr/chokidar/tree/7c50e25d10a497ce4409f6e52eb630f0d7647b97) to watch for file changes. Currently, file change events are interpreted roughly as "the file just changed". Joplin reads the file from disk and updates the note. However, Chokidar can throttle events:
1. If the file changes multiple times in the same 50ms, Chokidar only emits the first event (see the upstream [`index.js/_throttle`](https://github.com/paulmillr/chokidar/blob/7c50e25d10a497ce4409f6e52eb630f0d7647b97/index.js#L659) and [usage](https://github.com/paulmillr/chokidar/blob/7c50e25d10a497ce4409f6e52eb630f0d7647b97/index.js#L616)).
2. If there's another change event, greater than, e.g., 51ms after the emitted change, Chokidar emits the event.
   - This won't be exactly 50ms, since Chokidar uses `setTimeout` and there might be a delay in clearing the event throttling.

*May* fix #14954.

# Solution

Defer processing of `Update` changes so that Joplin reads the file just after the **end** of each 50ms block, rather than the start.

# Testing

This pull request includes an automated test that fails if the changes to `ExternalEditWatcher.ts` are reverted. This test:
1. Creates a note and starts watching it.
2. Appends to the note.
3. After 10ms, appends to the note again.
4. Repeats (3) two more times.
5. Verifies that the note includes all of the changes.

If I revert the changes to `ExternalEditWatcher`, the test (**edit**: usually, but not always) fails with
```
    - Expected  - 1
    + Received  + 1

      Object {
    -   "body": "test1234",
    +   "body": "test123",
        "title": "Testing",
      }

      66 |                      // Should detect both changes
      67 |                      await waitFor(async () => {
    > 68 |                              expect(await Note.load(note.id)).toMatchObject({
         |                                                               ^
      69 |                                      title: 'Testing',
      70 |                                      body: 'test1234',
      71 |                              });

      at toMatchObject (services/ExternalEditWatcher.test.ts:68:38)
      at waitFor (testing/waitFor.ts:14:4)
      at Object.<anonymous> (services/ExternalEditWatcher.test.ts:67:4)
```

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->