### PR TITLE
Mobile: Fixes #14771: Prevent Note Tags dialog from closing before discard confirmation on web

### DIFF
--- a/packages/app-mobile/components/Modal.tsx
+++ b/packages/app-mobile/components/Modal.tsx
@@ -233,6 +233,7 @@ const ModalComponent = Platform.OS === 'web' ? (props: ModalElementProps) => {
 		open={props.visible}
 		onCancel={props.onClose}
 		onShow={props.onShow}
+		preventAutoCloseOnCancel={true}
 	>
 		{props.children}
 	</Dialog>;

--- a/packages/app-mobile/components/screens/NoteTagsDialog.tsx
+++ b/packages/app-mobile/components/screens/NoteTagsDialog.tsx
@@ -51,32 +51,36 @@ const NoteTagsDialogComponent: React.FC<Props> = props => {
 		props.onCloseRequested?.();
 	}, [props.onCloseRequested, noteId, noteTags]);
 
-	const onCancelPress = useCallback(() => {
-		props.onCloseRequested?.();
-	}, [props.onCloseRequested]);
-
 	const hasUnsavedChanges = useCallback(() => {
 		if (noteTags.length !== originalTags.length) return true;
 		return noteTags.some(tag => !originalTags.includes(tag)) ||
 			originalTags.some(tag => !noteTags.includes(tag));
 	}, [noteTags, originalTags]);
 
