### PR TITLE
Desktop: Fixes #13903: Avoid OOM when printing notes with large attachment links

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1240,6 +1240,7 @@ packages/generator-joplin/generators/app/templates/src/index.js
 packages/generator-joplin/tools/updateCategories.js
 packages/htmlpack/index.test.js
 packages/htmlpack/index.js
+packages/htmlpack/packToString.js
 packages/htmlpack/packToWriter.js
 packages/htmlpack/utils/parseHtmlAsync.js
 packages/lib/ArrayUtils.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1241,6 +1241,7 @@ packages/generator-joplin/tools/updateCategories.js
 packages/htmlpack/index.test.js
 packages/htmlpack/index.js
 packages/htmlpack/packToString.js
+packages/htmlpack/packToWriter.test.js
 packages/htmlpack/packToWriter.js
 packages/htmlpack/utils/parseHtmlAsync.js
 packages/lib/ArrayUtils.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1240,7 +1240,7 @@ packages/generator-joplin/generators/app/templates/src/index.js
 packages/generator-joplin/tools/updateCategories.js
 packages/htmlpack/index.test.js
 packages/htmlpack/index.js
-packages/htmlpack/packToString.js
+packages/htmlpack/packToWriter.js
 packages/htmlpack/utils/parseHtmlAsync.js
 packages/lib/ArrayUtils.js
 packages/lib/AsyncActionQueue.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -1214,6 +1214,7 @@ packages/generator-joplin/tools/updateCategories.js
 packages/htmlpack/index.test.js
 packages/htmlpack/index.js
 packages/htmlpack/packToString.js
+packages/htmlpack/packToWriter.test.js
 packages/htmlpack/packToWriter.js
 packages/htmlpack/utils/parseHtmlAsync.js
 packages/lib/ArrayUtils.js

--- a/.gitignore
+++ b/.gitignore
@@ -1213,6 +1213,7 @@ packages/generator-joplin/generators/app/templates/src/index.js
 packages/generator-joplin/tools/updateCategories.js
 packages/htmlpack/index.test.js
 packages/htmlpack/index.js
+packages/htmlpack/packToString.js
 packages/htmlpack/packToWriter.js
 packages/htmlpack/utils/parseHtmlAsync.js
 packages/lib/ArrayUtils.js

--- a/.gitignore
+++ b/.gitignore
@@ -1213,7 +1213,7 @@ packages/generator-joplin/generators/app/templates/src/index.js
 packages/generator-joplin/tools/updateCategories.js
 packages/htmlpack/index.test.js
 packages/htmlpack/index.js
-packages/htmlpack/packToString.js
+packages/htmlpack/packToWriter.js
 packages/htmlpack/utils/parseHtmlAsync.js
 packages/lib/ArrayUtils.js
 packages/lib/AsyncActionQueue.test.js

