### PR TITLE
Desktop: Fixes #15031: Stabilize heading task-marker hashes and link handling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1066,6 +1066,7 @@ packages/editor/CodeMirror/extensions/links/followLinkTooltipExtension.js
 packages/editor/CodeMirror/extensions/links/referenceLinksStateField.js
 packages/editor/CodeMirror/extensions/links/utils/findLineMatchingLink.test.js
 packages/editor/CodeMirror/extensions/links/utils/findLineMatchingLink.js
+packages/editor/CodeMirror/extensions/links/utils/getUrlAtPosition.test.js
 packages/editor/CodeMirror/extensions/links/utils/getUrlAtPosition.js
 packages/editor/CodeMirror/extensions/links/utils/openLink.js
 packages/editor/CodeMirror/extensions/markdownDecorationExtension.test.js
@@ -1136,6 +1137,7 @@ packages/editor/CodeMirror/utils/isInSyntaxNode.js
 packages/editor/CodeMirror/utils/markdown/codeBlockLanguages/allLanguages.js
 packages/editor/CodeMirror/utils/markdown/codeBlockLanguages/defaultLanguage.js
 packages/editor/CodeMirror/utils/markdown/codeBlockLanguages/lookUpLanguage.js
+packages/editor/CodeMirror/utils/markdown/getCheckboxAtPosition.test.js
 packages/editor/CodeMirror/utils/markdown/getCheckboxAtPosition.js
 packages/editor/CodeMirror/utils/markdown/renumberSelectedLists.test.js
 packages/editor/CodeMirror/utils/markdown/renumberSelectedLists.js
@@ -1843,6 +1845,7 @@ packages/renderer/HtmlToHtml.test.js
 packages/renderer/HtmlToHtml.js
 packages/renderer/InMemoryCache.js
 packages/renderer/MarkupToHtml.js
+packages/renderer/MdToHtml.test.js
 packages/renderer/MdToHtml.js
 packages/renderer/MdToHtml/createEventHandlingAttrs.test.js
 packages/renderer/MdToHtml/createEventHandlingAttrs.js

--- a/.gitignore
+++ b/.gitignore
@@ -1039,6 +1039,7 @@ packages/editor/CodeMirror/extensions/links/followLinkTooltipExtension.js
 packages/editor/CodeMirror/extensions/links/referenceLinksStateField.js
 packages/editor/CodeMirror/extensions/links/utils/findLineMatchingLink.test.js
 packages/editor/CodeMirror/extensions/links/utils/findLineMatchingLink.js
+packages/editor/CodeMirror/extensions/links/utils/getUrlAtPosition.test.js
 packages/editor/CodeMirror/extensions/links/utils/getUrlAtPosition.js
 packages/editor/CodeMirror/extensions/links/utils/openLink.js
 packages/editor/CodeMirror/extensions/markdownDecorationExtension.test.js
@@ -1109,6 +1110,7 @@ packages/editor/CodeMirror/utils/isInSyntaxNode.js
 packages/editor/CodeMirror/utils/markdown/codeBlockLanguages/allLanguages.js
 packages/editor/CodeMirror/utils/markdown/codeBlockLanguages/defaultLanguage.js
 packages/editor/CodeMirror/utils/markdown/codeBlockLanguages/lookUpLanguage.js
+packages/editor/CodeMirror/utils/markdown/getCheckboxAtPosition.test.js
 packages/editor/CodeMirror/utils/markdown/getCheckboxAtPosition.js
 packages/editor/CodeMirror/utils/markdown/renumberSelectedLists.test.js
 packages/editor/CodeMirror/utils/markdown/renumberSelectedLists.js
@@ -1816,6 +1818,7 @@ packages/renderer/HtmlToHtml.test.js
 packages/renderer/HtmlToHtml.js
 packages/renderer/InMemoryCache.js
 packages/renderer/MarkupToHtml.js
+packages/renderer/MdToHtml.test.js
 packages/renderer/MdToHtml.js
 packages/renderer/MdToHtml/createEventHandlingAttrs.test.js
 packages/renderer/MdToHtml/createEventHandlingAttrs.js

--- a/packages/editor/CodeMirror/editorCommands/jumpToHash.test.ts
+++ b/packages/editor/CodeMirror/editorCommands/jumpToHash.test.ts
@@ -53,4 +53,18 @@ describe('jumpToHash', () => {
 		expect(jumpToHash(editor, 'line-2')).toBe(true);
 		expect(editor.state.selection.main.anchor).toBe(editor.state.doc.length);
 	});
+
+	test.each([
+		'## [x] Line 2',
+		'## [X] Line 2',
+	])('should jump to checkbox-prefixed Markdown headers using legacy hashes (%s)', async (heading: string) => {
+		const editor = await createTestEditor(
+			`Line 1\n${heading}`,
+			EditorSelection.cursor(0),
+			['ATXHeading2'],
+		);
+
+		expect(jumpToHash(editor, 'x-line-2')).toBe(true);
+		expect(editor.state.selection.main.anchor).toBe(editor.state.doc.length);
+	});
 });

