### PR TITLE
Resolves #14252: Add OIDC support for WebDAV sync

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -472,6 +472,7 @@ packages/app-desktop/gui/ToolbarSpace.js
 packages/app-desktop/gui/TrashNotification/TrashNotification.js
 packages/app-desktop/gui/TrashNotification/TrashNotificationMessage.js
 packages/app-desktop/gui/UpdateNotification/UpdateNotification.js
+packages/app-desktop/gui/WebDavOidcLoginScreen.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/AppDialogs.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/ModalMessageOverlay.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/PluginDialogs.js

--- a/.gitignore
+++ b/.gitignore
@@ -445,6 +445,7 @@ packages/app-desktop/gui/ToolbarSpace.js
 packages/app-desktop/gui/TrashNotification/TrashNotification.js
 packages/app-desktop/gui/TrashNotification/TrashNotificationMessage.js
 packages/app-desktop/gui/UpdateNotification/UpdateNotification.js
+packages/app-desktop/gui/WebDavOidcLoginScreen.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/AppDialogs.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/ModalMessageOverlay.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/PluginDialogs.js

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -79,6 +79,12 @@ class ConfigScreenComponent extends React.Component<any, any> {
 		await shared.checkSyncConfig(this, this.state.settings);
 	}
 
+	private isWebDavOidcTarget_(settings: Record<string, unknown>) {
+		const syncTargetId = settings['sync.target'] as number;
+		if (![SyncTargetRegistry.nameToId('nextcloud'), SyncTargetRegistry.nameToId('webdav')].includes(syncTargetId)) return false;
+		return settings[`sync.${syncTargetId}.authMethod`] === 'oidc';
+	}
+
 	public UNSAFE_componentWillMount() {
 		this.setState({ settings: this.props.settings });
 	}