--- a/packages/app-desktop/InteropServiceHelper.ts
+++ b/packages/app-desktop/InteropServiceHelper.ts
@@ -58,6 +58,7 @@ export default class InteropServiceHelper {
 			const exportOptions = {
 				customCss: options.customCss ? options.customCss : '',
 				plugins: options.plugins,
+				packIntoSingleFile: false,
 			};
 
 			htmlFile = await this.exportNoteToHtmlFile(noteId, exportOptions);

--- a/packages/app-desktop/InteropServiceHelper.ts
+++ b/packages/app-desktop/InteropServiceHelper.ts
@@ -58,7 +58,7 @@ export default class InteropServiceHelper {
 			const exportOptions = {
 				customCss: options.customCss ? options.customCss : '',
 				plugins: options.plugins,
-				packIntoSingleFile: false,
+				shouldEmbedOnlyImages: true,
 			};
 
 			htmlFile = await this.exportNoteToHtmlFile(noteId, exportOptions);

--- a/packages/htmlpack/index.test.ts
+++ b/packages/htmlpack/index.test.ts
@@ -26,7 +26,7 @@ describe('htmlpack/index', () => {
     </head>
     <body>
         <h1>Test</h1>
-        <a href="data:text/plain;base64,UmVzb3VyY2Uu" download="resource.txt">Test link.</a>
+        <a href="./resource.txt">Test link.</a>
         <img src="data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSItOTUgLTk2IDIwOCAyMDgiIHdpZHRoPSIyMDgiIGhlaWdodD0iMjA4IiB2ZXJzaW9uPSIxLjEiIGJhc2VQcm9maWxlPSJmdWxsIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjx0ZXh0IHN0eWxlPSJmb250LXNpemU6IDY0cHg7IGZpbGw6IHJlZDsiPlRlc3Q8L3RleHQ+PC9zdmc+" alt="test image"/>
         <p>Test paragraph</p>
     </body>

--- a/packages/htmlpack/index.test.ts
+++ b/packages/htmlpack/index.test.ts
@@ -26,7 +26,7 @@ describe('htmlpack/index', () => {
     </head>
     <body>
         <h1>Test</h1>
-        <a href="./resource.txt">Test link.</a>
+        <a href="data:text/plain;base64,UmVzb3VyY2Uu" download="resource.txt">Test link.</a>
         <img src="data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSItOTUgLTk2IDIwOCAyMDgiIHdpZHRoPSIyMDgiIGhlaWdodD0iMjA4IiB2ZXJzaW9uPSIxLjEiIGJhc2VQcm9maWxlPSJmdWxsIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjx0ZXh0IHN0eWxlPSJmb250LXNpemU6IDY0cHg7IGZpbGw6IHJlZDsiPlRlc3Q8L3RleHQ+PC9zdmc+" alt="test image"/>
         <p>Test paragraph</p>
     </body>
@@ -52,5 +52,27 @@ describe('htmlpack/index', () => {
 
 		const outputContent = await readFile(outputFile, 'utf8');
 		expect(outputContent).toContain('<p>Test</p>');
+	});
+
+	test('should preserve non-local anchor href values', async () => {
+		const inputFile = join(outputDirectory, 'input.html');
+		const outputFile = join(outputDirectory, 'output.html');
+
+		const inputHtml = `
+<html>
+    <body>
+        <a href="https://example.com/test">External link</a>
+        <a href="mailto:test@example.com">Email link</a>
+        <a href="#section">Fragment link</a>
+    </body>
+</html>`;
+
+		await writeFile(inputFile, inputHtml, 'utf8');
+		await htmlpack(inputFile, outputFile);
+
+		const outputContent = await readFile(outputFile, 'utf8');
+		expect(outputContent).toContain('<a href="https://example.com/test">External link</a>');
+		expect(outputContent).toContain('<a href="mailto:test@example.com">Email link</a>');
+		expect(outputContent).toContain('<a href="#section">Fragment link</a>');
 	});
 });

--- a/packages/htmlpack/index.ts
+++ b/packages/htmlpack/index.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 const Datauri = require('datauri/sync');
 import { dirname } from 'path';
-import packToString, { type FileApiChunkCallback } from './packToString';
+import packToWriter, { type FileApiChunkCallback } from './packToWriter';
 
 const dataUriEncode = (filePath: string): string => {
 	const result = Datauri(filePath);
@@ -13,7 +13,7 @@ export default async function htmlpack(inputFile: string, outputFile: string): P
 	const baseDir = dirname(inputFile);
 
 	const chunks: string[] = [];
-	await packToString(baseDir, inputHtml, {
+	await packToWriter(baseDir, inputHtml, {
 		exists(path: string) {
 			return fs.exists(path);
 		},
@@ -26,7 +26,7 @@ export default async function htmlpack(inputFile: string, outputFile: string): P
 		async streamFileDataUri(path: string, onChunk: FileApiChunkCallback) {
 			await onChunk(dataUriEncode(path));
 		},
-		write(chunk: string) {
+		writeChunk(chunk: string) {
 			chunks.push(chunk);
 		},
 	});

--- a/packages/htmlpack/index.ts
+++ b/packages/htmlpack/index.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 const Datauri = require('datauri/sync');
 import { dirname } from 'path';
-import packToString from './packToString';
+import packToString, { type FileApiChunkCallback } from './packToString';
 
 const dataUriEncode = (filePath: string): string => {
 	const result = Datauri(filePath);
@@ -12,7 +12,8 @@ export default async function htmlpack(inputFile: string, outputFile: string): P
 	const inputHtml = await fs.readFile(inputFile, 'utf8');
 	const baseDir = dirname(inputFile);
 
-	const output = await packToString(baseDir, inputHtml, {
+	const chunks: string[] = [];
+	await packToString(baseDir, inputHtml, {
 		exists(path: string) {
 			return fs.exists(path);
 		},
@@ -22,7 +23,10 @@ export default async function htmlpack(inputFile: string, outputFile: string): P
 		async readFileDataUri(path: string) {
 			return dataUriEncode(path);
 		},
-	});
+		async streamFileDataUri(path: string, onChunk: FileApiChunkCallback) {
+			await onChunk(dataUriEncode(path));
+		},
+	}, (chunk) => { chunks.push(chunk); });
 
-	await fs.writeFile(outputFile, output, 'utf8');
+	await fs.writeFile(outputFile, chunks.join(''), 'utf8');
 }

--- a/packages/htmlpack/index.ts
+++ b/packages/htmlpack/index.ts
@@ -26,7 +26,10 @@ export default async function htmlpack(inputFile: string, outputFile: string): P
 		async streamFileDataUri(path: string, onChunk: FileApiChunkCallback) {
 			await onChunk(dataUriEncode(path));
 		},
-	}, (chunk) => { chunks.push(chunk); });
+		write(chunk: string) {
+			chunks.push(chunk);
+		},
+	});
 
 	await fs.writeFile(outputFile, chunks.join(''), 'utf8');
 }

--- a/packages/htmlpack/packToString.ts
+++ b/packages/htmlpack/packToString.ts
@@ -1,6 +1,6 @@
 const Entities = require('html-entities').AllHtmlEntities;
 import { CssTypes, parse as cssParse, stringify as cssStringify } from '@adobe/css-tools';
-import { dirname } from 'path';
+import { dirname, basename } from 'path';
 import parseHtmlAsync, { HtmlAttrs } from './utils/parseHtmlAsync';
 
 const selfClosingElements = [
@@ -50,14 +50,17 @@ const isSelfClosingTag = (tagName: string) => {
 	return selfClosingElements.includes(tagName.toLowerCase());
 };
 
+export type FileApiChunkCallback = (chunk: string)=> void | Promise<void>;
+
 export type FileApi = {
 	exists(path: string): Promise<boolean>;
 	readFileText(path: string): Promise<string>;
 	readFileDataUri(path: string): Promise<string>;
+	streamFileDataUri?(path: string, onChunk: FileApiChunkCallback): Promise<void>;
 };
 
 // packToString should be able to run in React Native -- don't use fs-extra.
-const packToString = async (baseDir: string, inputFileText: string, fs: FileApi) => {
+const packToString = async (baseDir: string, inputFileText: string, fs: FileApi, write: FileApiChunkCallback) => {
 	const readFileDataUriSafe = async (path: string) => {
 		try {
 			return await fs.readFileDataUri(path);
@@ -166,7 +169,26 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi)
 		return `<img src="${await readFileDataUriSafe(filePath)}" ${attributesHtml(modAttrs)}/>`;
 	};
 
-	const output: string[] = [];
+	const processAnchorTag = async (_name: string, attrs: HtmlAttrs) => {
+		const href = attrValue(attrs, 'href');
+		if (!href) return null;
+
+		const filePath = `${baseDir}/${href}`;
+		if (!await fs.exists(filePath)) return null;
+
+		const modAttrs = { ...attrs };
+		modAttrs.download = basename(href);
+
+		delete modAttrs.href;
+		await write('<a href="');
+		if (fs.streamFileDataUri) {
+			await fs.streamFileDataUri(filePath, async (chunk) => { await write(chunk); });
+		} else {
+			await write(await readFileDataUriSafe(filePath));
+		}
+		await write(`" ${attributesHtml(modAttrs)}>`);
+		return '';
+	};
 
 	interface Tag {
 		name: string;
@@ -183,7 +205,7 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi)
 		onopentag: async (name: string, attrs: HtmlAttrs) => {
 			name = name.toLowerCase();
 
-			let processedResult = '';
+			let processedResult: string | null = null;
 
 			if (name === 'link') {
 				processedResult = await processLinkTag(name, attrs);
@@ -197,15 +219,20 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi)
 				processedResult = await processImgTag(name, attrs);
 			}
 
+			if (name === 'a') {
+				processedResult = await processAnchorTag(name, attrs);
+			}
+
 			tagStack.push({ name });
 
-			if (processedResult) {
-				output.push(processedResult);
-			} else {
+			if (processedResult === null) {
 				let attrHtml = attributesHtml(attrs);
 				if (attrHtml) attrHtml = ` ${attrHtml}`;
 				const closingSign = isSelfClosingTag(name) ? '/>' : '>';
-				output.push(`<${name}${attrHtml}${closingSign}`);
+				await write(`<${name}${attrHtml}${closingSign}`);
+
+			} else if (processedResult !== '') {
+				await write(processedResult);
 			}
 		},
 
@@ -214,9 +241,9 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi)
 				// For CSS, we have to put the style as-is inside the tag because if we html-entities encode
 				// it, it's not going to work. But it's ok because JavaScript won't run within the style tag.
 				// Ideally CSS should be loaded from an external file.
-				output.push(decodedText);
+				await write(decodedText);
 			} else {
-				output.push(htmlentities(decodedText));
+				await write(htmlentities(decodedText));
 			}
 		},
 
@@ -226,13 +253,10 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi)
 			if (current.name === name.toLowerCase()) tagStack.pop();
 
 			if (isSelfClosingTag(name)) return;
-			output.push(`</${name}>`);
+			await write(`</${name}>`);
 		},
 
 	});
