### PR TITLE
Desktop: Importing from OneNote: Fix import of ink with negative bounding box coordinates

### DIFF
--- a/packages/onenote-converter/parser/src/one/property/simple.rs
+++ b/packages/onenote-converter/parser/src/one/property/simple.rs
@@ -90,11 +90,8 @@ pub(crate) fn parse_vec(prop_type: PropertyType, object: &Object) -> Result<Opti
 }
 
 pub(crate) fn parse_vec_u16(prop_type: PropertyType, object: &Object) -> Result<Option<Vec<u16>>> {
-    let data = match object.props().get(prop_type) {
-        Some(value) => value.to_vec().ok_or_else(|| {
-            ErrorKind::MalformedOneNoteFileData("vec u16 value is not a vec".into())
-        })?,
-        None => return Ok(None),
+    let Some(data) = parse_vec(prop_type, object)? else {
+        return Ok(None);
     };
 
     let vec = data
@@ -106,16 +103,26 @@ pub(crate) fn parse_vec_u16(prop_type: PropertyType, object: &Object) -> Result<
 }
 
 pub(crate) fn parse_vec_u32(prop_type: PropertyType, object: &Object) -> Result<Option<Vec<u32>>> {
-    let data = match object.props().get(prop_type) {
-        Some(value) => value
-            .to_vec()
-            .ok_or_else(|| ErrorKind::MalformedOneNoteFileData("vec value is not a vec".into()))?,
-        None => return Ok(None),
+    let Some(data) = parse_vec(prop_type, object)? else {
+        return Ok(None);
     };
 
     let vec = data
         .chunks_exact(4)
         .map(|v| u32::from_le_bytes([v[0], v[1], v[2], v[3]]))
+        .collect();
+
+    Ok(Some(vec))
+}
+
+pub(crate) fn parse_vec_i32(prop_type: PropertyType, object: &Object) -> Result<Option<Vec<i32>>> {
+    let Some(data) = parse_vec(prop_type, object)? else {
+        return Ok(None);
+    };
+
+    let vec = data
+        .chunks_exact(4)
+        .map(|v| i32::from_le_bytes([v[0], v[1], v[2], v[3]]))
         .collect();
 
     Ok(Some(vec))

--- a/packages/onenote-converter/parser/src/one/property_set/ink_data_node.rs
+++ b/packages/onenote-converter/parser/src/one/property_set/ink_data_node.rs
@@ -8,7 +8,7 @@ use parser_utils::errors::{ErrorKind, Result};
 /// An ink data container.
 pub(crate) struct Data {
     pub(crate) strokes: Vec<ExGuid>,
-    pub(crate) bounding_box: Option<[u32; 4]>,
+    pub(crate) bounding_box: Option<[i32; 4]>,
 }
 
 pub(crate) fn parse(object: &Object) -> Result<Data> {
@@ -20,7 +20,7 @@ pub(crate) fn parse(object: &Object) -> Result<Data> {
         ObjectReference::parse_vec(PropertyType::InkStrokes, object)?.ok_or_else(|| {
             ErrorKind::MalformedOneNoteFileData("ink data node has no strokes".into())
         })?;
-    let bounding_box = simple::parse_vec_u32(PropertyType::InkBoundingBox, object)?
+    let bounding_box = simple::parse_vec_i32(PropertyType::InkBoundingBox, object)?
         .filter(|values| values.len() == 4)
         .map(|values| [values[0], values[1], values[2], values[3]]);
 


### PR DESCRIPTION
# Problem

Ink bounding boxes were imported with unsigned coordinates. However, it's possible for these coordinates to be negative. As a result, negative bounding box coordinates were incorrectly imported as large positive numbers.

See https://github.com/laurent22/joplin/issues/13549#issuecomment-4167393560

# Solution

Import bounding box coordinates as `i32`s, rather than `u32`s.

# Validation

**Manual verification**: See https://github.com/laurent22/joplin/issues/13549#issuecomment-4172577600. I have verified that ink objects that were previously offscreen/incorrectly sized after import are now visible.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->