### PR TITLE
Desktop: Fixes #14950: Inline computed styles when copying from the Markdown preview pane

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -827,7 +827,39 @@
 		}));
 
 		// By default, Chromium inlines body styles (e.g. theme background color) into the clipboard HTML.
-		// Intercept the copy event and write only the selected content to bypass this behaviour.
+		// Intercept the copy event and write only the selected content with inlined light-theme styles
+		// to bypass this behaviour.
+		const clipboardCssProps = [
+			'font-family', 'font-size', 'font-weight', 'font-style',
+			'text-decoration-line', 'line-height', 'color',
+			'background-color',
+			'margin-top', 'margin-bottom', 'margin-left', 'margin-right',
+			'padding-top', 'padding-bottom', 'padding-left', 'padding-right',
+			'border-top', 'border-bottom', 'border-left', 'border-right',
+			'border-collapse', 'border-radius',
+			'list-style-type',
+			'white-space', 'text-align',
+			'opacity',
+		];
+
+		// Values from packages/lib/themes/light.ts
+		const lightThemeOverrideCss = [
+			'body, #joplin-container-content, #rendered-md { background-color: transparent !important; color: #32373F !important; }',
+			'html *, html *::before, html *::after { background-color: transparent !important; }',
+			'a { color: #155BDA !important; }',
+			'code, .inline-code, .mce-content-body code { color: rgb(0,0,0) !important; background-color: rgb(243,243,243) !important; border-color: rgb(220,220,220) !important; }',
+			'pre.hljs { background-color: rgb(243,243,243) !important; }',
+			'pre.hljs code { background-color: transparent !important; }',
+			'kbd { color: rgb(0,0,0) !important; background-color: rgb(243,243,243) !important; }',
+			'table, table thead, table tbody, table tr, table td, table th { background-color: transparent !important; color: #32373F !important; }',
+			'table th { background-color: rgb(247,247,247) !important; }',
+			'table:has(thead) tr:nth-child(even) { background-color: rgb(247,247,247) !important; }',
+			'table td, table th { border-color: rgb(220,220,220) !important; }',
+			'blockquote { border-left-color: rgb(220,220,220) !important; opacity: 0.7 !important; }',
+			'h1 { border-bottom-color: #dddddd !important; }',
+			'mark { background-color: #F3B717 !important; color: black !important; }',
+		].join('\n');
+
 		document.addEventListener('copy', webviewLib.logEnabledEventHandler(e => {
 			const selection = window.getSelection();
 			if (!selection || selection.isCollapsed) return;
@@ -850,6 +882,35 @@
 					wrapper.appendChild(el);
 				}
 				node = node.parentElement;
+			}
+
+			const overrideStyle = document.createElement('style');
+			overrideStyle.textContent = lightThemeOverrideCss;
+			document.head.appendChild(overrideStyle);
+
+			const renderedMd = document.getElementById('rendered-md') || contentElement;
+			wrapper.style.cssText = 'position:absolute;left:-9999px;visibility:hidden;pointer-events:none';
+			renderedMd.appendChild(wrapper);
+
+			try {
+				const elements = wrapper.querySelectorAll('*');
+				for (const el of elements) {
+					let cs;
+					try { cs = window.getComputedStyle(el); } catch (_) { continue; }
+
+					const parts = [];
+					for (const prop of clipboardCssProps) {
+						const val = cs.getPropertyValue(prop);
+						if (val) parts.push(`${prop}: ${val}`);
+					}
+					if (parts.length > 0) {
+						el.setAttribute('style', parts.join('; '));
+					}
+				}
+			} finally {
+				renderedMd.removeChild(wrapper);
+				overrideStyle.remove();
+				wrapper.style.cssText = '';
 			}
 
 			e.clipboardData.setData('text/html', wrapper.innerHTML);

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -827,8 +827,7 @@
 		}));
 
 		// By default, Chromium inlines body styles (e.g. theme background color) into the clipboard HTML.
-		// Intercept the copy event and write only the selected content with inlined light-theme styles
-		// to bypass this behaviour.
+		// Intercept the copy event and write only the selected content with inlined light-theme styles to bypass this behaviour.
 		const clipboardCssProps = [
 			'font-family', 'font-size', 'font-weight', 'font-style',
 			'text-decoration-line', 'line-height', 'color',
@@ -842,7 +841,6 @@
 			'opacity',
 		];
 
-		// Values from packages/lib/themes/light.ts
 		const lightThemeOverrideCss = [
 			'body, #joplin-container-content, #rendered-md { background-color: transparent !important; color: #32373F !important; }',
 			'html *, html *::before, html *::after { background-color: transparent !important; }',

--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -432,7 +432,9 @@ test.describe('markdownEditor', () => {
 		});
 
 		expect(clipboardHtml).toContain('hello');
-		expect(clipboardHtml).not.toMatch(/background-color\s*:/i);
-		expect(clipboardHtml).toContain('<strong>');
+		// Dark theme background (#1D2024) must not leak into clipboard
+		expect(clipboardHtml).not.toMatch(/1D2024/i);
+		expect(clipboardHtml).toContain('<strong');
+		expect(clipboardHtml).toMatch(/font-weight/i);
 	});
 });


### PR DESCRIPTION
AI Disclosure:
AI was used to assist during the development of this PR(mainly to find the best possible solution). All suggestions were reviewed, tested, and verified.

Issue(Fixes #14950):
When copying content from the Markdown preview pane and pasting into external apps (like Gmail, Google Docs, or Word), all formatting was lost: bold, italic, fonts, table borders, etc. were stripped because the clipboard HTML had no inline styles.

This was a regression introduced in #14474, which intercepted the copy event and wrote bare HTML to the clipboard without any CSS styling.


Fix:
The fix reads the CSS styles from each element and writes them directly as
inline styles into the clipboard HTML. This way, external apps like Gmail
know exactly how to render bold, borders, fonts, etc.

To avoid dark-theme colors leaking into the paste, a temporary light-theme
CSS override is applied before reading the styles. The override values is taken from `packages/lib/themes/light.ts`.

Test: added integration test and also did manual testing(attached a screen recording)

Screen Recording:

https://github.com/user-attachments/assets/f9277ae3-2d34-4222-a1a1-a84e23e839b9


