### PR TITLE
 Mobile: Fix "Editor font" and "Editor font size" being ignored in the New Editor #14974

### DIFF
--- a/packages/app-mobile/components/NoteEditor/MarkdownEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/MarkdownEditor.tsx
@@ -15,7 +15,7 @@ import useWebViewSetup from '../../contentScripts/markdownEditorBundle/useWebVie
 
 const logger = Logger.create('MarkdownEditor');
 
-function useCss(themeId: number): string {
+function useCss(themeId: number, fontFamily: string, fontSize: number, fontSizeUnits: string): string {
 	return useMemo(() => {
 		const theme = themeStyle(themeId);
 		const themeVariableCss = themeToCss(theme);
@@ -24,6 +24,7 @@ function useCss(themeId: number): string {
 
 			:root {
 				background-color: ${theme.backgroundColor};
+				font-size: ${fontSize}${fontSizeUnits};
 			}
 
 			body {
@@ -37,8 +38,7 @@ function useCss(themeId: number): string {
 				padding-right: 1px;
 				padding-bottom: 1px;
 				padding-top: 10px;
-
-				font-size: 13pt;
+				font-family: ${fontFamily};
 			}
 
 			* {
@@ -79,7 +79,7 @@ function useCss(themeId: number): string {
 				}
 			}
 		`;
-	}, [themeId]);
+	}, [themeId, fontFamily, fontSize, fontSizeUnits]);
 }
 
 function useHtml(): string {
@@ -149,7 +149,12 @@ const MarkdownEditor: React.FC<EditorProps> = props => {
 		true;
 	`;
 
-	const css = useCss(props.themeId);
+	const css = useCss(
+		props.themeId,
+		props.editorSettings.themeData.fontFamily,
+		props.editorSettings.themeData.fontSize,
+		props.editorSettings.themeData.fontSizeUnits || 'px',
+	);
 	const html = useHtml();
 
 	const onMessage = useCallback((event: OnMessageEvent) => {

--- a/packages/app-mobile/components/NoteEditor/MarkdownEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/MarkdownEditor.tsx
@@ -41,6 +41,10 @@ function useCss(themeId: number, fontFamily: string, fontSize: number, fontSizeU
 				font-family: ${fontFamily};
 			}
 
+			.cm-editor, .cm-editor * {
+				font-family: ${fontFamily} !important;
+			}
+
 			* {
 				scrollbar-width: thin;
 				scrollbar-color: rgba(100, 100, 100, 0.7) rgba(0, 0, 0, 0.1);

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -78,7 +78,7 @@ interface Props {
 
 function fontFamilyFromSettings() {
 	const font = editorFont(Setting.value('style.editor.fontFamily') as number);
-	return font ? `${font}, sans-serif` : 'sans-serif';
+	return font ? `${JSON.stringify(font)}, sans-serif` : 'sans-serif';
 }
 
 function editorTheme(themeId: number) {

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -78,7 +78,9 @@ interface Props {
 
 function fontFamilyFromSettings() {
 	const font = editorFont(Setting.value('style.editor.fontFamily') as number);
-	return font ? `${JSON.stringify(font)}, sans-serif` : 'sans-serif';
+	if (!font) return 'sans-serif';
+	if (font === 'monospace') return 'monospace, sans-serif';
+	return `${JSON.stringify(font)}, sans-serif`;
 }
 
 function editorTheme(themeId: number) {

--- a/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
@@ -17,7 +17,7 @@ import shim from '@joplin/lib/shim';
 
 const logger = Logger.create('RichTextEditor');
 
-function useCss(themeId: number, editorCss: string): string {
+function useCss(themeId: number, editorCss: string, fontFamily: string, fontSize: number, fontSizeUnits: string): string {
 	return useMemo(() => {
 		const theme = themeStyle(themeId);
 		const themeVariableCss = themeToCss(theme);
@@ -27,7 +27,7 @@ function useCss(themeId: number, editorCss: string): string {
 
 			:root {
 				background-color: ${theme.backgroundColor};
-				font-size: 13pt;
+				font-size: ${fontSize}${fontSizeUnits};
 			}
 
 			body {
@@ -42,7 +42,7 @@ function useCss(themeId: number, editorCss: string): string {
 				padding-bottom: 1px;
 				padding-top: 10px;
 
-				font-family: ${JSON.stringify(theme.fontFamily)}, sans-serif;
+				font-family: ${fontFamily};
 			}
 
 			.RichTextEditor {
@@ -52,13 +52,10 @@ function useCss(themeId: number, editorCss: string): string {
 				position: relative;
 			}
 		`;
-	}, [themeId, editorCss]);
+	}, [themeId, editorCss, fontFamily, fontSize, fontSizeUnits]);
 }
 
-function useHtml(initialCss: string): string {
-	const cssRef = useRef(initialCss);
-	cssRef.current = initialCss;
-
+function useHtml(): string {
 	return useMemo(() => `
 		<!DOCTYPE html>
 		<html>
@@ -127,8 +124,14 @@ const RichTextEditor: React.FC<EditorProps> = props => {
 		true;
 	`;
 
-	const css = useCss(props.themeId, editorWebViewSetup.pageSetup.css);
-	const html = useHtml(css);
+	const css = useCss(
+		props.themeId,
+		editorWebViewSetup.pageSetup.css,
+		props.editorSettings.themeData.fontFamily,
+		props.editorSettings.themeData.fontSize,
+		props.editorSettings.themeData.fontSizeUnits || 'px',
+	);
+	const html = useHtml();
 
 	const onMessage = useCallback((event: OnMessageEvent) => {
 		const data = event.nativeEvent.data;

--- a/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
@@ -3,7 +3,7 @@ import themeToCss from '@joplin/lib/services/style/themeToCss';
 import ExtendedWebView from '../ExtendedWebView';
 
 import * as React from 'react';
-import { useMemo, useCallback, useRef } from 'react';
+import { useMemo, useCallback } from 'react';
 import { NativeSyntheticEvent } from 'react-native';
 
 import { EditorProps } from './types';
@@ -43,6 +43,10 @@ function useCss(themeId: number, editorCss: string, fontFamily: string, fontSize
 				padding-top: 10px;
 
 				font-family: ${fontFamily};
+			}
+
+			.prosemirror-editor, .prosemirror-editor *, .ProseMirror, .ProseMirror *, .RichTextEditor, .RichTextEditor * {
+				font-family: ${fontFamily} !important;
 			}
 
 			.RichTextEditor {


### PR DESCRIPTION
## Description

Resolve issue #14974 by ensuring that user-defined "Editor font" and "Editor font size" settings are correctly applied to the mobile app's "New Editor" in both Markdown and Rich Text modes.

### Key Changes:
1.  **NoteEditor.tsx**: Updated to safely quote font names containing spaces (e.g., "Courier New") using `JSON.stringify` for reliable CSS injection.
2.  **RichTextEditor.tsx & MarkdownEditor.tsx**: Refactored the `useCss` hook usage to accept dynamic font settings (fontFamily, fontSize, and units) from the app's `editorSettings`, replacing hardcoded legacy values.
3.  **Real-time Updates**: Added font properties to the `useCss` hook's dependency arrays, allowing the editor's appearance to update instantly when settings are changed without requiring an app restart.


https://github.com/user-attachments/assets/4b78cddd-9adc-4f23-9fcb-990253a46499



### Verification:
Tested manually on the mobile "Web" version. Verified that:
- Changing **Editor font size** (e.g., from 13 to 40) now correctly resizes text in both editor modes.
- Changing **Editor font** (e.g., to "Monospace") is properly reflected in the Rich Text and Markdown editors.

<img width="1550" height="141" alt="Screenshot 2026-04-02 004548" src="https://github.com/user-attachments/assets/bde31d0e-b0ce-4b75-a5fb-96d0f8c21109" />