### PR TITLE
Show release notes inline in update notification

### DIFF
--- a/packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx
+++ b/packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { useCallback, useContext, useEffect } from 'react';
-import { UpdateInfo } from 'electron-updater';
 import { ipcRenderer, IpcRendererEvent } from 'electron';
-import { AutoUpdaterEvents } from '../../services/autoUpdater/AutoUpdaterService';
+import { AutoUpdaterEvents, UpdateDownloadedInfo } from '../../services/autoUpdater/AutoUpdaterService';
 import { _ } from '@joplin/lib/locale';
 import shim from '@joplin/lib/shim';
 import { PopupNotificationContext } from '../PopupNotification/PopupNotificationProvider';
 import Button, { ButtonLevel } from '../Button/Button';
 import { NotificationType } from '../PopupNotification/types';
+import { ReleaseNotesContent } from './releaseNotesParser';
 
 interface Props {
 }
@@ -18,12 +18,6 @@ export enum UpdateNotificationEvents {
 	Dismiss = 'dismiss-update-notification',
 }
 
-const changelogLink = 'https://github.com/laurent22/joplin/releases';
-
-const openChangelogLink = () => {
-	shim.openUrl(changelogLink);
-};
-
 const handleApplyUpdate = () => {
 	ipcRenderer.send('apply-update-now');
 };
