### PR TITLE
Mobile, Desktop: Fixes #13102: Keep list type when reordering items via drag and drop

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1183,6 +1183,8 @@ packages/editor/ProseMirror/testing/mockEditorApi.js
 packages/editor/ProseMirror/types.js
 packages/editor/ProseMirror/utils/SelectableNodeView.js
 packages/editor/ProseMirror/utils/UndoStackSynchronizer.js
+packages/editor/ProseMirror/utils/adjustListItemDropInsertPos.test.js
+packages/editor/ProseMirror/utils/adjustListItemDropInsertPos.js
 packages/editor/ProseMirror/utils/canReplaceSelectionWith.js
 packages/editor/ProseMirror/utils/clampPointToDocument.js
 packages/editor/ProseMirror/utils/computeSelectionFormatting.js

--- a/.gitignore
+++ b/.gitignore
@@ -1156,6 +1156,8 @@ packages/editor/ProseMirror/testing/mockEditorApi.js
 packages/editor/ProseMirror/types.js
 packages/editor/ProseMirror/utils/SelectableNodeView.js
 packages/editor/ProseMirror/utils/UndoStackSynchronizer.js
+packages/editor/ProseMirror/utils/adjustListItemDropInsertPos.test.js
+packages/editor/ProseMirror/utils/adjustListItemDropInsertPos.js
 packages/editor/ProseMirror/utils/canReplaceSelectionWith.js
 packages/editor/ProseMirror/utils/clampPointToDocument.js
 packages/editor/ProseMirror/utils/computeSelectionFormatting.js

