### PR TITLE
Mobile: Add 'Go to start/end of note' toolbar buttons

### DIFF
--- a/packages/app-mobile/components/EditorToolbar/utils/allToolbarCommandNamesFromState.ts
+++ b/packages/app-mobile/components/EditorToolbar/utils/allToolbarCommandNamesFromState.ts
@@ -37,6 +37,9 @@ const builtInCommandNames = [
 	'setTags',
 	EditorCommandType.ToggleSearch,
 	'hideKeyboard',
+	'-',
+	`editor.${EditorCommandType.GoDocStart}`,
+	`editor.${EditorCommandType.GoDocEnd}`,
 ];
 
 

--- a/packages/app-mobile/components/EditorToolbar/utils/selectedCommandNamesFromState.ts
+++ b/packages/app-mobile/components/EditorToolbar/utils/selectedCommandNamesFromState.ts
@@ -13,6 +13,8 @@ const omitFromDefault: string[] = [
 	`editor.${EditorCommandType.DeleteLine}`,
 	`editor.${EditorCommandType.DuplicateLine}`,
 	`editor.${EditorCommandType.SortSelectedLines}`,
+	`editor.${EditorCommandType.GoDocStart}`,
+	`editor.${EditorCommandType.GoDocEnd}`,
 ];
 
 // The "hide keyboard" button is only needed on iOS, so only show it there by default.

--- a/packages/app-mobile/components/NoteEditor/commandDeclarations.ts
+++ b/packages/app-mobile/components/NoteEditor/commandDeclarations.ts
@@ -168,6 +168,16 @@ const declarations: CommandDeclaration[] = [
 		label: () => _('Link'),
 		iconName: 'material link',
 	},
+	{
+		name: `editor.${EditorCommandType.GoDocStart}`,
+		label: () => _('Go to start of note'),
+		iconName: 'material page-first',
+	},
+	{
+		name: `editor.${EditorCommandType.GoDocEnd}`,
+		label: () => _('Go to end of note'),
+		iconName: 'material page-last',
+	},
 ];
 
 export default declarations;

--- a/packages/editor/ProseMirror/commands/commands.test.ts
+++ b/packages/editor/ProseMirror/commands/commands.test.ts
@@ -144,4 +144,21 @@ describe('ProseMirror/commands', () => {
 			}],
 		});
 	});
+
+	test('goDocEnd should move the cursor to the end of the document', () => {
+		const editor = createTestEditor({ html: '<p>First</p><p>Last</p>' });
+
+		commands[EditorCommandType.GoDocEnd](editor.state, editor.dispatch, editor);
+
+		expect(editor.state.selection.from).toBe(editor.state.doc.content.size - 1);
+	});
+
+	test('goDocStart should move the cursor to the start of the document', () => {
+		const editor = createTestEditor({ html: '<p>First</p><p>Last</p>' });
+
+		moveCursorToEnd(editor);
+		commands[EditorCommandType.GoDocStart](editor.state, editor.dispatch, editor);
+
+		expect(editor.state.selection.from).toBe(1);
+	});
 });

--- a/packages/editor/ProseMirror/commands/commands.ts
+++ b/packages/editor/ProseMirror/commands/commands.ts
@@ -1,4 +1,4 @@
-import { Command, EditorState, Transaction } from 'prosemirror-state';
+import { Command, EditorState, TextSelection, Transaction } from 'prosemirror-state';
 import { EditorCommandType } from '../../types';
 import { redo, undo } from 'prosemirror-history';
 import { autoJoin, selectAll, setBlockType, toggleMark } from 'prosemirror-commands';
@@ -247,8 +247,14 @@ const commands: Record<EditorCommandType, ExtendedCommand|null> = {
 	[EditorCommandType.InsertNewlineAndIndent]: null,
 	[EditorCommandType.SwapLineUp]: null,
 	[EditorCommandType.SwapLineDown]: null,
-	[EditorCommandType.GoDocEnd]: null,
-	[EditorCommandType.GoDocStart]: null,
+	[EditorCommandType.GoDocEnd]: (state, dispatch) => {
+		dispatch(state.tr.setSelection(TextSelection.atEnd(state.doc)).scrollIntoView());
+		return true;
+	},
+	[EditorCommandType.GoDocStart]: (state, dispatch) => {
+		dispatch(state.tr.setSelection(TextSelection.atStart(state.doc)).scrollIntoView());
+		return true;
+	},
 	[EditorCommandType.GoLineStart]: null,
 	[EditorCommandType.GoLineEnd]: null,
 	[EditorCommandType.GoLineUp]: null,


### PR DESCRIPTION
## Summary

- Adds two optional toolbar buttons: **Go to start of note** (`|<`) and **Go to end of note** (`>|`)
- Both are off by default (consistent with other utility buttons like Delete line, Swap line up/down)
- Implements `GoDocStart` and `GoDocEnd` in the ProseMirror editor, which were previously `null`
- Uses `page-first` / `page-last` MDI icons — the standard skip-to-start/end shape, no ambiguity with download/upload icons
- CodeMirror already had these commands via `cursorDocStart` / `cursorDocEnd`

## Test plan

- [ ] Open a note in the mobile editor
- [ ] Tap the toolbar settings gear → scroll to the bottom of Available — "Go to start of note" and "Go to end of note" appear with `|<` / `>|` icons
- [ ] Enable both, add multi-paragraph content, verify each button moves the cursor to the correct end
- [ ] Verify both buttons are absent from the default toolbar (off by default)
- [ ] Unit tests: `packages/editor/ProseMirror/commands/commands.test.ts`

## Screenshots
<img width="429" height="611" alt="image" src="https://github.com/user-attachments/assets/ffc6092a-a0ea-41df-b0f4-d4497cc78bc3" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)