### PR TITLE
fix: add MarkInfo and ViewerPreferences to accessible PDF output

### DIFF
--- a/packages/lib/services/ocr/utils/createAccessiblePdf.ts
+++ b/packages/lib/services/ocr/utils/createAccessiblePdf.ts
@@ -1,4 +1,5 @@
 import { PDFDocument, PDFFont, PDFPage, rgb, StandardFonts } from 'pdf-lib';
+import { PDFBool, PDFName } from 'pdf-lib';
 import { PdfOcrDetails, RecognizeResultLine } from './types';
 
 // The PDF OCR images are created at 2x scale by pdfToImages()
@@ -106,6 +107,14 @@ const createAccessiblePdf = async (
 		// Add invisible text layer on top
 		addInvisibleTextLayer(page, pageOcr.lines, font, pageWidth, pageHeight);
 	}
+
+	// Mark the PDF as tagged for accessibility (PDF/UA compliance)
+	// This adds MarkInfo and ViewerPreferences to the catalog,
+	// enabling screen readers to recognize this as a tagged document.
+	const markInfo = pdfDoc.context.obj({ Marked: PDFBool.True });
+	pdfDoc.catalog.set(PDFName.of('MarkInfo'), markInfo);
+	const viewerPrefs = pdfDoc.context.obj({ DisplayDocTitle: PDFBool.True });
+	pdfDoc.catalog.set(PDFName.of('ViewerPreferences'), viewerPrefs);
 
 	return pdfDoc.save();
 };


### PR DESCRIPTION
Fixes #14994

## Problem
The "Create accessible document" context menu option generates PDFs without accessibility tags. `pdf-lib` does not set `MarkInfo` or `ViewerPreferences` in the PDF catalog by default, so screen readers cannot identify the output as a tagged document - despite the feature being specifically for accessibility.

The note export path already handles this correctly via Electron's `generateTaggedPDF` flag in `InteropServiceHelper.ts`. This fix brings the OCR-based accessible PDF path to the same standard.

## Fix
Inject `MarkInfo << /Marked true >>` and `ViewerPreferences` into the PDF catalog using `pdf-lib`'s low-level context API, immediately before saving the document.

## Changes
File :`packages/lib/services/ocr/utils/createAccessiblePdf.ts` 

Change: Added MarkInfo and ViewerPreferences to PDF catalog 

## Note
This adds the required catalog entries for tagged PDFs. A fully PDF/UA compliant document would additionally require a structure tree,which is beyond the scope of this fix and the current pdf-lib capabilities.

## Test Plan
1. Open a note with headings and lists in Joplin desktop
2. Right-click → Export → "Create accessible PDF"
3. Open the PDF in a hex editor or PDF inspector (e.g. `pdfinfo`, `pdfid.py`, or Adobe Acrobat's preflight)
4. Verify `MarkInfo` dictionary is present in the PDF catalog with `/Marked true`
5. Verify `ViewerPreferences` is present
6. Before this fix: these entries were absent entirely