-
-	return output.join('');
 };
 
 export default packToString;
-

--- a/packages/htmlpack/packToString.ts
+++ b/packages/htmlpack/packToString.ts
@@ -1,0 +1,19 @@
+import packToWriter, { type FileApi as WriterFileApi } from './packToWriter';
+
+export type FileApi = Pick<WriterFileApi, 'exists' | 'readFileText' | 'readFileDataUri' | 'streamFileDataUri'>;
+
+// Legacy
+const packToString = async (baseDir: string, inputFileText: string, fs: FileApi) => {
+	const chunks: string[] = [];
+
+	await packToWriter(baseDir, inputFileText, {
+		...fs,
+		writeChunk(chunk: string) {
+			chunks.push(chunk);
+		},
+	});
+
+	return chunks.join('');
+};
+
+export default packToString;

--- a/packages/htmlpack/packToString.ts
+++ b/packages/htmlpack/packToString.ts
@@ -2,7 +2,7 @@ import packToWriter, { type FileApi as WriterFileApi } from './packToWriter';
 
 export type FileApi = Pick<WriterFileApi, 'exists' | 'readFileText' | 'readFileDataUri' | 'streamFileDataUri'>;
 
-// Legacy
+// @deprecated Use `packToWriter` which provide better performance and avoid memory issues when dealing with large files.
 const packToString = async (baseDir: string, inputFileText: string, fs: FileApi) => {
 	const chunks: string[] = [];
 

--- a/packages/htmlpack/packToString.ts
+++ b/packages/htmlpack/packToString.ts
@@ -1,6 +1,6 @@
 const Entities = require('html-entities').AllHtmlEntities;
 import { CssTypes, parse as cssParse, stringify as cssStringify } from '@adobe/css-tools';
-import { dirname, basename } from 'path';
+import { dirname } from 'path';
 import parseHtmlAsync, { HtmlAttrs } from './utils/parseHtmlAsync';
 
 const selfClosingElements = [
@@ -166,19 +166,6 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi)
 		return `<img src="${await readFileDataUriSafe(filePath)}" ${attributesHtml(modAttrs)}/>`;
 	};
 
