### PR TITLE
Mobile: Fixes #15116: Fix markdown editor not scrolling to search results

### DIFF
--- a/packages/editor/CodeMirror/extensions/searchExtension.ts
+++ b/packages/editor/CodeMirror/extensions/searchExtension.ts
@@ -174,6 +174,19 @@ const searchExtension = (onEvent: OnEventCallback, settings: EditorSettings): Ex
 			},
 		} : undefined),
 
+		// On mobile, scrolling is handled externally (page-level native scroll), so
+		// .cm-scroller has no internal scroll. A @codemirror/view upgrade (6.35→6.41)
+		// added rect-clipping after each failed scroll attempt, which prevents the
+		// fallback window.scrollBy from firing. Use native element.scrollIntoView to
+		// fix findNext/findPrevious and GoDocEnd.
+		settings.useExternalSearch ? EditorView.scrollHandler.of((view, range) => {
+			const { node } = view.domAtPos(range.head);
+			const el = node.nodeType === Node.ELEMENT_NODE ? node as Element : node.parentElement;
+			if (!el) return false;
+			el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+			return true;
+		}) : [],
+
 		autoScrollToMatchPlugin,
 
 		EditorState.transactionExtender.of((tr) => {


### PR DESCRIPTION
Fixes #15116

### Problem
After the CodeMirror upgrade in v3.6.16 ([CodeMirror Upgrade](https://github.com/laurent22/joplin/pull/15007)), the inline search in the markdown editor stopped scrolling to matched results when tapping find next or find previous
The matches were highlighted correctly but the editor stayed at its current scroll position, making off-screen results invisible. The go to end of note toolbar action was also broken for the same reason

The root cause is a change in @codemirror/view 6.41.0 , the scrollRectIntoView function gained a new rect-clipping step that runs after each scroll attempt. On mobile, the editor uses external page-level scrolling, meaning .cm-scroller has no internal scroll capability. So, when CodeMirror tried to scroll the scroller and failed, the new clipping code made the target appear already in view from the window's perspective, so the fallback window.scrollBy was never called

### Fix
Added a EditorView.scrollHandler in searchExtension.ts that is only active when useExternalSearch is true (mobile only)
Instead of relying on CodeMirror's internal scroll logic, it uses the browser's native element.scrollIntoView which works correctly with page-level scrolling. The handler returns true to tell CodeMirror to skip its own scroll logic

### Test Plan
Tested manually :

https://github.com/user-attachments/assets/03885d1d-f98f-4352-a720-11f9eb000c51


**AI Assistance Disclosure:**

I used AI to research what changed between @codemirror/view 6.35.0 and 6.41.0 that could affect scroll behavior, specifically comparing the scrollRectIntoView function across both versions to identify the new rect-clipping code as the root cause and also used in getting the mock data for local testing