### PR TITLE
Desktop: Fixes #14990: Fix inline formatting with trailing/leading whitespace

### DIFF
--- a/packages/editor/CodeMirror/editorCommands/markdownCommands.test.ts
+++ b/packages/editor/CodeMirror/editorCommands/markdownCommands.test.ts
@@ -38,6 +38,36 @@ describe('markdownCommands', () => {
 		expect(editor.state.doc.toString()).toBe('Testing...');
 	});
 
+	it('should place formatting markers inside trailing whitespace', async () => {
+		const initialDocText = 'ABC  ';
+		const editor = await createTestEditor(
+			initialDocText, EditorSelection.range(0, initialDocText.length), [],
+		);
+
+		toggleBolded(editor);
+		expect(editor.state.doc.toString()).toBe('**ABC**  ');
+	});
+
+	it('should place formatting markers inside leading whitespace', async () => {
+		const initialDocText = '  ABC';
+		const editor = await createTestEditor(
+			initialDocText, EditorSelection.range(0, initialDocText.length), [],
+		);
+
+		toggleBolded(editor);
+		expect(editor.state.doc.toString()).toBe('  **ABC**');
+	});
+
+	it('should place formatting markers inside both leading and trailing whitespace', async () => {
+		const initialDocText = '  ABC  ';
+		const editor = await createTestEditor(
+			initialDocText, EditorSelection.range(0, initialDocText.length), [],
+		);
+
+		toggleBolded(editor);
+		expect(editor.state.doc.toString()).toBe('  **ABC**  ');
+	});
+
 	it('for a cursor, bolding, then italicizing, should produce a bold-italic region', async () => {
 		const initialDocText = '';
 		const editor = await createTestEditor(

--- a/packages/editor/CodeMirror/editorCommands/markdownCommands.test.ts
+++ b/packages/editor/CodeMirror/editorCommands/markdownCommands.test.ts
@@ -38,34 +38,22 @@ describe('markdownCommands', () => {
 		expect(editor.state.doc.toString()).toBe('Testing...');
 	});
 
-	it('should place formatting markers inside trailing whitespace', async () => {
-		const initialDocText = 'ABC  ';
+	it.each([
+		['trailing', 'ABC  ', '**ABC**  '],
+		['leading', '  ABC', '  **ABC**'],
+		['both leading and trailing', '  ABC  ', '  **ABC**  '],
+	])('should place formatting markers inside %s whitespace', async (_label, input, expected) => {
 		const editor = await createTestEditor(
-			initialDocText, EditorSelection.range(0, initialDocText.length), [],
+			input, EditorSelection.range(0, input.length), [],
 		);
 
 		toggleBolded(editor);
-		expect(editor.state.doc.toString()).toBe('**ABC**  ');
-	});
 
-	it('should place formatting markers inside leading whitespace', async () => {
-		const initialDocText = '  ABC';
-		const editor = await createTestEditor(
-			initialDocText, EditorSelection.range(0, initialDocText.length), [],
-		);
-
-		toggleBolded(editor);
-		expect(editor.state.doc.toString()).toBe('  **ABC**');
-	});
-
-	it('should place formatting markers inside both leading and trailing whitespace', async () => {
-		const initialDocText = '  ABC  ';
-		const editor = await createTestEditor(
-			initialDocText, EditorSelection.range(0, initialDocText.length), [],
-		);
-
-		toggleBolded(editor);
-		expect(editor.state.doc.toString()).toBe('  **ABC**  ');
+		expect(editor.state.doc.toString()).toBe(expected);
+		expect(editor.state.selection.main).toMatchObject({
+			from: 0,
+			to: expected.length,
+		});
 	});
 
 	it('for a cursor, bolding, then italicizing, should produce a bold-italic region', async () => {

--- a/packages/editor/CodeMirror/utils/formatting/toggleInlineRegionSurrounded.ts
+++ b/packages/editor/CodeMirror/utils/formatting/toggleInlineRegionSurrounded.ts
@@ -36,17 +36,34 @@ const toggleInlineRegionSurrounded = (
 			insert: content,
 		});
 	} else {
+		// When the selection is non-empty, trim leading/trailing whitespace so that
+		// formatting markers are placed adjacent to the text content.
+		let insertFrom = sel.from;
+		let insertTo = sel.to;
+
+		if (!sel.empty) {
+			const leadingWhitespace = content.match(/^\s*/)?.[0] ?? '';
+			const trailingWhitespace = content.match(/\s*$/)?.[0] ?? '';
+			insertFrom += leadingWhitespace.length;
+			insertTo -= trailingWhitespace.length;
+
+			// If the entire selection is whitespace, fall back to the original range.
+			if (insertFrom >= insertTo) {
+				insertFrom = sel.from;
+				insertTo = sel.to;
+			}
+		}
+
 		changes.push({
-			from: sel.from,
+			from: insertFrom,
 			insert: spec.template.start,
 		});
 
 		changes.push({
-			from: sel.to,
+			from: insertTo,
 			insert: spec.template.end,
 		});
 
-		// If not a caret,
 		if (!sel.empty) {
 			// Select the surrounding chars.
 			finalSelEnd += spec.template.start.length + spec.template.end.length;


### PR DESCRIPTION
AI Assistance Disclosure: Used to write the test and check the written code, all the changes were verified my me.

Fixes (issue #14990): updated `toggleInlineRegionSurrounded.ts` to detect leading or trailing whitespace in the selection and adjust the insertion points.

Test: added three test cases to `markdownCommands.test.ts`

Screen Recording:

https://github.com/user-attachments/assets/fa709d4b-9bb3-4055-a274-1ba3fa8a092e




