### PR TITLE
Mobile: Remove unnecessary padding at bottom of note in view mode

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -1678,9 +1678,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 					!note || !note.body.trim() ? null : (
 						<NoteBodyViewer
 							style={this.styles().noteBodyViewer}
-							// Extra bottom padding to make it possible to scroll past the
-							// action button (so that it doesn't overlap the text)
-							paddingBottom={150}
+							paddingBottom={0}
 							noteBody={note.body}
 							noteMarkupLanguage={note.markup_language}
 							noteResources={this.state.noteResources}


### PR DESCRIPTION
PR https://github.com/laurent22/joplin/pull/14363 changed the behaviour on mobile, so that switching between view and edit mode on a note is a toggle in the header bar. As the view mode originally had a floating button to switch to edit mode, a large area of padding was added to the bottom of the note, in order to prevent the button from overlapping the note contents when scrolled to the bottom. As this extra padding is no longer necessary, this PR removes it.

### Testing

**Before change:**

<img width="250" height="802" alt="Capture0" src="https://github.com/user-attachments/assets/9ea5a1f7-1411-41dc-bb4b-2265d70a9855" />

**Web screenshots with change:**

<img width="250" height="758" alt="Capture" src="https://github.com/user-attachments/assets/ce6449bd-1856-4d7a-b899-1001287bea0f" />
<img width="250" height="759" alt="Capture2" src="https://github.com/user-attachments/assets/63a805cd-ad46-4383-8171-45d6e1a4224a" />

**Android screenshots with change:**

<img width="250" height="886" alt="Capture3" src="https://github.com/user-attachments/assets/0ec9891d-5d43-4a72-b356-2835cae80157" />
<img width="250" height="892" alt="Capture4" src="https://github.com/user-attachments/assets/433b60ee-6de3-4d3d-8787-e39ae2ec22f2" />
<img width="250" height="889" alt="Capture5" src="https://github.com/user-attachments/assets/b39c080a-94c8-436d-8cb2-2b0be960f0d0" />