### PR TITLE
Desktop: Fixes #14628: Fix additional crashes which can happen when many windows are opened and closed

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -351,7 +351,7 @@ export default class ElectronAppWrapper {
 			const joplinId = this.windowIdFromWebContents(focusedWebContents);
 
 			if (joplinId !== null) {
-				this.win_.webContents.send('window-focused', joplinId);
+				this.activeWindow().webContents.send('window-focused', joplinId);
 			}
 		};
 


### PR DESCRIPTION
PRs https://github.com/laurent22/joplin/pull/14892 and https://github.com/laurent22/joplin/pull/14849 addressed some scenarios where the renderer could crash when closing windows in the desktop app, since the Electron upgrade in Joplin 3.6. It is still however possible to produce renderer crashes when many windows are opened and closed repeatedly.

With both PRs merged, I am still able to consistently produce the renderer crash when opening many new windows (and occasionally with a few), using the following reproduction steps:
- Open 12 windows of the same note
- Close them one by one, newest to oldest
- Open 6 windows of note A and note B in an alternating pattern
- Close them one by one, oldest to newest
- At some point between the start and end of these steps, the renderer is gone crash will occur

The crash occurs due to the error 'sendToFrame() failed: Error: Render frame was disposed before WebFrameMain could be accessed', which occurs when attempting to invoke window.webContents.send on a window where the renderer is no longer available. To address the issue, the sendWindowFocused function has been amended to get the active window by using the this.activeWindow() function, instead of using this.win_ directly, which returns 'BrowserWindow.getFocusedWindow() ?? this.win_'

### Testing

With the above reproduction steps and further opening and closing of windows, I am no longer able to reproduce the crash