### PR TITLE
Web: Fix crash that happens when the app receives an unknown message

### DIFF
--- a/packages/app-mobile/utils/ipc/RNToWebViewMessenger.ts
+++ b/packages/app-mobile/utils/ipc/RNToWebViewMessenger.ts
@@ -5,6 +5,9 @@ import { WebViewControl } from '../../components/ExtendedWebView/types';
 import { RefObject } from 'react';
 import { OnMessageEvent } from '../../components/ExtendedWebView/types';
 import { Platform } from 'react-native';
+import Logger from '@joplin/utils/Logger';
+
+const logger = Logger.create('RNToWebViewMessenger');
 
 const canUseOptimizedPostMessage = Platform.OS === 'web';
 
@@ -41,10 +44,11 @@ export default class RNToWebViewMessenger<LocalInterface, RemoteInterface> exten
 
 	public onWebViewMessage = (event: OnMessageEvent) => {
 		if (!this.hasBeenClosed()) {
-			if (canUseOptimizedPostMessage) {
-				void this.onMessage(event.nativeEvent.data);
+			const data = canUseOptimizedPostMessage ? event.nativeEvent.data : JSON.parse(event.nativeEvent.data);
+			if (typeof data === 'object' && data !== null && typeof data.kind === 'string') {
+				void this.onMessage(data);
 			} else {
-				void this.onMessage(JSON.parse(event.nativeEvent.data));
+				logger.info('Unknown message format:', event.nativeEvent.data);
 			}
 		}
 	};

--- a/packages/app-mobile/utils/ipc/RNToWebViewMessenger.ts
+++ b/packages/app-mobile/utils/ipc/RNToWebViewMessenger.ts
@@ -44,7 +44,18 @@ export default class RNToWebViewMessenger<LocalInterface, RemoteInterface> exten
 
 	public onWebViewMessage = (event: OnMessageEvent) => {
 		if (!this.hasBeenClosed()) {
-			const data = canUseOptimizedPostMessage ? event.nativeEvent.data : JSON.parse(event.nativeEvent.data);
+			let data;
+			if (canUseOptimizedPostMessage) {
+				data = event.nativeEvent.data;
+			} else {
+				try {
+					data = JSON.parse(event.nativeEvent.data);
+				} catch {
+					logger.warn('Failed to parse message:', event.nativeEvent.data);
+					return;
+				}
+			}
+
 			if (typeof data === 'object' && data !== null && typeof data.kind === 'string') {
 				void this.onMessage(data);
 			} else {


### PR DESCRIPTION
For example, extensions can send messages which would crash the app because those messages may not have the `.kind` property