### PR TITLE
Docs(webdav): Note nginx webdav ext module requirement

### DIFF
--- a/readme/apps/sync/webdav.md
+++ b/readme/apps/sync/webdav.md
@@ -10,7 +10,7 @@ WebDAV-compatible services that are known to work with Joplin:
 - [HiDrive](https://www.strato.fr/stockage-en-ligne/) from Strato. [Setup help](https://github.com/laurent22/joplin/issues/309)
 - [InfiniCLOUD](https://infini-cloud.net/)
 - [Mailbox.org WebDAV](https://kb.mailbox.org/en/private/drive/) [Setup help](https://userforum-en.mailbox.org/topic/2766-unable-to-sync-joplin-notes-with-mailbox-org-via-webdav#comment-10946)
-- [Nginx WebDAV Module](https://nginx.org/en/docs/http/ngx_http_dav_module.html)
+- [Nginx WebDAV Module](https://nginx.org/en/docs/http/ngx_http_dav_module.html), requires [http_dav_ext_module](https://github.com/arut/nginx-dav-ext-module)
 - [Nextcloud](https://nextcloud.com/)
 - [OwnCloud](https://owncloud.org/)
 - [Seafile](https://www.seafile.com/)


### PR DESCRIPTION
- the base ngx_http_dav_module lacks PROPFIND which is needed by Joplin

**Test Plan**
- I tested base ngx_http_dav_module on my server and was returned an error within Joplin configuration check: `PROPFIND: Unknown error 2 (500):`
- I added extended module which adds PROPFIND function and error was resolved.
- I previewed my markdown change in my IDE prior to submission and tested link. 