### PR TITLE
Desktop: Fixes #14628: Fix incorrectly re-instated code

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -395,20 +395,6 @@ export default class ElectronAppWrapper {
 		};
 		addWindowEventHandlers(this.win_.webContents);
 
-		// BrowserWindow 'focus' fires when the OS gives focus to the application window
-		// (i.e. coming from another app or from the taskbar), not on intra-app focus switches.
-		// We use a dedicated IPC channel so the renderer can trigger an immediate sync on
-		// OS-level focus gain without conflating it with the 'window-focused' channel that
-		// handles Joplin-internal window routing.
-		this.win_.on('focus', () => {
-			try {
-				this.win_?.webContents.send('main-window-focused');
-			} catch (error) {
-				// Can fail if the render frame is temporarily disposed during window teardown.
-				console.warn('Failed to send main-window-focused:', error);
-			}
-		});
-
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		this.win_.on('close', (event: any) => {
 			// If it's on macOS, the app is completely closed only if the user chooses to close the app (willQuitApp_ will be true)

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -733,22 +733,6 @@ class Application extends BaseApplication {
 				}
 			});
 
-			// Trigger an immediate sync when the main window gains OS-level focus (i.e. the user
-			// switches back to Joplin from another application) or when the system wakes from sleep.
-			// A 30-second cool-down prevents duplicate syncs during rapid focus-in/focus-out cycles.
-			const minResumeSyncIntervalMs = 30_000;
-			let lastFocusSyncTime = 0;
-
-			const scheduleResumeSync = () => {
-				const now = Date.now();
-				if (now - lastFocusSyncTime > minResumeSyncIntervalMs) {
-					lastFocusSyncTime = now;
-					void reg.scheduleSync(0);
-				}
-			};
-
-			ipcRenderer.on('main-window-focused', scheduleResumeSync);
-			ipcRenderer.on('system-resumed', scheduleResumeSync);
 			ipcRenderer.on('secondary-window-closing', (_event, windowId: string) => {
 				this.dispatch({ type: 'WINDOW_CLOSE', windowId });
 			});


### PR DESCRIPTION
There were additional mistakes which were merged in via https://github.com/laurent22/joplin/pull/14849, which incorrectly re-instated some partial changes which had been reverted. I had not realised at the time when I implemented a PR for corrections, but some of the code in the final state of the PR was re-instated from https://github.com/laurent22/joplin/commit/0fa3a509d65be723a6e7768d43c3d599ddb01da3, so I have now removed those changes and verified the 2 renderer crash fixes still work correctly