### PR TITLE
 Mobile: Fixes #15061: Fix profile list not scrollable to last item on Manage Profiles screen

### DIFF
--- a/packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx
+++ b/packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx
@@ -38,6 +38,9 @@ const useStyle = (themeId: number) => {
 				right: 0,
 				bottom: 0,
 			},
+			profileList: {
+				flex: 1,
+			},
 			profileListItem: {
 				paddingLeft: theme.margin,
 				paddingRight: theme.margin,
@@ -206,15 +209,15 @@ export default (props: Props) => {
 	return (
 		<View style={style.root}>
 			<ScreenHeader title={_('Profiles')} showSaveButton={false} showSideMenuButton={false} showSearchButton={false} />
-			<View>
-				<FlatList
-					data={profiles}
-					renderItem={renderProfileItem}
-					keyExtractor={profile => profile.id}
-					// Needed so that the list rerenders when its dependencies change:
-					extraData={extraListItemData}
-				/>
-			</View>
+			<FlatList
+				style={style.profileList}
+				data={profiles}
+				renderItem={renderProfileItem}
+				keyExtractor={profile => profile.id}
+				// Needed so that the list rerenders when its dependencies change:
+				extraData={extraListItemData}
+				contentContainerStyle={{ paddingBottom: 80 }}
+			/>
 			<FAB
 				icon="plus"
 				accessibilityLabel={_('New profile')}


### PR DESCRIPTION
Fixes #15061
### Problem

On the Manage Profiles screen, if you have enough profiles to overflow the screen, you can't scroll all the way down ; the last item is unreachable. The root cause was a plain `View` wrapping the `FlatList` with no flex styling. That caused the list to size itself based on content rather than the available space, so React Native had no room to scroll within

On top of that, even if scrolling had worked, the floating action button sits absolutely positioned at the bottom of the screen and would have covered the last list item anyway

### Fix

Removed the wrapper `View` and gave the `FlatList flex: 1` directly, so it fills the space between the header and the bottom of the screen and becomes properly scrollable. Added `paddingBottom: 80` to the `contentContainerStyle` so the last profile clears the FAB when scrolled to the bottom.

### Testing
**BEFORE:**

https://github.com/user-attachments/assets/5faca6dc-9a6a-4e86-9a4f-4d37f2ebab54


**AFTER**

https://github.com/user-attachments/assets/d8de9c63-4bd9-48ee-84c6-ba7f1b0b7d90

