### PR TITLE
Chore: Development: Fix VSCode 1.114.0 shows a large number of `tsc` errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@crowdin/cli": "4",
     "@joplin/utils": "~2.12",
     "@seiyab/eslint-plugin-react-hooks": "4.5.1-beta.0",
+    "@types/jest": "29.5.14",
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",
     "cspell": "5.21.2",

--- a/packages/lib/services/synchronizer/syncInfoUtils.test.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.test.ts
@@ -342,12 +342,12 @@ describe('syncInfoUtils', () => {
 		Setting.setValue('sync.wipeOutFailSafe', true);
 		const syncInfo = new SyncInfo();
 		await fileApi().put('info.json', syncInfo.serialize());
-		expect(checkSyncTargetIsValid(fileApi())).resolves.not.toThrow();
+		await expect(checkSyncTargetIsValid(fileApi())).resolves.not.toThrow();
 	}));
 
 	it('should succeed when info.json does not exist and failsafe is disabled for checkSyncTargetIsValid', (async () => {
 		Setting.setValue('sync.wipeOutFailSafe', false);
-		expect(checkSyncTargetIsValid(fileApi())).resolves.not.toThrow();
+		await expect(checkSyncTargetIsValid(fileApi())).resolves.not.toThrow();
 	}));
 
 	it('should fail with failsafe error when info.json does not exist for checkSyncTargetIsValid', (async () => {
@@ -398,7 +398,7 @@ describe('syncInfoUtils', () => {
 
 	it('should succeed when info.json and .sync/version.txt does not exist when sync items are not present for fetchSyncInfo', (async () => {
 		Setting.setValue('sync.wipeOutFailSafe', true);
-		expect(fetchSyncInfo(fileApi())).resolves.not.toThrow();
+		await expect(fetchSyncInfo(fileApi())).resolves.not.toThrow();
 	}));
 
 	it('should merge revision service settings based on timestamps', () => {

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -1,5 +1,8 @@
 {
 	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"types": ["node", "jest", "jest-expect-message"]
+	},
 	"include": [
 		"**/*.ts",
 		"**/*.tsx"

--- a/packages/server/src/db.test.ts
+++ b/packages/server/src/db.test.ts
@@ -26,21 +26,21 @@ describe('db', () => {
 			'PostgreSQL 15.3 (Debian 15.3-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit',
 			'PostgreSQL 16.3, compiled by Visual C++ build 1938, 64-bit"',
 		],
-	)('should handle versionCheck on all known string versions', (versionDescription: string) => {
+	)('should handle versionCheck on all known string versions', async (versionDescription: string) => {
 
-		expect(versionCheck(mockedDb(versionDescription))).resolves.toBe(undefined);
+		await expect(versionCheck(mockedDb(versionDescription))).resolves.toBe(undefined);
 	});
 
 	it.each([
 		'PostgreSQL 11.16 (Debian 11.16-1.pgdg90+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit',
-	])('should throw because it is a outdated version', (versionDescription: string) => {
+	])('should throw because it is a outdated version', async (versionDescription: string) => {
 
-		expect(versionCheck(mockedDb(versionDescription))).rejects.toThrow(`Postgres version not supported: ${versionDescription}. Min required version is: 12.0`);
+		await expect(versionCheck(mockedDb(versionDescription))).rejects.toThrow(`Postgres version not supported: ${versionDescription}. Min required version is: 12.0`);
 	});
 
-	it('should not check version if client is not SQLite', () => {
+	it('should not check version if client is not SQLite', async () => {
 		const sqliteDb = mockedDb('invalid version', DatabaseConfigClient.SQLite);
 
-		expect(versionCheck(sqliteDb)).resolves.toBe(undefined);
+		await expect(versionCheck(sqliteDb)).resolves.toBe(undefined);
 	});
 });

--- a/packages/server/src/models/ApplicationModel.test.ts
+++ b/packages/server/src/models/ApplicationModel.test.ts
@@ -16,7 +16,7 @@ describe('ApplicationModel', () => {
 	});
 
 	test('should throw if applicationAuthId is not an uuid', async () => {
-		expect(models().application().createAppPassword('not-uuid')).rejects.toThrow('Application not authorized yet.');
+		await expect(models().application().createAppPassword('not-uuid')).rejects.toThrow('Application not authorized yet.');
 	});
 
 	test('should generate a notification after an application is authorized', async () => {

--- a/packages/server/src/models/UserItemModels.test.ts
+++ b/packages/server/src/models/UserItemModels.test.ts
@@ -17,7 +17,7 @@ describe('UserItemModel', () => {
 	test('should throw error if item does not exist', async () => {
 		const mockUserId = 'not-a-real-user-id';
 		const mockId = 'not-a-real-item-id';
-		expect(async () => models().userItem().add(mockUserId, mockId)).rejects.toThrow('No such item: not-a-real-item-id');
+		await expect(async () => models().userItem().add(mockUserId, mockId)).rejects.toThrow('No such item: not-a-real-item-id');
 	});
 });
 

--- a/packages/server/src/models/UserItemModels.test.ts
+++ b/packages/server/src/models/UserItemModels.test.ts
@@ -17,7 +17,7 @@ describe('UserItemModel', () => {
 	test('should throw error if item does not exist', async () => {
 		const mockUserId = 'not-a-real-user-id';
 		const mockId = 'not-a-real-item-id';
-		await expect(async () => models().userItem().add(mockUserId, mockId)).rejects.toThrow('No such item: not-a-real-item-id');
+		await expect(models().userItem().add(mockUserId, mockId)).rejects.toThrow('No such item: not-a-real-item-id');
 	});
 });
 

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -2,7 +2,8 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"outDir": "dist",
-		"rootDir": "./src/"
+		"rootDir": "./src/",
+		"types": ["node", "jest", "jest-expect-message"]
 	},
 	"rootDir": ".",
 	"include": [

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "dist"
+		"outDir": "dist",
+		"rootDir": "./src/"
 	},
 	"rootDir": ".",
 	"include": [

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -5,7 +5,6 @@
 		"rootDir": "./src/",
 		"types": ["node", "jest", "jest-expect-message"]
 	},
-	"rootDir": ".",
 	"include": [
         "**/*.ts",
         "**/*.tsx",

--- a/packages/transcribe/src/api/handler/createJob.test.ts
+++ b/packages/transcribe/src/api/handler/createJob.test.ts
@@ -62,7 +62,7 @@ describe('createJob', () => {
 			imagesFolder: './images',
 		};
 
-		expect(async () => createJob(requirements)).rejects.toThrow();
+		await expect(async () => createJob(requirements)).rejects.toThrow();
 
 		const job = await queue.fetch();
 		expect(job).toBeNull();

--- a/packages/transcribe/src/api/handler/createJob.test.ts
+++ b/packages/transcribe/src/api/handler/createJob.test.ts
@@ -62,7 +62,7 @@ describe('createJob', () => {
 			imagesFolder: './images',
 		};
 
-		await expect(async () => createJob(requirements)).rejects.toThrow();
+		await expect(createJob(requirements)).rejects.toThrow();
 
 		const job = await queue.fetch();
 		expect(job).toBeNull();

--- a/packages/transcribe/src/services/queue/SqliteQueue.ts
+++ b/packages/transcribe/src/services/queue/SqliteQueue.ts
@@ -49,7 +49,7 @@ export default class SqliteQueue implements BaseQueue {
 
 	private async createQueue() {
 		const isQueueCreated = await this.sqlite.select('*').from('queue').where({ name: this.name }).first();
-		if (isQueueCreated) return null;
+		if (isQueueCreated) return;
 
 		return this.sqlite.insert({ name: this.name }).table('queue');
 	}

--- a/packages/transcribe/src/services/queue/SqliteQueue.ts
+++ b/packages/transcribe/src/services/queue/SqliteQueue.ts
@@ -49,7 +49,7 @@ export default class SqliteQueue implements BaseQueue {
 
 	private async createQueue() {
 		const isQueueCreated = await this.sqlite.select('*').from('queue').where({ name: this.name }).first();
-		if (isQueueCreated) return;
+		if (isQueueCreated) return null;
 
 		return this.sqlite.insert({ name: this.name }).table('queue');
 	}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,76 +5,76 @@
   "repository": "https://github.com/laurent22/joplin/tree/dev/packages/utils",
   "exports": {
     ".": {
-      "default": "./dist/index.js",
-      "types": "./index.ts"
+      "types": "./index.ts",
+      "default": "./dist/index.js"
     },
     "./bytes": {
-      "default": "./dist/bytes.js",
-      "types": "./bytes.ts"
+      "types": "./bytes.ts",
+      "default": "./dist/bytes.js"
     },
     "./dom": {
-      "default": "./dist/dom.js",
-      "types": "./dom.ts"
+      "types": "./dom.ts",
+      "default": "./dist/dom.js"
     },
     "./env": {
-      "default": "./dist/env.js",
-      "types": "./env.ts"
+      "types": "./env.ts",
+      "default": "./dist/env.js"
     },
     "./object": {
-      "default": "./dist/object.js",
-      "types": "./object.ts"
+      "types": "./object.ts",
+      "default": "./dist/object.js"
     },
     "./fs": {
-      "default": "./dist/fs.js",
-      "types": "./fs.ts"
+      "types": "./fs.ts",
+      "default": "./dist/fs.js"
     },
     "./html": {
-      "default": "./dist/html.js",
-      "types": "./html.ts"
+      "types": "./html.ts",
+      "default": "./dist/html.js"
     },
     "./Logger": {
-      "default": "./dist/Logger.js",
-      "types": "./Logger.ts"
+      "types": "./Logger.ts",
+      "default": "./dist/Logger.js"
     },
     "./markdown": {
-      "default": "./dist/markdown.js",
-      "types": "./markdown.ts"
+      "types": "./markdown.ts",
+      "default": "./dist/markdown.js"
     },
     "./net": {
-      "default": "./dist/net.js",
-      "types": "./net.ts"
+      "types": "./net.ts",
+      "default": "./dist/net.js"
     },
     "./time": {
-      "default": "./dist/time.js",
-      "types": "./time.ts"
+      "types": "./time.ts",
+      "default": "./dist/time.js"
     },
     "./types": {
-      "default": "./dist/types.js",
-      "types": "./types.ts"
+      "types": "./types.ts",
+      "default": "./dist/types.js"
     },
     "./url": {
-      "default": "./dist/url.js",
-      "types": "./url.ts"
+      "types": "./url.ts",
+      "default": "./dist/url.js"
     },
     "./ipc": {
-      "default": "./dist/ipc.js",
-      "types": "./ipc.ts"
+      "types": "./ipc.ts",
+      "default": "./dist/ipc.js"
     },
     "./path": {
-      "default": "./dist/path.js",
-      "types": "./path.ts"
+      "types": "./path.ts",
+      "default": "./dist/path.js"
     },
     "./cli": {
-      "default": "./dist/cli.js",
-      "types": "./cli.ts"
+      "types": "./cli.ts",
+      "default": "./dist/cli.js"
     },
     "./array": {
-      "default": "./dist/array.js",
-      "types": "./array.ts"
+      "types": "./array.ts",
+      "default": "./dist/array.js"
     },
     "./version": {
-      "default": "./dist/version.js",
-      "types": "./version.ts"
+      "types": "./version.ts",
+      "default": "./dist/version.js"
     }
   },
   "publishConfig": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,24 +4,78 @@
   "description": "Utilities for Joplin",
   "repository": "https://github.com/laurent22/joplin/tree/dev/packages/utils",
   "exports": {
-    ".": "./dist/index.js",
-    "./bytes": "./dist/bytes.js",
-    "./dom": "./dist/dom.js",
-    "./env": "./dist/env.js",
-    "./object": "./dist/object.js",
-    "./fs": "./dist/fs.js",
-    "./html": "./dist/html.js",
-    "./Logger": "./dist/Logger.js",
-    "./markdown": "./dist/markdown.js",
-    "./net": "./dist/net.js",
-    "./time": "./dist/time.js",
-    "./types": "./dist/types.js",
-    "./url": "./dist/url.js",
-    "./ipc": "./dist/ipc.js",
-    "./path": "./dist/path.js",
-    "./cli": "./dist/cli.js",
-    "./array": "./dist/array.js",
-    "./version": "./dist/version.js"
+    ".": {
+      "default": "./dist/index.js",
+      "types": "./index.ts"
+    },
+    "./bytes": {
+      "default": "./dist/bytes.js",
+      "types": "./bytes.ts"
+    },
+    "./dom": {
+      "default": "./dist/dom.js",
+      "types": "./dom.ts"
+    },
+    "./env": {
+      "default": "./dist/env.js",
+      "types": "./env.ts"
+    },
+    "./object": {
+      "default": "./dist/object.js",
+      "types": "./object.ts"
+    },
+    "./fs": {
+      "default": "./dist/fs.js",
+      "types": "./fs.ts"
+    },
+    "./html": {
+      "default": "./dist/html.js",
+      "types": "./html.ts"
+    },
+    "./Logger": {
+      "default": "./dist/Logger.js",
+      "types": "./Logger.ts"
+    },
+    "./markdown": {
+      "default": "./dist/markdown.js",
+      "types": "./markdown.ts"
+    },
+    "./net": {
+      "default": "./dist/net.js",
+      "types": "./net.ts"
+    },
+    "./time": {
+      "default": "./dist/time.js",
+      "types": "./time.ts"
+    },
+    "./types": {
+      "default": "./dist/types.js",
+      "types": "./types.ts"
+    },
+    "./url": {
+      "default": "./dist/url.js",
+      "types": "./url.ts"
+    },
+    "./ipc": {
+      "default": "./dist/ipc.js",
+      "types": "./ipc.ts"
+    },
+    "./path": {
+      "default": "./dist/path.js",
+      "types": "./path.ts"
+    },
+    "./cli": {
+      "default": "./dist/cli.js",
+      "types": "./cli.ts"
+    },
+    "./array": {
+      "default": "./dist/array.js",
+      "types": "./array.ts"
+    },
+    "./version": {
+      "default": "./dist/version.js",
+      "types": "./version.ts"
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -6,7 +6,6 @@
 		"strict": true,
 		"strictNullChecks": true
 	},
-	"rootDir": ".",
 	"include": [
         "**/*.ts",
         "**/*.tsx",

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"outDir": "dist",
+		"rootDir": ".",
 		"strict": true,
 		"strictNullChecks": true
 	},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
 		"jsx": "react",
 		"skipLibCheck": true,
 		"allowUmdGlobalAccess": true,
+		"types": ["node", "jest"]
 	},
 	"exclude": [
 		"**/node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
 		"noUnusedParameters": true,
 		"strictBindCallApply": true,
 		"strictFunctionTypes": true,
-		"strictNullChecks": false,
 		"sourceMap": true,
 		"jsx": "react",
 		"skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
 		"noUnusedParameters": true,
 		"strictBindCallApply": true,
 		"strictFunctionTypes": true,
+		"strictNullChecks": false,
 		"sourceMap": true,
 		"jsx": "react",
 		"skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 		"target": "es2017",
 		"esModuleInterop": false,
 		//"lib": ["es2015", "es2020.string", "dom", "dom.iterable"],
+		"strict": false,
 		"alwaysStrict": true,
 		"forceConsistentCasingInFileNames": true,
 		"listEmittedFiles": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -46321,6 +46321,7 @@ __metadata:
     "@joplin/utils": "npm:~2.12"
     "@seiyab/eslint-plugin-react-hooks": "npm:4.5.1-beta.0"
     "@types/fs-extra": "npm:11.0.4"
+    "@types/jest": "npm:29.5.14"
     "@typescript-eslint/eslint-plugin": "npm:6.21.0"
     "@typescript-eslint/parser": "npm:6.21.0"
     cspell: "npm:5.21.2"


### PR DESCRIPTION
# Problem

VSCode 1.114.0 uses [TypeScript v6](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/) ([Visual Studio Code release notes](https://code.visualstudio.com/updates/v1_114#_typescript-60)). Joplin's current `tsconfig.json` results in a large number of TypeScript errors.

# Solution

Upgrade `tsconfig.json` and various other project files to make them **mostly** compatible with TypeScript v6:
- Fixes resolution errors related to `@joplin/utils/...` imports by manually specifying the path to the types for each file.
- Specifies the `types` array manually (see ["types now defaults to []"](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#types-now-defaults-to-)).
  - This includes adding `jest` to `types` for the toplevel `tsconfig.json`.
  - An alternative would be to set `"types": ["*"]`, but this reportedly [degrades compilation performance](https://devblogs.microsoft.com/typescript/announcing-typescript-6.0/#up-front-adjustments).
- Sets `strict` to `false` (see ["strict is now `true` by default"](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#simple-default-changes)).
- Manually specifies `rootDir` (see ["rootDir now defaults to `.`"](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#rootdir-now-defaults-to-)).

This means that *most* Visual Studio Code IDE errors related to its use of TypeScript v6 are silenced/resolved.

Additionally, this pull request fixes several missing `await`s found by ESLint with the new `tsconfig.json` (see [comment](https://github.com/laurent22/joplin/pull/14989#issuecomment-4180695734)).

> [!NOTE]
>
> This pull request makes Joplin closer to compatible with TypeScript v6, but doesn't do the upgrade: The TypeScript v6 upgrade will be a much larger change:
> - We will need to [upgrade `typescript-eslint`](https://github.com/typescript-eslint/typescript-eslint/issues/12123#issuecomment-4149852796) and possibly `eslint`.
> - TypeScript v6 isn't finding type definitions for some imports (e.g. `playwright-core/types/structs`, `@replit/codemirror-vim`).

# Validation

Local checks:
- [x] `yarn tsc` passes (also run in CI)
- [x] The desktop app can start and it's possible to create a note (also tested in CI)
- [x] The web app starts and it's possible to open and edit a note (not tested in CI).


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md
If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->