### PR TITLE
Desktop, Mobile: Fixes #14990: Prevent inline formatting from wrapping trailing spaces

### DIFF
--- a/packages/editor/CodeMirror/editorCommands/markdownCommands.test.ts
+++ b/packages/editor/CodeMirror/editorCommands/markdownCommands.test.ts
@@ -75,6 +75,15 @@ describe('markdownCommands', () => {
 		expect(editor4.state.doc.toString()).toBe(' **word** ');
 	});
 
+	it('should gracefully handle applying formatting to whitespace-only selections', async () => {
+		const onlySpaces = '   ';
+		const editorSpace = await createTestEditor(
+			onlySpaces, EditorSelection.range(0, onlySpaces.length), [],
+		);
+		expect(() => toggleBolded(editorSpace)).not.toThrow();
+		expect(editorSpace.state.doc.toString()).toBe('**   **');
+	});
+
 	it('for a cursor, bolding, then italicizing, should produce a bold-italic region', async () => {
 		const initialDocText = '';
 		const editor = await createTestEditor(

--- a/packages/editor/CodeMirror/editorCommands/markdownCommands.test.ts
+++ b/packages/editor/CodeMirror/editorCommands/markdownCommands.test.ts
@@ -38,6 +38,43 @@ describe('markdownCommands', () => {
 		expect(editor.state.doc.toString()).toBe('Testing...');
 	});
 
+	it('should not wrap trailing or leading whitespace inside bold/italic markers (issue #14990)', async () => {
+		// Selecting "word " (with a trailing space) and bolding should produce "**word** "
+		const trailingSpace = 'word ';
+		const editor1 = await createTestEditor(
+			trailingSpace, EditorSelection.range(0, trailingSpace.length), [],
+		);
+		toggleBolded(editor1);
+		expect(editor1.state.doc.toString()).toBe('**word** ');
+
+		// Toggling again should restore the original text
+		toggleBolded(editor1);
+		expect(editor1.state.doc.toString()).toBe('word ');
+
+		// Same check for italic
+		const editor2 = await createTestEditor(
+			trailingSpace, EditorSelection.range(0, trailingSpace.length), [],
+		);
+		toggleItalicized(editor2);
+		expect(editor2.state.doc.toString()).toBe('*word* ');
+
+		// Leading whitespace should also stay outside the markers
+		const leadingSpace = ' word';
+		const editor3 = await createTestEditor(
+			leadingSpace, EditorSelection.range(0, leadingSpace.length), [],
+		);
+		toggleBolded(editor3);
+		expect(editor3.state.doc.toString()).toBe(' **word**');
+
+		// Both leading and trailing whitespace
+		const bothSpaces = ' word ';
+		const editor4 = await createTestEditor(
+			bothSpaces, EditorSelection.range(0, bothSpaces.length), [],
+		);
+		toggleBolded(editor4);
+		expect(editor4.state.doc.toString()).toBe(' **word** ');
+	});
+
 	it('for a cursor, bolding, then italicizing, should produce a bold-italic region', async () => {
 		const initialDocText = '';
 		const editor = await createTestEditor(

--- a/packages/editor/CodeMirror/utils/formatting/toggleInlineRegionSurrounded.ts
+++ b/packages/editor/CodeMirror/utils/formatting/toggleInlineRegionSurrounded.ts
@@ -36,23 +36,33 @@ const toggleInlineRegionSurrounded = (
 			insert: content,
 		});
 	} else {
+		// Trim leading/trailing whitespace so that formatting markers don't wrap spaces.
+		// E.g. selecting "word " and bolding should produce "**word** ", not "**word **".
+		// This mirrors the identical guard already present in the CodeMirror v5 wrapSelections helper.
+		const rawContent = doc.sliceString(sel.from, sel.to);
+		const leadingWS = rawContent.length - rawContent.trimStart().length;
+		const trailingWS = rawContent.length - rawContent.trimEnd().length;
+		const effectiveStart = sel.from + leadingWS;
+		const effectiveEnd = sel.to - trailingWS;
+
 		changes.push({
-			from: sel.from,
+			from: effectiveStart,
 			insert: spec.template.start,
 		});
 
 		changes.push({
-			from: sel.to,
+			from: effectiveEnd,
 			insert: spec.template.end,
 		});
 
 		// If not a caret,
 		if (!sel.empty) {
-			// Select the surrounding chars.
-			finalSelEnd += spec.template.start.length + spec.template.end.length;
+			// Select the surrounding chars (from start-marker to end-marker, inclusive).
+			finalSelStart = effectiveStart;
+			finalSelEnd = effectiveEnd + spec.template.start.length + spec.template.end.length;
 		} else {
 			// Position the caret within the added content.
-			finalSelStart = sel.from + spec.template.start.length;
+			finalSelStart = effectiveStart + spec.template.start.length;
 			finalSelEnd = finalSelStart;
 		}
 	}

--- a/packages/editor/CodeMirror/utils/formatting/toggleInlineRegionSurrounded.ts
+++ b/packages/editor/CodeMirror/utils/formatting/toggleInlineRegionSurrounded.ts
@@ -40,10 +40,12 @@ const toggleInlineRegionSurrounded = (
 		// E.g. selecting "word " and bolding should produce "**word** ", not "**word **".
 		// This mirrors the identical guard already present in the CodeMirror v5 wrapSelections helper.
 		const rawContent = doc.sliceString(sel.from, sel.to);
-		const leadingWS = rawContent.length - rawContent.trimStart().length;
-		const trailingWS = rawContent.length - rawContent.trimEnd().length;
-		const effectiveStart = sel.from + leadingWS;
-		const effectiveEnd = sel.to - trailingWS;
+		let effectiveStart = sel.from;
+		let effectiveEnd = sel.to;
+		if (rawContent.trim().length > 0) {
+			effectiveStart = sel.from + (rawContent.length - rawContent.trimStart().length);
+			effectiveEnd = sel.to - (rawContent.length - rawContent.trimEnd().length);
+		}
 
 		changes.push({
 			from: effectiveStart,


### PR DESCRIPTION
## Description
Fixes #14990.

**The Bug:** When applying inline formatting (like bold or italic) to a selection that includes trailing or leading whitespace in the CodeMirror 6 editor, the formatting characters incorrectly wrapped the whitespace (e.g., `"word "` became `**word **`).

**The Root Cause & Fix:**
While the legacy `v5` editor had explicit bounds-checking for whitespace, the `v6` `toggleInlineRegionSurrounded` utility lacked this trimming logic. 

I updated `toggleInlineRegionSurrounded.ts` to dynamically calculate `effectiveStart` and `effectiveEnd` by trimming the raw selection string. The formatting wrappers are now correctly inserted at these trimmed boundaries, and the post-formatting selection range is accurately updated to span only the marked content.

**Testing:**
Added a regression test to `markdownCommands.test.ts` to explicitly verify that trailing and leading whitespace are excluded from formatting markers. All tests pass locally.