### PR TITLE
Mobile: Fixes #15060: Fix shared note not persisted to active notebook

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -404,6 +404,29 @@ describe('screens/Note', () => {
 		unmount();
 	});
 
+	it('should set title, body, and parent_id correctly when a note is created via share', async () => {
+		const folder = await Folder.save({ title: 'Share target folder', parent_id: '' });
+		const note = await Note.save({ parent_id: folder.id }, { provisional: true });
+
+		store.dispatch({
+			type: 'NAV_GO',
+			routeName: 'Note',
+			noteId: note.id,
+			sharedData: { title: 'Shared title', text: 'https://example.com' },
+		});
+		store.dispatch({ type: 'NOTE_UPDATE_ONE', note: { ...note }, provisional: true });
+
+		const { unmount } = render(<WrappedNoteScreen />);
+
+		await waitForNoteToMatch(note.id, {
+			title: 'Shared title',
+			body: 'https://example.com',
+			parent_id: folder.id,
+		});
+
+		unmount();
+	});
+
 	it('should always start in edit mode for provisional notes regardless of noteVisiblePanes', async () => {
 		store.dispatch({
 			type: 'NOTE_VISIBLE_PANES_SET',

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -591,7 +591,13 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 				logger.info('Sharing: handleShareData: Processing...');
 				await handleShared(sharedData, activeFolder.id, this.props.dispatch);
 			} else {
-				reg.logger().info('Cannot handle share - no valid active folder found');
+				reg.logger().warn('Cannot handle share - no valid active folder found');
+				void this.dropdownAlert_({
+					type: 'error',
+					title: _('Cannot share'),
+					message: _('No valid notebook is available. Please create or select a notebook and try again.'),
+				});
+				ShareExtension.close();
 			}
 		} else {
 			logger.info('Sharing: received empty share data.');

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -586,14 +586,12 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 		if (sharedData) {
 			reg.logger().info('Received shared data');
 
-			// selectedFolderId can be null if no screens other than "All notes"
-			// have been opened.
-			const targetFolder = this.props.selectedFolderId ?? (await Folder.defaultFolder())?.id;
-			if (targetFolder) {
+			const activeFolder = await Folder.getValidActiveFolder();
+			if (activeFolder) {
 				logger.info('Sharing: handleShareData: Processing...');
-				await handleShared(sharedData, targetFolder, this.props.dispatch);
+				await handleShared(sharedData, activeFolder.id, this.props.dispatch);
 			} else {
-				reg.logger().info('Cannot handle share - default folder id is not set');
+				reg.logger().info('Cannot handle share - no valid active folder found');
 			}
 		} else {
 			logger.info('Sharing: received empty share data.');

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -340,7 +340,7 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent) => {
 shared.initState = async function(comp: BaseNoteScreenComponent) {
 	const note = await shared.reloadNote(comp);
 
-	if (comp.props.sharedData) {
+	if (comp.props.sharedData && note) {
 		// Use the note returned by reloadNote directly to avoid a race condition where
 		// comp.state.note is still the initial empty note (Note.new() with parent_id='')
 		// because React hasn't flushed reloadNote's setState yet. Without this, the

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -304,7 +304,10 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent) => {
 
 	const fromShare = !!comp.props.sharedData;
 	if (note) {
-		const folder = Folder.byId(comp.props.folders, note.parent_id);
+		let folder = Folder.byId(comp.props.folders, note.parent_id);
+		if (!folder && note.parent_id) {
+			folder = await Folder.load(note.parent_id);
+		}
 		comp.setState({
 			lastSavedNote: { ...note },
 			note: note,
@@ -338,11 +341,23 @@ shared.initState = async function(comp: BaseNoteScreenComponent) {
 	const note = await shared.reloadNote(comp);
 
 	if (comp.props.sharedData) {
+		// Use the note returned by reloadNote directly to avoid a race condition where
+		// comp.state.note is still the initial empty note (Note.new() with parent_id='')
+		// because React hasn't flushed reloadNote's setState yet. Without this, the
+		// scheduled save would overwrite parent_id with an empty string in the DB.
+		const updatedNote = { ...note };
+		const fieldsToSave: NoteEntity = { id: note.id };
 		if (comp.props.sharedData.title) {
-			this.noteComponent_change(comp, 'title', comp.props.sharedData.title);
+			updatedNote.title = comp.props.sharedData.title;
+			fieldsToSave.title = comp.props.sharedData.title;
 		}
 		if (comp.props.sharedData.text) {
-			this.noteComponent_change(comp, 'body', comp.props.sharedData.text);
+			updatedNote.body = comp.props.sharedData.text;
+			fieldsToSave.body = comp.props.sharedData.text;
+		}
+		if (fieldsToSave.title !== undefined || fieldsToSave.body !== undefined) {
+			await Note.save(fieldsToSave);
+			comp.setState({ note: updatedNote, lastSavedNote: updatedNote });
 		}
 		if (comp.props.sharedData.resources) {
 			for (let i = 0; i < comp.props.sharedData.resources.length; i++) {


### PR DESCRIPTION
Fixes #15060
### Problem
When sharing a link or text to Joplin from another app (e.g. Chrome), the new note was not being saved to the active notebook. The notebook picker showed "..." and the note only appeared under All Notes

Two root causes:

1. `Folder.byId` only searches folders already in Redux state : if the target folder wasn't loaded yet, the picker showed nothing.
2. In `initState`, after reloadNote sets the note via `comp.setState`, React doesn't flush state synchronously. The shared data handler immediately read `comp.state.note`, which was still the initial empty note (`parent_id = ''`), and scheduled a save that overwrote the correct `parent_id` in the database
### Fix
Added a fallback to `Folder.load` in reloadNote so the folder is fetched from the database if it's not in Redux state

In `initState`, instead of reading from `comp.state.note` (which may be stale), the note returned directly from `reloadNote` is used. Title and body from shared data are saved as a partial update (`Note.save({ id, title, body })`), which leaves `parent_id` untouched in the database

Took existing behaviour in version 3.5 as reference 

### Test Plan
A test was added in `Note.test.tsx` that creates a provisional note inside a specific folder and dispatches a `NAV_GO` action with `sharedData` (title + URL). It then waits for the note in the database to have the correct title, body, and parent_id  directly verifying that the race condition is resolved and the note lands in the right notebook

### Tested Manually:

https://github.com/user-attachments/assets/b9043892-0747-4350-85a1-91e16d3ab15b

### AI Assistance Disclosure:
Tool AI help in improving wording of PR description