### PR TITLE
Desktop: Fixes #15107: Defer sync after master password save to prevent encryption enable race

### DIFF
--- a/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
@@ -78,7 +78,7 @@ export default function(props: Props) {
 				} else {
 					throw new Error(`Unknown mode: ${mode}`);
 				}
-				void reg.scheduleSync();
+				void reg.waitForSyncFinishedThenSync(null);
 				onClose();
 			} catch (error) {
 				void shim.showErrorDialog(error.message);

--- a/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
@@ -78,7 +78,7 @@ export default function(props: Props) {
 				} else {
 					throw new Error(`Unknown mode: ${mode}`);
 				}
-				void reg.waitForSyncFinishedThenSync();
+				void reg.scheduleSync();
 				onClose();
 			} catch (error) {
 				void shim.showErrorDialog(error.message);

--- a/packages/lib/registry.ts
+++ b/packages/lib/registry.ts
@@ -97,7 +97,7 @@ class Registry {
 	// This can be used when some data has been modified and we want to make
 	// sure it gets synced. So we wait for the current sync operation to
 	// finish (if one is running), then we trigger a sync just after.
-	public waitForSyncFinishedThenSync = async () => {
+	public waitForSyncFinishedThenSync = async (delay = 0) => {
 		if (!Setting.value('sync.target')) {
 			this.logger().info('waitForSyncFinishedThenSync - cancelling because no sync target is selected.');
 			return;
@@ -107,7 +107,7 @@ class Registry {
 		try {
 			const synchronizer = await this.syncTarget().synchronizer();
 			await synchronizer.waitForSyncToFinish();
-			await this.scheduleSync(0);
+			await this.scheduleSync(delay);
 		} finally {
 			this.waitForReSyncCalls_.pop();
 		}

--- a/packages/lib/registry.ts
+++ b/packages/lib/registry.ts
@@ -97,7 +97,7 @@ class Registry {
 	// This can be used when some data has been modified and we want to make
 	// sure it gets synced. So we wait for the current sync operation to
 	// finish (if one is running), then we trigger a sync just after.
-	public waitForSyncFinishedThenSync = async (delay = 0) => {
+	public waitForSyncFinishedThenSync = async (delay: number | null = 0) => {
 		if (!Setting.value('sync.target')) {
 			this.logger().info('waitForSyncFinishedThenSync - cancelling because no sync target is selected.');
 			return;


### PR DESCRIPTION
Fixes #15107

## Problem

Enabling encryption after setting up sync results in it reverting to disabled within seconds. A second enable is needed for it to stick.

## Root cause

Regression from #14664. The new enable flow opens the master password dialog before enabling encryption. On save, the dialog calls `waitForSyncFinishedThenSync()` which triggers an immediate sync (delay 0). The enable flow only resumes in `EncryptionConfigScreen`'s `useEffect` after the dialog closes, so the sync can race with it and overwrite the encryption state with stale sync info. In 3.5 this wasn't an issue because enable completed before sync was triggered.


## Solution

Added an optional `delay` parameter to `reg.waitForSyncFinishedThenSync()` (defaulting to `0` to preserve existing behavior), and pass it through to `scheduleSync`. In the master password dialog save handler, call `waitForSyncFinishedThenSync(null)` so it still waits for any running sync to finish but defers the follow-up sync using `scheduleSync`'s default ~10s delay. This matches pre-#14664 timing and gives the enable flow time to complete.


## Test plan

1. Set up a filesystem sync target and synchronise once
2. Go to Tools > Options > Encryption, set a master password, click Enable
3. Observe encryption stays enabled and does not revert after sync

**Recordings**

Before fix (encryption reverts after enable):

https://github.com/user-attachments/assets/b3f9b200-a344-4f78-8f23-6d18fec17978

After fix (encryption stays enabled):

https://github.com/user-attachments/assets/c998a6f5-c271-4ef5-a342-ba722ca26d09

AI disclosure: Used AI tools for debugging and understanding the race condition. All changes tested manually.