-	const onModalClose = useCallback(async () => {
+	const canClose = useCallback(async () => {
 		if (hasUnsavedChanges()) {
 			const shouldDiscard = await shim.showConfirmationDialog(
 				_('You have unsaved tag changes. Discard them?'),
 			);
-			if (!shouldDiscard) return;
+			if (!shouldDiscard) return false;
 		}
-		onCancelPress();
-	}, [onCancelPress, hasUnsavedChanges]);
+
+		return true;
+	}, [hasUnsavedChanges]);
+
+	const onCloseRequest = useCallback(() => {
+		void (async () => {
+			if (!await canClose()) return;
+			props.onCloseRequested?.();
+		})();
+	}, [canClose, props.onCloseRequested]);
 
 	const modalProps = useMemo(() => {
 		return {
 			...modalPropOverrides,
-			onClose: onModalClose,
+			onClose: onCloseRequest,
 		};
-	}, [onModalClose]);
+	}, [onCloseRequest]);
 
 	useAsyncEffect(async (event) => {
 		const tags = await Tag.tagsByNoteId(noteId);
@@ -90,7 +94,7 @@ const NoteTagsDialogComponent: React.FC<Props> = props => {
 	return <ModalDialog
 		themeId={props.themeId}
 		onOkPress={onOkayPress}
-		onCancelPress={onCancelPress}
+		onCancelPress={onCloseRequest}
 		buttonBarEnabled={!savingTags}
 		okTitle={_('Apply')}
 		cancelTitle={_('Cancel')}

--- a/packages/lib/components/Dialog.tsx
+++ b/packages/lib/components/Dialog.tsx
@@ -128,13 +128,15 @@ const useDialogElement = (containerDocument: Document, onCancel: undefined|OnCan
 		if (clickedOutsideContent) {
 			const onCancel = onCancelRef.current;
 			if (onCancel) {
-				skipCloseCancelRef.current = true;
+				if (preventAutoCloseOnCancel) {
+					skipCloseCancelRef.current = true;
+				}
 				onCancel();
 			} else {
 				setClickedOutsideContent(false);
 			}
 		}
-	}, [clickedOutsideContent, setClickedOutsideContent]);
+	}, [clickedOutsideContent, setClickedOutsideContent, preventAutoCloseOnCancel]);
 
 	useEffect(() => {
 		if (!containerDocument) return () => {};
@@ -147,15 +149,26 @@ const useDialogElement = (containerDocument: Document, onCancel: undefined|OnCan
 				// decide whether to close (for example, to confirm unsaved changes).
 				event.preventDefault();
 				skipCloseCancelRef.current = true;
+				onCancelRef.current?.();
+				return;
 			}
-			onCancelRef.current?.();
+
+			const canCancel = !!onCancelRef.current;
+			if (!canCancel) {
+				// Prevents [Escape] from closing the dialog. In many places, this is handled
+				// by external logic.
+				// See https://stackoverflow.com/a/61021326
+				event.preventDefault();
+			}
 		});
 
 		const removedReturnValue = 'removed-from-dom';
 		dialog.addEventListener('close', () => {
 			const closedByCancel = dialog.returnValue !== removedReturnValue;
-			if (closedByCancel && !skipCloseCancelRef.current) {
-				onCancelRef.current?.();
+			if (closedByCancel) {
+				if (!preventAutoCloseOnCancel || !skipCloseCancelRef.current) {
+					onCancelRef.current?.();
+				}
 			}
 
 			skipCloseCancelRef.current = false;

--- a/packages/lib/components/Dialog.tsx
+++ b/packages/lib/components/Dialog.tsx
@@ -139,13 +139,10 @@ const useDialogElement = (containerDocument: Document, onCancel: undefined|OnCan
 		const dialog = containerDocument.createElement('dialog');
 		dialog.classList.add('dialog-modal-layer');
 		dialog.addEventListener('cancel', event => {
-			const canCancel = !!onCancelRef.current;
-			if (!canCancel) {
-				// Prevents [Escape] from closing the dialog. In many places, this is handled
-				// by external logic.
-				// See https://stackoverflow.com/a/61021326
-				event.preventDefault();
-			}
+			// Prevent the native dialog element from auto-closing so the app can
+			// decide whether to close (for example, to confirm unsaved changes).
+			event.preventDefault();
+			onCancelRef.current?.();
 		});
 
 		const removedReturnValue = 'removed-from-dom';

--- a/packages/lib/components/Dialog.tsx
+++ b/packages/lib/components/Dialog.tsx
@@ -15,6 +15,7 @@ interface Props {
 	onShow?: OnShowListener;
 	contentStyle?: CSSProperties;
 	open?: boolean;
+	preventAutoCloseOnCancel?: boolean;
 	contentFillsScreen?: boolean;
 	children: ReactNode;
 }
@@ -32,7 +33,7 @@ const Dialog: FC<Props> = props => {
 	// Because useEffect cleanup can happen after an element is removed from the HTML DOM, the dialog is managed
 	// using native HTML APIs. This allows us to call .close() while the dialog is still attached to the DOM, which
 	// allows the browser to restore the focus from before the dialog was opened.
-	const dialogElement = useDialogElement(containerDocument, props.onCancel);
+	const dialogElement = useDialogElement(containerDocument, props.onCancel, props.preventAutoCloseOnCancel ?? false);
 	useDialogClassNames(dialogElement, props.className);
 
 	const [contentRendered, setContentRendered] = useState(false);
@@ -114,7 +115,7 @@ const useClickedOutsideContent = (dialogElement: HTMLDialogElement|null) => {
 	return [clickedOutsideContent, setClickedOutsideContent] as const;
 };
 
-const useDialogElement = (containerDocument: Document, onCancel: undefined|OnCancelListener) => {
+const useDialogElement = (containerDocument: Document, onCancel: undefined|OnCancelListener, preventAutoCloseOnCancel: boolean) => {
 	const [dialogElement, setDialogElement] = useState<HTMLDialogElement|null>(null);
 
 	const onCancelRef = useRef(onCancel);
@@ -141,10 +142,12 @@ const useDialogElement = (containerDocument: Document, onCancel: undefined|OnCan
 		const dialog = containerDocument.createElement('dialog');
 		dialog.classList.add('dialog-modal-layer');
 		dialog.addEventListener('cancel', event => {
-			// Prevent the native dialog element from auto-closing so the app can
-			// decide whether to close (for example, to confirm unsaved changes).
-			event.preventDefault();
-			skipCloseCancelRef.current = true;
+			if (preventAutoCloseOnCancel) {
+				// Prevent the native dialog element from auto-closing so the app can
+				// decide whether to close (for example, to confirm unsaved changes).
+				event.preventDefault();
+				skipCloseCancelRef.current = true;
+			}
 			onCancelRef.current?.();
 		});
 
@@ -178,7 +181,7 @@ const useDialogElement = (containerDocument: Document, onCancel: undefined|OnCan
 			}
 			dialog.remove();
 		};
-	}, [containerDocument]);
+	}, [containerDocument, preventAutoCloseOnCancel]);
 
 	return dialogElement;
 };

--- a/packages/lib/components/Dialog.tsx
+++ b/packages/lib/components/Dialog.tsx
@@ -119,6 +119,7 @@ const useDialogElement = (containerDocument: Document, onCancel: undefined|OnCan
 
 	const onCancelRef = useRef(onCancel);
 	onCancelRef.current = onCancel;
+	const skipCloseCancelRef = useRef(false);
 
 	const [clickedOutsideContent, setClickedOutsideContent] = useClickedOutsideContent(dialogElement);
 
@@ -126,6 +127,7 @@ const useDialogElement = (containerDocument: Document, onCancel: undefined|OnCan
 		if (clickedOutsideContent) {
 			const onCancel = onCancelRef.current;
 			if (onCancel) {
+				skipCloseCancelRef.current = true;
 				onCancel();
 			} else {
 				setClickedOutsideContent(false);
@@ -142,15 +144,18 @@ const useDialogElement = (containerDocument: Document, onCancel: undefined|OnCan
 			// Prevent the native dialog element from auto-closing so the app can
 			// decide whether to close (for example, to confirm unsaved changes).
 			event.preventDefault();
+			skipCloseCancelRef.current = true;
 			onCancelRef.current?.();
 		});
 
 		const removedReturnValue = 'removed-from-dom';
 		dialog.addEventListener('close', () => {
 			const closedByCancel = dialog.returnValue !== removedReturnValue;
-			if (closedByCancel) {
+			if (closedByCancel && !skipCloseCancelRef.current) {
 				onCancelRef.current?.();
 			}
+
+			skipCloseCancelRef.current = false;
 
 			// Work around what seems to be an Electron bug -- if an input or contenteditable region is refocused after
 			// dismissing a dialog, it won't be editable.


### PR DESCRIPTION
### **PR Description**


### Problem
After PR #14777 was merged, there is a web regression in the Note Tags dialog:

Pressing Escape closes the dialog before the unsaved-changes warning is handled.
Pressing Cancel with unsaved changes can leave the UI in a broken/frozen state.
The unsaved-changes warning behavior is inconsistent between close paths.
### Solution
This PR unifies dialog close handling so all close paths use the same confirmation flow:

Escape/backdrop close on web now routes through app-controlled close logic first.
Cancel button uses the same unsaved-changes confirmation flow.
The dialog only closes when the user confirms discarding changes.
If the user cancels the warning, the Note Tags dialog remains open and usable.

### Test Plan
Manual testing on web (Windows):

Open a note and open the Tags dialog.
Add/remove tags (create unsaved changes).
Press Escape.
Verify confirmation dialog appears before Note Tags dialog closes.
In confirmation dialog, click Cancel.
Verify Note Tags dialog stays open and UI remains responsive.
Press Escape again, click OK.
Verify Note Tags dialog closes and unsaved changes are discarded.
Repeat with Cancel button in Note Tags dialog.
Verify same confirmation behavior occurs and no UI freeze.
Notes
This is a regression fix following merged PR #14777.
Behavior now matches expected usability: all close actions consistently protect unsaved changes.

### Video
[screen-capture.webm](https://github.com/user-attachments/assets/ea3353b2-908b-4b31-9b24-caf9047ee8cc)




