### PR TITLE
Mobile: Fix monospace font being quoted in RTE CSS causing it to not …

### DIFF
--- a/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
@@ -24,7 +24,7 @@ function useCss(themeId: number, editorCss: string, fontFamilyId: number): strin
 		const theme = themeStyle(themeId);
 		const themeVariableCss = themeToCss(theme);
 		const font = editorFont(fontFamilyId);
-		const fontFamily = font ? `${JSON.stringify(font)}, sans-serif` : 'sans-serif';
+		const fontFamily = font ? `${font === 'monospace' ? font : JSON.stringify(font)}, sans-serif` : 'sans-serif';
 		return `
 			${themeVariableCss}
 			${editorCss}


### PR DESCRIPTION
Fixes a follow up issue from #14974
Issue - [comment-link](https://github.com/laurent22/joplin/pull/14995#issuecomment-4187394980)

### Summary
When the font setting was set to monospace, the RTE was generating font-family: "monospace", sans-serif in the CSS with quotes around monospace
Generic CSS font families like monospace must be unquoted, so browsers were ignoring it and falling back to the default font

The fix skips quoting for monoscope

### Test
Tested manually on the web version of the mobile app  switching the editor font to monospace now correctly applies the font in the RTE

https://github.com/user-attachments/assets/79866b54-7190-4155-b02c-9df8dca7a45f

