### PR TITLE
Server: Fixes #583: Redirect to correct share when following links between independently published notes

### DIFF
--- a/packages/server/src/models/ShareModel.test.ts
+++ b/packages/server/src/models/ShareModel.test.ts
@@ -341,4 +341,69 @@ describe('ShareModel', () => {
 		const updatedNote = await models().item().load(note.id);
 		expect(updatedNote.owner_id).toBe(session2.user_id);
 	});
+
+	// linkedNoteShareUrl: R=0, I=0, P=ε → O=N
+	test('should return null from linkedNoteShareUrl when the linked note does not exist', async () => {
+		const { user: user1 } = await createUserAndSession(1);
+
+		await createItemTree(user1.id, '', {
+			'000000000000000000000000000000F1': {
+				'00000000000000000000000000000001': null,
+			},
+		});
+
+		const share = await models().share().shareNote(user1, '00000000000000000000000000000001', '', false);
+		const url = await models().share().linkedNoteShareUrl(share, '00000000000000000000000000000099');
+		expect(url).toBeNull();
+	});
+
+	// linkedNoteShareUrl: R=0, I=1, P=0 → O=N
+	test('should return null from linkedNoteShareUrl when the linked note has no note share', async () => {
+		const { user: user1 } = await createUserAndSession(1);
+
+		await createItemTree(user1.id, '', {
+			'000000000000000000000000000000F1': {
+				'00000000000000000000000000000001': null,
+				'00000000000000000000000000000002': null,
+			},
+		});
+
+		const share = await models().share().shareNote(user1, '00000000000000000000000000000001', '', false);
+		// note 2 exists but is not shared via ShareType.Note
+		const url = await models().share().linkedNoteShareUrl(share, '00000000000000000000000000000002');
+		expect(url).toBeNull();
+	});
+
+	// linkedNoteShareUrl: R=1, I=ε, P=ε → O=N
+	test('should return null from linkedNoteShareUrl when the share is recursive', async () => {
+		const { user: user1 } = await createUserAndSession(1);
+
+		await createItemTree(user1.id, '', {
+			'000000000000000000000000000000F1': {
+				'00000000000000000000000000000001': null,
+			},
+		});
+
+		const share = await models().share().shareNote(user1, '00000000000000000000000000000001', '', true);
+		const url = await models().share().linkedNoteShareUrl(share, '00000000000000000000000000000001');
+		expect(url).toBeNull();
+	});
+
+	// linkedNoteShareUrl: R=0, I=1, P=1 → O=U
+	test('should return a URL from linkedNoteShareUrl when the linked note is shared', async () => {
+		const { user: user1 } = await createUserAndSession(1);
+
+		await createItemTree(user1.id, '', {
+			'000000000000000000000000000000F1': {
+				'00000000000000000000000000000001': null,
+				'00000000000000000000000000000002': null,
+			},
+		});
+
+		const share = await models().share().shareNote(user1, '00000000000000000000000000000001', '', false);
+		// note 2 is shared via ShareType.Note, making P=1 for it
+		await models().share().shareNote(user1, '00000000000000000000000000000002', '', false);
+		const url = await models().share().linkedNoteShareUrl(share, '00000000000000000000000000000002');
+		expect(url).not.toBeNull();
+	});
 });

--- a/packages/server/src/models/ShareModel.test.ts
+++ b/packages/server/src/models/ShareModel.test.ts
@@ -402,8 +402,8 @@ describe('ShareModel', () => {
 
 		const share = await models().share().shareNote(user1, '00000000000000000000000000000001', '', false);
 		// note 2 is shared via ShareType.Note, making P=1 for it
-		await models().share().shareNote(user1, '00000000000000000000000000000002', '', false);
+		const note2Share = await models().share().shareNote(user1, '00000000000000000000000000000002', '', false);
 		const url = await models().share().linkedNoteShareUrl(share, '00000000000000000000000000000002');
-		expect(url).not.toBeNull();
+		expect(url).toContain(`/shares/${note2Share.id}`);
 	});
 });

--- a/packages/server/src/models/ShareModel.ts
+++ b/packages/server/src/models/ShareModel.ts
@@ -108,6 +108,18 @@ export default class ShareModel extends BaseModel<Share> {
 		return setQueryParameters(`${this.personalizedUserContentBaseUrl(shareOwnerId)}/shares/${id}`, query);
 	}
 
