### PR TITLE
Desktop: Fixes #15100: Fix pasting images from clipboard when no image/* format is reported

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -91,6 +91,16 @@ export function resourcesStatus(resourceInfos: any) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+const clipboardImageToResource = async (image: any, mime: string) => {
+	const fileExt = mimeUtils.toFileExtension(mime);
+	const filePath = `${Setting.value('tempDir')}/${md5(Date.now())}.${fileExt}`;
+	await shim.writeImageToFile(image, mime, filePath);
+	const md = await commandAttachFileToBody('', [filePath]);
+	await shim.fsDriver().remove(filePath);
+	return md;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 export async function getResourcesFromPasteEvent(event: any) {
 	const output = [];
 	const formats = clipboard.availableFormats();
@@ -104,19 +114,22 @@ export async function getResourcesFromPasteEvent(event: any) {
 				continue;
 			}
 			if (event) event.preventDefault();
-
-			const image = clipboard.readImage();
-
-			const fileExt = mimeUtils.toFileExtension(format);
-			const filePath = `${Setting.value('tempDir')}/${md5(Date.now())}.${fileExt}`;
-
-			await shim.writeImageToFile(image, format, filePath);
-			const md = await commandAttachFileToBody('', [filePath]);
-			await shim.fsDriver().remove(filePath);
-
+			const md = await clipboardImageToResource(clipboard.readImage(), format);
 			if (md) output.push(md);
 		}
 	}
+
+	// Some applications (e.g. macshot) copy images to the clipboard without
+	// an image/* format, but clipboard.readImage() can still read them.
+	if (!output.length) {
+		const image = clipboard.readImage();
+		if (!image.isEmpty()) {
+			if (event) event.preventDefault();
+			const md = await clipboardImageToResource(image, 'image/png');
+			if (md) output.push(md);
+		}
+	}
+
 	return output;
 }
 

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -95,9 +95,12 @@ const clipboardImageToResource = async (image: any, mime: string) => {
 	const fileExt = mimeUtils.toFileExtension(mime);
 	const filePath = `${Setting.value('tempDir')}/${md5(Date.now())}.${fileExt}`;
 	await shim.writeImageToFile(image, mime, filePath);
-	const md = await commandAttachFileToBody('', [filePath]);
-	await shim.fsDriver().remove(filePath);
-	return md;
+	try {
+		const md = await commandAttachFileToBody('', [filePath]);
+		return md;
+	} finally {
+		await shim.fsDriver().remove(filePath);
+	}
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied

--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -491,7 +491,7 @@ const shim = {
 	},
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	writeImageToFile: (_image: any, _format: any, _filePath: string): void => {
+	writeImageToFile: (_image: any, _format: any, _filePath: string): Promise<void> => {
 		throw new Error('Not implemented');
 	},
 

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -262,4 +262,5 @@ bgcolor
 bordercolor
 togglefullscreen
 onestore
+macshot
 pdate


### PR DESCRIPTION
Some screenshot tools (e.g. macshot on macOS) copy images to the clipboard in a way that Joplin didn't recognise, causing paste to silently do nothing. Images from these tools can now be pasted into both the Markdown and Rich Text editors