--- a/packages/editor/CodeMirror/editorCommands/jumpToHash.test.ts
+++ b/packages/editor/CodeMirror/editorCommands/jumpToHash.test.ts
@@ -38,4 +38,19 @@ describe('jumpToHash', () => {
 		expect(jumpToHash(editor, 'line-2')).toBe(true);
 		expect(editor.state.selection.main.anchor).toBe(editor.state.doc.length);
 	});
+
+	test.each([
+		'## [ ] Line 2',
+		'## [x] Line 2',
+		'## [X] Line 2',
+	])('should jump to checkbox-prefixed Markdown headers (%s)', async (heading: string) => {
+		const editor = await createTestEditor(
+			`Line 1\n${heading}`,
+			EditorSelection.cursor(0),
+			['ATXHeading2'],
+		);
+
+		expect(jumpToHash(editor, 'line-2')).toBe(true);
+		expect(editor.state.selection.main.anchor).toBe(editor.state.doc.length);
+	});
 });

--- a/packages/editor/CodeMirror/editorCommands/jumpToHash.ts
+++ b/packages/editor/CodeMirror/editorCommands/jumpToHash.ts
@@ -2,7 +2,7 @@ import { ensureSyntaxTree } from '@codemirror/language';
 import { EditorSelection } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import uslug from '@joplin/fork-uslug/lib/uslug';
-import { normalizeHeadingTextForHash } from '@joplin/utils/markdown';
+import { headingHashesForText } from '@joplin/utils/markdown';
 import { SyntaxNodeRef } from '@lezer/common';
 import htmlNodeInfo from '../utils/htmlNodeInfo';
 