@@ -31,13 +25,35 @@ const handleApplyUpdate = () => {
 const UpdateNotification: React.FC<Props> = () => {
 	const popupManager = useContext(PopupNotificationContext);
 
-	const handleUpdateDownloaded = useCallback((_event: IpcRendererEvent, info: UpdateInfo) => {
+	const handleUpdateDownloaded = useCallback((_event: IpcRendererEvent, info: UpdateDownloadedInfo) => {
+		const openReleasePage = () => {
+			if (info.pageUrl) {
+				shim.openUrl(info.pageUrl);
+			}
+		};
+
 		const notification = popupManager.createPopup(() => (
 			<div className='update-notification'>
-				{_('A new update (%s) is available', info.version)}
-				<button className='link-button' onClick={openChangelogLink}>{
-					_('See changelog')
-				}</button>
+				<div className='update-notification-header'>
+					<span className='update-notification-title'>
+						{_('A new update (%s) is available', info.version)}
+					</span>
+					{info.pageUrl && (
+						<button className='link-button' onClick={openReleasePage}>
+							{_('Full release notes')}
+						</button>
+					)}
+				</div>
+				{info.releaseNotes && (
+					<div
+						className='update-notification-release-notes'
+						tabIndex={0}
+						role='region'
+						aria-label={_('Release notes')}
+					>
+						<ReleaseNotesContent markdown={info.releaseNotes} />
+					</div>
+				)}
 				<div className='buttons'>
 					<Button
 						level={ButtonLevel.Tertiary}
@@ -75,7 +91,6 @@ const UpdateNotification: React.FC<Props> = () => {
 			ipcRenderer.removeListener(AutoUpdaterEvents.UpdateNotAvailable, handleUpdateNotAvailable);
 		};
 	}, [handleUpdateDownloaded, handleUpdateNotAvailable]);
-
 
 	return (
 		<div style={{ display: 'none' }}/>

--- a/packages/app-desktop/gui/UpdateNotification/releaseNotesParser.test.ts
+++ b/packages/app-desktop/gui/UpdateNotification/releaseNotesParser.test.ts
@@ -1,0 +1,55 @@
+import { parseReleaseNotes } from './releaseNotesParser';
+
+describe('releaseNotesParser', () => {
+
+	it('should return empty array for empty or null input', () => {
+		expect(parseReleaseNotes('')).toEqual([]);
+		expect(parseReleaseNotes(null)).toEqual([]);
+	});
+
+	it('should parse a heading', () => {
+		expect(parseReleaseNotes('## What\'s New')).toEqual([
+			{ type: 'heading', level: 2, content: 'What\'s New' },
+		]);
+	});
+
+	it('should parse list items', () => {
+		expect(parseReleaseNotes('- Item one\n- Item two')).toEqual([
+			{ type: 'list-item', content: 'Item one' },
+			{ type: 'list-item', content: 'Item two' },
+		]);
+	});
+
+	it('should parse a horizontal rule', () => {
+		expect(parseReleaseNotes('---')).toEqual([{ type: 'hr' }]);
+	});
+
+	it('should strip GitHub noise (issue numbers, commit hashes, author attributions)', () => {
+		const input = [
+			'- Fixed bug (#4727)',
+			'- Added feature (#3157 by [@user](https://github.com/user))',
+			'- Improved sync (a6caa35)',
+		].join('\n');
+		expect(parseReleaseNotes(input)).toEqual([
+			{ type: 'list-item', content: 'Fixed bug' },
+			{ type: 'list-item', content: 'Added feature' },
+			{ type: 'list-item', content: 'Improved sync' },
+		]);
+	});
+
+	it('should skip lines that are empty after cleaning', () => {
+		expect(parseReleaseNotes('- (#4727)')).toEqual([]);
+	});
+
+	it('should handle mixed content', () => {
+		const result = parseReleaseNotes('## v3.2.1\n- Note editor improvements\n---\n### Bug Fixes\n- Fixed crash (#1234)');
+		expect(result).toEqual([
+			{ type: 'heading', level: 2, content: 'v3.2.1' },
+			{ type: 'list-item', content: 'Note editor improvements' },
+			{ type: 'hr' },
+			{ type: 'heading', level: 3, content: 'Bug Fixes' },
+			{ type: 'list-item', content: 'Fixed crash' },
+		]);
+	});
+
+});

--- a/packages/app-desktop/gui/UpdateNotification/releaseNotesParser.tsx
+++ b/packages/app-desktop/gui/UpdateNotification/releaseNotesParser.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { cleanReleaseNoteLine } from '../../utils/checkForUpdatesUtils';
+
+// Strict discriminated union — each node type carries exactly the data it needs
+export type ReleaseNoteNode =
+	| { type: 'heading'; level: number; content: string }
+	| { type: 'list-item'; content: string }
+	| { type: 'paragraph'; content: string }
+	| { type: 'hr' };
+
+export const parseReleaseNotes = (markdown: string | null | undefined): ReleaseNoteNode[] => {
+	if (!markdown || !markdown.trim()) return [];
+
+	const nodes: ReleaseNoteNode[] = [];
+
+	for (const rawLine of markdown.split('\n')) {
+		const line = rawLine.trim();
+		if (!line) continue;
+
+		// Horizontal rule: ---, ***, ___
+		if (/^[-*_]{3,}$/.test(line)) {
+			nodes.push({ type: 'hr' });
+			continue;
+		}
+
+		// Headings: ## Title
+		const headingMatch = line.match(/^(#{1,6})\s+(.+)/);
+		if (headingMatch) {
+			const content = cleanReleaseNoteLine(headingMatch[2]);
+			if (content) nodes.push({ type: 'heading', level: headingMatch[1].length, content });
+			continue;
+		}
+
+		// List items: - item, * item, + item
+		const listMatch = line.match(/^[-*+]\s+(.+)/);
+		if (listMatch) {
+			const content = cleanReleaseNoteLine(listMatch[1]);
+			if (content) nodes.push({ type: 'list-item', content });
+			continue;
+		}
+
+		// Paragraph
+		const content = cleanReleaseNoteLine(line);
+		if (content) nodes.push({ type: 'paragraph', content });
+	}
+
+	return nodes;
+};
+
+interface ReleaseNotesContentProps {
+	markdown: string;
+}
+
+// Groups consecutive list-item nodes under a single <ul> for valid semantic HTML.
+export const ReleaseNotesContent: React.FC<ReleaseNotesContentProps> = ({ markdown }) => {
+	const nodes = parseReleaseNotes(markdown);
+	if (nodes.length === 0) return null;
+
+	const elements: React.ReactElement[] = [];
+	let i = 0;
+
+	while (i < nodes.length) {
+		const node = nodes[i];
+		const key = `rn-${i}`;
+
+		if (node.type === 'heading') {
+			const HeadingTag = `h${Math.min(Math.max(node.level, 1), 6)}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+			elements.push(<HeadingTag key={key}>{node.content}</HeadingTag>);
+			i++;
+		} else if (node.type === 'list-item') {
+			const listItems: React.ReactElement[] = [];
+			while (i < nodes.length) {
+				const current = nodes[i];
+				if (current.type !== 'list-item') break;
+				listItems.push(<li key={`rn-${i}`}>{current.content}</li>);
+				i++;
+			}
+			elements.push(<ul key={key}>{listItems}</ul>);
+		} else if (node.type === 'paragraph') {
+			elements.push(<p key={key}>{node.content}</p>);
+			i++;
+		} else {
+			// hr
+			elements.push(<hr key={key} />);
+			i++;
+		}
+	}
+
+	return <>{elements}</>;
+};

--- a/packages/app-desktop/gui/UpdateNotification/style.scss
+++ b/packages/app-desktop/gui/UpdateNotification/style.scss
@@ -1,11 +1,108 @@
+// Widen the popup content area when it contains our notification
+.popup-notification-item > .content:has(.update-notification) {
+	max-width: min(360px, 80vw);
+}
+
 .update-notification {
 	display: flex;
 	flex-direction: column;
-	align-items: flex-start;
+	gap: 8px;
+
+	> .update-notification-header {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: 2px 8px;
+
+		> .update-notification-title {
+			font-weight: 600;
+		}
+
+		> .link-button {
+			font-size: 0.85em;
+			opacity: 0.7;
+			background: none;
+			border: none;
+			padding: 0;
+			color: inherit;
+			cursor: pointer;
+			text-decoration: underline;
+			text-decoration-color: transparent;
+			transition: opacity 0.2s ease, text-decoration-color 0.2s ease;
+
+			&:hover {
+				opacity: 1;
+				text-decoration-color: currentColor;
+			}
+		}
+	}
+
+	// Release notes flow as natural content, with a subtle left accent
+	> .update-notification-release-notes {
+		max-height: 200px;
+		overflow-y: auto;
+		overflow-x: hidden;
+		scrollbar-gutter: stable;
+		word-break: break-word;
+		font-size: 0.9em;
+		line-height: 1.5;
+		padding: 4px 6px 4px 10px;
+		border-left: 2px solid var(--joplin-divider-color);
+		opacity: 0.9;
+
+		&:focus {
+			outline: 2px solid var(--joplin-color4);
+			outline-offset: 2px;
+			border-radius: 2px;
+		}
+
+		h1, h2, h3, h4, h5, h6 {
+			font-size: 0.9em;
+			font-weight: 600;
+			margin: 8px 0 2px 0;
+
+			&:first-child {
+				margin-top: 0;
+			}
+		}
+
+		p {
+			margin: 1px 0;
+		}
+
+		ul {
+			margin: 2px 0;
+			padding-left: 14px;
+		}
+
+		li {
+			list-style-type: disc;
+			margin: 1px 0;
+		}
+
+		hr {
+			border: none;
+			border-top: 1px solid var(--joplin-divider-color);
+			margin: 6px 0;
+		}
+	}
 
 	> .buttons {
 		display: flex;
-		gap: 10px;
-		margin-top: 8px;
+		gap: 8px;
+
+		button {
+			transition: filter 0.15s ease, transform 0.1s ease;
+			cursor: pointer;
+
+			&:hover {
+				filter: brightness(1.15);
+			}
+
+			&:active {
+				transform: scale(0.97);
+				filter: brightness(0.95);
+			}
+		}
 	}
 }

--- a/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
+++ b/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
@@ -7,6 +7,13 @@ const shim: typeof ShimType = require('@joplin/lib/shim').default;
 import { GitHubRelease, GitHubReleaseAsset, handleReleaseResponseError } from '../../utils/checkForUpdatesUtils';
 import * as semver from 'semver';
 
+export interface UpdateDownloadedInfo {
+	version: string;
+	releaseNotes: string;
+	pageUrl: string;
+	prerelease: boolean;
+}
+
 export enum AutoUpdaterEvents {
 	CheckingForUpdate = 'checking-for-update',
 	UpdateAvailable = 'update-available',
@@ -54,6 +61,7 @@ export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
 	private allowDowngrade = false;
 	private isManualCheckInProgress = false;
 	private isUpdateInProgress = false;
+	private latestRelease_: GitHubRelease = null;
 
 	public constructor(mainWindow: BrowserWindow, logger: LoggerWrapper, devMode: boolean, includePreReleases: boolean) {
 		this.window_ = mainWindow;
@@ -135,6 +143,7 @@ export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
 
 		try {
 			const release: GitHubRelease = await this.fetchLatestRelease(this.includePreReleases_);
+			this.latestRelease_ = release;
 
 			try {
 				let assetUrl = this.getDownloadUrlForPlatform(release, shim.platformName(), process.arch);
@@ -212,6 +221,12 @@ export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
 	};
 
 	private promptUserToUpdate = async (info: UpdateInfo): Promise<void> => {
-		this.window_.webContents.send(AutoUpdaterEvents.UpdateDownloaded, info);
+		const updateInfo: UpdateDownloadedInfo = {
+			version: info.version,
+			releaseNotes: this.latestRelease_?.body ?? '',
+			pageUrl: this.latestRelease_?.html_url ?? '',
+			prerelease: this.latestRelease_?.prerelease ?? false,
+		};
+		this.window_.webContents.send(AutoUpdaterEvents.UpdateDownloaded, updateInfo);
 	};
 }

--- a/packages/app-desktop/utils/checkForUpdatesUtils.ts
+++ b/packages/app-desktop/utils/checkForUpdatesUtils.ts
@@ -37,6 +37,19 @@ function getMajorMinorTagName(tagName: string) {
 	return s.join('.');
 }
 
+// Cleans up a single line of release notes by stripping GitHub-specific noise:
+// - Issue numbers and author names: (#3157 by [@user](https://github.com/user))
+// - Commit hashes: (a6caa35)
+// - Bare issue numbers: (#4727)
+export const cleanReleaseNoteLine = (line: string): string => {
+	return line
+		.replace(/\(#.* by .*\)/g, '')
+		.replace(/\([0-9a-z]{7}\)/g, '')
+		.replace(/\(#[0-9]+\)/g, '')
+		.replace(/ {2}/g, ' ')
+		.trim();
+};
+
 export const extractVersionInfo = (releases: GitHubRelease[], platform: Platform, arch: Architecture, portable: boolean, options: CheckForUpdateOptions) => {
 	options = { includePreReleases: false, ...options };
 
@@ -117,14 +130,7 @@ export const extractVersionInfo = (releases: GitHubRelease[], platform: Platform
 		const lines = releaseNotes.join('\n\n* * *\n\n').split('\n');
 		const output = [];
 		for (const line of lines) {
-			const r = line
-				.replace(/\(#.* by .*\)/g, '') // Removes issue numbers and names - (#3157 by [@user](https://github.com/user))
-				.replace(/\([0-9a-z]{7}\)/g, '') // Removes commits - "sync state or data (a6caa35)"
-				.replace(/\(#[0-9]+\)/g, '') // Removes issue numbers - "(#4727)"
-				.replace(/ {2}/g, ' ')
-				.trim();
-
-			output.push(r);
+			output.push(cleanReleaseNoteLine(line));
 		}
 		return output.join('\n');
 	}


### PR DESCRIPTION
FIxes : # #14251
Right now the update popup just says "a new version is available" — you have to go to GitHub to see what actually changed.
This adds the release notes directly inside the notification so you can read them before restarting. It parses the GitHub release body into clean headings and bullet points and links to the full release page if you want more detail.
<img width="1461" height="870" alt="Screenshot from 2026-04-05 20-41-50" src="https://github.com/user-attachments/assets/b7f7e6f8-0b6f-4e0d-9ff0-826c13dcc28d" />
