### PR TITLE
Mobile: Fixes #14974: Fix editor font setting being ignored in the Rich Text Editor

### DIFF
--- a/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
@@ -1,6 +1,8 @@
 import { themeStyle } from '@joplin/lib/theme';
 import themeToCss from '@joplin/lib/services/style/themeToCss';
 import ExtendedWebView from '../ExtendedWebView';
+import Setting from '@joplin/lib/models/Setting';
+import { editorFont } from '../global-style';
 
 import * as React from 'react';
 import { useMemo, useCallback, useRef } from 'react';
@@ -21,6 +23,8 @@ function useCss(themeId: number, editorCss: string): string {
 	return useMemo(() => {
 		const theme = themeStyle(themeId);
 		const themeVariableCss = themeToCss(theme);
+		const font = editorFont(Setting.value('style.editor.fontFamily') as number);
+		const fontFamily = font ? `${JSON.stringify(font)}, sans-serif` : 'sans-serif';
 		return `
 			${themeVariableCss}
 			${editorCss}
@@ -42,7 +46,7 @@ function useCss(themeId: number, editorCss: string): string {
 				padding-bottom: 1px;
 				padding-top: 10px;
 
-				font-family: ${JSON.stringify(theme.fontFamily)}, sans-serif;
+				font-family: ${fontFamily} !important;
 			}
 
 			.RichTextEditor {

--- a/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
@@ -19,11 +19,11 @@ import shim from '@joplin/lib/shim';
 
 const logger = Logger.create('RichTextEditor');
 
-function useCss(themeId: number, editorCss: string): string {
+function useCss(themeId: number, editorCss: string, fontFamilyId: number): string {
 	return useMemo(() => {
 		const theme = themeStyle(themeId);
 		const themeVariableCss = themeToCss(theme);
-		const font = editorFont(Setting.value('style.editor.fontFamily') as number);
+		const font = editorFont(fontFamilyId);
 		const fontFamily = font ? `${JSON.stringify(font)}, sans-serif` : 'sans-serif';
 		return `
 			${themeVariableCss}
@@ -56,7 +56,7 @@ function useCss(themeId: number, editorCss: string): string {
 				position: relative;
 			}
 		`;
-	}, [themeId, editorCss]);
+	}, [themeId, editorCss, fontFamilyId]);
 }
 
 function useHtml(initialCss: string): string {
@@ -131,7 +131,7 @@ const RichTextEditor: React.FC<EditorProps> = props => {
 		true;
 	`;
 
-	const css = useCss(props.themeId, editorWebViewSetup.pageSetup.css);
+	const css = useCss(props.themeId, editorWebViewSetup.pageSetup.css, Setting.value('style.editor.fontFamily') as number);
 	const html = useHtml(css);
 
 	const onMessage = useCallback((event: OnMessageEvent) => {


### PR DESCRIPTION
Fixes #14974

### Problem
When you change the editor font in settings > editor on mobile, it works fine in the markdown editor but the rich text editor completely ignores it and always shows the default font. This has been broken since the RTE was introduced on mobile

The problem was in two parts. First, the CSS injected into the RTE's webview was pulling the font from the global UI theme instead of the actual editor font setting. Second, the renderer also injects its own body { font-family } rule on every render  and since that style tag lands inside the document body, it comes later in document order than our head styles and quietly wins the cascade, undoing whatever we set

### FIx
The fix reads the font setting the same way the markdown editor already does, using the existing editorFont() helper, and marks it !important so it is not overridden by the renderer's bundled styles. The renderer bundle is precompiled, so we cant change what it injects without a full rebuild , so !important is the right tool here

Also fixed a stale memo bug where changing the font setting would not update the RTE immediately ; the font ID is now passed as a parameter to useCss and tracked as a proper useMemo dependency

### Why this Approach?
Chose to actually fix the RTE rather than keeping a warning on the setting. The desktop app already supports custom fonts in the RTE, so this should work on mobile too

### Test Plan

Open any note in the Rich Text Editor on Android or iOS

Go to settings > editor > editor font and select the monospace option, Come back to the note ; the editor text should immediately reflect the new font without needing a restart

Switch back to the default font and confirm it reverts , then switch to the markdown editor and confirm it also still respects the setting independently

### Tested Manually:

https://github.com/user-attachments/assets/c032286f-dc45-45e0-93f8-aad0ed842943