+	public async linkedNoteShareUrl(share: Share, linkedNoteJopId: string): Promise<string | null> {
+		if (share.recursive) return null;
+
+		const noteItem = await this.models().item().loadByJopId(share.owner_id, linkedNoteJopId);
+		if (!noteItem) return null;
+
+		const noteShare = await this.itemShare(ShareType.Note, noteItem.id);
+		if (!noteShare) return null;
+
+		return this.shareUrl(noteShare.owner_id, noteShare.id);
+	}
+
 	public async byItemId(itemId: Uuid): Promise<Share | null> {
 		const r = await this.byItemIds([itemId]);
 		return r.length ? r[0] : null;

--- a/packages/server/src/routes/index/shares.ts
+++ b/packages/server/src/routes/index/shares.ts
@@ -1,9 +1,9 @@
-import { SubPath, ResponseType, Response } from '../../utils/routeUtils';
+import { SubPath, ResponseType, Response, redirect } from '../../utils/routeUtils';
 import Router from '../../utils/Router';
 import { RouteType } from '../../utils/types';
 import { AppContext } from '../../utils/types';
 import { ErrorForbidden, ErrorNotFound } from '../../utils/errors';
-import { Item, Share } from '../../services/database/types';
+import { Item, Share, ShareType } from '../../services/database/types';
 import { ModelType } from '@joplin/lib/BaseModel';
 import { FileViewerResponse, renderItem as renderJoplinItem } from '../../utils/joplinUtils';
 import { friendlySafeFilename } from '@joplin/lib/path-utils';
@@ -38,6 +38,16 @@ router.get('shares/:id', async (path: SubPath, ctx: AppContext) => {
 
 	const user = await ctx.joplin.models.user().load(share.owner_id);
 	if (!user.enabled) throw new ErrorForbidden('This account has been disabled');
+
+	if (ctx.query.note_id && !share.recursive) {
+		const noteItem = await ctx.joplin.models.item().loadByJopId(share.owner_id, ctx.query.note_id as string);
+		if (!noteItem) throw new ErrorForbidden('This linked note has not been published');
+
+		const noteShare = await shareModel.itemShare(ShareType.Note, noteItem.id);
+		if (!noteShare) throw new ErrorForbidden('This linked note has not been published');
+
+		return redirect(ctx, shareModel.shareUrl(noteShare.owner_id, noteShare.id));
+	}
 
 	const itemModel = ctx.joplin.models.item();
 

--- a/packages/server/src/routes/index/shares.ts
+++ b/packages/server/src/routes/index/shares.ts
@@ -3,7 +3,7 @@ import Router from '../../utils/Router';
 import { RouteType } from '../../utils/types';
 import { AppContext } from '../../utils/types';
 import { ErrorForbidden, ErrorNotFound } from '../../utils/errors';
-import { Item, Share, ShareType } from '../../services/database/types';
+import { Item, Share } from '../../services/database/types';
 import { ModelType } from '@joplin/lib/BaseModel';
 import { FileViewerResponse, renderItem as renderJoplinItem } from '../../utils/joplinUtils';
 import { friendlySafeFilename } from '@joplin/lib/path-utils';
@@ -40,13 +40,9 @@ router.get('shares/:id', async (path: SubPath, ctx: AppContext) => {
 	if (!user.enabled) throw new ErrorForbidden('This account has been disabled');
 
 	if (ctx.query.note_id && !share.recursive) {
-		const noteItem = await ctx.joplin.models.item().loadByJopId(share.owner_id, ctx.query.note_id as string);
-		if (!noteItem) throw new ErrorForbidden('This linked note has not been published');
-
-		const noteShare = await shareModel.itemShare(ShareType.Note, noteItem.id);
-		if (!noteShare) throw new ErrorForbidden('This linked note has not been published');
-
-		return redirect(ctx, shareModel.shareUrl(noteShare.owner_id, noteShare.id));
+		const redirectUrl = await shareModel.linkedNoteShareUrl(share, ctx.query.note_id as string);
+		if (redirectUrl) return redirect(ctx, redirectUrl);
+		throw new ErrorForbidden('This linked note has not been published');
 	}
 
 	const itemModel = ctx.joplin.models.item();


### PR DESCRIPTION
What this fixes
Clicking a link to another published note would not work even when the linked note was published.
What changed
In packages/server/src/routes/index/shares.ts — when a ?note_id= link is followed on a non-recursive share, we now check if the linked note has its own share and redirect there if so.


https://github.com/user-attachments/assets/f642c642-181c-499b-b8e2-3ccfe4a0907f


How to test
Publish two notes separately (A and B)
Put an internal link to note B inside note A
Open note A and click on note B from note A
Should redirect to note B instead of failing
