### PR TITLE
Mobile: Fixes #15004: Fix back button disabled after navigating away from a deleted notebook

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -966,6 +966,7 @@ packages/app-mobile/utils/ShareUtils.test.js
 packages/app-mobile/utils/ShareUtils.js
 packages/app-mobile/utils/TlsUtils.js
 packages/app-mobile/utils/appDefaultState.js
+packages/app-mobile/utils/appReducer.test.js
 packages/app-mobile/utils/appReducer.js
 packages/app-mobile/utils/autodetectTheme.js
 packages/app-mobile/utils/buildStartupTasks.js

--- a/.gitignore
+++ b/.gitignore
@@ -939,6 +939,7 @@ packages/app-mobile/utils/ShareUtils.test.js
 packages/app-mobile/utils/ShareUtils.js
 packages/app-mobile/utils/TlsUtils.js
 packages/app-mobile/utils/appDefaultState.js
+packages/app-mobile/utils/appReducer.test.js
 packages/app-mobile/utils/appReducer.js
 packages/app-mobile/utils/autodetectTheme.js
 packages/app-mobile/utils/buildStartupTasks.js

--- a/packages/app-mobile/utils/appReducer.test.ts
+++ b/packages/app-mobile/utils/appReducer.test.ts
@@ -1,0 +1,47 @@
+import appReducer from './appReducer';
+import appDefaultState, { DEFAULT_ROUTE } from './appDefaultState';
+
+// The reducer uses a module-level navHistory array. To isolate tests, each test
+// should dispatch a NAV_GO with clearHistory: true before asserting.
+
+const notesRoute = { type: 'NAV_GO', routeName: 'Notes', folderId: 'folder1' };
+const settingsRoute = { type: 'NAV_GO', routeName: 'Config' };
+
+const clearHistory = () => appReducer(appDefaultState, { type: 'NAV_GO', routeName: 'Notes', clearHistory: true });
+
+describe('appReducer', () => {
+	test('historyCanGoBack is true after navigating from Notes to Settings', () => {
+		let state = clearHistory();
+		state = appReducer(state, notesRoute);
+		state = appReducer(state, settingsRoute);
+		expect(state.historyCanGoBack).toBe(true);
+	});
+
+	test('historyCanGoBack remains true after navigating away from a deleted route', () => {
+		// Simulate: navigate to a folder, folder gets deleted (route.isDeleted = true),
+		// then navigate to Settings, back button must still be available.
+		let state = clearHistory();
+		state = appReducer(state, notesRoute);
+
+		// Mark the current route as deleted (as FOLDER_DELETE does)
+		state = { ...state, route: { ...state.route, isDeleted: true } };
+
+		// Navigate forward (e.g. open Settings)
+		state = appReducer(state, settingsRoute);
+
+		expect(state.historyCanGoBack).toBe(true);
+	});
+
+	test('going back from Settings after folder deletion lands on DEFAULT_ROUTE', () => {
+		let state = clearHistory();
+		state = appReducer(state, notesRoute);
+
+		state = { ...state, route: { ...state.route, isDeleted: true } };
+		state = appReducer(state, settingsRoute);
+
+		// Go back
+		state = appReducer(state, { type: 'NAV_BACK' });
+
+		expect(state.route.routeName).toBe(DEFAULT_ROUTE.routeName);
+	});
+});

--- a/packages/app-mobile/utils/appReducer.test.ts
+++ b/packages/app-mobile/utils/appReducer.test.ts
@@ -1,13 +1,23 @@
 import appReducer from './appReducer';
 import appDefaultState, { DEFAULT_ROUTE } from './appDefaultState';
 
-// The reducer uses a module-level navHistory array. To isolate tests, each test
-// should dispatch a NAV_GO with clearHistory: true before asserting.
-
 const notesRoute = { type: 'NAV_GO', routeName: 'Notes', folderId: 'folder1' };
 const settingsRoute = { type: 'NAV_GO', routeName: 'Config' };
+const deletedFolderId = 'folder1';
 
 const clearHistory = () => appReducer(appDefaultState, { type: 'NAV_GO', routeName: 'Notes', clearHistory: true });
