### PR TITLE
Mobile: Fix #15104: Truncate verbose decryption error payloads in Status screen

### DIFF
--- a/packages/app-mobile/components/screens/status.tsx
+++ b/packages/app-mobile/components/screens/status.tsx
@@ -25,6 +25,7 @@ interface State {
 interface ProcessedLine {
 	key: string;
 	text?: string;
+	sectionName?: string;
 	isSection?: boolean;
 	isDivider?: boolean;
 	retryAllHandler?: ()=> void;
@@ -45,9 +46,9 @@ const processReport = (report: ReportSection[], refreshScreen: OnRefreshScreen, 
 		let style: TextStyle = { ...baseStyle };
 		style.fontWeight = 'bold';
 		if (i > 0) style.paddingTop = 20;
-		lines.push({ key: `section_${i}`, isSection: true, text: section.title });
+		lines.push({ key: `section_${i}`, isSection: true, text: section.title, sectionName: section.name });
 		if (section.canRetryAll) {
-			lines.push({ key: `retry_all_${i}`, text: '', retryAllHandler: section.retryAllHandler });
+			lines.push({ key: `retry_all_${i}`, text: '', retryAllHandler: section.retryAllHandler, sectionName: section.name });
 		}
 
 		for (const n in section.body) {
@@ -76,7 +77,7 @@ const processReport = (report: ReportSection[], refreshScreen: OnRefreshScreen, 
 				if (item.type === ReportItemType.OpenList) {
 					currentList = [];
 				} else if (item.type === ReportItemType.CloseList) {
-					lines.push({ key: `list_${i}_${n}`, listItems: currentList });
+					lines.push({ key: `list_${i}_${n}`, listItems: currentList, sectionName: section.name });
 					currentList = null;
 				}
 				text = item.text;
@@ -84,7 +85,7 @@ const processReport = (report: ReportSection[], refreshScreen: OnRefreshScreen, 
 				text = item;
 			}
 
-			const line = { key: `item_${i}_${n}`, text: text, retryHandler, ignoreHandler };
+			const line = { key: `item_${i}_${n}`, text: text, retryHandler, ignoreHandler, sectionName: section.name };
 			if (currentList) {
 				// The OpenList item, for example, might be empty and should be skipped:
 				const hasContent = line.text || retryHandler || ignoreHandler;
@@ -96,7 +97,7 @@ const processReport = (report: ReportSection[], refreshScreen: OnRefreshScreen, 
 			}
 		}
 
-		lines.push({ key: `divider2_${i}`, isDivider: true });
+		lines.push({ key: `divider2_${i}`, isDivider: true, sectionName: section.name });
 	}
 
 	return lines;
@@ -204,7 +205,8 @@ class StatusScreenComponent extends BaseScreenComponent<Props, State> {
 				</View>
 			) : null;
 
-			const textComponent = text ? <Text style={style} role={textRole}>{text}</Text> : null;
+			const isFailedDecryptionErrorHeader = item.sectionName === 'failedDecryption' && text?.startsWith('Items with error:');
+			const textComponent = text ? <Text style={style} role={textRole} numberOfLines={isFailedDecryptionErrorHeader ? 2 : undefined} ellipsizeMode={isFailedDecryptionErrorHeader ? 'tail' : undefined}>{text}</Text> : null;
 			if (item.isDivider) {
 				return <View style={styles.divider} role='separator' key={item.key} />;
 			} else if (item.listItems) {

--- a/packages/app-mobile/components/screens/status.tsx
+++ b/packages/app-mobile/components/screens/status.tsx
@@ -25,7 +25,6 @@ interface State {
 interface ProcessedLine {
 	key: string;
 	text?: string;
-	sectionName?: string;
 	isSection?: boolean;
 	isDivider?: boolean;
 	retryAllHandler?: ()=> void;
@@ -46,9 +45,9 @@ const processReport = (report: ReportSection[], refreshScreen: OnRefreshScreen, 
 		let style: TextStyle = { ...baseStyle };
 		style.fontWeight = 'bold';
 		if (i > 0) style.paddingTop = 20;
-		lines.push({ key: `section_${i}`, isSection: true, text: section.title, sectionName: section.name });
+		lines.push({ key: `section_${i}`, isSection: true, text: section.title });
 		if (section.canRetryAll) {
-			lines.push({ key: `retry_all_${i}`, text: '', retryAllHandler: section.retryAllHandler, sectionName: section.name });
+			lines.push({ key: `retry_all_${i}`, text: '', retryAllHandler: section.retryAllHandler });
 		}
 
 		for (const n in section.body) {
@@ -77,7 +76,7 @@ const processReport = (report: ReportSection[], refreshScreen: OnRefreshScreen, 
 				if (item.type === ReportItemType.OpenList) {
 					currentList = [];
 				} else if (item.type === ReportItemType.CloseList) {
-					lines.push({ key: `list_${i}_${n}`, listItems: currentList, sectionName: section.name });
+					lines.push({ key: `list_${i}_${n}`, listItems: currentList });
 					currentList = null;
 				}
 				text = item.text;
@@ -85,7 +84,7 @@ const processReport = (report: ReportSection[], refreshScreen: OnRefreshScreen, 
 				text = item;
 			}
 
-			const line = { key: `item_${i}_${n}`, text: text, retryHandler, ignoreHandler, sectionName: section.name };
+			const line = { key: `item_${i}_${n}`, text: text, retryHandler, ignoreHandler };
 			if (currentList) {
 				// The OpenList item, for example, might be empty and should be skipped:
 				const hasContent = line.text || retryHandler || ignoreHandler;
@@ -97,7 +96,7 @@ const processReport = (report: ReportSection[], refreshScreen: OnRefreshScreen, 
 			}
 		}
 
-		lines.push({ key: `divider2_${i}`, isDivider: true, sectionName: section.name });
+		lines.push({ key: `divider2_${i}`, isDivider: true });
 	}
 
 	return lines;
@@ -205,9 +204,7 @@ class StatusScreenComponent extends BaseScreenComponent<Props, State> {
 				</View>
 			) : null;
 
-			const localizedItemsWithErrorPrefix = _('Items with error: %s', '');
-			const isFailedDecryptionErrorHeader = item.sectionName === 'failedDecryption' && text?.startsWith(localizedItemsWithErrorPrefix);
-			const textComponent = text ? <Text style={style} role={textRole} numberOfLines={isFailedDecryptionErrorHeader ? 2 : undefined} ellipsizeMode={isFailedDecryptionErrorHeader ? 'tail' : undefined}>{text}</Text> : null;
+			const textComponent = text ? <Text style={style} role={textRole} numberOfLines={2} ellipsizeMode='tail'>{text}</Text> : null;
 			if (item.isDivider) {
 				return <View style={styles.divider} role='separator' key={item.key} />;
 			} else if (item.listItems) {

--- a/packages/app-mobile/components/screens/status.tsx
+++ b/packages/app-mobile/components/screens/status.tsx
@@ -205,7 +205,8 @@ class StatusScreenComponent extends BaseScreenComponent<Props, State> {
 				</View>
 			) : null;
 
-			const isFailedDecryptionErrorHeader = item.sectionName === 'failedDecryption' && text?.startsWith('Items with error:');
+			const localizedItemsWithErrorPrefix = _('Items with error: %s', '');
+			const isFailedDecryptionErrorHeader = item.sectionName === 'failedDecryption' && text?.startsWith(localizedItemsWithErrorPrefix);
 			const textComponent = text ? <Text style={style} role={textRole} numberOfLines={isFailedDecryptionErrorHeader ? 2 : undefined} ellipsizeMode={isFailedDecryptionErrorHeader ? 'tail' : undefined}>{text}</Text> : null;
 			if (item.isDivider) {
 				return <View style={styles.divider} role='separator' key={item.key} />;


### PR DESCRIPTION
**Fixes #15104**

**AI Assistance Disclosure**
I used AI to navigate the project's codebase and trace the sync status data flow. 

**Problem**
On the mobile Sync Status screen, decryption error payloads (e.g., corrupted cipher text) render as an infinite "wall of text." This breaks the UI layout and makes it difficult to navigate the status report or access the "Retry/Ignore" buttons.

**Solution**
I simplified the fix by applying `numberOfLines={2}` directly to the text component. Since status items are usually short, this prevents the layout from breaking without needing extra properties in the data layer.

**Test Plan**
I verified the fix by simulating long decryption error strings in the sync report. Long messages now truncate to 2 lines with an ellipsis, while standard status items remain unaffected. (See attached video)

**Video Demonstration**
[vid5.webm](https://github.com/user-attachments/assets/0c29c124-3325-4d52-bcdf-3909b4860359)