@@ -24,7 +24,9 @@ const jumpToHash = (view: EditorView, hash: string) => {
 			const nodeText = nodeToText(node)
 				.replace(/^#+\s/, '') // Leading #s in headers
 				.replace(/\n-+$/, ''); // Trailing --s in headers
-			matches = hash === uslug(normalizeHeadingTextForHash(nodeText));
+
+			const { canonicalHash, legacyHash } = headingHashesForText(nodeText, uslug);
+			matches = hash === canonicalHash || hash === legacyHash;
 		} else if (node.name === 'HTMLBlock') {
 			// CodeMirror adds HTML information to Markdown documents using overlays attached
 			// to HTMLTag and HTMLBlock nodes.

--- a/packages/editor/CodeMirror/editorCommands/jumpToHash.ts
+++ b/packages/editor/CodeMirror/editorCommands/jumpToHash.ts
@@ -2,6 +2,7 @@ import { ensureSyntaxTree } from '@codemirror/language';
 import { EditorSelection } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import uslug from '@joplin/fork-uslug/lib/uslug';
+import { normalizeHeadingTextForHash } from '@joplin/utils/markdown';
 import { SyntaxNodeRef } from '@lezer/common';
 import htmlNodeInfo from '../utils/htmlNodeInfo';
 
@@ -23,7 +24,7 @@ const jumpToHash = (view: EditorView, hash: string) => {
 			const nodeText = nodeToText(node)
 				.replace(/^#+\s/, '') // Leading #s in headers
 				.replace(/\n-+$/, ''); // Trailing --s in headers
-			matches = hash === uslug(nodeText);
+			matches = hash === uslug(normalizeHeadingTextForHash(nodeText));
 		} else if (node.name === 'HTMLBlock') {
 			// CodeMirror adds HTML information to Markdown documents using overlays attached
 			// to HTMLTag and HTMLBlock nodes.

--- a/packages/editor/CodeMirror/extensions/links/utils/findLineMatchingLink.test.ts
+++ b/packages/editor/CodeMirror/extensions/links/utils/findLineMatchingLink.test.ts
@@ -12,6 +12,8 @@ describe('findLineMatchingLink', () => {
 		['## [ ] Heading', '#heading', 1],
 		['## [x] Heading', '#heading', 1],
 		['## [X] Heading', '#heading', 1],
+		['## [x] Heading', '#x-heading', 1],
+		['## [X] Heading', '#x-heading', 1],
 		// Should match headings not on the first line
 		['\n### Heading', '#heading', 2],
 		['# Test\n\n### Heading', '#heading', 3],

--- a/packages/editor/CodeMirror/extensions/links/utils/findLineMatchingLink.test.ts
+++ b/packages/editor/CodeMirror/extensions/links/utils/findLineMatchingLink.test.ts
@@ -9,6 +9,9 @@ describe('findLineMatchingLink', () => {
 		['# Heading', '#heading', 1],
 		['## Heading', '#heading', 1],
 		['### Heading', '#heading', 1],
+		['## [ ] Heading', '#heading', 1],
+		['## [x] Heading', '#heading', 1],
+		['## [X] Heading', '#heading', 1],
 		// Should match headings not on the first line
 		['\n### Heading', '#heading', 2],
 		['# Test\n\n### Heading', '#heading', 3],

--- a/packages/editor/CodeMirror/extensions/links/utils/findLineMatchingLink.ts
+++ b/packages/editor/CodeMirror/extensions/links/utils/findLineMatchingLink.ts
@@ -1,6 +1,6 @@
 import { EditorState, Line } from '@codemirror/state';
 import uslug from '@joplin/fork-uslug/lib/uslug';
-import { normalizeHeadingTextForHash } from '@joplin/utils/markdown';
+import { headingHashesForText } from '@joplin/utils/markdown';
 
 // Searches the given `state` for a line that matches the target link.
 const findLineMatchingLink = (link: string, state: EditorState): Line|null => {
@@ -12,7 +12,10 @@ const findLineMatchingLink = (link: string, state: EditorState): Line|null => {
 	const matchesLine = (line: string) => {
 		if (isAnchorLink) {
 			line = line.replace(/^#+/, '').trim();
-			return uslug(normalizeHeadingTextForHash(line)) === link.substring(1);
+			const { canonicalHash, legacyHash } = headingHashesForText(line, uslug);
+			const requestedHash = link.substring(1);
+
+			return requestedHash === canonicalHash || requestedHash === legacyHash;
 		} else if (isFootnote) {
 			return line.trim().startsWith(`${link}:`);
 		}

--- a/packages/editor/CodeMirror/extensions/links/utils/findLineMatchingLink.ts
+++ b/packages/editor/CodeMirror/extensions/links/utils/findLineMatchingLink.ts
@@ -1,5 +1,6 @@
 import { EditorState, Line } from '@codemirror/state';
 import uslug from '@joplin/fork-uslug/lib/uslug';
+import { normalizeHeadingTextForHash } from '@joplin/utils/markdown';
 
 // Searches the given `state` for a line that matches the target link.
 const findLineMatchingLink = (link: string, state: EditorState): Line|null => {
@@ -11,7 +12,7 @@ const findLineMatchingLink = (link: string, state: EditorState): Line|null => {
 	const matchesLine = (line: string) => {
 		if (isAnchorLink) {
 			line = line.replace(/^#+/, '').trim();
-			return uslug(line) === link.substring(1);
+			return uslug(normalizeHeadingTextForHash(line)) === link.substring(1);
 		} else if (isFootnote) {
 			return line.trim().startsWith(`${link}:`);
 		}

--- a/packages/editor/CodeMirror/extensions/links/utils/getUrlAtPosition.test.ts
+++ b/packages/editor/CodeMirror/extensions/links/utils/getUrlAtPosition.test.ts
@@ -1,0 +1,22 @@
+import { syntaxTree } from '@codemirror/language';
+import { EditorSelection } from '@codemirror/state';
+import createTestEditor from '../../../testing/createTestEditor';
+import forceFullParse from '../../../testing/forceFullParse';
+import getUrlAtPosition from './getUrlAtPosition';
+import referenceLinkStateField from '../referenceLinksStateField';
+
+describe('getUrlAtPosition', () => {
+	test.each([
+		['inside [x] marker text', (doc: string) => doc.indexOf('[x]') + 1],
+		['inside surrounding link label text', (doc: string) => doc.indexOf('note') + 1],
+		['at the label closing bracket', (doc: string) => doc.lastIndexOf('](')],
+	])('should extract URL for link labels with task markers (%s)', async (_label, getPosition) => {
+		const doc = '[My note#[x] title](:/abc123#x-title)';
+		const editor = await createTestEditor(doc, EditorSelection.cursor(0), [], [referenceLinkStateField]);
+		forceFullParse(editor.state);
+
+		const position = getPosition(doc);
+		const match = getUrlAtPosition(position, syntaxTree(editor.state), editor.state);
+		expect(match?.url).toBe(':/abc123#x-title');
+	});
+});

--- a/packages/editor/CodeMirror/extensions/links/utils/getUrlAtPosition.ts
+++ b/packages/editor/CodeMirror/extensions/links/utils/getUrlAtPosition.ts
@@ -13,6 +13,39 @@ type MatchedUrl = {
 	label?: string;
 };
 
+const inlineLinkUrlAtPosition = (text: string, position: number): string|null => {
+	for (let start = position; start >= 0; start--) {
+		if (text[start] !== '[') continue;
+
+		let depth = 0;
+		let labelEnd = -1;
+		for (let i = start; i < text.length; i++) {
+			const char = text[i];
+			if (char === '[') {
+				depth++;
+			} else if (char === ']') {
+				depth--;
+				if (depth === 0) {
+					labelEnd = i;
+					break;
+				}
+			}
+		}
+
+		if (labelEnd < 0 || text[labelEnd + 1] !== '(') continue;
+
+		const urlStart = labelEnd + 2;
+		const urlEnd = text.indexOf(')', urlStart);
+		if (urlEnd < 0) continue;
+
+		if (position < start || position > labelEnd) continue;
+
+		return text.substring(urlStart, urlEnd);
+	}
+
+	return null;
+};
+
 const getUrlAtPosition = (pos: number, tree: Tree, state: EditorState): MatchedUrl|null => {
 	const nodeText = (node: SyntaxNodeRef) => {
 		return state.doc.sliceString(node.from, node.to);
@@ -45,6 +78,11 @@ const getUrlAtPosition = (pos: number, tree: Tree, state: EditorState): MatchedU
 		} else {
 			iterator = iterator.next;
 		}
+	}
+
+	const fallbackUrl = inlineLinkUrlAtPosition(state.doc.toString(), pos);
+	if (fallbackUrl) {
+		return { type: MatchedUrlType.Link, url: fallbackUrl };
 	}
 
 	return null;

--- a/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
@@ -64,6 +64,21 @@ class CheckboxWidget extends WidgetType {
 const completedTaskClassName = 'cm-md-completed-item';
 const completedListItemDecoration = Decoration.line({ class: completedTaskClassName, isFullLine: true });
 
+const getTaskListMarker = (node: SyntaxNodeRef) => {
+	if (node.name !== 'TaskMarker') return null;
+
+	const taskNode = node.node.parent;
+	if (!taskNode || taskNode.name !== 'Task') return null;
+
+	const listContainer = taskNode.parent;
+	if (!listContainer) return null;
+
+	const listMarker = listContainer.getChild('ListMark');
+	if (!listMarker) return null;
+
+	return listMarker;
+};
+
 const replaceCheckboxes = [
 	EditorView.theme({
 		[`& .${checkboxClassName}`]: {
@@ -94,12 +109,12 @@ const replaceCheckboxes = [
 	makeReplaceExtension({
 		getRevealStrategy: (node, state) => {
 			if (node.name === 'TaskMarker') {
-				const container = node.node.parent?.parent;
-				const listMarker = container?.getChild('ListMark');
+				const listMarker = getTaskListMarker(node);
+				if (!listMarker) return false;
 
 				// Intersection check logic similar to nodeIntersectsSelection but with custom range
 				const selection = state.selection.main;
-				const rangeFrom = listMarker ? listMarker.from : node.from;
+				const rangeFrom = listMarker.from;
 				const rangeTo = node.to;
 
 				const rangeContains = (point: number) => point >= rangeFrom && point <= rangeTo;
@@ -118,6 +133,8 @@ const replaceCheckboxes = [
 			};
 
 			if (node.name === 'TaskMarker') {
+				if (!getTaskListMarker(node)) return null;
+
 				const containerLine = state.doc.lineAt(node.from);
 				const labelText = state.doc.sliceString(node.to, containerLine.to);
 
@@ -132,11 +149,8 @@ const replaceCheckboxes = [
 		},
 		getDecorationRange: (node, state) => {
 			if (node.name === 'TaskMarker') {
-				const container = node.node.parent?.parent;
-				const listMarker = container?.getChild('ListMark');
-				if (!listMarker) {
-					return null;
-				}
+				const listMarker = getTaskListMarker(node);
+				if (!listMarker) return [node.from, node.to];
 
 				return [listMarker.from, node.to];
 			} else if (node.name === 'Task') {

--- a/packages/editor/CodeMirror/utils/markdown/getCheckboxAtPosition.test.ts
+++ b/packages/editor/CodeMirror/utils/markdown/getCheckboxAtPosition.test.ts
@@ -1,0 +1,25 @@
+import { syntaxTree } from '@codemirror/language';
+import { EditorSelection } from '@codemirror/state';
+import createTestEditor from '../../testing/createTestEditor';
+import forceFullParse from '../../testing/forceFullParse';
+import getCheckboxAtPosition from './getCheckboxAtPosition';
+
+describe('getCheckboxAtPosition', () => {
+	test('should detect checkboxes in task list items', async () => {
+		const doc = '- [x] Test item';
+		const editor = await createTestEditor(doc, EditorSelection.cursor(0), []);
+		forceFullParse(editor.state);
+
+		const checkboxPos = doc.indexOf('[x]') + 1;
+		expect(getCheckboxAtPosition(checkboxPos, syntaxTree(editor.state))).toBeTruthy();
+	});
+
+	test('should ignore task markers inside link labels', async () => {
+		const doc = '[My note#[x] title](:/abc123#x-title)';
+		const editor = await createTestEditor(doc, EditorSelection.cursor(0), []);
+		forceFullParse(editor.state);
+
+		const taskMarkerPos = doc.indexOf('[x]') + 1;
+		expect(getCheckboxAtPosition(taskMarkerPos, syntaxTree(editor.state))).toBeNull();
+	});
+});

--- a/packages/editor/CodeMirror/utils/markdown/getCheckboxAtPosition.ts
+++ b/packages/editor/CodeMirror/utils/markdown/getCheckboxAtPosition.ts
@@ -1,10 +1,23 @@
 import { Tree } from '@lezer/common';
 
+const isTaskListCheckbox = (node: Tree['topNode']) => {
+	let parent = node.parent;
+	while (parent) {
+		if (parent.name === 'Task') return true;
+		parent = parent.parent;
+	}
+
+	return false;
+};
+
 const getCheckboxAtPosition = (pos: number, tree: Tree) => {
 	let iterator = tree.resolveStack(pos);
 
 	while (true) {
 		if (iterator.node.name === 'TaskMarker') {
+			if (!isTaskListCheckbox(iterator.node.node)) {
+				break;
+			}
 			return iterator.node;
 		}
 

--- a/packages/editor/ProseMirror/commands/commands.test.ts
+++ b/packages/editor/ProseMirror/commands/commands.test.ts
@@ -95,6 +95,9 @@ describe('ProseMirror/commands', () => {
 
 		expect(jumpToHash('test-heading-2')).toBe(true);
 		expect(editor.state.selection.$anchor.parent.textContent).toBe('[x] Test heading 2');
+
+		expect(jumpToHash('x-test-heading-2')).toBe(true);
+		expect(editor.state.selection.$anchor.parent.textContent).toBe('[x] Test heading 2');
 	});
 
 	test('textTable should insert a table', () => {

--- a/packages/editor/ProseMirror/commands/commands.test.ts
+++ b/packages/editor/ProseMirror/commands/commands.test.ts
@@ -83,6 +83,20 @@ describe('ProseMirror/commands', () => {
 		expect(editor.state.selection.$anchor.parent.textContent).toBe('Test heading 2');
 	});
 
+	test('jumpToHash should ignore leading task markers in heading hashes', () => {
+		const editor = createTestEditor({ html: '<h1>[ ] Test heading 1</h1><h2>[x] Test heading 2</h2>' });
+
+		const jumpToHash = (hash: string) => {
+			return commands[EditorCommandType.JumpToHash](editor.state, editor.dispatch, editor, [hash]);
+		};
+
+		expect(jumpToHash('test-heading-1')).toBe(true);
+		expect(editor.state.selection.$anchor.parent.textContent).toBe('[ ] Test heading 1');
+
+		expect(jumpToHash('test-heading-2')).toBe(true);
+		expect(editor.state.selection.$anchor.parent.textContent).toBe('[x] Test heading 2');
+	});
+
 	test('textTable should insert a table', () => {
 		const editor = createTestEditor({ html: '<p></p>' });
 

--- a/packages/editor/ProseMirror/utils/forEachHeading.ts
+++ b/packages/editor/ProseMirror/utils/forEachHeading.ts
@@ -1,4 +1,5 @@
 import uslug from '@joplin/fork-uslug/lib/uslug';
+import { normalizeHeadingTextForHash } from '@joplin/utils/markdown';
 import { Node } from 'prosemirror-model';
 
 type OnHeading = (node: Node, hash: string, pos: number)=> boolean|void;
@@ -8,7 +9,7 @@ const forEachHeading = (doc: Node, callback: OnHeading) => {
 	const seenHashes = new Set<string>();
 	doc.descendants((node, pos) => {
 		if (node.type.name === 'heading') {
-			const originalHash = uslug(node.textContent);
+			const originalHash = uslug(normalizeHeadingTextForHash(node.textContent));
 
 			let hash = originalHash;
 			let counter = 1;

--- a/packages/editor/ProseMirror/utils/forEachHeading.ts
+++ b/packages/editor/ProseMirror/utils/forEachHeading.ts
@@ -1,25 +1,33 @@
 import uslug from '@joplin/fork-uslug/lib/uslug';
-import { normalizeHeadingTextForHash } from '@joplin/utils/markdown';
+import { headingHashesForText } from '@joplin/utils/markdown';
 import { Node } from 'prosemirror-model';
 
-type OnHeading = (node: Node, hash: string, pos: number)=> boolean|void;
+type OnHeading = (node: Node, hashes: string[], pos: number)=> boolean|void;
+
+const makeUniqueHash = (baseHash: string, seenHashes: Set<string>) => {
+	let hash = baseHash;
+	let counter = 1;
+	while (seenHashes.has(hash)) {
+		counter++;
+		hash = `${baseHash}-${counter}`;
+	}
+
+	seenHashes.add(hash);
+	return hash;
+};
 
 const forEachHeading = (doc: Node, callback: OnHeading) => {
 	let done = false;
-	const seenHashes = new Set<string>();
+	const seenCanonicalHashes = new Set<string>();
+	const seenLegacyHashes = new Set<string>();
 	doc.descendants((node, pos) => {
 		if (node.type.name === 'heading') {
-			const originalHash = uslug(normalizeHeadingTextForHash(node.textContent));
+			const { canonicalHash, legacyHash } = headingHashesForText(node.textContent, uslug);
+			const uniqueCanonicalHash = makeUniqueHash(canonicalHash, seenCanonicalHashes);
+			const uniqueLegacyHash = makeUniqueHash(legacyHash, seenLegacyHashes);
+			const hashes = uniqueCanonicalHash === uniqueLegacyHash ? [uniqueCanonicalHash] : [uniqueCanonicalHash, uniqueLegacyHash];
 
-			let hash = originalHash;
-			let counter = 1;
-			while (seenHashes.has(hash)) {
-				counter++;
-				hash = `${originalHash}-${counter}`;
-			}
-			seenHashes.add(hash);
-
-			done = !!callback(node, hash, pos);
+			done = !!callback(node, hashes, pos);
 		}
 		return !done;
 	});

--- a/packages/editor/ProseMirror/utils/jumpToHash.ts
+++ b/packages/editor/ProseMirror/utils/jumpToHash.ts
@@ -8,8 +8,8 @@ const jumpToHash = (targetHash: string): Command => (state, dispatch, view) => {
 	}
 
 	let targetHeaderPos: number|null = null;
-	forEachHeading(view.state.doc, (node, hash, pos) => {
-		if (hash === targetHash) {
+	forEachHeading(view.state.doc, (node, hashes, pos) => {
+		if (hashes.includes(targetHash)) {
 			// Subtract one to move the selection to the end of
 			// the node:
 			targetHeaderPos = pos + node.nodeSize - 1;

--- a/packages/renderer/MdToHtml.test.ts
+++ b/packages/renderer/MdToHtml.test.ts
@@ -1,0 +1,15 @@
+import MdToHtml from './MdToHtml';
+
+describe('MdToHtml', () => {
+	test('should generate stable heading anchors for task-marker headings', async () => {
+		const renderer = new MdToHtml();
+
+		const unchecked = await renderer.render('## [ ] Title');
+		const checked = await renderer.render('## [x] Title');
+		const checkedUppercase = await renderer.render('## [X] Title');
+
+		expect(unchecked.html).toContain('id="title"');
+		expect(checked.html).toContain('id="title"');
+		expect(checkedUppercase.html).toContain('id="title"');
+	});
+});

--- a/packages/renderer/MdToHtml.test.ts
+++ b/packages/renderer/MdToHtml.test.ts
@@ -12,4 +12,21 @@ describe('MdToHtml', () => {
 		expect(checked.html).toContain('id="title"');
 		expect(checkedUppercase.html).toContain('id="title"');
 	});
+
+	test('should expose legacy alias anchors when canonical and legacy hashes differ', async () => {
+		const renderer = new MdToHtml();
+		const checked = await renderer.render('## [x] Title');
+
+		expect(checked.html).toContain('id="title"');
+		expect(checked.html).toContain('id="x-title"');
+		expect(checked.html).toContain('class="joplin-legacy-header-anchor"');
+	});
+
+	test('should not emit legacy alias anchors when canonical and legacy hashes are identical', async () => {
+		const renderer = new MdToHtml();
+		const plainHeading = await renderer.render('## Title');
+
+		expect(plainHeading.html).toContain('id="title"');
+		expect(plainHeading.html).not.toContain('joplin-legacy-header-anchor');
+	});
 });

--- a/packages/renderer/MdToHtml.ts
+++ b/packages/renderer/MdToHtml.ts
@@ -6,6 +6,7 @@ import validateLinks from './MdToHtml/validateLinks';
 import { Options as NoteStyleOptions } from './noteStyle';
 import { FsDriver, ItemIdToUrlHandler, MarkupRenderer, OptionsResourceModel, RenderOptions, RenderResult, RenderResultPluginAsset, ResourceInfos } from './types';
 import hljs from './highlight';
+import { normalizeHeadingTextForHash } from '@joplin/utils/markdown';
 // Use a require() to support bundling on mobile:
 import MarkdownIt = require('markdown-it');
 
@@ -81,7 +82,7 @@ const plugins: RendererPlugins = {
 const defaultNoteStyle = require('./defaultNoteStyle');
 
 function slugify(s: string): string {
-	return uslug(s);
+	return uslug(normalizeHeadingTextForHash(s));
 }
 
 // Share across all instances of MdToHtml

--- a/packages/renderer/MdToHtml.ts
+++ b/packages/renderer/MdToHtml.ts
@@ -6,7 +6,7 @@ import validateLinks from './MdToHtml/validateLinks';
 import { Options as NoteStyleOptions } from './noteStyle';
 import { FsDriver, ItemIdToUrlHandler, MarkupRenderer, OptionsResourceModel, RenderOptions, RenderResult, RenderResultPluginAsset, ResourceInfos } from './types';
 import hljs from './highlight';
-import { normalizeHeadingTextForHash } from '@joplin/utils/markdown';
+import { headingHashesForText, normalizeHeadingTextForHash } from '@joplin/utils/markdown';
 // Use a require() to support bundling on mobile:
 import MarkdownIt = require('markdown-it');
 
@@ -84,6 +84,19 @@ const defaultNoteStyle = require('./defaultNoteStyle');
 function slugify(s: string): string {
 	return uslug(normalizeHeadingTextForHash(s));
 }
+
+const makeUniqueHash = (baseHash: string, seenHashes: Set<string>) => {
+	let hash = baseHash;
+	let counter = 1;
+
+	while (seenHashes.has(hash)) {
+		counter++;
+		hash = `${baseHash}-${counter}`;
+	}
+
+	seenHashes.add(hash);
+	return hash;
+};
 
 // Share across all instances of MdToHtml
 const inMemoryCache = new InMemoryCache(20);
@@ -632,7 +645,36 @@ export default class MdToHtml implements MarkupRenderer {
 			});
 		}
 
-		loadPlugin(markdownItAnchor, { slugify: slugify });
+		const defaultHeadingOpenRenderer = markdownIt.renderer.rules.heading_open;
+		markdownIt.renderer.rules.heading_open = (tokens, index, options, environment, self) => {
+			const rendered = defaultHeadingOpenRenderer
+				? defaultHeadingOpenRenderer(tokens, index, options, environment, self)
+				: self.renderToken(tokens, index, options);
+
+			const legacyHeadingId = tokens[index].meta?.legacyHeadingId;
+			if (!legacyHeadingId) {
+				return rendered;
+			}
+
+			const escapedLegacyId = htmlentities(legacyHeadingId);
+			return `${rendered}<a class="joplin-legacy-header-anchor" id="${escapedLegacyId}" aria-hidden="true"></a>`;
+		};
+
+		const seenLegacyHashes = new Set<string>();
+
+		loadPlugin(markdownItAnchor, {
+			slugify: slugify,
+			callback: (token: MarkdownIt.Token, headingInfo: { title: string; slug: string }) => {
+				const { legacyHash } = headingHashesForText(headingInfo.title, uslug);
+				const uniqueLegacyHash = makeUniqueHash(legacyHash, seenLegacyHashes);
+				if (uniqueLegacyHash === headingInfo.slug) return;
+
+				token.meta = {
+					...token.meta,
+					legacyHeadingId: uniqueLegacyHash,
+				};
+			},
+		});
 
 		for (const key in plugins) {
 			if (this.pluginEnabled(key)) {

--- a/packages/utils/markdown.test.ts
+++ b/packages/utils/markdown.test.ts
@@ -1,4 +1,4 @@
-import { extractUrls } from './markdown';
+import { extractUrls, normalizeHeadingTextForHash } from './markdown';
 import { Link } from './types';
 
 describe('markdown', () => {
@@ -50,6 +50,16 @@ describe('markdown', () => {
 	])('should extract URLs', (md: string, expected: Link[]) => {
 		const actual = extractUrls(md);
 		expect(actual).toEqual(expected);
+	});
+
+	test.each([
+		['[ ] title', 'title'],
+		['[x] title', 'title'],
+		['[X] title', 'title'],
+		['[x]title', '[x]title'],
+		['title [x] suffix', 'title [x] suffix'],
+	])('should normalize heading text for hash generation', (input: string, expected: string) => {
+		expect(normalizeHeadingTextForHash(input)).toBe(expected);
 	});
 
 });

--- a/packages/utils/markdown.test.ts
+++ b/packages/utils/markdown.test.ts
@@ -1,4 +1,4 @@
-import { extractUrls, normalizeHeadingTextForHash } from './markdown';
+import { extractUrls, headingHashesForText, normalizeHeadingTextForHash } from './markdown';
 import { Link } from './types';
 
 describe('markdown', () => {
@@ -60,6 +60,15 @@ describe('markdown', () => {
 		['title [x] suffix', 'title [x] suffix'],
 	])('should normalize heading text for hash generation', (input: string, expected: string) => {
 		expect(normalizeHeadingTextForHash(input)).toBe(expected);
+	});
+
+	test.each([
+		['[x] title', { canonicalHash: 'title', legacyHash: 'x-title' }],
+		['[ ] title', { canonicalHash: 'title', legacyHash: 'title' }],
+		['title', { canonicalHash: 'title', legacyHash: 'title' }],
+	])('should return canonical and legacy hashes for headings', (input: string, expected: { canonicalHash: string; legacyHash: string }) => {
+		const slugify = (text: string) => text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+		expect(headingHashesForText(input, slugify)).toEqual(expected);
 	});
 
 });

--- a/packages/utils/markdown.ts
+++ b/packages/utils/markdown.ts
@@ -3,6 +3,12 @@
 import * as MarkdownIt from 'markdown-it';
 import { Link } from './types';
 
+const headingTaskMarkerPattern = /^\[(?: |x|X)\]\s+/;
+
+export const normalizeHeadingTextForHash = (text: string): string => {
+	return text.replace(headingTaskMarkerPattern, '');
+};
+
 // enable file link URLs in MarkdownIt. Keeps other URL restrictions of
 // MarkdownIt untouched. Format [link name](file://...)
 const validateLinks = (url: string) => {

--- a/packages/utils/markdown.ts
+++ b/packages/utils/markdown.ts
@@ -9,6 +9,16 @@ export const normalizeHeadingTextForHash = (text: string): string => {
 	return text.replace(headingTaskMarkerPattern, '');
 };
 
+export const headingHashesForText = (text: string, slugify: (text: string)=> string) => {
+	const canonicalHash = slugify(normalizeHeadingTextForHash(text));
+	const legacyHash = slugify(text);
+
+	return {
+		canonicalHash,
+		legacyHash,
+	};
+};
+
 // enable file link URLs in MarkdownIt. Keeps other URL restrictions of
 // MarkdownIt untouched. Format [link name](file://...)
 const validateLinks = (url: string) => {


### PR DESCRIPTION
## Summary

This PR fixes internal heading-link behavior when Markdown headings start with task markers such as `[ ]`, `[x]`, or `[X]`.

It addresses two related desktop editor/rendering issues:

1. heading hashes changed when the checkbox state changed, so copied internal links could break
2. `[x]` text inside inline Markdown link labels could interfere with normal link-follow behavior in CodeMirror

## Problem

There were two user-visible problems.

### 1. Heading links were unstable

A heading such as:

```md
## [ ] My heading
````

and the same heading after toggling the checkbox:

```md
## [x] My heading
```

could produce different internal hashes. That meant a copied link like `#x-my-heading` or `#my-heading` might stop working after the checkbox state changed.

### 2. Inline links containing `#[x] ...` in the label could behave incorrectly

In the Markdown editor, a link label containing task-marker text such as:

```md
[Jump to #[x] My heading](:/note-id#x-my-heading)
```

could have broken or partial link detection around the `[x]` part, which could interfere with Ctrl+Click follow behavior.

## Root cause

* heading hash generation and matching used raw heading text across renderer, CodeMirror, and ProseMirror
* task-marker handling in CodeMirror could act without confirming real task-list context
* URL extraction around the cursor position was brittle for some inline Markdown links whose labels contained task-marker text

## What changed

* added `normalizeHeadingTextForHash` in `packages/utils/markdown.ts`
* normalized heading text before slug generation and matching in:

  * `packages/renderer/MdToHtml.ts`
  * `packages/editor/CodeMirror/extensions/links/utils/findLineMatchingLink.ts`
  * `packages/editor/CodeMirror/editorCommands/jumpToHash.ts`
  * `packages/editor/ProseMirror/utils/forEachHeading.ts`
* restricted checkbox detection, toggling, and replacement to real task-list context
* added a small inline-link URL fallback in `getUrlAtPosition` for cursor-inside-label cases
* preserved backwards compatibility for existing legacy hashes such as `#x-...`
* added focused regression tests across utils, renderer, CodeMirror, and ProseMirror

## Why this is safe

* the change is narrowly scoped to heading hash normalization and task-marker/link interaction points
* normal task-list checkbox behavior is preserved
* legacy `#x-...` heading links remain supported
* no plugin code was changed
* no Markdown parser rewrite or unrelated refactor was introduced

## Testing

### Automated

Added/updated tests for:

* heading hash normalization
* CodeMirror hash matching and jump-to-hash with `[ ]` / `[x]` / `[X]` headings
* ProseMirror jump-to-hash with task-marker-prefixed headings
* URL extraction for links whose labels contain `#[x]` text
* checkbox detection guards so inline link labels do not trigger checkbox handling
* legacy-hash compatibility for existing `#x-...` links

Ran:

* `yarn workspace @joplin/utils test markdown.test.ts`
* `yarn workspace @joplin/renderer test MdToHtml.test.ts`
* `yarn workspace @joplin/editor test CodeMirror/extensions/links/utils/findLineMatchingLink.test.ts CodeMirror/editorCommands/jumpToHash.test.ts CodeMirror/extensions/links/utils/getUrlAtPosition.test.ts CodeMirror/utils/markdown/getCheckboxAtPosition.test.ts ProseMirror/commands/commands.test.ts`
* `yarn workspace @joplin/utils tsc`
* `yarn workspace @joplin/editor tsc`
* `yarn workspace @joplin/renderer tsc`

### Manual verification

#### Scenario 1: Heading hash stays stable across checkbox state changes

1. Create a note with a heading:

   ```md
   ## [ ] My heading
   ```
2. Create an internal link to that heading.
3. Follow the link and verify it resolves correctly.
4. Change the heading to:

   ```md
   ## [x] My heading
   ```
5. Follow the same internal link again.
6. Verify the link still resolves to the heading.

#### Scenario 2: Legacy `#x-...` links still work

1. Create a heading:

   ```md
   ## [x] My heading
   ```
2. Open or create a link using the legacy hash form:

   ```md
   [Legacy link](:/note-id#x-my-heading)
   ```
3. Follow the link.
4. Verify it still resolves to the heading.

#### Scenario 3: Canonical normalized links also work

1. Use the same heading:

   ```md
   ## [x] My heading
   ```
2. Create or open a normalized link:

   ```md
   [Canonical link](:/note-id#my-heading)
   ```
3. Follow the link.
4. Verify it resolves to the same heading.

#### Scenario 4: Inline link labels containing `#[x]` still follow correctly

1. Create a link whose label contains task-marker text, for example:

   ```md
   [Jump to #[x] My heading](:/note-id#my-heading)
   ```
2. Place the cursor over different parts of the label, including the `[x]` segment.
3. Ctrl+Click the link in the Markdown editor.
4. Verify the link follows correctly and the `[x]` portion does not get treated as a task checkbox.

#### Scenario 5: Real task-list checkboxes still work normally

1. Create a normal task list item:

   ```md
   - [ ] Task item
   ```
2. Toggle the checkbox in the editor.
3. Verify normal checkbox interaction still works as before.

Fixes #15031
