### PR TITLE
Desktop: Resolves #14990: Keep leading and trailing spaces outside inline formatting markers

### DIFF
--- a/packages/editor/CodeMirror/CodeMirrorControl.test.ts
+++ b/packages/editor/CodeMirror/CodeMirrorControl.test.ts
@@ -203,6 +203,14 @@ describe('CodeMirrorControl', () => {
 			typeText: null,
 			expected: 'x [ABC](test) y',
 		},
+		{
+			initialText: 'x    y',
+			selection: EditorSelection.range(1, 5),
+			left: '[',
+			right: '](test)',
+			typeText: null,
+			expected: 'x    y',
+		},
 	])('wrapSelections should surround all selections with the given text (case %#)', ({ initialText, selection, typeText, left, right, expected }) => {
 		const control = createEditorControl(initialText);
 		control.editor.dispatch({

--- a/packages/editor/CodeMirror/CodeMirrorControl.test.ts
+++ b/packages/editor/CodeMirror/CodeMirrorControl.test.ts
@@ -195,6 +195,14 @@ describe('CodeMirrorControl', () => {
 			typeText: 'cursor',
 			expected: 'This [cursor]\ntest[cursor]',
 		},
+		{
+			initialText: 'x ABC y',
+			selection: EditorSelection.range(1, 6),
+			left: '[',
+			right: '](test)',
+			typeText: null,
+			expected: 'x [ABC](test) y',
+		},
 	])('wrapSelections should surround all selections with the given text (case %#)', ({ initialText, selection, typeText, left, right, expected }) => {
 		const control = createEditorControl(initialText);
 		control.editor.dispatch({

--- a/packages/editor/CodeMirror/CodeMirrorControl.test.ts
+++ b/packages/editor/CodeMirror/CodeMirrorControl.test.ts
@@ -202,6 +202,7 @@ describe('CodeMirrorControl', () => {
 			right: '](test)',
 			typeText: null,
 			expected: 'x [ABC](test) y',
+			expectMainSel: { from: 3, to: 6 },
 		},
 		{
 			initialText: 'x    y',
@@ -210,8 +211,9 @@ describe('CodeMirrorControl', () => {
 			right: '](test)',
 			typeText: null,
 			expected: 'x    y',
+			expectMainSel: { from: 1, to: 5 },
 		},
-	])('wrapSelections should surround all selections with the given text (case %#)', ({ initialText, selection, typeText, left, right, expected }) => {
+	])('wrapSelections should surround all selections with the given text (case %#)', ({ initialText, selection, typeText, left, right, expected, expectMainSel }) => {
 		const control = createEditorControl(initialText);
 		control.editor.dispatch({
 			selection,
@@ -223,6 +225,11 @@ describe('CodeMirrorControl', () => {
 		}
 
 		expect(control.editor.state.doc.toString()).toBe(expected);
+		if (expectMainSel) {
+			const main = control.editor.state.selection.main;
+			expect(main.from).toBe(expectMainSel.from);
+			expect(main.to).toBe(expectMainSel.to);
+		}
 	});
 
 	it('updateBody should update the note ID facet and dispatch changes', () => {

--- a/packages/editor/CodeMirror/CodeMirrorControl.ts
+++ b/packages/editor/CodeMirror/CodeMirrorControl.ts
@@ -119,7 +119,7 @@ export default class CodeMirrorControl extends CodeMirror5Emulation implements E
 		this.editor.dispatch(
 			this.editor.state.changeByRange(range => {
 				const update = toggleInlineSelectionFormat(this.editor.state, regionSpec, range);
-				if (!update.range.empty) {
+				if (update.didChange !== false && !update.range.empty) {
 					// Deselect the start and end characters (roughly preserve the original
 					// selection).
 					update.range = EditorSelection.range(

--- a/packages/editor/CodeMirror/editorCommands/markdownCommands.test.ts
+++ b/packages/editor/CodeMirror/editorCommands/markdownCommands.test.ts
@@ -38,6 +38,32 @@ describe('markdownCommands', () => {
 		expect(editor.state.doc.toString()).toBe('Testing...');
 	});
 
+	it.each([
+		{
+			initial: 'x ABC y',
+			selection: EditorSelection.range(1, 6),
+			afterToggle: 'x **ABC** y',
+			selFrom: 2,
+			selTo: 9,
+		},
+		{
+			initial: 'x **ABC** y',
+			selection: EditorSelection.range(1, 10),
+			afterToggle: 'x ABC y',
+			selFrom: 2,
+			selTo: 5,
+		},
+	])('toggleBolded keeps selection-edge whitespace outside markers %#', async ({ initial, selection, afterToggle, selFrom, selTo }) => {
+		const editor = await createTestEditor(initial, selection, []);
+
+		toggleBolded(editor);
+
+		const mainSel = editor.state.selection.main;
+		expect(editor.state.doc.toString()).toBe(afterToggle);
+		expect(mainSel.from).toBe(selFrom);
+		expect(mainSel.to).toBe(selTo);
+	});
+
 	it('for a cursor, bolding, then italicizing, should produce a bold-italic region', async () => {
 		const initialDocText = '';
 		const editor = await createTestEditor(

--- a/packages/editor/CodeMirror/editorCommands/markdownCommands.test.ts
+++ b/packages/editor/CodeMirror/editorCommands/markdownCommands.test.ts
@@ -64,6 +64,19 @@ describe('markdownCommands', () => {
 		expect(mainSel.to).toBe(selTo);
 	});
 
+	it('toggleBolded leaves whitespace-only selection unchanged', async () => {
+		const initialDocText = 'x    y';
+		const selection = EditorSelection.range(1, 5);
+		const editor = await createTestEditor(initialDocText, selection, []);
+
+		toggleBolded(editor);
+
+		const mainSel = editor.state.selection.main;
+		expect(editor.state.doc.toString()).toBe(initialDocText);
+		expect(mainSel.from).toBe(selection.from);
+		expect(mainSel.to).toBe(selection.to);
+	});
+
 	it('for a cursor, bolding, then italicizing, should produce a bold-italic region', async () => {
 		const initialDocText = '';
 		const editor = await createTestEditor(

--- a/packages/editor/CodeMirror/utils/formatting/toggleInlineRegionSurrounded.ts
+++ b/packages/editor/CodeMirror/utils/formatting/toggleInlineRegionSurrounded.ts
@@ -9,19 +9,37 @@ import { SelectionUpdate } from './types';
 // every selection range with asterisks (including the caret).
 // If the selection is already surrounded by these characters, they are
 // removed.
+//
+// Leading/trailing whitespace on a non-empty selection is kept outside the
+// markers (see app-desktop CodeMirror v5 wrapSelections).
 const toggleInlineRegionSurrounded = (
 	doc: DocumentText, sel: SelectionRange, spec: RegionSpec,
 ): SelectionUpdate => {
-	let content = doc.sliceString(sel.from, sel.to);
-	const startMatchLen = findInlineMatch(doc, spec, sel, MatchSide.Start);
-	const endMatchLen = findInlineMatch(doc, spec, sel, MatchSide.End);
+	let workSel = sel;
+	if (!sel.empty) {
+		const selected = doc.sliceString(sel.from, sel.to);
+		const leadMatch = /^\s*/.exec(selected);
+		const trailMatch = /\s*$/.exec(selected);
+		const leadLen = leadMatch ? leadMatch[0].length : 0;
+		const trailLen = trailMatch ? trailMatch[0].length : 0;
+		const coreFrom = sel.from + leadLen;
+		const coreTo = sel.to - trailLen;
+		if (coreFrom >= coreTo) {
+			return { range: sel };
+		}
+		workSel = EditorSelection.range(coreFrom, coreTo);
+	}
+
+	let content = doc.sliceString(workSel.from, workSel.to);
+	const startMatchLen = findInlineMatch(doc, spec, workSel, MatchSide.Start);
+	const endMatchLen = findInlineMatch(doc, spec, workSel, MatchSide.End);
 
 	const startsWithBefore = startMatchLen >= 0;
 	const endsWithAfter = endMatchLen >= 0;
 
 	const changes = [];
-	let finalSelStart = sel.from;
-	let finalSelEnd = sel.to;
+	let finalSelStart = workSel.from;
+	let finalSelEnd = workSel.to;
 
 	if (startsWithBefore && endsWithAfter) {
 		// Remove the before and after.
@@ -31,18 +49,18 @@ const toggleInlineRegionSurrounded = (
 		finalSelEnd -= startMatchLen + endMatchLen;
 
 		changes.push({
-			from: sel.from,
-			to: sel.to,
+			from: workSel.from,
+			to: workSel.to,
 			insert: content,
 		});
 	} else {
 		changes.push({
-			from: sel.from,
+			from: workSel.from,
 			insert: spec.template.start,
 		});
 
 		changes.push({
-			from: sel.to,
+			from: workSel.to,
 			insert: spec.template.end,
 		});
 
@@ -52,7 +70,7 @@ const toggleInlineRegionSurrounded = (
 			finalSelEnd += spec.template.start.length + spec.template.end.length;
 		} else {
 			// Position the caret within the added content.
-			finalSelStart = sel.from + spec.template.start.length;
+			finalSelStart = workSel.from + spec.template.start.length;
 			finalSelEnd = finalSelStart;
 		}
 	}

--- a/packages/editor/CodeMirror/utils/formatting/toggleInlineRegionSurrounded.ts
+++ b/packages/editor/CodeMirror/utils/formatting/toggleInlineRegionSurrounded.ts
@@ -25,7 +25,10 @@ const toggleInlineRegionSurrounded = (
 		const coreFrom = sel.from + leadLen;
 		const coreTo = sel.to - trailLen;
 		if (coreFrom >= coreTo) {
-			return { range: sel };
+			return {
+				range: sel,
+				didChange: false,
+			};
 		}
 		workSel = EditorSelection.range(coreFrom, coreTo);
 	}
@@ -78,6 +81,7 @@ const toggleInlineRegionSurrounded = (
 	return {
 		changes,
 		range: EditorSelection.range(finalSelStart, finalSelEnd),
+		didChange: true,
 	};
 };
 

--- a/packages/editor/CodeMirror/utils/formatting/toggleInlineSelectionFormat.ts
+++ b/packages/editor/CodeMirror/utils/formatting/toggleInlineSelectionFormat.ts
@@ -22,6 +22,7 @@ const toggleInlineSelectionFormat = (
 
 		return {
 			range: EditorSelection.cursor(newCursorPos),
+			didChange: false,
 		};
 	}
 

--- a/packages/editor/CodeMirror/utils/formatting/types.ts
+++ b/packages/editor/CodeMirror/utils/formatting/types.ts
@@ -1,5 +1,5 @@
 import { ChangeSpec, SelectionRange } from '@codemirror/state';
 
 // Specifies the update of a single selection region and its contents
-export type SelectionUpdate = { range: SelectionRange; changes?: ChangeSpec };
+export type SelectionUpdate = { range: SelectionRange; changes?: ChangeSpec; didChange?: boolean };
 


### PR DESCRIPTION
Fixes #14990

**AI Assistance Disclosure**
I used AI to help locate the CodeMirror 6 text-wrapping utility and assist with the selection-boundary math. I have personally reviewed and manually tested all logic.

**Problem**
When a user highlights text with leading/trailing spaces (e.g., ` ABC `) and applies inline formatting, CodeMirror 6 blindly wraps the spaces too (e.g., `** ABC **`). This breaks Markdown rendering.

**Solution**
I updated the CM6 text wrapping utility (`toggleInlineRegionSurrounded.ts`) to intelligently trim edge whitespace before applying formatting markers, mirroring CM5's behavior:
* **Core Selection (`workSel`):** Computes a core selection excluding edge spaces. Markers are inserted strictly around this core.
* **Whitespace Guard:** Aborts if the selection contains *only* spaces to prevent orphaned markers.
* **Caret Preservation:** Leaves empty selections (blinking cursor) untouched, keeping standard typing behavior unchanged.

**Test Plan**
* **Automated:** Added test cases to `markdownCommands.test.ts` and `CodeMirrorControl.test.ts` for padded selections. All 38 tests pass.
* **Manual:** Verified `Ctrl+B`, `Ctrl+I`, and toolbar commands correctly place markers inside padded spaces, safely ignore whitespace-only selections, and properly restore cursor highlights.

**Video Demonstration**
https://www.loom.com/share/6693398d084b4c2ea6c6bfff26f130e5