### PR TITLE
Desktop: Resolves #15029 Fix: Prevent unexpected focus shift when switching notebooks or using Go To

### DIFF
--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -75,7 +75,7 @@ const NoteList = (props: Props) => {
 
 	const { activeNoteId, setActiveNoteId } = useActiveDescendantId(props.selectedFolderId, props.selectedNoteIds);
 	const focusNote = useFocusNote(listRef, props.notes, makeItemIndexVisible, setActiveNoteId);
-	useRefocusOnDeletion(props.notes.length, props.selectedNoteIds, props.focusedField, props.selectedFolderId, focusNote);
+	useRefocusOnDeletion(props.notes.length, props.selectedNoteIds, props.focusedField, props.selectedFolderId, listRef, focusNote);
 
 	const moveNote = useMoveNote(
 		props.notesParentType,

--- a/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.test.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.test.ts
@@ -1,16 +1,45 @@
 import { renderHook } from '@testing-library/react';
+import { focus } from '@joplin/lib/utils/focusHandler';
 import useRefocusOnDeletion from './useRefocusOnDeletion';
 
+const createFocusContext = () => {
+	const listElement = document.createElement('div');
+	const listItem = document.createElement('button');
+	listElement.appendChild(listItem);
+	document.body.appendChild(listElement);
+
+	const editor = document.createElement('textarea');
+	document.body.appendChild(editor);
+
+	return {
+		listRef: { current: listElement },
+		listItem,
+		editor,
+		cleanup: () => {
+			listElement.remove();
+			editor.remove();
+		},
+	};
+};
+
 describe('useRefocusOnDeletion', () => {
-	it('should refocus when a note is deleted in the same folder', () => {
+	it('should refocus when a note is deleted in the same folder and note list has focus', () => {
+		const { listRef, listItem, cleanup } = createFocusContext();
 		const focusNote = jest.fn();
-		const { rerender } = renderHook(
-			({ noteCount }: { noteCount: number }) =>
-				useRefocusOnDeletion(noteCount, ['note-1'], '', 'folder-1', focusNote),
-			{ initialProps: { noteCount: 3 } },
-		);
-		rerender({ noteCount: 2 });
-		expect(focusNote).toHaveBeenCalledWith('note-1');
+
+		try {
+			const { rerender } = renderHook(
+				({ noteCount }: { noteCount: number }) =>
+					useRefocusOnDeletion(noteCount, ['note-1'], '', 'folder-1', listRef, focusNote),
+				{ initialProps: { noteCount: 3 } },
+			);
+
+			focus('useRefocusOnDeletion.test/listItem', listItem);
+			rerender({ noteCount: 2 });
+			expect(focusNote).toHaveBeenCalledWith('note-1');
+		} finally {
+			cleanup();
+		}
 	});
 
 	test.each([
@@ -18,25 +47,58 @@ describe('useRefocusOnDeletion', () => {
 		['another field has focus', 3, 2, 'editor', ['note-1']],
 		['multiple notes are selected', 3, 2, '', ['note-1', 'note-2']],
 	])('should not refocus when %s', (_label, initialCount, newCount, focusedField, noteIds) => {
+		const { listRef, listItem, cleanup } = createFocusContext();
 		const focusNote = jest.fn();
-		const { rerender } = renderHook(
-			({ noteCount }: { noteCount: number }) =>
-				useRefocusOnDeletion(noteCount, noteIds, focusedField, 'folder-1', focusNote),
-			{ initialProps: { noteCount: initialCount } },
-		);
-		rerender({ noteCount: newCount });
-		expect(focusNote).not.toHaveBeenCalled();
+
+		try {
+			const { rerender } = renderHook(
+				({ noteCount }: { noteCount: number }) =>
+					useRefocusOnDeletion(noteCount, noteIds, focusedField, 'folder-1', listRef, focusNote),
+				{ initialProps: { noteCount: initialCount } },
+			);
+
+			focus('useRefocusOnDeletion.test/listItem', listItem);
+			rerender({ noteCount: newCount });
+			expect(focusNote).not.toHaveBeenCalled();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('should not refocus while editor has focus during background note deletion', () => {
+		const { listRef, editor, cleanup } = createFocusContext();
+		const focusNote = jest.fn();
+
+		try {
+			const { rerender } = renderHook(
+				({ noteCount }: { noteCount: number }) =>
+					useRefocusOnDeletion(noteCount, ['note-1'], '', 'folder-1', listRef, focusNote),
+				{ initialProps: { noteCount: 3 } },
+			);
+
+			focus('useRefocusOnDeletion.test/editor', editor);
+			rerender({ noteCount: 2 });
+			expect(focusNote).not.toHaveBeenCalled();
+		} finally {
+			cleanup();
+		}
 	});
 
 	it('should not refocus when switching to a folder with fewer notes across two rerenders', () => {
+		const { listRef, cleanup } = createFocusContext();
 		const focusNote = jest.fn();
-		const { rerender } = renderHook(
-			({ noteCount, folderId }: { noteCount: number; folderId: string }) =>
-				useRefocusOnDeletion(noteCount, ['note-1'], '', folderId, focusNote),
-			{ initialProps: { noteCount: 3, folderId: 'folder-1' } },
-		);
-		rerender({ noteCount: 3, folderId: 'folder-2' });
-		rerender({ noteCount: 2, folderId: 'folder-2' });
-		expect(focusNote).not.toHaveBeenCalled();
+
+		try {
+			const { rerender } = renderHook(
+				({ noteCount, folderId }: { noteCount: number; folderId: string }) =>
+					useRefocusOnDeletion(noteCount, ['note-1'], '', folderId, listRef, focusNote),
+				{ initialProps: { noteCount: 3, folderId: 'folder-1' } },
+			);
+			rerender({ noteCount: 3, folderId: 'folder-2' });
+			rerender({ noteCount: 2, folderId: 'folder-2' });
+			expect(focusNote).not.toHaveBeenCalled();
+		} finally {
+			cleanup();
+		}
 	});
 });

--- a/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.test.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.test.ts
@@ -28,13 +28,14 @@ describe('useRefocusOnDeletion', () => {
 		expect(focusNote).not.toHaveBeenCalled();
 	});
 
-	it('should not refocus when switching to a folder with fewer notes', () => {
+	it('should not refocus when switching to a folder with fewer notes across two rerenders', () => {
 		const focusNote = jest.fn();
 		const { rerender } = renderHook(
 			({ noteCount, folderId }: { noteCount: number; folderId: string }) =>
 				useRefocusOnDeletion(noteCount, ['note-1'], '', folderId, focusNote),
 			{ initialProps: { noteCount: 3, folderId: 'folder-1' } },
 		);
+		rerender({ noteCount: 3, folderId: 'folder-2' });
 		rerender({ noteCount: 2, folderId: 'folder-2' });
 		expect(focusNote).not.toHaveBeenCalled();
 	});

--- a/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.test.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.test.ts
@@ -85,7 +85,7 @@ describe('useRefocusOnDeletion', () => {
 	});
 
 	it('should not refocus when switching to a folder with fewer notes across two rerenders', () => {
-		const { listRef, cleanup } = createFocusContext();
+		const { listRef, listItem, cleanup } = createFocusContext();
 		const focusNote = jest.fn();
 
 		try {
@@ -94,6 +94,7 @@ describe('useRefocusOnDeletion', () => {
 					useRefocusOnDeletion(noteCount, ['note-1'], '', folderId, listRef, focusNote),
 				{ initialProps: { noteCount: 3, folderId: 'folder-1' } },
 			);
+			focus('useRefocusOnDeletion.test/listItem', listItem);
 			rerender({ noteCount: 3, folderId: 'folder-2' });
 			rerender({ noteCount: 2, folderId: 'folder-2' });
 			expect(focusNote).not.toHaveBeenCalled();

--- a/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.ts
@@ -8,17 +8,30 @@ const useRefocusOnDeletion = (
 	focusNote: (noteId: string)=> void,
 ) => {
 	const previousNoteCount = usePrevious(noteCount, 0);
-	const lastFolderIdRef = useRef(selectedFolderId);
+	const lastNoteCountFolderRef = useRef(selectedFolderId);
+	const folderChangedSinceLastNoteCountRef = useRef(false);
+
+	// Track folder changes between noteCount snapshots
+	useEffect(() => {
+		if (selectedFolderId !== lastNoteCountFolderRef.current) {
+			folderChangedSinceLastNoteCountRef.current = true;
+		}
+	}, [selectedFolderId]);
 
 	useEffect(() => {
 		const noteWasRemoved = noteCount < previousNoteCount;
-		const folderDidNotChange = selectedFolderId === lastFolderIdRef.current;
+		// Only refocus if folder hasn't changed since last noteCount snapshot.
+		// This prevents false refocus when navigating to a folder with fewer notes.
+		const folderDidNotChange = !folderChangedSinceLastNoteCountRef.current;
+
 		if (noteWasRemoved && folderDidNotChange && selectedNoteIds.length === 1 && !focusedField) {
 			focusNote(selectedNoteIds[0]);
 		}
 
+		// When noteCount changes, update snapshot and reset folder-change tracking
 		if (noteCount !== previousNoteCount) {
-			lastFolderIdRef.current = selectedFolderId;
+			lastNoteCountFolderRef.current = selectedFolderId;
+			folderChangedSinceLastNoteCountRef.current = false;
 		}
 	}, [noteCount, previousNoteCount, selectedNoteIds, focusedField, selectedFolderId, focusNote]);
 };

--- a/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.ts
@@ -1,10 +1,11 @@
-import { useEffect, useRef } from 'react';
+import { RefObject, useEffect, useRef } from 'react';
 import usePrevious from '@joplin/lib/hooks/usePrevious';
 const useRefocusOnDeletion = (
 	noteCount: number,
 	selectedNoteIds: string[],
 	focusedField: string,
 	selectedFolderId: string,
+	listRef: RefObject<HTMLDivElement>,
 	focusNote: (noteId: string)=> void,
 ) => {
 	const previousNoteCount = usePrevious(noteCount, 0);
@@ -20,11 +21,12 @@ const useRefocusOnDeletion = (
 
 	useEffect(() => {
 		const noteWasRemoved = noteCount < previousNoteCount;
+		const noteListHasFocus = !!listRef.current && listRef.current.contains(document.activeElement);
 		// Only refocus if folder hasn't changed since last noteCount snapshot.
 		// This prevents false refocus when navigating to a folder with fewer notes.
 		const folderDidNotChange = !folderChangedSinceLastNoteCountRef.current;
 
-		if (noteWasRemoved && folderDidNotChange && selectedNoteIds.length === 1 && !focusedField) {
+		if (noteWasRemoved && folderDidNotChange && selectedNoteIds.length === 1 && !focusedField && noteListHasFocus) {
 			focusNote(selectedNoteIds[0]);
 		}
 
@@ -33,6 +35,6 @@ const useRefocusOnDeletion = (
 			lastNoteCountFolderRef.current = selectedFolderId;
 			folderChangedSinceLastNoteCountRef.current = false;
 		}
-	}, [noteCount, previousNoteCount, selectedNoteIds, focusedField, selectedFolderId, focusNote]);
+	}, [noteCount, previousNoteCount, selectedNoteIds, focusedField, selectedFolderId, listRef, focusNote]);
 };
 export default useRefocusOnDeletion;

--- a/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import usePrevious from '@joplin/lib/hooks/usePrevious';
 const useRefocusOnDeletion = (
 	noteCount: number,
@@ -8,13 +8,18 @@ const useRefocusOnDeletion = (
 	focusNote: (noteId: string)=> void,
 ) => {
 	const previousNoteCount = usePrevious(noteCount, 0);
-	const previousFolderId = usePrevious(selectedFolderId, '');
+	const lastFolderIdRef = useRef(selectedFolderId);
+
 	useEffect(() => {
 		const noteWasRemoved = noteCount < previousNoteCount;
-		const folderDidNotChange = selectedFolderId === previousFolderId;
+		const folderDidNotChange = selectedFolderId === lastFolderIdRef.current;
 		if (noteWasRemoved && folderDidNotChange && selectedNoteIds.length === 1 && !focusedField) {
 			focusNote(selectedNoteIds[0]);
 		}
-	}, [noteCount, previousNoteCount, selectedNoteIds, focusedField, selectedFolderId, previousFolderId, focusNote]);
+
+		if (noteCount !== previousNoteCount) {
+			lastFolderIdRef.current = selectedFolderId;
+		}
+	}, [noteCount, previousNoteCount, selectedNoteIds, focusedField, selectedFolderId, focusNote]);
 };
 export default useRefocusOnDeletion;


### PR DESCRIPTION
**Fixes: #15029**

## Summary:
When navigating between notebooks using keyboard arrow keys, focus unexpectedly shifts from the notebook list to the notes list after a few seconds. Additionally, the "Go To" feature exhibits inconsistent behavior where focus sometimes lands on the notes list instead of the selected note. 

## Fix:
The `useRefocusOnDeletion` hook was incorrectly refocusing during notebook folder switches due to lagging state updates across render cycles. When users navigated to a different folder using keyboard, the folder ID and note count updated on separate renders. By the time the note count updated, the `usePrevious` hook had already captured the new folder ID, causing the hook to mistakenly believe a note was deleted in the same folder when in fact the folder had switched. 

**Updated focus refocus logic to:**
- Track the folder associated with the last note-count change using a stable `useRef` instead of the lagging `usePrevious` hook
- Only update the ref when the note count actually changes, ensuring the guard depends on consistent state history
- Filter refocus to only occur when a note is genuinely deleted within the same folder, blocking false positives during folder transitions
- Maintain all existing single-note deletion behavior and backward compatibility

## Changes Made
`packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.ts`:
- Imported `useRef` from React to create a stable `lastFolderIdRef` 
- Replaced `usePrevious(selectedFolderId, '')` with `useRef(selectedFolderId)` to track the folder at the last note-count snapshot
- Updated `folderDidNotChange` guard to compare against `lastFolderIdRef.current` instead of the lagging previous folder value
- Added logic to update `lastFolderIdRef.current` only when the note count changes, ensuring the ref remains synchronized with the snapshot point
- Removed `previousFolderId` from the effect dependency array to stabilize the guard

`packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.test.ts`:
- Enhanced regression test case to reproduce the two-rerender folder-switch scenario: first rerender changes folder while preserving note count, second rerender decreases note count in the new folder
- Updated test description to clarify the multi-rerender timing requirement
- Verified all existing tests (single-line deletion, note count increase, other field focus, multiple note selection) continue to pass

## Testing:
**BEFORE:**

https://github.com/user-attachments/assets/6e21b3b7-68a7-4f72-a88c-e89204332d43

**AFTER:**

https://github.com/user-attachments/assets/ffcfe61b-223d-4b55-990b-4809b639108b


All five test cases pass, including:
- Refocus behavior still works when a note is deleted within the same folder
- No refocus when note count increases
- No refocus when editing another field
- No refocus when multiple notes are selected
- No refocus when switching to a folder with fewer notes across separate render cycles

## AI Disclosure:
AI was used to make changes to the test.
AI was used to make the vocabulary for the PR description.