### PR TITLE
Desktop: Fixes #14788: UI Polish for Sync Panel (omit redundant timestamp)

### DIFF
--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -84,7 +84,7 @@ const SidebarComponent = (props: Props) => {
 			<i className={`fas fa-caret-${syncReportExpanded ? 'down' : 'right'}`} />
 			{(completedTime || props.syncStarted) ? (
 				<span className="timestamp">
-					{props.syncStarted ? _('Last sync: In progress...') : _('Last sync: %s', completedTime)}
+					{props.syncStarted ? _('Last sync: In progress...') : (syncReportExpanded && completedTime ? _('Last sync:') : _('Last sync: %s', completedTime))}
 				</span>
 			) : ''}
 		</button>


### PR DESCRIPTION
## Description: 

This is a follow-up to #14881 to address UI polish feedback.
As suggested, when the sync log is expanded, and the sync is complete, the timestamp in the header is now omitted to avoid redundancy with the 'Completed' line in the log itself.

Collapsed state: Timestamp remains visible in the header.
<img width="309" height="126" alt="Screenshot 2026-04-09 215836" src="https://github.com/user-attachments/assets/dc0315fc-a9eb-4556-a915-adb83037729c" />

Expanded (Finished): Timestamp is hidden from the header (but present in the log).
<img width="289" height="140" alt="Screenshot 2026-04-09 220457" src="https://github.com/user-attachments/assets/381248ae-00b5-4cf0-a82e-8bb3a4203753" />

Expanded (In Progress): Header shows 'In progress...'.
<img width="297" height="147" alt="Screenshot 2026-04-09 215813" src="https://github.com/user-attachments/assets/c5889c79-adaf-4a72-a193-b959104bd3e5" />

## Screen Recording

https://github.com/user-attachments/assets/f6810102-dcf5-4e2a-8642-312d3a6b82d2