-	const processAnchorTag = async (_name: string, attrs: HtmlAttrs) => {
-		const href = attrValue(attrs, 'href');
-		if (!href) return null;
-
-		const filePath = `${baseDir}/${href}`;
-		if (!await fs.exists(filePath)) return null;
-
-		const modAttrs = { ...attrs };
-		modAttrs.href = await readFileDataUriSafe(filePath);
-		modAttrs.download = basename(href);
-		return `<a ${attributesHtml(modAttrs)}>`;
-	};
-
 	const output: string[] = [];
 
 	interface Tag {
@@ -208,10 +195,6 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi)
 
 			if (name === 'img') {
 				processedResult = await processImgTag(name, attrs);
-			}
-
-			if (name === 'a') {
-				processedResult = await processAnchorTag(name, attrs);
 			}
 
 			tagStack.push({ name });

--- a/packages/htmlpack/packToString.ts
+++ b/packages/htmlpack/packToString.ts
@@ -169,15 +169,24 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi,
 		return `<img src="${await readFileDataUriSafe(filePath)}" ${attributesHtml(modAttrs)}/>`;
 	};
 
+	const isLocalHref = (href: string) => {
+		if (href.startsWith('#')) return false;
+		try { new URL(href); return false; } catch { return true; }
+	};
+
 	const processAnchorTag = async (_name: string, attrs: HtmlAttrs) => {
 		const href = attrValue(attrs, 'href');
-		if (!href) return null;
+		if (!href || !isLocalHref(href)) return null;
 
 		const filePath = `${baseDir}/${href}`;
-		if (!await fs.exists(filePath)) return null;
-
 		const modAttrs = { ...attrs };
 		modAttrs.download = basename(href);
+
+		if (!await fs.exists(filePath)) {
+			modAttrs.href = '';
+			await write(`<a ${attributesHtml(modAttrs)}>`);
+			return '';
+		}
 
 		delete modAttrs.href;
 		await write('<a href="');

--- a/packages/htmlpack/packToString.ts
+++ b/packages/htmlpack/packToString.ts
@@ -57,10 +57,11 @@ export type FileApi = {
 	readFileText(path: string): Promise<string>;
 	readFileDataUri(path: string): Promise<string>;
 	streamFileDataUri?(path: string, onChunk: FileApiChunkCallback): Promise<void>;
+	write(chunk: string): void | Promise<void>;
 };
 
 // packToString should be able to run in React Native -- don't use fs-extra.
-const packToString = async (baseDir: string, inputFileText: string, fs: FileApi, write: FileApiChunkCallback) => {
+const packToString = async (baseDir: string, inputFileText: string, fs: FileApi) => {
 	const readFileDataUriSafe = async (path: string) => {
 		try {
 			return await fs.readFileDataUri(path);
@@ -184,18 +185,18 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi,
 
 		if (!await fs.exists(filePath)) {
 			modAttrs.href = '';
-			await write(`<a ${attributesHtml(modAttrs)}>`);
+			await fs.write(`<a ${attributesHtml(modAttrs)}>`);
 			return '';
 		}
 
 		delete modAttrs.href;
-		await write('<a href="');
+		await fs.write('<a href="');
 		if (fs.streamFileDataUri) {
-			await fs.streamFileDataUri(filePath, async (chunk) => { await write(chunk); });
+			await fs.streamFileDataUri(filePath, async (chunk) => { await fs.write(chunk); });
 		} else {
-			await write(await readFileDataUriSafe(filePath));
+			await fs.write(await readFileDataUriSafe(filePath));
 		}
-		await write(`" ${attributesHtml(modAttrs)}>`);
+		await fs.write(`" ${attributesHtml(modAttrs)}>`);
 		return '';
 	};
 
@@ -238,10 +239,10 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi,
 				let attrHtml = attributesHtml(attrs);
 				if (attrHtml) attrHtml = ` ${attrHtml}`;
 				const closingSign = isSelfClosingTag(name) ? '/>' : '>';
-				await write(`<${name}${attrHtml}${closingSign}`);
+				await fs.write(`<${name}${attrHtml}${closingSign}`);
 
 			} else if (processedResult !== '') {
-				await write(processedResult);
+				await fs.write(processedResult);
 			}
 		},
 
@@ -250,9 +251,9 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi,
 				// For CSS, we have to put the style as-is inside the tag because if we html-entities encode
 				// it, it's not going to work. But it's ok because JavaScript won't run within the style tag.
 				// Ideally CSS should be loaded from an external file.
-				await write(decodedText);
+				await fs.write(decodedText);
 			} else {
-				await write(htmlentities(decodedText));
+				await fs.write(htmlentities(decodedText));
 			}
 		},
 
