### PR TITLE
Desktop: Markdown editor: Fix unselected `<span>`s are hidden in HTML notes

### DIFF
--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -7,26 +7,40 @@ import activateMainMenuItem from './util/activateMainMenuItem';
 import setSettingValue from './util/setSettingValue';
 import { toForwardSlashes } from '@joplin/utils/path';
 import mockClipboard from './util/mockClipboard';
+import { ElectronApplication, Page } from '@playwright/test';
 
+const importAndOpenHtmlExport = async (mainWindow: Page, electronApp: ElectronApplication, noteTitle: string) => {
+	const mainScreen = await new MainScreen(mainWindow).setup();
+	await mainScreen.waitFor();
+
+	await mainScreen.importHtmlDirectory(electronApp, join(__dirname, 'resources', 'html-import'));
+	const importedFolder = mainScreen.sidebar.container.getByText('html-import');
+	await importedFolder.waitFor();
+
+	// Retry -- focusing the imported-folder may fail in some cases
+	await expect(async () => {
+		await importedFolder.click();
+
+		await mainScreen.noteList.focusContent(electronApp);
+
+		const importedHtmlFileItem = mainScreen.noteList.getNoteItemByTitle(noteTitle);
+		await importedHtmlFileItem.click({ timeout: 300 });
+	}).toPass();
+
+	return { mainScreen };
+};
 
 test.describe('markdownEditor', () => {
+	test('editor should render the full content of HTML notes', async ({ mainWindow, electronApp }) => {
+		const { mainScreen } = await importAndOpenHtmlExport(mainWindow, electronApp, 'test-html-file-with-spans');
+
+		const editor = mainScreen.noteEditor.codeMirrorEditor;
+		// Regression test: The <span> should not be hidden by inline Markdown rendering (since this is an HTML note):
+		await expect(editor).toHaveText('<p><span style="margin-left: 100px;">test</span></p>');
+	});
+
 	test('preview pane should render images in HTML notes', async ({ mainWindow, electronApp }) => {
-		const mainScreen = await new MainScreen(mainWindow).setup();
-		await mainScreen.waitFor();
-
-		await mainScreen.importHtmlDirectory(electronApp, join(__dirname, 'resources', 'html-import'));
-		const importedFolder = mainScreen.sidebar.container.getByText('html-import');
-		await importedFolder.waitFor();
-
-		// Retry -- focusing the imported-folder may fail in some cases
-		await expect(async () => {
-			await importedFolder.click();
-
-			await mainScreen.noteList.focusContent(electronApp);
-
-			const importedHtmlFileItem = mainScreen.noteList.getNoteItemByTitle('test-html-file-with-image');
-			await importedHtmlFileItem.click({ timeout: 300 });
-		}).toPass();
+		const { mainScreen } = await importAndOpenHtmlExport(mainWindow, electronApp, 'test-html-file-with-image');
 
 		const viewerFrame = mainScreen.noteEditor.getNoteViewerFrameLocator();
 		// Should render headers

--- a/packages/app-desktop/integration-tests/resources/html-import/test-html-file-with-spans.html
+++ b/packages/app-desktop/integration-tests/resources/html-import/test-html-file-with-spans.html
@@ -1,0 +1,1 @@
+<p><span style="margin-left: 100px;">test</span></p>

--- a/packages/editor/CodeMirror/configFromSettings.ts
+++ b/packages/editor/CodeMirror/configFromSettings.ts
@@ -109,7 +109,7 @@ const configFromSettings = (settings: EditorSettings, context: RenderedContentCo
 		extensions.push(Prec.low(keymap.of(defaultKeymap)));
 	}
 
-	if (settings.inlineRenderingEnabled) {
+	if (settings.inlineRenderingEnabled && settings.language === EditorLanguageType.Markdown) {
 		extensions.push(renderingExtension());
 	}
 

--- a/packages/editor/CodeMirror/configFromSettings.ts
+++ b/packages/editor/CodeMirror/configFromSettings.ts
@@ -109,6 +109,8 @@ const configFromSettings = (settings: EditorSettings, context: RenderedContentCo
 		extensions.push(Prec.low(keymap.of(defaultKeymap)));
 	}
 
+	// Only enable in-editor rendering for Markdown notes. In-editor rendering can result in
+	// confusing output in HTML notes (e.g. some, but not most, tags hidden).
 	if (settings.inlineRenderingEnabled && settings.language === EditorLanguageType.Markdown) {
 		extensions.push(renderingExtension());
 	}


### PR DESCRIPTION
# Problem

In-editor rendering, which supports replacing `<span>`s not contained within the selection, was enabled for HTML notes. This could be confusing for complicated HTML, in which some HTML would disappear/reappear based on the cursor position.

**Note**: This issue was observed while debugging `.one` file import issues.

# Solution

Disable in-editor rendering for HTML notes.

# Testing

This pull request includes an automated test that fails when the changes to `packages/editor` are not applied. The test 1) imports an HTML note, then 2) asserts that the full content of the note is displayed in the editor.
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->