### PR TITLE
Docs: Update sync/s3.md with new UpCloud URL

### DIFF
--- a/readme/apps/sync/s3.md
+++ b/readme/apps/sync/s3.md
@@ -76,8 +76,8 @@ If you provide a configuration and you receive "success!" on the "check config" 
 - Force Path Style: unchecked
 
 ## UpCloud
-- URL: `https://<account>.<region>.upcloudobjects.com` (They will provide you with multiple URLs, the one that follows this pattern should work.)
-- Region: required
+- URL: `https://<string>.upcloudobjects.com` (Use the "S3 endpoint" URL.)
+- Region: required (example: `europe-2`)
 - Force Path Style: unchecked
 
 ## Tebi


### PR DESCRIPTION
Edited the UpCloud section of the s3 readme to reflect new URL style, also provided a region example.