### PR TITLE
Desktop: Fix copy/paste not working in Settings text fields

### DIFF
--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -200,6 +200,11 @@ function menuItemSetEnabled(id: string, enabled: boolean) {
 	const menu = Menu.getApplicationMenu();
 	const menuItem = menu.getMenuItemById(id);
 	if (!menuItem) return;
+	// Don't disable menu items that have a role (e.g. copy, paste, cut,
+	// selectAll). Since Electron 40, disabling a role-based menu item also
+	// prevents the native role behaviour, which breaks clipboard operations
+	// in non-editor input fields such as the Settings screen.
+	if (!enabled && menuItem.role) return;
 	menuItem.enabled = enabled;
 }
 


### PR DESCRIPTION
Since the Electron 40 upgrade, disabling role-based menu items (Copy, Cut, Paste, Select All) also prevents their native clipboard behaviour. This broke copy/paste in non-editor inputs like the Settings screen. Fix by not disabling menu items that have a role, since Electron ignores the click handler for role-based items anyway.