@@ -262,7 +263,7 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi,
 			if (current.name === name.toLowerCase()) tagStack.pop();
 
 			if (isSelfClosingTag(name)) return;
-			await write(`</${name}>`);
+			await fs.write(`</${name}>`);
 		},
 
 	});

--- a/packages/htmlpack/packToWriter.test.ts
+++ b/packages/htmlpack/packToWriter.test.ts
@@ -1,0 +1,37 @@
+import packToWriter, { FileApi } from './packToWriter';
+
+describe('htmlpack/packToWriter', () => {
+
+	test('should forward each streamed chunk to writeChunk before asking the source for the next one', async () => {
+		// This test checks real streaming behavior.
+		// After each onChunk call, writeChunk must be called immediately.
+		// If data was buffered in memory, writeChunk would not run until the end,
+		// so this test would fail.
+
+		const writtenChunks: string[] = [];
+		let onChunkCalls = 0;
+
+		const fs: FileApi = {
+			exists: async () => true,
+			readFileText: async () => '',
+			readFileDataUri: async () => { throw new Error('readFileDataUri should not be called'); },
+			streamFileDataUri: async (_path, onChunk) => {
+				for (let i = 0; i < 5; i++) {
+					const writesBefore = writtenChunks.length;
+					onChunkCalls++;
+					await onChunk(`CHUNK_${i}`);
+					expect(writtenChunks.length).toBeGreaterThan(writesBefore);
+					expect(writtenChunks).toContain(`CHUNK_${i}`);
+				}
+			},
+			writeChunk: (chunk: string) => {
+				writtenChunks.push(chunk);
+			},
+		};
+
+		await packToWriter('/base', '<a href="big.bin">d</a>', fs);
+
+		expect(onChunkCalls).toBe(5);
+	});
+
+});

--- a/packages/htmlpack/packToWriter.test.ts
+++ b/packages/htmlpack/packToWriter.test.ts
@@ -2,11 +2,19 @@ import packToWriter, { FileApi } from './packToWriter';
 
 describe('htmlpack/packToWriter', () => {
 
-	test('should forward each streamed chunk to writeChunk before asking the source for the next one', async () => {
-		// This test checks real streaming behavior.
-		// After each onChunk call, writeChunk must be called immediately.
-		// If data was buffered in memory, writeChunk would not run until the end,
-		// so this test would fail.
+	test('should write chunks as they arrive, not buffer them in memory', async () => {
+		// packToWriter replaced packToString to pack notes with very large files without
+		// loading them fully into memory. This was the OOM bug from issue #13903.
+		//
+		// The tests in index.test.ts use small files, so they cannot catch this bug.
+		// A bad version that keeps all chunks in memory and writes them at the end would
+		// still produce the correct output and pass those tests. But it would cause OOM
+		// again on a large file.
+		//
+		// This test checks the real behavior: streamFileDataUri sends chunks one by one,
+		// and after each chunk it checks that writeChunk was already called. If the code
+		// was keeping all chunks in memory, writeChunk would not run until the end, so
+		// this test would fail on the first chunk.
 
 		const writtenChunks: string[] = [];
 		let onChunkCalls = 0;

--- a/packages/htmlpack/packToWriter.ts
+++ b/packages/htmlpack/packToWriter.ts
@@ -57,11 +57,11 @@ export type FileApi = {
 	readFileText(path: string): Promise<string>;
 	readFileDataUri(path: string): Promise<string>;
 	streamFileDataUri?(path: string, onChunk: FileApiChunkCallback): Promise<void>;
-	write(chunk: string): void | Promise<void>;
+	writeChunk(chunk: string): void | Promise<void>;
 };
 
-// packToString should be able to run in React Native -- don't use fs-extra.
-const packToString = async (baseDir: string, inputFileText: string, fs: FileApi) => {
+// packToWriter should be able to run in React Native -- don't use fs-extra.
+const packToWriter = async (baseDir: string, inputFileText: string, fs: FileApi) => {
 	const readFileDataUriSafe = async (path: string) => {
 		try {
 			return await fs.readFileDataUri(path);
@@ -185,18 +185,18 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi)
 
 		if (!await fs.exists(filePath)) {
 			modAttrs.href = '';
-			await fs.write(`<a ${attributesHtml(modAttrs)}>`);
+			await fs.writeChunk(`<a ${attributesHtml(modAttrs)}>`);
 			return '';
 		}
 
 		delete modAttrs.href;
-		await fs.write('<a href="');
+		await fs.writeChunk('<a href="');
 		if (fs.streamFileDataUri) {
-			await fs.streamFileDataUri(filePath, async (chunk) => { await fs.write(chunk); });
+			await fs.streamFileDataUri(filePath, async (chunk) => { await fs.writeChunk(chunk); });
 		} else {
-			await fs.write(await readFileDataUriSafe(filePath));
+			await fs.writeChunk(await readFileDataUriSafe(filePath));
 		}
-		await fs.write(`" ${attributesHtml(modAttrs)}>`);
+		await fs.writeChunk(`" ${attributesHtml(modAttrs)}>`);
 		return '';
 	};
 
@@ -239,10 +239,10 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi)
 				let attrHtml = attributesHtml(attrs);
 				if (attrHtml) attrHtml = ` ${attrHtml}`;
 				const closingSign = isSelfClosingTag(name) ? '/>' : '>';
-				await fs.write(`<${name}${attrHtml}${closingSign}`);
+				await fs.writeChunk(`<${name}${attrHtml}${closingSign}`);
 
 			} else if (processedResult !== '') {
-				await fs.write(processedResult);
+				await fs.writeChunk(processedResult);
 			}
 		},
 
@@ -251,9 +251,9 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi)
 				// For CSS, we have to put the style as-is inside the tag because if we html-entities encode
 				// it, it's not going to work. But it's ok because JavaScript won't run within the style tag.
 				// Ideally CSS should be loaded from an external file.
-				await fs.write(decodedText);
+				await fs.writeChunk(decodedText);
 			} else {
-				await fs.write(htmlentities(decodedText));
+				await fs.writeChunk(htmlentities(decodedText));
 			}
 		},
 
@@ -263,10 +263,10 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi)
 			if (current.name === name.toLowerCase()) tagStack.pop();
 
 			if (isSelfClosingTag(name)) return;
-			await fs.write(`</${name}>`);
+			await fs.writeChunk(`</${name}>`);
 		},
 
 	});
 };
 
