### PR TITLE
Mobile: Resolves #15061: Fix Manage profiles screen is not scrollable

### DIFF
--- a/packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx
+++ b/packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx
@@ -42,6 +42,12 @@ const useStyle = (themeId: number) => {
 				paddingLeft: theme.margin,
 				paddingRight: theme.margin,
 			},
+			flatList: {
+				flex: 1,
+			},
+			flatListContent: {
+				paddingBottom: 80,
+			},
 		});
 	}, [themeId]);
 };
@@ -206,15 +212,15 @@ export default (props: Props) => {
 	return (
 		<View style={style.root}>
 			<ScreenHeader title={_('Profiles')} showSaveButton={false} showSideMenuButton={false} showSearchButton={false} />
-			<View>
-				<FlatList
-					data={profiles}
-					renderItem={renderProfileItem}
-					keyExtractor={profile => profile.id}
-					// Needed so that the list rerenders when its dependencies change:
-					extraData={extraListItemData}
-				/>
-			</View>
+			<FlatList
+				style={style.flatList}
+				contentContainerStyle={style.flatListContent}
+				data={profiles}
+				renderItem={renderProfileItem}
+				keyExtractor={profile => profile.id}
+				// Needed so that the list rerenders when its dependencies change:
+				extraData={extraListItemData}
+			/>
 			<FAB
 				icon="plus"
 				accessibilityLabel={_('New profile')}


### PR DESCRIPTION
## Summary: 

This Pull Request addresses the issue #15061 , where the **"Manage Profiles"** screen was not scrollable on mobile devices. If a user had many profiles, the list would overflow the screen, and those at the bottom would be unreachable.

## Problem: 

The `FlatList `component was wrapped in a `View `without a constrained height or flex property. This prevents the list from growing and scrolling within its container, causing it to simply clip at the edge of the screen.

## Solution:

- Added `flex: 1` to the FlatList so it correctly fills the available space between the header and the bottom of the screen.
- Removed the redundant wrapping View to simplify the component tree.
- Added 80px of paddingBottom to the contentContainerStyle. 
- This ensures that even when scrolled to the very bottom, the last profile item remains fully visible and is not obscured by the Floating Action Button.

## ScreenRecording

https://github.com/user-attachments/assets/2f17dc4d-fb20-475e-90c4-643bc4a8f078