--- a/packages/editor/ProseMirror/createEditor.ts
+++ b/packages/editor/ProseMirror/createEditor.ts
@@ -172,6 +172,7 @@ const createEditor = async (
 			insertPos = adjustListItemDropInsertPos(tr.doc, insertPos, slice);
 
 			const beforeInsert = tr.doc;
+			const insertStepStart = tr.steps.length;
 			const isNodeSlice = slice.openStart === 0 && slice.openEnd === 0 && slice.content.childCount === 1;
 			if (isNodeSlice) {
 				tr.replaceRangeWith(insertPos, insertPos, slice.content.firstChild);
@@ -180,7 +181,10 @@ const createEditor = async (
 			}
 
 			if (!tr.doc.eq(beforeInsert)) {
-				const mappedPos = tr.mapping.map(insertPos, 1);
+				// Only map through the insert steps — insertPos is already
+				// in post-deleteSelection coordinates, so mapping through
+				// the full tr.mapping would apply the delete offset twice.
+				const mappedPos = tr.mapping.slice(insertStepStart).map(insertPos, 1);
 				const clampedPos = Math.min(mappedPos, tr.doc.content.size);
 				tr.setSelection(Selection.near(tr.doc.resolve(clampedPos), -1));
 				focus('createEditor', view);

--- a/packages/editor/ProseMirror/createEditor.ts
+++ b/packages/editor/ProseMirror/createEditor.ts
@@ -1,6 +1,6 @@
 import { focus } from '@joplin/lib/utils/focusHandler';
 import { ContentScriptData, EditorCommandType, EditorControl, EditorProps, EditorSettings, SearchState, UpdateBodyOptions, UserEventSource } from '../types';
-import { EditorState, NodeSelection, Selection, TextSelection, Transaction } from 'prosemirror-state';
+import { EditorState, Selection, TextSelection, Transaction } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { DOMParser as ProseMirrorDomParser } from 'prosemirror-model';
 import { history } from 'prosemirror-history';
@@ -36,16 +36,7 @@ interface ProseMirrorControl extends EditorControl {
 	getSettings(): EditorSettings;
 }
 
-interface DraggingState {
-	move: boolean;
-	node?: NodeSelection;
-}
-
 const eventCoords = (event: MouseEvent) => ({ left: event.clientX, top: event.clientY });
-
-const getDraggingState = (view: EditorView): DraggingState | null => {
-	return (view as EditorView & { dragging: DraggingState | null }).dragging;
-};
 
 
 const createEditor = async (
@@ -163,9 +154,6 @@ const createEditor = async (
 		handleDrop: (view, event, slice, moved) => {
 			if (!moved) return false;
 
-			const dragging = getDraggingState(view);
-			if (!dragging?.node) return false;
-
 			const eventPos = view.posAtCoords(eventCoords(event));
 			if (!eventPos) return false;
 
@@ -178,7 +166,7 @@ const createEditor = async (
 			}
 
 			const tr = view.state.tr;
-			dragging.node.replace(tr);
+			tr.deleteSelection();
 
 			insertPos = tr.mapping.map(insertPos);
 			insertPos = adjustListItemDropInsertPos(tr.doc, insertPos, slice);

--- a/packages/editor/ProseMirror/createEditor.ts
+++ b/packages/editor/ProseMirror/createEditor.ts
@@ -197,10 +197,11 @@ const createEditor = async (
 				tr.setSelection(Selection.near(tr.doc.resolve(clampedPos), -1));
 				focus('createEditor', view);
 				view.dispatch(tr.setMeta('uiEvent', 'drop'));
+				event.preventDefault();
+				return true;
 			}
 
-			event.preventDefault();
-			return true;
+			return false;
 		},
 		dispatchTransaction: transaction => {
 			const newState = view.state.apply(transaction);

--- a/packages/editor/ProseMirror/createEditor.ts
+++ b/packages/editor/ProseMirror/createEditor.ts
@@ -1,9 +1,10 @@
 import { focus } from '@joplin/lib/utils/focusHandler';
 import { ContentScriptData, EditorCommandType, EditorControl, EditorProps, EditorSettings, SearchState, UpdateBodyOptions, UserEventSource } from '../types';
-import { EditorState, TextSelection, Transaction } from 'prosemirror-state';
+import { EditorState, NodeSelection, Selection, TextSelection, Transaction } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { DOMParser as ProseMirrorDomParser } from 'prosemirror-model';
 import { history } from 'prosemirror-history';
+import { dropPoint } from 'prosemirror-transform';
 import commands from './commands/commands';
 import schema from './schema';
 import { gapCursor } from 'prosemirror-gapcursor';
@@ -29,10 +30,22 @@ import postprocessEditorOutput from './utils/postprocessEditorOutput';
 import detailsPlugin from './plugins/detailsPlugin';
 import tablePlugin from './plugins/tablePlugin';
 import clampPointToDocument from './utils/clampPointToDocument';
+import adjustListItemDropInsertPos from './utils/adjustListItemDropInsertPos';
 
 interface ProseMirrorControl extends EditorControl {
 	getSettings(): EditorSettings;
 }
+
+interface DraggingState {
+	move: boolean;
+	node?: NodeSelection;
+}
+
+const eventCoords = (event: MouseEvent) => ({ left: event.clientX, top: event.clientY });
+
+const getDraggingState = (view: EditorView): DraggingState | null => {
+	return (view as EditorView & { dragging: DraggingState | null }).dragging;
+};
 
 
 const createEditor = async (
@@ -147,6 +160,48 @@ const createEditor = async (
 
 	const view = new EditorView(parentElement, {
 		state: await createInitialState(props.initialText),
+		handleDrop: (view, event, slice, moved) => {
+			if (!moved) return false;
+
+			const dragging = getDraggingState(view);
+			if (!dragging?.node) return false;
+
+			const eventPos = view.posAtCoords(eventCoords(event));
+			if (!eventPos) return false;
+
+			let insertPos = dropPoint(view.state.doc, eventPos.pos, slice) ?? eventPos.pos;
+			const initialAdjustedInsertPos = adjustListItemDropInsertPos(view.state.doc, insertPos, slice);
+
+			// If no adjustment is required, use ProseMirror's default drop handling.
+			if (initialAdjustedInsertPos === insertPos) {
+				return false;
+			}
+
+			const tr = view.state.tr;
+			dragging.node.replace(tr);
+
+			insertPos = tr.mapping.map(insertPos);
+			insertPos = adjustListItemDropInsertPos(tr.doc, insertPos, slice);
+
+			const beforeInsert = tr.doc;
+			const isNodeSlice = slice.openStart === 0 && slice.openEnd === 0 && slice.content.childCount === 1;
+			if (isNodeSlice) {
+				tr.replaceRangeWith(insertPos, insertPos, slice.content.firstChild);
+			} else {
+				tr.replaceRange(insertPos, insertPos, slice);
+			}
+
+			if (!tr.doc.eq(beforeInsert)) {
+				const mappedPos = tr.mapping.map(insertPos, 1);
+				const clampedPos = Math.min(mappedPos, tr.doc.content.size);
+				tr.setSelection(Selection.near(tr.doc.resolve(clampedPos), -1));
+				focus('createEditor', view);
+				view.dispatch(tr.setMeta('uiEvent', 'drop'));
+			}
+
+			event.preventDefault();
+			return true;
+		},
 		dispatchTransaction: transaction => {
 			const newState = view.state.apply(transaction);
 

--- a/packages/editor/ProseMirror/utils/adjustListItemDropInsertPos.test.ts
+++ b/packages/editor/ProseMirror/utils/adjustListItemDropInsertPos.test.ts
@@ -65,11 +65,12 @@ const moveSecondItemAboveFirst = (state: EditorState, useAdjustedInsertPos: bool
 
 const listItemTexts = (listNode: ProseMirrorNode) => {
 	const result: string[] = [];
-	listNode.forEach(node => {
+	for (let i = 0; i < listNode.childCount; i++) {
+		const node = listNode.child(i);
 		if (node.type === schema.nodes.list_item) {
 			result.push(node.textContent);
 		}
-	});
+	}
 	return result;
 };
 

--- a/packages/editor/ProseMirror/utils/adjustListItemDropInsertPos.test.ts
+++ b/packages/editor/ProseMirror/utils/adjustListItemDropInsertPos.test.ts
@@ -1,0 +1,108 @@
+import { Node as ProseMirrorNode, Slice } from 'prosemirror-model';
+import { NodeSelection, EditorState } from 'prosemirror-state';
+import { dropPoint } from 'prosemirror-transform';
+import schema from '../schema';
+import adjustListItemDropInsertPos from './adjustListItemDropInsertPos';
+
+const listItemNode = (text: string) => (
+	schema.nodes.list_item.create(
+		null,
+		schema.nodes.paragraph.create(null, schema.text(text)),
+	)
+);
+
+const makeState = (listType: 'bullet_list' | 'ordered_list') => {
+	return EditorState.create({
+		schema,
+		doc: schema.nodes.doc.create(null, [
+			schema.nodes.paragraph.create(null, schema.text('intro')),
+			schema.nodes[listType].create(null, [
+				listItemNode('one'),
+				listItemNode('two'),
+			]),
+		]),
+	});
+};
+
+const findListItemPosByText = (doc: ProseMirrorNode, text: string) => {
+	let result = -1;
+	doc.descendants((node, pos) => {
+		if (node.type === schema.nodes.list_item && node.textContent === text) {
+			result = pos;
+			return false;
+		}
+		return true;
+	});
+
+	if (result < 0) {
+		throw new Error(`List item not found: ${text}`);
+	}
+
+	return result;
+};
+
+const moveSecondItemAboveFirst = (state: EditorState, useAdjustedInsertPos: boolean) => {
+	const secondListItemPos = findListItemPosByText(state.doc, 'two');
+	const selection = NodeSelection.create(state.doc, secondListItemPos);
+	const listBoundaryPos = selection.$from.before(selection.$from.depth);
+	const slice = selection.content();
+	const insertPos = dropPoint(state.doc, listBoundaryPos, slice);
+	if (insertPos === null) {
+		throw new Error('Unable to compute drop insertion point.');
+	}
+
+	const tr = state.tr;
+	selection.replace(tr);
+
+	let mappedInsertPos = tr.mapping.map(insertPos);
+	if (useAdjustedInsertPos) {
+		mappedInsertPos = adjustListItemDropInsertPos(tr.doc, mappedInsertPos, slice);
+	}
+
+	tr.replaceRange(mappedInsertPos, mappedInsertPos, slice);
+	return tr.doc;
+};
+
+const listItemTexts = (listNode: ProseMirrorNode) => {
+	const result: string[] = [];
+	listNode.forEach(node => {
+		if (node.type === schema.nodes.list_item) {
+			result.push(node.textContent);
+		}
+	});
+	return result;
+};
+
+describe('adjustListItemDropInsertPos', () => {
+	test('keeps dragged bullet list items in a bullet list at list boundary drop positions', () => {
+		const state = makeState('bullet_list');
+		const unadjusted = moveSecondItemAboveFirst(state, false);
+		const adjusted = moveSecondItemAboveFirst(state, true);
+
+		expect(unadjusted.firstChild.type).toBe(schema.nodes.paragraph);
+		expect(unadjusted.child(1).type).toBe(schema.nodes.ordered_list);
+
+		expect(adjusted.firstChild.type).toBe(schema.nodes.paragraph);
+		expect(adjusted.child(1).type).toBe(schema.nodes.bullet_list);
+		expect(listItemTexts(adjusted.child(1))).toStrictEqual(['two', 'one']);
+	});
+
+	test('keeps dragged ordered list items in an ordered list at list boundary drop positions', () => {
+		const state = makeState('ordered_list');
+		const adjusted = moveSecondItemAboveFirst(state, true);
+
+		expect(adjusted.firstChild.type).toBe(schema.nodes.paragraph);
+		expect(adjusted.child(1).type).toBe(schema.nodes.ordered_list);
+		expect(adjusted.childCount).toBe(2);
+		expect(listItemTexts(adjusted.child(1))).toStrictEqual(['two', 'one']);
+	});
+
+	test('does not modify insertion positions for non-list-item slices', () => {
+		const state = makeState('bullet_list');
+		const paragraphSelection = NodeSelection.create(state.doc, 0);
+		const slice = paragraphSelection.content();
+
+		expect(slice instanceof Slice).toBe(true);
+		expect(adjustListItemDropInsertPos(state.doc, 7, slice)).toBe(7);
+	});
+});

--- a/packages/editor/ProseMirror/utils/adjustListItemDropInsertPos.ts
+++ b/packages/editor/ProseMirror/utils/adjustListItemDropInsertPos.ts
@@ -1,0 +1,39 @@
+import { Node as ProseMirrorNode, Slice } from 'prosemirror-model';
+
+const isListItemNode = (node: ProseMirrorNode) => (
+	node.type.name === 'list_item' || node.type.name === 'task_list_item'
+);
+
+const getDraggedListItemType = (slice: Slice) => {
+	if (slice.openStart !== 0 || slice.openEnd !== 0 || slice.content.childCount !== 1) {
+		return null;
+	}
+
+	const draggedNode = slice.content.firstChild;
+	if (!isListItemNode(draggedNode)) {
+		return null;
+	}
+
+	return draggedNode.type;
+};
+
+const adjustListItemDropInsertPos = (doc: ProseMirrorNode, insertPos: number, slice: Slice): number => {
+	const draggedListItemType = getDraggedListItemType(slice);
+	if (!draggedListItemType) {
+		return insertPos;
+	}
+
+	const $pos = doc.resolve(insertPos);
+
+	// If dropping right before/after a compatible list, force insertion into that list.
+	if ($pos.nodeAfter?.type.contentMatch.matchType(draggedListItemType)) {
+		return insertPos + 1;
+	}
+	if ($pos.nodeBefore?.type.contentMatch.matchType(draggedListItemType)) {
+		return insertPos - 1;
+	}
+
+	return insertPos;
+};
+
+export default adjustListItemDropInsertPos;


### PR DESCRIPTION
Fixes #13102

Problem
when dragging  list items to reorder them in the rich text editor , the list type would change example bullet list would become numbered list after a frag 

Solution 
Fixed by adjusting the drop position so the item lands inside the existing list instead of outside it. Falls back to default behavior for non-list drags. Added unit tests.


https://github.com/user-attachments/assets/9a4d7211-0125-4061-b215-4287eeed8487