@@ -286,6 +292,33 @@ class ConfigScreenComponent extends React.Component<any, any> {
 								level={ButtonLevel.Primary}
 								onClick={goToSamlLogin}
 								disabled={!server || server?.trim().length === 0}
+							/>
+						</div>,
+					);
+				}
+
+				if (this.isWebDavOidcTarget_(settings)) {
+					const syncTargetId = settings['sync.target'] as number;
+					const oidcIssuer = (settings[`sync.${syncTargetId}.oidcIssuer`] as string || '').trim();
+					const oidcClientId = (settings[`sync.${syncTargetId}.oidcClientId`] as string || '').trim();
+
+					const goToWebDavOidcLogin = async () => {
+						const done = await shared.saveSettings(this);
+						if (!done) return;
+
+						this.props.dispatch({
+							type: 'NAV_GO',
+							routeName: 'WebDavOidcLogin',
+						});
+					};
+
+					settingComps.push(
+						<div key="connect_to_webdav_oidc_button" style={this.rowStyle_}>
+							<Button
+								title={_('Connect using OpenID Connect')}
+								level={ButtonLevel.Primary}
+								onClick={goToWebDavOidcLogin}
+								disabled={!oidcIssuer || !oidcClientId}
 							/>
 						</div>,
 					);
@@ -504,4 +537,3 @@ const mapStateToProps = (state: any) => {
 };
 
 export default connect(mapStateToProps)(ConfigScreenComponent);
-

--- a/packages/app-desktop/gui/Root.tsx
+++ b/packages/app-desktop/gui/Root.tsx
@@ -6,6 +6,7 @@ import ConfigScreen from './ConfigScreen/ConfigScreen';
 import StatusScreen from './StatusScreen/StatusScreen';
 import OneDriveLoginScreen from './OneDriveLoginScreen';
 import DropboxLoginScreen from './DropboxLoginScreen';
+import WebDavOidcLoginScreen from './WebDavOidcLoginScreen';
 import ErrorBoundary from './ErrorBoundary';
 import { themeStyle } from '@joplin/lib/theme';
 import MenuBar from './MenuBar';
@@ -161,6 +162,7 @@ class RootComponent extends React.Component<Props, any> {
 			Main: { screen: MainScreen },
 			OneDriveLogin: { screen: OneDriveLoginScreen, title: () => _('OneDrive Login') },
 			DropboxLogin: { screen: DropboxLoginScreen, title: () => _('Dropbox Login') },
+			WebDavOidcLogin: { screen: WebDavOidcLoginScreen, title: () => _('OpenID Connect Login') },
 			JoplinCloudLogin: { screen: JoplinCloudLoginScreen, title: () => _('Joplin Cloud Login') },
 			JoplinServerSamlLogin: { screen: SsoLoginScreen(new SamlShared()), title: () => _('Joplin Server Login') },
 			Import: { screen: ImportScreen, title: () => _('Import') },

--- a/packages/app-desktop/gui/WebDavOidcLoginScreen.tsx
+++ b/packages/app-desktop/gui/WebDavOidcLoginScreen.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import ButtonBar from './ConfigScreen/ButtonBar';
+import { _ } from '@joplin/lib/locale';
+
+const { connect } = require('react-redux');
+import { reg } from '@joplin/lib/registry';
+import Setting from '@joplin/lib/models/Setting';
+import bridge from '../services/bridge';
+const { themeStyle } = require('@joplin/lib/theme');
+const OidcApi = require('@joplin/lib/OidcApi').default;
+const OidcApiNodeUtils = require('@joplin/lib/oidc-api-node-utils').default;
+
+interface Props {
+	themeId: number;
+}
+
+interface OidcApiUtils {
+	cancelOAuthDance(): void;
+	oauthDance(targetConsole?: { log: (message: string)=> void }): Promise<unknown>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+class WebDavOidcLoginScreenComponent extends React.Component<any, any> {
+	private oidcApiUtils_: OidcApiUtils = null;
+
+	public constructor(props: Props) {
+		super(props);
+
+		this.state = {
+			authLog: [],
+		};
+	}
+
+	public async componentDidMount() {
+		await this.startLogin_();
+	}
+
+	public componentWillUnmount() {
+		if (this.oidcApiUtils_) this.oidcApiUtils_.cancelOAuthDance();
+	}
+
+	private log_(message: string) {
+		this.setState((state: { authLog: { key: string; text: string }[] }) => {
+			const authLog = state.authLog.slice();
+			authLog.push({ key: (Date.now() + Math.random()).toString(), text: message });
+			return { authLog };
+		});
+	}
+
+	private async startLogin_() {
+		const syncTargetId = Setting.value('sync.target');
+		if (![5, 6].includes(syncTargetId)) {
+			this.log_(_('OpenID Connect login is not available for this synchronisation target.'));
+			return;
+		}
+
+		const api = new OidcApi({
+			issuer: Setting.value(`sync.${syncTargetId}.oidcIssuer`),
+			clientId: Setting.value(`sync.${syncTargetId}.oidcClientId`),
+			clientSecret: Setting.value(`sync.${syncTargetId}.oidcClientSecret`),
+			scope: Setting.value(`sync.${syncTargetId}.oidcScope`),
+		});
+
+		this.oidcApiUtils_ = new OidcApiNodeUtils(api);
+
+		try {
+			const auth = await this.oidcApiUtils_.oauthDance({
+				log: (message: string) => this.log_(message),
+			});
+
+			Setting.setValue(`sync.${syncTargetId}.auth`, auth ? JSON.stringify(auth) : null);
+
+			if (!auth) {
+				this.log_(_('Authentication was not completed (did not receive an authentication token).'));
+				return;
+			}
+
+			await bridge().showInfoMessageBox(_('You are now logged into your account.'));
+			void reg.scheduleSync(0);
+			this.props.dispatch({ type: 'NAV_BACK' });
+		} catch (error) {
+			this.log_(error.message);
+		}
+	}
+
+	public render() {
+		const theme = themeStyle(this.props.themeId);
+
+		const logComps = [];
+		for (const l of this.state.authLog) {
+			if (l.text.indexOf('http:') === 0) {
+				logComps.push(<a key={l.key} style={theme.urlStyle} href="#" onClick={() => { void bridge().openExternal(l.text); }}>{l.text}</a>);
+			} else {
+				logComps.push(<p key={l.key} style={theme.textStyle}>{l.text}</p>);
+			}
+		}
+
+		return (
+			<div style={{ display: 'flex', flexDirection: 'column', height: '100%', backgroundColor: theme.backgroundColor }}>
+				<div style={{ padding: theme.configScreenPadding, flex: 1, color: theme.color }}>
+					{logComps}
+				</div>
+				<ButtonBar
+					onCancelClick={() => this.props.dispatch({ type: 'NAV_BACK' })}
+				/>
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = (state: { settings: { theme: number } }) => {
+	return {
+		themeId: state.settings.theme,
+	};
+};
+
+export default connect(mapStateToProps)(WebDavOidcLoginScreenComponent);

--- a/packages/lib/BaseSyncTarget.ts
+++ b/packages/lib/BaseSyncTarget.ts
@@ -38,7 +38,7 @@ export default class BaseSyncTarget {
 
 	// Returns true if the sync target expects a non-empty sync.{id}.password
 	// setting.
-	public static requiresPassword() {
+	public static requiresPassword(_settings: Record<string, unknown>|null = null) {
 		return false;
 	}
 

--- a/packages/lib/OidcApi.js
+++ b/packages/lib/OidcApi.js
@@ -1,0 +1,196 @@
+const shim = require('./shim').default;
+const { Digest } = require('./services/e2ee/types');
+
+const { Buffer } = require('buffer');
+const { stringify } = require('query-string');
+const urlUtils = require('./urlUtils.js');
+
+class OidcApi {
+	constructor(options) {
+		this.options_ = options;
+		this.auth_ = null;
+		this.discovery_ = null;
+		this.pendingAuth_ = null;
+		this.listeners_ = {
+			authRefreshed: [],
+		};
+	}
+
+	on(eventName, callback) {
+		this.listeners_[eventName].push(callback);
+	}
+
+	dispatch_(eventName, auth) {
+		const listeners = this.listeners_[eventName] || [];
+		for (const listener of listeners) {
+			listener(auth);
+		}
+	}
+
+	auth() {
+		return this.auth_;
+	}
+
+	setAuth(auth) {
+		this.auth_ = this.normaliseAuth_(auth);
+		this.dispatch_('authRefreshed', this.auth());
+	}
+
+	async authCodeUrl(redirectUri) {
+		const discovery = await this.discovery();
+		const state = await this.randomBase64Url_(24);
+		const codeVerifier = await this.randomBase64Url_(64);
+		const codeChallenge = await this.codeChallenge_(codeVerifier);
+
+		this.pendingAuth_ = {
+			redirectUri,
+			state,
+			codeVerifier,
+		};
+
+		const query = {
+			client_id: this.options_.clientId,
+			scope: this.options_.scope || 'openid profile email offline_access',
+			response_type: 'code',
+			redirect_uri: redirectUri,
+			code_challenge: codeChallenge,
+			code_challenge_method: 'S256',
+			state,
+		};
+
+		return `${discovery.authorization_endpoint}?${stringify(query)}`;
+	}
+
+	async execTokenRequest(code, redirectUri, state = null) {
+		if (!this.pendingAuth_) throw new Error('Missing pending OIDC authentication state');
+		if (this.pendingAuth_.redirectUri !== redirectUri) throw new Error('Unexpected OIDC redirect URI');
+		if (this.pendingAuth_.state !== state) throw new Error('Unexpected OIDC state value');
+
+		const pendingAuth = this.pendingAuth_;
+		this.pendingAuth_ = null;
+
+		return this.execTokenRequest_({
+			client_id: this.options_.clientId,
+			code,
+			code_verifier: pendingAuth.codeVerifier,
+			redirect_uri: redirectUri,
+			grant_type: 'authorization_code',
+			client_secret: this.options_.clientSecret || '',
+		});
+	}
+
+	async refreshAuthToken() {
+		if (!this.auth_ || !this.auth_.refresh_token) throw new Error('Cannot refresh token: authentication data is missing. Starting the synchronisation again may fix the problem.');
+
+		return this.execTokenRequest_({
+			client_id: this.options_.clientId,
+			refresh_token: this.auth_.refresh_token,
+			grant_type: 'refresh_token',
+			client_secret: this.options_.clientSecret || '',
+		});
+	}
+
+	async ensureValidAccessToken(minValidityMs = 60 * 1000) {
+		if (!this.auth_ || !this.auth_.access_token) return null;
+		if (!this.auth_.expires_at) return this.auth_.access_token;
+		if (!this.auth_.refresh_token) return this.auth_.access_token;
+		if (this.auth_.expires_at - Date.now() > minValidityMs) return this.auth_.access_token;
+
+		await this.refreshAuthToken();
+		return this.auth() ? this.auth().access_token : null;
+	}
+
+	async discovery() {
+		if (this.discovery_) return this.discovery_;
+
+		const response = await shim.fetch(this.discoveryUrl(), {
+			method: 'GET',
+			headers: {
+				Accept: 'application/json',
+			},
+		});
+
+		const text = await response.text();
+		if (!response.ok) throw new Error(`Could not retrieve OIDC discovery metadata: ${response.status}: ${response.statusText}: ${text}`);
+
+		const discovery = JSON.parse(text);
+		if (!discovery.authorization_endpoint || !discovery.token_endpoint) throw new Error('Invalid OIDC discovery metadata');
+
+		this.discovery_ = discovery;
+		return this.discovery_;
+	}
+
+	discoveryUrl() {
+		const issuer = (this.options_.issuer || '').trim();
+		if (!issuer) throw new Error('OIDC issuer or discovery URL is missing');
+		if (issuer.includes('/.well-known/openid-configuration')) return issuer;
+
+		const url = new URL(issuer);
+		const pathname = url.pathname === '/' ? '' : url.pathname.replace(/\/$/, '');
+		url.pathname = `${pathname ? `/.well-known/openid-configuration${pathname}` : '/.well-known/openid-configuration'}`;
+		url.search = '';
+		url.hash = '';
+		return url.toString();
+	}
+
+	async execTokenRequest_(body) {
+		const requestBody = { ...body };
+		if (!requestBody.client_secret) delete requestBody.client_secret;
+
+		const discovery = await this.discovery();
+		const response = await shim.fetch(discovery.token_endpoint, {
+			method: 'POST',
+			body: urlUtils.objectToQueryString(requestBody),
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+				Accept: 'application/json',
+			},
+		});
+
+		const text = await response.text();
+		if (!response.ok) {
+			let errorCode = '';
+			try {
+				errorCode = JSON.parse(text).error || '';
+			} catch (error) {
+				errorCode = '';
+			}
+
+			if (['invalid_client', 'invalid_grant', 'unauthorized_client'].includes(errorCode)) this.setAuth(null);
+
+			throw new Error(`Could not retrieve auth token: ${response.status}: ${response.statusText}: ${text}`);
+		}
+
+		const auth = JSON.parse(text);
+		this.setAuth(auth);
+		return this.auth();
+	}
+
+	normaliseAuth_(auth) {
+		if (!auth) return null;
+
+		const output = { ...auth };
+		if (!output.expires_at && output.expires_in !== undefined) {
+			output.expires_at = Date.now() + Number(output.expires_in) * 1000;
+		}
+
+		return output;
+	}
+
+	async codeChallenge_(value) {
+		const digest = await shim.crypto.digest(Digest.sha256, new TextEncoder().encode(value));
+		return this.base64UrlEncode_(digest);
+	}
+
+	async randomBase64Url_(byteCount) {
+		const bytes = await shim.randomBytes(byteCount);
+		return this.base64UrlEncode_(bytes);
+	}
+
+	base64UrlEncode_(value) {
+		return Buffer.from(value).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+	}
+}
+
+module.exports = OidcApi;
+module.exports.default = OidcApi;

--- a/packages/lib/OidcApi.test.js
+++ b/packages/lib/OidcApi.test.js
@@ -1,0 +1,114 @@
+const shim = require('./shim').default;
+const OidcApi = require('./OidcApi').default;
+
+const makeResponse = (status, body) => {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		statusText: status === 200 ? 'OK' : 'Error',
+		text: async () => typeof body === 'string' ? body : JSON.stringify(body),
+	};
+};
+
+describe('OidcApi', () => {
+	let originalFetch;
+	let originalRandomBytes;
+	let originalDigest;
+
+	beforeEach(() => {
+		originalFetch = shim.fetch;
+		originalRandomBytes = shim.randomBytes;
+		originalDigest = shim.crypto.digest;
+
+		shim.randomBytes = jest.fn(async byteCount => Buffer.alloc(byteCount, 1));
+		shim.crypto.digest = jest.fn(async () => Buffer.from('digest-value'));
+	});
+
+	afterEach(() => {
+		shim.fetch = originalFetch;
+		shim.randomBytes = originalRandomBytes;
+		shim.crypto.digest = originalDigest;
+	});
+
+	test('should build an auth URL and exchange an auth code', async () => {
+		const fetchMock = jest.fn(async (url, options) => {
+			if (url.includes('/.well-known/openid-configuration')) {
+				return makeResponse(200, {
+					issuer: 'https://issuer.example.com',
+					authorization_endpoint: 'https://issuer.example.com/auth',
+					token_endpoint: 'https://issuer.example.com/token',
+				});
+			}
+
+			expect(url).toBe('https://issuer.example.com/token');
+			expect(options.method).toBe('POST');
+			expect(options.body).toContain('grant_type=authorization_code');
+			expect(options.body).toContain('code=auth-code');
+			expect(options.body).toContain('redirect_uri=http%3A%2F%2Flocalhost%3A9967');
+			expect(options.body).toContain('code_verifier=');
+
+			return makeResponse(200, {
+				access_token: 'access-token',
+				refresh_token: 'refresh-token',
+				expires_in: 3600,
+			});
+		});
+
+		shim.fetch = fetchMock;
+
+		const api = new OidcApi({
+			issuer: 'https://issuer.example.com',
+			clientId: 'client-id',
+			scope: 'openid offline_access',
+		});
+
+		const authUrl = await api.authCodeUrl('http://localhost:9967');
+		const parsedAuthUrl = new URL(authUrl);
+		expect(parsedAuthUrl.origin + parsedAuthUrl.pathname).toBe('https://issuer.example.com/auth');
+		expect(parsedAuthUrl.searchParams.get('client_id')).toBe('client-id');
+		expect(parsedAuthUrl.searchParams.get('scope')).toBe('openid offline_access');
+		expect(parsedAuthUrl.searchParams.get('code_challenge_method')).toBe('S256');
+		expect(parsedAuthUrl.searchParams.get('state')).toBeTruthy();
+
+		await api.execTokenRequest('auth-code', 'http://localhost:9967', parsedAuthUrl.searchParams.get('state'));
+
+		expect(api.auth().access_token).toBe('access-token');
+		expect(api.auth().refresh_token).toBe('refresh-token');
+		expect(api.auth().expires_at).toBeGreaterThan(Date.now());
+	});
+
+	test('should refresh an expired access token', async () => {
+		const fetchMock = jest.fn(async url => {
+			if (url.includes('/.well-known/openid-configuration')) {
+				return makeResponse(200, {
+					issuer: 'https://issuer.example.com',
+					authorization_endpoint: 'https://issuer.example.com/auth',
+					token_endpoint: 'https://issuer.example.com/token',
+				});
+			}
+
+			return makeResponse(200, {
+				access_token: 'fresh-access-token',
+				refresh_token: 'refresh-token',
+				expires_in: 3600,
+			});
+		});
+
+		shim.fetch = fetchMock;
+
+		const api = new OidcApi({
+			issuer: 'https://issuer.example.com',
+			clientId: 'client-id',
+		});
+
+		api.setAuth({
+			access_token: 'expired-access-token',
+			refresh_token: 'refresh-token',
+			expires_at: Date.now() - 1,
+		});
+
+		const accessToken = await api.ensureValidAccessToken();
+		expect(accessToken).toBe('fresh-access-token');
+		expect(api.auth().access_token).toBe('fresh-access-token');
+	});
+});

--- a/packages/lib/SyncTargetNextcloud.js
+++ b/packages/lib/SyncTargetNextcloud.js
@@ -30,22 +30,38 @@ class SyncTargetNextcloud extends BaseSyncTarget {
 	}
 
 	async isAuthenticated() {
+		if (SyncTargetWebDAV.isOidcAuthMethod_(SyncTargetNextcloud.id())) {
+			return !!Setting.value('sync.5.auth');
+		}
+
 		return true;
 	}
 
-	static requiresPassword() {
-		return true;
+	authRouteName() {
+		if (Setting.value('appType') !== 'desktop') return null;
+		if (!SyncTargetWebDAV.isOidcAuthMethod_(SyncTargetNextcloud.id())) return null;
+		return 'WebDavOidcLogin';
+	}
+
+	static requiresPassword(settings = null) {
+		return !SyncTargetWebDAV.isOidcAuthMethod_(SyncTargetNextcloud.id(), settings);
 	}
 
 	static async checkConfig(options) {
-		return SyncTargetWebDAV.checkConfig(options);
+		return SyncTargetWebDAV.checkConfig(options, SyncTargetNextcloud.id());
 	}
 
 	async initFileApi() {
 		const fileApi = await SyncTargetWebDAV.newFileApi_(SyncTargetNextcloud.id(), {
 			path: () => Setting.value('sync.5.path'),
+			authMethod: () => Setting.value('sync.5.authMethod'),
 			username: () => Setting.value('sync.5.username'),
 			password: () => Setting.value('sync.5.password'),
+			auth: () => Setting.value('sync.5.auth'),
+			oidcIssuer: () => Setting.value('sync.5.oidcIssuer'),
+			oidcClientId: () => Setting.value('sync.5.oidcClientId'),
+			oidcClientSecret: () => Setting.value('sync.5.oidcClientSecret'),
+			oidcScope: () => Setting.value('sync.5.oidcScope'),
 			ignoreTlsErrors: () => Setting.value('net.ignoreTlsErrors'),
 		});
 

--- a/packages/lib/SyncTargetWebDAV.js
+++ b/packages/lib/SyncTargetWebDAV.js
@@ -4,10 +4,52 @@ const Setting = require('./models/Setting').default;
 const { FileApi } = require('./file-api.js');
 const Synchronizer = require('./Synchronizer').default;
 const WebDavApi = require('./WebDavApi').default;
+const OidcApi = require('./OidcApi').default;
 const { FileApiDriverWebDav } = require('./file-api-driver-webdav');
 const checkProviderIsSupported = require('./utils/webDAVUtils').default;
 
 class SyncTargetWebDAV extends BaseSyncTarget {
+	static authMethod_(syncTargetId, settings = null) {
+		const key = `sync.${syncTargetId}.authMethod`;
+		if (settings) {
+			if (typeof settings.authMethod === 'function') return settings.authMethod() || 'password';
+			if (typeof settings.authMethod === 'string') return settings.authMethod || 'password';
+			if (key in settings) return settings[key] || 'password';
+		}
+
+		return Setting.value(key) || 'password';
+	}
+
+	static isOidcAuthMethod_(syncTargetId, settings = null) {
+		return SyncTargetWebDAV.authMethod_(syncTargetId, settings) === 'oidc';
+	}
+
+	static newOidcApi_(syncTargetId, options, saveAuth = false) {
+		const api = new OidcApi({
+			issuer: options.oidcIssuer ? options.oidcIssuer() : Setting.value(`sync.${syncTargetId}.oidcIssuer`),
+			clientId: options.oidcClientId ? options.oidcClientId() : Setting.value(`sync.${syncTargetId}.oidcClientId`),
+			clientSecret: options.oidcClientSecret ? options.oidcClientSecret() : Setting.value(`sync.${syncTargetId}.oidcClientSecret`),
+			scope: options.oidcScope ? options.oidcScope() : Setting.value(`sync.${syncTargetId}.oidcScope`),
+		});
+
+		const authString = options.auth ? options.auth() : Setting.value(`sync.${syncTargetId}.auth`);
+		if (authString) {
+			try {
+				api.setAuth(JSON.parse(authString));
+			} catch (error) {
+				// Ignore invalid auth and let the user sign in again.
+			}
+		}
+
+		if (saveAuth) {
+			api.on('authRefreshed', auth => {
+				Setting.setValue(`sync.${syncTargetId}.auth`, auth ? JSON.stringify(auth) : null);
+			});
+		}
+
+		return api;
+	}
+
 	static id() {
 		return 6;
 	}
@@ -29,11 +71,21 @@ class SyncTargetWebDAV extends BaseSyncTarget {
 	}
 
 	async isAuthenticated() {
+		if (SyncTargetWebDAV.isOidcAuthMethod_(SyncTargetWebDAV.id())) {
+			return !!Setting.value('sync.6.auth');
+		}
+
 		return true;
 	}
 
-	static requiresPassword() {
-		return true;
+	authRouteName() {
+		if (Setting.value('appType') !== 'desktop') return null;
+		if (!SyncTargetWebDAV.isOidcAuthMethod_(SyncTargetWebDAV.id())) return null;
+		return 'WebDavOidcLogin';
+	}
+
+	static requiresPassword(settings = null) {
+		return !SyncTargetWebDAV.isOidcAuthMethod_(SyncTargetWebDAV.id(), settings);
 	}
 
 	static async newFileApi_(syncTargetId, options) {
@@ -44,6 +96,16 @@ class SyncTargetWebDAV extends BaseSyncTarget {
 			ignoreTlsErrors: () => options.ignoreTlsErrors(),
 		};
 
+		if (SyncTargetWebDAV.isOidcAuthMethod_(syncTargetId, options)) {
+			const oidcApi = SyncTargetWebDAV.newOidcApi_(syncTargetId, options, true);
+			apiOptions.authMethod = () => 'bearer';
+			apiOptions.accessToken = async () => oidcApi.ensureValidAccessToken();
+			apiOptions.onAuthError = async () => {
+				await oidcApi.refreshAuthToken();
+				return true;
+			};
+		}
+
 		const api = new WebDavApi(apiOptions);
 		const driver = new FileApiDriverWebDav(api);
 		const fileApi = new FileApi('', driver);
@@ -51,10 +113,7 @@ class SyncTargetWebDAV extends BaseSyncTarget {
 		return fileApi;
 	}
 
-	static async checkConfig(options) {
-		const fileApi = await SyncTargetWebDAV.newFileApi_(SyncTargetWebDAV.id(), options);
-		fileApi.requestRepeatCount_ = 0;
-
+	static async checkConfig(options, syncTargetId = SyncTargetWebDAV.id()) {
 		const output = {
 			ok: false,
 			errorMessage: '',
@@ -62,8 +121,25 @@ class SyncTargetWebDAV extends BaseSyncTarget {
 
 		try {
 			checkProviderIsSupported(options.path());
-			const result = await fileApi.stat('');
-			if (!result) throw new Error(`WebDAV directory not found: ${options.path()}`);
+			if (SyncTargetWebDAV.isOidcAuthMethod_(syncTargetId, options)) {
+				if (!options.oidcIssuer || !options.oidcIssuer()) throw new Error(_('OIDC issuer or discovery URL is missing'));
+				if (!options.oidcClientId || !options.oidcClientId()) throw new Error(_('OIDC client ID is missing'));
+
+				const oidcApi = SyncTargetWebDAV.newOidcApi_(syncTargetId, options);
+				await oidcApi.discovery();
+
+				if (Setting.value(`sync.${syncTargetId}.auth`)) {
+					const fileApi = await SyncTargetWebDAV.newFileApi_(syncTargetId, options);
+					fileApi.requestRepeatCount_ = 0;
+					const result = await fileApi.stat('');
+					if (!result) throw new Error(`WebDAV directory not found: ${options.path()}`);
+				}
+			} else {
+				const fileApi = await SyncTargetWebDAV.newFileApi_(syncTargetId, options);
+				fileApi.requestRepeatCount_ = 0;
+				const result = await fileApi.stat('');
+				if (!result) throw new Error(`WebDAV directory not found: ${options.path()}`);
+			}
 			output.ok = true;
 		} catch (error) {
 			output.errorMessage = error.message;
@@ -76,8 +152,14 @@ class SyncTargetWebDAV extends BaseSyncTarget {
 	async initFileApi() {
 		const fileApi = await SyncTargetWebDAV.newFileApi_(SyncTargetWebDAV.id(), {
 			path: () => Setting.value('sync.6.path'),
+			authMethod: () => Setting.value('sync.6.authMethod'),
 			username: () => Setting.value('sync.6.username'),
 			password: () => Setting.value('sync.6.password'),
+			auth: () => Setting.value('sync.6.auth'),
+			oidcIssuer: () => Setting.value('sync.6.oidcIssuer'),
+			oidcClientId: () => Setting.value('sync.6.oidcClientId'),
+			oidcClientSecret: () => Setting.value('sync.6.oidcClientSecret'),
+			oidcScope: () => Setting.value('sync.6.oidcScope'),
 			ignoreTlsErrors: () => Setting.value('net.ignoreTlsErrors'),
 		});
 

--- a/packages/lib/WebDavApi.test.js
+++ b/packages/lib/WebDavApi.test.js
@@ -1,0 +1,55 @@
+const shim = require('./shim').default;
+const WebDavApi = require('./WebDavApi').default;
+
+const makeResponse = (status, body) => {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		statusText: status === 200 ? 'OK' : 'Unauthorized',
+		text: async () => body,
+	};
+};
+
+describe('WebDavApi', () => {
+	let originalFetch;
+
+	beforeEach(() => {
+		originalFetch = shim.fetch;
+	});
+
+	afterEach(() => {
+		shim.fetch = originalFetch;
+	});
+
+	test('should refresh bearer auth and retry the request once', async () => {
+		let accessToken = 'expired-token';
+		const fetchMock = jest.fn(async (_url, options) => {
+			if (options.headers.Authorization === 'Bearer expired-token') {
+				return makeResponse(401, 'Unauthorized');
+			}
+
+			return makeResponse(200, 'done');
+		});
+
+		shim.fetch = fetchMock;
+
+		const api = new WebDavApi({
+			baseUrl: () => 'https://example.com/webdav',
+			username: () => '',
+			password: () => '',
+			authMethod: () => 'bearer',
+			accessToken: async () => accessToken,
+			onAuthError: async () => {
+				accessToken = 'fresh-token';
+				return true;
+			},
+		});
+
+		const result = await api.exec('GET', 'status', null, null, { responseFormat: 'text' });
+
+		expect(result).toBe('done');
+		expect(fetchMock.mock.calls).toHaveLength(2);
+		expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer expired-token');
+		expect(fetchMock.mock.calls[1][1].headers.Authorization).toBe('Bearer fresh-token');
+	});
+});

--- a/packages/lib/WebDavApi.ts
+++ b/packages/lib/WebDavApi.ts
@@ -19,6 +19,9 @@ interface WebDavApiOptions {
 	baseUrl(): string;
 	username(): string;
 	password(): string;
+	authMethod?(): 'basic'|'bearer';
+	accessToken?(): Promise<string | null>|string | null;
+	onAuthError?(): Promise<boolean>;
 	ignoreTlsErrors?(): boolean;
 }
 
@@ -39,6 +42,7 @@ interface ExecOptions {
 	target?: 'string' | 'file';
 	source?: 'file';
 	path?: string;
+	retryAuth?: boolean;
 }
 
 // detection state, whether invalid If-None-Match header is accepted by server
@@ -107,7 +111,7 @@ class WebDavApi {
 		return this.logger_;
 	}
 
-	private authToken(): string | null {
+	private basicAuthToken_(): string | null {
 		if (!this.options_.username() || !this.options_.password()) return null;
 		try {
 			// Note: Non-ASCII passwords will throw an error about Latin1 characters - https://github.com/laurent22/joplin/issues/246
@@ -118,6 +122,18 @@ class WebDavApi {
 			(error as Error).message = `Cannot encode username/password: ${(error as Error).message}`;
 			throw error;
 		}
+	}
+
+	private async authorizationHeader_(): Promise<string | null> {
+		const authMethod = this.options_.authMethod ? this.options_.authMethod() : 'basic';
+		if (authMethod === 'bearer') {
+			if (!this.options_.accessToken) return null;
+			const accessToken = await this.options_.accessToken();
+			return accessToken ? `Bearer ${accessToken}` : null;
+		}
+
+		const authToken = this.basicAuthToken_();
+		return authToken ? `Basic ${authToken}` : null;
 	}
 
 	public baseUrl(): string {
@@ -427,10 +443,11 @@ class WebDavApi {
 
 		if (!options.responseFormat) options.responseFormat = 'json';
 		if (!options.target) options.target = 'string';
+		if (options.retryAuth === undefined) options.retryAuth = true;
 
-		const authToken = this.authToken();
+		const authorizationHeader = await this.authorizationHeader_();
 
-		if (authToken) headers['Authorization'] = `Basic ${authToken}`;
+		if (authorizationHeader) headers['Authorization'] = authorizationHeader;
 
 		// That should not be needed, but it is required for React Native 0.63+
 		// https://github.com/facebook/react-native/issues/30176
@@ -525,6 +542,19 @@ class WebDavApi {
 		};
 
 		if (!response.ok) {
+			if (options.retryAuth && this.options_.onAuthError && ['401', '403'].includes(`${response.status}`)) {
+				try {
+					const didRefreshAuth = await this.options_.onAuthError();
+					if (didRefreshAuth) {
+						const retryHeaders = { ...headers };
+						delete retryHeaders['Authorization'];
+						return this.exec(method, path, body, retryHeaders, { ...options, retryAuth: false });
+					}
+				} catch (error) {
+					// Keep the original server error below.
+				}
+			}
+
 			// When using fetchBlob we only get a string (not xml or json) back
 			if (options.target === 'file') throw newError('fetchBlob error', response.status);
 
@@ -544,8 +574,10 @@ class WebDavApi {
 			let message = 'Unknown error 2';
 			if (response.status === 401 || response.status === 403) {
 				// No auth token means an empty username or password
-				if (!authToken) {
+				if (!authorizationHeader) {
 					message = _('Access denied: Please re-enter your password and/or username');
+				} else if (authorizationHeader.startsWith('Bearer ')) {
+					message = _('Access denied: Please reconnect to your account');
 				} else {
 					message = _('Access denied: Please check your username and password');
 				}

--- a/packages/lib/components/shared/config/shouldShowMissingPasswordWarning.ts
+++ b/packages/lib/components/shared/config/shouldShowMissingPasswordWarning.ts
@@ -4,7 +4,7 @@ import SyncTargetRegistry from '../../../SyncTargetRegistry';
 const shouldShowMissingPasswordWarning = (syncTargetId: number, settings: any) => {
 	const syncTargetClass = SyncTargetRegistry.classById(syncTargetId);
 
-	return syncTargetClass.requiresPassword() && !settings[`sync.${syncTargetId}.password`];
+	return syncTargetClass.requiresPassword(settings) && !settings[`sync.${syncTargetId}.password`];
 };
 
 export default shouldShowMissingPasswordWarning;

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -56,6 +56,17 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 	}
 
 	const emptyDirWarning = _('Attention: If you change this location, make sure you copy all your content to it before syncing, otherwise all files will be removed! See the FAQ for more details: %s', 'https://joplinapp.org/help/faq');
+	const syncTargetSettingVisible = (targetName: string, settings: Record<string, unknown>, authMethod: string|null = null) => {
+		try {
+			const targetId = SyncTargetRegistry.nameToId(targetName);
+			if (settings['sync.target'] !== targetId) return false;
+			if (!authMethod) return true;
+
+			return (settings[`sync.${targetId}.authMethod`] || 'password') === authMethod;
+		} catch (error) {
+			return false;
+		}
+	};
 
 	// A "public" setting means that it will show up in the various config screens (or config command for the CLI tool), however
 	// if if private a setting might still be handled and modified by the app. For instance, the settings related to sorting notes are not
@@ -179,11 +190,31 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			section: 'sync',
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			show: (settings: any) => {
-				return settings['sync.target'] === SyncTargetRegistry.nameToId('nextcloud');
+				return syncTargetSettingVisible('nextcloud', settings);
 			},
 			public: true,
 			label: () => _('Nextcloud WebDAV URL'),
 			description: () => emptyDirWarning,
+			storage: SettingStorage.File,
+		},
+		'sync.5.authMethod': {
+			value: 'password',
+			type: SettingItemType.String,
+			section: 'sync',
+			isEnum: true,
+			appTypes: [AppType.Desktop],
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			show: (settings: any) => {
+				return syncTargetSettingVisible('nextcloud', settings);
+			},
+			public: true,
+			label: () => _('Authentication method'),
+			options: () => {
+				return {
+					password: _('Password'),
+					oidc: _('OpenID Connect (OIDC)'),
+				};
+			},
 			storage: SettingStorage.File,
 		},
 		'sync.5.username': {
@@ -192,7 +223,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			section: 'sync',
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			show: (settings: any) => {
-				return settings['sync.target'] === SyncTargetRegistry.nameToId('nextcloud');
+				return syncTargetSettingVisible('nextcloud', settings, 'password');
 			},
 			public: true,
 			label: () => _('Nextcloud username'),
@@ -204,11 +235,65 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			section: 'sync',
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			show: (settings: any) => {
-				return settings['sync.target'] === SyncTargetRegistry.nameToId('nextcloud');
+				return syncTargetSettingVisible('nextcloud', settings, 'password');
 			},
 			public: true,
 			label: () => _('Nextcloud password'),
 			secure: true,
+		},
+		'sync.5.oidcIssuer': {
+			value: '',
+			type: SettingItemType.String,
+			section: 'sync',
+			appTypes: [AppType.Desktop],
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			show: (settings: any) => {
+				return syncTargetSettingVisible('nextcloud', settings, 'oidc');
+			},
+			public: true,
+			label: () => _('Nextcloud OIDC issuer or discovery URL'),
+			storage: SettingStorage.File,
+		},
+		'sync.5.oidcClientId': {
+			value: '',
+			type: SettingItemType.String,
+			section: 'sync',
+			appTypes: [AppType.Desktop],
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			show: (settings: any) => {
+				return syncTargetSettingVisible('nextcloud', settings, 'oidc');
+			},
+			public: true,
+			label: () => _('Nextcloud OIDC client ID'),
+			storage: SettingStorage.File,
+		},
+		'sync.5.oidcClientSecret': {
+			value: '',
+			type: SettingItemType.String,
+			section: 'sync',
+			appTypes: [AppType.Desktop],
+			advanced: true,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			show: (settings: any) => {
+				return syncTargetSettingVisible('nextcloud', settings, 'oidc');
+			},
+			public: true,
+			label: () => _('Nextcloud OIDC client secret'),
+			secure: true,
+		},
+		'sync.5.oidcScope': {
+			value: 'openid profile email offline_access',
+			type: SettingItemType.String,
+			section: 'sync',
+			appTypes: [AppType.Desktop],
+			advanced: true,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			show: (settings: any) => {
+				return syncTargetSettingVisible('nextcloud', settings, 'oidc');
+			},
+			public: true,
+			label: () => _('Nextcloud OIDC scope'),
+			storage: SettingStorage.File,
 		},
 
 		'sync.6.path': {
@@ -217,11 +302,31 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			section: 'sync',
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			show: (settings: any) => {
-				return settings['sync.target'] === SyncTargetRegistry.nameToId('webdav');
+				return syncTargetSettingVisible('webdav', settings);
 			},
 			public: true,
 			label: () => _('WebDAV URL'),
 			description: () => emptyDirWarning,
+			storage: SettingStorage.File,
+		},
+		'sync.6.authMethod': {
+			value: 'password',
+			type: SettingItemType.String,
+			section: 'sync',
+			isEnum: true,
+			appTypes: [AppType.Desktop],
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			show: (settings: any) => {
+				return syncTargetSettingVisible('webdav', settings);
+			},
+			public: true,
+			label: () => _('Authentication method'),
+			options: () => {
+				return {
+					password: _('Password'),
+					oidc: _('OpenID Connect (OIDC)'),
+				};
+			},
 			storage: SettingStorage.File,
 		},
 		'sync.6.username': {
@@ -230,7 +335,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			section: 'sync',
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			show: (settings: any) => {
-				return settings['sync.target'] === SyncTargetRegistry.nameToId('webdav');
+				return syncTargetSettingVisible('webdav', settings, 'password');
 			},
 			public: true,
 			label: () => _('WebDAV username'),
@@ -242,11 +347,65 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			section: 'sync',
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			show: (settings: any) => {
-				return settings['sync.target'] === SyncTargetRegistry.nameToId('webdav');
+				return syncTargetSettingVisible('webdav', settings, 'password');
 			},
 			public: true,
 			label: () => _('WebDAV password'),
 			secure: true,
+		},
+		'sync.6.oidcIssuer': {
+			value: '',
+			type: SettingItemType.String,
+			section: 'sync',
+			appTypes: [AppType.Desktop],
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			show: (settings: any) => {
+				return syncTargetSettingVisible('webdav', settings, 'oidc');
+			},
+			public: true,
+			label: () => _('WebDAV OIDC issuer or discovery URL'),
+			storage: SettingStorage.File,
+		},
+		'sync.6.oidcClientId': {
+			value: '',
+			type: SettingItemType.String,
+			section: 'sync',
+			appTypes: [AppType.Desktop],
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			show: (settings: any) => {
+				return syncTargetSettingVisible('webdav', settings, 'oidc');
+			},
+			public: true,
+			label: () => _('WebDAV OIDC client ID'),
+			storage: SettingStorage.File,
+		},
+		'sync.6.oidcClientSecret': {
+			value: '',
+			type: SettingItemType.String,
+			section: 'sync',
+			appTypes: [AppType.Desktop],
+			advanced: true,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			show: (settings: any) => {
+				return syncTargetSettingVisible('webdav', settings, 'oidc');
+			},
+			public: true,
+			label: () => _('WebDAV OIDC client secret'),
+			secure: true,
+		},
+		'sync.6.oidcScope': {
+			value: 'openid profile email offline_access',
+			type: SettingItemType.String,
+			section: 'sync',
+			appTypes: [AppType.Desktop],
+			advanced: true,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			show: (settings: any) => {
+				return syncTargetSettingVisible('webdav', settings, 'oidc');
+			},
+			public: true,
+			label: () => _('WebDAV OIDC scope'),
+			storage: SettingStorage.File,
 		},
 
 		'sync.8.path': {
@@ -480,6 +639,8 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 
 		'sync.3.auth': { value: '', type: SettingItemType.String, public: false },
 		'sync.4.auth': { value: '', type: SettingItemType.String, public: false },
+		'sync.5.auth': { value: '', type: SettingItemType.String, public: false },
+		'sync.6.auth': { value: '', type: SettingItemType.String, public: false },
 		'sync.7.auth': { value: '', type: SettingItemType.String, public: false },
 		'sync.9.auth': { value: '', type: SettingItemType.String, public: false },
 		'sync.10.auth': { value: '', type: SettingItemType.String, public: false },

--- a/packages/lib/models/settings/settingValidations.ts
+++ b/packages/lib/models/settings/settingValidations.ts
@@ -16,7 +16,9 @@ const validateUrlProtocol = async (_oldValue: string, newValue: string) => {
 const validations: Record<string, ValidationHandler> = {
 
 	'sync.5.path': validateUrlProtocol,
+	'sync.5.oidcIssuer': validateUrlProtocol,
 	'sync.6.path': validateUrlProtocol,
+	'sync.6.oidcIssuer': validateUrlProtocol,
 	'sync.9.path': validateUrlProtocol,
 	'sync.11.path': validateUrlProtocol,
 

--- a/packages/lib/oidc-api-node-utils.js
+++ b/packages/lib/oidc-api-node-utils.js
@@ -1,0 +1,130 @@
+const { _ } = require('./locale');
+const { findAvailablePort } = require('./net-utils');
+const shim = require('./shim').default;
+
+const http = require('http');
+const urlParser = require('url');
+const enableServerDestroy = require('server-destroy');
+
+class OidcApiNodeUtils {
+	constructor(api) {
+		this.api_ = api;
+		this.oauthServer_ = null;
+	}
+
+	api() {
+		return this.api_;
+	}
+
+	possibleOAuthDancePorts() {
+		return [9967, 8967, 8867];
+	}
+
+	makePage(message) {
+		const header = `
+		<!doctype html>
+		<html><head><meta charset="utf-8"></head><body>`;
+
+		const footer = `
+		</body></html>
+		`;
+
+		return header + message + footer;
+	}
+
+	cancelOAuthDance() {
+		if (!this.oauthServer_) return;
+		this.oauthServer_.destroy();
+	}
+
+	async oauthDance(targetConsole = null) {
+		if (targetConsole === null) targetConsole = console;
+
+		this.api().setAuth(null);
+
+		const port = await findAvailablePort(require('tcp-port-used'), this.possibleOAuthDancePorts(), 0);
+		if (!port) throw new Error(_('All potential ports are in use - please report the issue at %s', 'https://github.com/laurent22/joplin'));
+
+		const redirectUri = `http://localhost:${port}`;
+		const authCodeUrl = await this.api().authCodeUrl(redirectUri);
+
+		return new Promise((resolve, reject) => {
+			this.oauthServer_ = http.createServer();
+			let caughtError = null;
+
+			this.oauthServer_.on('request', (request, response) => {
+				const url = urlParser.parse(request.url, true);
+
+				if (url.pathname === '/auth') {
+					response.writeHead(302, { Location: authCodeUrl });
+					response.end();
+					return;
+				}
+
+				const query = url.query;
+
+				const writeResponse = (code, message) => {
+					response.writeHead(code, { 'Content-Type': 'text/html' });
+					response.write(this.makePage(message));
+					response.end();
+				};
+
+				const waitAndDestroy = () => {
+					shim.setTimeout(() => {
+						this.oauthServer_.destroy();
+						this.oauthServer_ = null;
+					}, 1000);
+				};
+
+				if (query.error) {
+					caughtError = new Error(`${query.error}: ${query.error_description || _('Authentication was cancelled or rejected.')}`);
+					writeResponse(400, caughtError.message);
+					waitAndDestroy();
+					return;
+				}
+
+				if (!query.code) {
+					caughtError = new Error('"code" query parameter is missing');
+					writeResponse(400, caughtError.message);
+					waitAndDestroy();
+					return;
+				}
+
+				void (async () => {
+					try {
+						await this.api().execTokenRequest(query.code, redirectUri, query.state);
+						writeResponse(200, _('The application has been authorised - you may now close this browser tab.'));
+						targetConsole.log('');
+						targetConsole.log(_('The application has been successfully authorised.'));
+						waitAndDestroy();
+					} catch (error) {
+						caughtError = error;
+						writeResponse(400, error.message);
+						targetConsole.log('');
+						targetConsole.log(error.message);
+						waitAndDestroy();
+					}
+				})();
+			});
+
+			this.oauthServer_.on('close', () => {
+				if (caughtError) {
+					reject(caughtError);
+				} else {
+					resolve(this.api().auth());
+				}
+			});
+
+			this.oauthServer_.listen(port);
+
+			enableServerDestroy(this.oauthServer_);
+
+			targetConsole.log(_('Please open the following URL in your browser to authenticate the application.'));
+			targetConsole.log('');
+			targetConsole.log(`http://127.0.0.1:${port}/auth`);
+		});
+	}
+}
+
+module.exports = OidcApiNodeUtils;
+module.exports.default = OidcApiNodeUtils;

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -261,3 +261,4 @@ llamacpp
 bgcolor
 bordercolor
 togglefullscreen
+OIDC


### PR DESCRIPTION
## Summary

 This adds desktop OIDC authentication support for the WebDAV and Nextcloud sync targets.

 It introduces a desktop-only OIDC auth mode in sync settings, a browser-based login flow with a localhost callback, bearer-token support in the WebDAV client, and token refresh handling for authenticated sync requests.

  ## What changed

  - Added `authMethod` support for WebDAV and Nextcloud sync settings with `password` and `oidc` modes
  - Added desktop-only OIDC settings for issuer/discovery URL, client ID, optional client secret, and scope
  - Added hidden auth storage for WebDAV and Nextcloud OIDC tokens
  - Added a desktop OIDC login screen and route for WebDAV/Nextcloud
  - Added bearer-token support to `WebDavApi`
  - Added token refresh and one retry on `401/403` for OIDC-authenticated WebDAV requests
  - Made WebDAV and Nextcloud auth checks and missing-password warnings aware of the selected auth mode
  - Added targeted tests for:
         - OIDC authorize/token handling
         - WebDAV bearer auth refresh-and-retry
         - missing-password warning behavior in OIDC mode

  ## Testing

  - `corepack yarn install --immutable`
  - `corepack yarn workspace @joplin/lib test OidcApi.test.js WebDavApi.test.js shouldShowMissingPasswordWarning.test.js`
  - `corepack yarn workspace @joplin/lib tsc`
  - `corepack yarn workspace @joplin/app-desktop tsc`

  ## Notes

  - This is desktop-only
  - Existing password-based WebDAV and Nextcloud setups continue to use the current behavior by default
  - This has not been validated yet against a live ownCloud or Nextcloud OIDC deployment, so live end-to-end verification is still needed.