+
+// Simulates the exact scenario: navigate to a folder with no prior history, then delete it
+const makeDeletedRouteWithEmptyHistory = () => {
+	let state = appReducer(appDefaultState, {
+		type: 'NAV_GO',
+		routeName: 'Notes',
+		folderId: deletedFolderId,
+		clearHistory: true,
+	});
+	state = appReducer(state, { type: 'FOLDER_DELETE', id: deletedFolderId });
+	return state;
+};
 
 describe('appReducer', () => {
 	test('historyCanGoBack is true after navigating from Notes to Settings', () => {
@@ -18,13 +28,7 @@ describe('appReducer', () => {
 	});
 
 	test('historyCanGoBack remains true after navigating away from a deleted route', () => {
-		// Simulate: navigate to a folder, folder gets deleted (route.isDeleted = true),
-		// then navigate to Settings, back button must still be available.
-		let state = clearHistory();
-		state = appReducer(state, notesRoute);
-
-		// Mark the current route as deleted (as FOLDER_DELETE does)
-		state = { ...state, route: { ...state.route, isDeleted: true } };
+		let state = makeDeletedRouteWithEmptyHistory();
 
 		// Navigate forward (e.g. open Settings)
 		state = appReducer(state, settingsRoute);
@@ -33,15 +37,12 @@ describe('appReducer', () => {
 	});
 
 	test('going back from Settings after folder deletion lands on DEFAULT_ROUTE', () => {
-		let state = clearHistory();
-		state = appReducer(state, notesRoute);
-
-		state = { ...state, route: { ...state.route, isDeleted: true } };
+		let state = makeDeletedRouteWithEmptyHistory();
 		state = appReducer(state, settingsRoute);
 
 		// Go back
 		state = appReducer(state, { type: 'NAV_BACK' });
 
-		expect(state.route.routeName).toBe(DEFAULT_ROUTE.routeName);
+		expect(state.route).toEqual(DEFAULT_ROUTE);
 	});
 });

--- a/packages/app-mobile/utils/appReducer.ts
+++ b/packages/app-mobile/utils/appReducer.ts
@@ -1,6 +1,6 @@
 import reducer from '@joplin/lib/reducer';
 import { AppState } from './types';
-import appDefaultState from './appDefaultState';
+import appDefaultState, { DEFAULT_ROUTE } from './appDefaultState';
 import fastDeepEqual = require('fast-deep-equal');
 import Logger from '@joplin/utils/Logger';
 
@@ -76,6 +76,10 @@ const appReducer = (state = appDefaultState, action: any) => {
 					if (currentRoute.isDeleted) {
 						// Do not add the item to the history, and remove the last item in the history if that is now the selected item
 						removeLatestFolderIfSelected(navHistory, action);
+						// Push DEFAULT_ROUTE so there's always a valid back target after deletion
+						if (!navHistory.length) {
+							navHistory.push(DEFAULT_ROUTE);
+						}
 					} else if (isDifferentRoute) {
 						navHistory.push(currentRoute);
 					}


### PR DESCRIPTION
Fixes #15004
### Problem

On a fresh install, the welcome notebook is the first and only screen shown, since the user navigates directly into it without any prior screens, navHistory is empty. When the welcome notebook is deleted, the route is marked isDeleted, on the next navigation (ex: opening settings), the deleted route is skipped when building nav history ; but since navHistory was already empty, it remains empty. This causes historyCanGoBack to be false, graying out the back button and making the hardware back button exit the app.

This does not affect manually created notebooks because by the time a user creates and deletes one, there is already navigation history built up

### Fix

In the NAV_GO case of appReducer, when the current route is marked deleted and navHistory is empty after skipping it, DEFAULT_ROUTE (All Notes) is pushed as a fallback ; ensuring there is always a valid screen to go back to

### Test Plan

A new test file packages/app-mobile/utils/appReducer.test.ts is added with three tests:

- Verifies historyCanGoBack is true after normal navigation from Notes to Settings
- Verifies historyCanGoBack remains true after navigating away from a deleted route with empty history - the core regression test
- Verifies that pressing back after folder deletion lands on DEFAULT_ROUTE (All Notes)

Also tested it manually:
### BEFORE

https://github.com/user-attachments/assets/ff35b5e9-edd6-4243-abf1-8bd877ed9648


### AFTER

https://github.com/user-attachments/assets/3e3200ce-5b84-45e4-8e68-97e7e1866648


### AI Assistance Disclosure:
Took AI help in writing the tests [ I wrote the tests at the end manually ]