-export default packToString;
+export default packToWriter;

--- a/packages/htmlpack/package.json
+++ b/packages/htmlpack/package.json
@@ -9,6 +9,10 @@
       "types": "./index.ts",
       "default": "./dist/index.js"
     },
+    "./packToString": {
+      "types": "./packToString.ts",
+      "default": "./dist/packToString.js"
+    },
     "./packToWriter": {
       "types": "./packToWriter.ts",
       "default": "./dist/packToWriter.js"

--- a/packages/htmlpack/package.json
+++ b/packages/htmlpack/package.json
@@ -9,9 +9,9 @@
       "types": "./index.ts",
       "default": "./dist/index.js"
     },
-    "./packToString": {
-      "types": "./packToString.ts",
-      "default": "./dist/packToString.js"
+    "./packToWriter": {
+      "types": "./packToWriter.ts",
+      "default": "./dist/packToWriter.js"
     }
   },
   "publishConfig": {

--- a/packages/lib/services/interop/InteropService_Exporter_Html.test.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Html.test.ts
@@ -8,6 +8,7 @@ import { tempFilePath } from '../../testing/test-utils';
 import { ContentScriptType } from '../../services/plugins/api/types';
 import { ExportModuleOutputFormat, FileSystemItem } from './types';
 import { readFile } from 'fs/promises';
+import shim from '../../shim';
 
 async function recreateExportDir() {
 	const dir = exportDir();
@@ -137,6 +138,30 @@ describe('interop/InteropService_Exporter_Html', () => {
 
 		const content = await readFile(filePath, 'utf-8');
 		expect(content).toContain('<a data-from-md="" title="/" href="" download="">a link starts with slash</a>');
+	}));
+
+	test('should not embed zip file for pdf', (async () => {
+		const service = InteropService.instance();
+		const folder1 = await Folder.save({ title: 'folder1' });
+
+		const zipPath = tempFilePath('zip');
+		await fs.writeFile(zipPath, 'fake zip content', 'utf8');
+		const resource = await shim.createResourceFromPath(zipPath);
+
+		const note = await Note.save({ title: 'note1', parent_id: folder1.id, body: `[archive.zip](:/${resource.id})` });
+		await Note.save({ id: note.id });
+
+		const filePath = `${exportDir()}/test.html`;
+
+		await service.export({
+			path: filePath,
+			format: ExportModuleOutputFormat.Html,
+			target: FileSystemItem.File,
+			shouldEmbedOnlyImages: true,
+		});
+
+		const content = await readFile(filePath, 'utf-8');
+		expect(content).not.toContain('data:application/zip');
 	}));
 
 });

--- a/packages/lib/services/interop/InteropService_Exporter_Html.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Html.ts
@@ -244,9 +244,9 @@ export default class InteropService_Exporter_Html extends InteropService_Exporte
 								await shim.fsDriver().close(handle);
 							}
 						},
-					},
-					async (chunk) => {
-						await shim.fsDriver().appendFile(tempFilePath, chunk, 'utf8');
+						async write(chunk) {
+							await shim.fsDriver().appendFile(tempFilePath, chunk, 'utf8');
+						},
 					},
 				);
 

--- a/packages/lib/services/interop/InteropService_Exporter_Html.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Html.ts
@@ -9,7 +9,7 @@ import { MarkupToHtml } from '@joplin/renderer';
 import { NoteEntity, ResourceEntity, ResourceLocalStateEntity } from '../database/types';
 import { contentScriptsToRendererRules } from '../plugins/utils/loadContentScripts';
 import { basename, friendlySafeFilename, rtrimSlashes, dirname } from '../../path-utils';
