### PR TITLE
Server: use shared markdown renderer for email HTML

### DIFF
--- a/packages/server/src/services/email/utils.ts
+++ b/packages/server/src/services/email/utils.ts
@@ -1,14 +1,10 @@
-import MarkdownIt = require('markdown-it');
+import renderMarkdown from '../../utils/renderMarkdown';
 
 export function markdownBodyToPlainText(md: string): string {
 	// Just convert the links to plain URLs
 	return md.replace(/\[.*\]\((.*)\)/g, '$1');
 }
 
-// TODO: replace with renderMarkdown()
 export function markdownBodyToHtml(md: string): string {
-	const markdownIt = new MarkdownIt({
-		linkify: true,
-	});
-	return markdownIt.render(md);
+	return renderMarkdown(md);
 }


### PR DESCRIPTION
## Summary
- Replace the duplicated MarkdownIt setup in the server email utility with the shared renderMarkdown helper.
- Remove the inline TODO from the email HTML renderer.
- Leave markdownBodyToPlainText unchanged.

## Testing
- Attempted corepack yarn workspace @joplin/server test src/services/email/utils.test.ts --runInBand --verbose=false.
- Blocked in this workspace because the Yarn/node_modules install state is missing.