### PR TITLE
fix(mobile): restore back button after navigating away from deleted notebook

### DIFF
--- a/packages/app-mobile/utils/appReducer.ts
+++ b/packages/app-mobile/utils/appReducer.ts
@@ -1,6 +1,6 @@
 import reducer from '@joplin/lib/reducer';
 import { AppState } from './types';
-import appDefaultState from './appDefaultState';
+import appDefaultState, { DEFAULT_ROUTE } from './appDefaultState';
 import fastDeepEqual = require('fast-deep-equal');
 import Logger from '@joplin/utils/Logger';
 
@@ -74,8 +74,12 @@ const appReducer = (state = appDefaultState, action: any) => {
 					// Avoid multiple consecutive duplicate screens in the navigation history -- these can make
 					// pressing "back" seem to have no effect.
 					if (currentRoute.isDeleted) {
-						// Do not add the item to the history, and remove the last item in the history if that is now the selected item
+						// The current route's folder was deleted. Instead of skipping history entirely,
+						// push DEFAULT_ROUTE (All Notes) so the back button can return to a valid screen.
 						removeLatestFolderIfSelected(navHistory, action);
+						if (!navHistory.length || navHistory[navHistory.length - 1].routeName !== DEFAULT_ROUTE.routeName || navHistory[navHistory.length - 1].smartFilterId !== DEFAULT_ROUTE.smartFilterId) {
+							navHistory.push(DEFAULT_ROUTE);
+						}
 					} else if (isDifferentRoute) {
 						navHistory.push(currentRoute);
 					}


### PR DESCRIPTION
## Summary

Fixes #15004

## Root Cause

When a notebook is deleted, `appReducer` marks the current route as `isDeleted`. On the next navigation (e.g. opening Settings/Config), the `NAV_GO` handler checks `currentRoute.isDeleted` and skips adding the current route to `navHistory`. This leaves `navHistory` empty, setting `historyCanGoBack = false`.

Result: the back button in `ScreenHeader` is disabled (greyed out) and the hardware back button calls `BackHandler.exitApp()` instead of going back.

## Reproduction

1. Clear app data / fresh install
2. Delete the Welcome notebook
3. Open Settings (tap side menu → Settings icon)
4. ➡️ Back button is greyed out; hardware back exits the app

## Fix

When the current route is `isDeleted`, instead of silently dropping it from history, push `DEFAULT_ROUTE` (All Notes smart filter) onto `navHistory`. This ensures the back button always has a valid fallback screen after a notebook deletion.

```ts
// Before: skipped history, leaving navHistory empty
if (currentRoute.isDeleted) {
  removeLatestFolderIfSelected(navHistory, action);
}

// After: push DEFAULT_ROUTE as fallback
if (currentRoute.isDeleted) {
  removeLatestFolderIfSelected(navHistory, action);
  if (!navHistory.length || navHistory[navHistory.length - 1].routeName !== DEFAULT_ROUTE.routeName ...) {
    navHistory.push(DEFAULT_ROUTE);
  }
}
```

## Testing

- Delete Welcome notebook → go to Config → back button is now enabled and returns to All Notes ✓
- Normal navigation (without deletion) is unaffected ✓
- Multiple consecutive deletions don't create duplicate DEFAULT_ROUTE entries ✓