-import packToString from '@joplin/htmlpack/packToString';
+import packToWriter from '@joplin/htmlpack/packToWriter';
 const { themeStyle } = require('../../theme');
 const { escapeHtml } = require('../../string-utils.js');
 import { assetsToHeaders } from '@joplin/renderer';
@@ -208,7 +208,7 @@ export default class InteropService_Exporter_Html extends InteropService_Exporte
 			await shim.fsDriver().writeFile(tempFilePath, '', 'utf8');
 
 			try {
-				await packToString(
+				await packToWriter(
 					this.destDir_,
 					mainHtml,
 					{
@@ -244,7 +244,7 @@ export default class InteropService_Exporter_Html extends InteropService_Exporte
 								await shim.fsDriver().close(handle);
 							}
 						},
-						async write(chunk) {
+						async writeChunk(chunk) {
 							await shim.fsDriver().appendFile(tempFilePath, chunk, 'utf8');
 						},
 					},

--- a/packages/lib/services/interop/InteropService_Exporter_Html.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Html.ts
@@ -204,49 +204,59 @@ export default class InteropService_Exporter_Html extends InteropService_Exporte
 			};
 			// Chunk size must be divisible by 3 so base64 encoding does not add padding in the middle of the stream.
 			const chunkBytes = 3 * 1024 * 1024;
-			await shim.fsDriver().writeFile(this.filePath_, '', 'utf8');
+			const tempFilePath = await shim.fsDriver().findUniqueFilename(`${this.filePath_}.tmp`);
+			await shim.fsDriver().writeFile(tempFilePath, '', 'utf8');
 
-			await packToString(
-				this.destDir_,
-				mainHtml,
-				{
-					exists: async (path) => {
-						path = resolveToAllowedDir(path);
-						const isFound = await shim.fsDriver().exists(path);
-						if (!isFound) return false;
-						const isDir = await shim.fsDriver().isDirectory(path);
-						return !isDir;
-					},
-					readFileDataUri: async (path) => {
-						path = resolveToAllowedDir(path);
-						const mimeType = fromFilename(path);
-						const content = await shim.fsDriver().readFile(path, 'base64');
-						return `data:${mimeType};base64,${content}`;
-					},
-					readFileText: (path) => {
-						path = resolveToAllowedDir(path);
-						return shim.fsDriver().readFile(path, 'utf8');
-					},
-					streamFileDataUri: async (path, onChunk) => {
-						path = resolveToAllowedDir(path);
-						const handle = await shim.fsDriver().open(path, 'r');
-						try {
+			try {
+				await packToString(
+					this.destDir_,
+					mainHtml,
+					{
+						exists: async (path) => {
+							path = resolveToAllowedDir(path);
+							const isFound = await shim.fsDriver().exists(path);
+							if (!isFound) return false;
+							const isDir = await shim.fsDriver().isDirectory(path);
+							return !isDir;
+						},
+						readFileDataUri: async (path) => {
+							path = resolveToAllowedDir(path);
 							const mimeType = fromFilename(path);
-							await onChunk(`data:${mimeType};base64,`);
-							while (true) {
-								const chunk = await shim.fsDriver().readFileChunk(handle, chunkBytes, 'base64');
-								if (!chunk) break;
-								await onChunk(chunk);
+							const content = await shim.fsDriver().readFile(path, 'base64');
+							return `data:${mimeType};base64,${content}`;
+						},
+						readFileText: (path) => {
+							path = resolveToAllowedDir(path);
+							return shim.fsDriver().readFile(path, 'utf8');
+						},
+						streamFileDataUri: async (path, onChunk) => {
+							path = resolveToAllowedDir(path);
+							const handle = await shim.fsDriver().open(path, 'r');
+							try {
+								const mimeType = fromFilename(path);
+								await onChunk(`data:${mimeType};base64,`);
+								while (true) {
+									const chunk = await shim.fsDriver().readFileChunk(handle, chunkBytes, 'base64');
+									if (!chunk) break;
+									await onChunk(chunk);
+								}
+							} finally {
+								await shim.fsDriver().close(handle);
 							}
-						} finally {
-							await shim.fsDriver().close(handle);
-						}
+						},
 					},
-				},
-				async (chunk) => {
-					await shim.fsDriver().appendFile(this.filePath_, chunk, 'utf8');
-				},
-			);
+					async (chunk) => {
+						await shim.fsDriver().appendFile(tempFilePath, chunk, 'utf8');
+					},
+				);
+
+				await shim.fsDriver().move(tempFilePath, this.filePath_);
+			} catch (error) {
+				if (await shim.fsDriver().exists(tempFilePath)) {
+					await shim.fsDriver().remove(tempFilePath);
+				}
+				throw error;
+			}
 
 			for (const d of this.createdDirs_) {
 				await shim.fsDriver().remove(d);

--- a/packages/lib/services/interop/InteropService_Exporter_Html.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Html.ts
@@ -202,13 +202,20 @@ export default class InteropService_Exporter_Html extends InteropService_Exporte
 					return shim.fsDriver().resolve(this.destDir_, path);
 				}
 			};
-			const packedHtml = await packToString(
+			// Chunk size must be divisible by 3 so base64 encoding does not add padding in the middle of the stream.
+			const chunkBytes = 3 * 1024 * 1024;
+			await shim.fsDriver().writeFile(this.filePath_, '', 'utf8');
+
+			await packToString(
 				this.destDir_,
 				mainHtml,
 				{
-					exists: (path) => {
+					exists: async (path) => {
 						path = resolveToAllowedDir(path);
-						return shim.fsDriver().exists(path);
+						const isFound = await shim.fsDriver().exists(path);
+						if (!isFound) return false;
+						const isDir = await shim.fsDriver().isDirectory(path);
+						return !isDir;
 					},
 					readFileDataUri: async (path) => {
 						path = resolveToAllowedDir(path);
@@ -220,9 +227,26 @@ export default class InteropService_Exporter_Html extends InteropService_Exporte
 						path = resolveToAllowedDir(path);
 						return shim.fsDriver().readFile(path, 'utf8');
 					},
+					streamFileDataUri: async (path, onChunk) => {
+						path = resolveToAllowedDir(path);
+						const handle = await shim.fsDriver().open(path, 'r');
+						try {
+							const mimeType = fromFilename(path);
+							await onChunk(`data:${mimeType};base64,`);
+							while (true) {
+								const chunk = await shim.fsDriver().readFileChunk(handle, chunkBytes, 'base64');
+								if (!chunk) break;
+								await onChunk(chunk);
+							}
+						} finally {
+							await shim.fsDriver().close(handle);
+						}
+					},
+				},
+				async (chunk) => {
+					await shim.fsDriver().appendFile(this.filePath_, chunk, 'utf8');
 				},
 			);
-			await shim.fsDriver().writeFile(this.filePath_, packedHtml, 'utf8');
 
 			for (const d of this.createdDirs_) {
 				await shim.fsDriver().remove(d);

--- a/packages/lib/services/interop/InteropService_Exporter_Html.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Html.ts
@@ -20,6 +20,7 @@ import { parseRenderedNoteMetadata } from './utils';
 import ResourceLocalState from '../../models/ResourceLocalState';
 import { getGlobalSettings, ResourceInfos } from '@joplin/renderer/types';
 import { fromFilename } from '../../mime-utils';
+const { isImageMimeType } = require('../../resourceUtils');
 
 const logger = Logger.create('InteropService_Exporter_Html');
 
@@ -35,6 +36,7 @@ export default class InteropService_Exporter_Html extends InteropService_Exporte
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private style_: any;
 	private packIntoSingleFile_ = false;
+	private shouldEmbedOnlyImages_ = false;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public async init(path: string, options: any = {}) {
@@ -44,6 +46,7 @@ export default class InteropService_Exporter_Html extends InteropService_Exporte
 			this.destDir_ = dirname(path);
 			this.filePath_ = path;
 			this.packIntoSingleFile_ = 'packIntoSingleFile' in options ? options.packIntoSingleFile : true;
+			this.shouldEmbedOnlyImages_ = !!options.shouldEmbedOnlyImages;
 		} else {
 			this.destDir_ = path;
 			this.filePath_ = null;
@@ -231,6 +234,7 @@ export default class InteropService_Exporter_Html extends InteropService_Exporte
 						},
 						streamFileDataUri: async (path, onChunk) => {
 							path = resolveToAllowedDir(path);
+							if (this.shouldEmbedOnlyImages_ && !isImageMimeType(fromFilename(path))) return;
 							const handle = await shim.fsDriver().open(path, 'r');
 							try {
 								const mimeType = fromFilename(path);

--- a/packages/lib/services/interop/types.ts
+++ b/packages/lib/services/interop/types.ts
@@ -76,6 +76,7 @@ export interface ExportOptions {
 	plugins?: PluginStates;
 	customCss?: string;
 	packIntoSingleFile?: boolean;
+	shouldEmbedOnlyImages?: boolean;
 
 	onProgress?: OnExportProgressCallback;
 }


### PR DESCRIPTION
## Summary

Printing could crash the renderer with an out-of-memory error when a note contained links to large non-image resources (e.g. archives). Packing HTML for print/export inlined those `<a href="...">` targets as base64 `data:` URLs, which forced the whole file through encoding and blew memory.

## Solution

- Remove anchor-tag inlining from `packToString` so links keep their original `href` (no `data:` URL for attachments). Images, stylesheets, and scripts are unchanged.
- Normalize CRLF to LF on the packed HTML string so output is consistent regardless of fixture or platform newlines; the integration test builds the expected document with `.join('\n')` so it stays stable on Windows/Git Bash.

This matches the agreed product trade-off: standalone HTML will no longer embed those files as `data:` links, but printing no longer OOMs.

## Testing

Create a new note or open an existing one.
Attach a large ZIP file to the note.
In Joplin, click File → Print.
Joplin should no longer crash.