### PR TITLE
Desktop: Importing from OneNote: Disable unresponsiveness warning while importing

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -59,6 +59,7 @@ export default class ElectronAppWrapper {
 	private secondaryWindows_: Map<SecondaryWindowId, SecondaryWindowData> = new Map();
 
 	private willQuitApp_ = false;
+	private enableUnresponsiveCheck_ = true;
 	private tray_: Tray = null;
 	private buildDir_: string = null;
 	private rendererProcessQuitReply_: RendererProcessQuitReply = null;
@@ -307,6 +308,8 @@ export default class ElectronAppWrapper {
 		let unresponsiveTimeout: ReturnType<typeof setTimeout>|null = null;
 
 		this.win_.webContents.on('unresponsive', () => {
+			if (!this.enableUnresponsiveCheck_) return;
+
 			// Don't show the "unresponsive" dialog immediately -- the "unresponsive" event
 			// can be fired when showing a dialog or modal (e.g. the update dialog).
 			//
@@ -894,6 +897,10 @@ export default class ElectronAppWrapper {
 
 	public getPluginProtocolHandler() {
 		return this.customProtocolHandlers_.pluginContent;
+	}
+
+	public setEnableUnresponsiveCheck(enabled: boolean) {
+		this.enableUnresponsiveCheck_ = enabled;
 	}
 
 	private async fixLinuxAccessibility_() {

--- a/packages/app-desktop/bridge.ts
+++ b/packages/app-desktop/bridge.ts
@@ -483,6 +483,10 @@ export class Bridge {
 		setLocale(locale);
 	}
 
+	public setEnableUnresponsiveCheck(enabled: boolean) {
+		this.electronWrapper_.setEnableUnresponsiveCheck(enabled);
+	}
+
 	public get Menu() {
 		return Menu;
 	}

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -35,6 +35,12 @@ const getOneNoteConverter = (): NativeOneNoteConverter => {
 	}
 };
 
+const setEnableUnresponsiveCheck = (enabled: boolean) => {
+	if (shim.isElectron()) {
+		shim.electronBridge().setEnableUnresponsiveCheck(enabled);
+	}
+};
+
 // See onenote-converter README.md for more information
 export default class InteropService_Importer_OneNote extends InteropService_Importer_Base {
 	protected importedNotes: Record<string, NoteEntity> = {};
@@ -119,6 +125,11 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			}
 
 			try {
+				// HACK: The OneNote importer currently runs in the renderer process on desktop.
+				// If importing a large file takes a long time, the "unresponsive" dialog can be
+				// shown. Work around this by temporarily disabling the dialog:
+				setEnableUnresponsiveCheck(false);
+
 				await oneNoteConverter(notebookFilePath, resolve(outputDirectory2), notebookBaseDir);
 			} catch (error) {
 				// Forward only the error message. Usually the stack trace points to bytes in the WASM file.
@@ -126,6 +137,8 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 				// length for auto-creating a forum post:
 				this.options_.onError?.(error.message ?? error);
 				console.error(error);
+			} finally {
+				setEnableUnresponsiveCheck(true);
 			}
 		}
 


### PR DESCRIPTION
# Problem

Importing a large, multi-gigabyte `.one` file can take several minutes. This can cause Joplin to display a "window is unresponsive" warning.

# Solution

Disable the "window is unresponsive" warning while the importer is running.

**Note**: This is a workaround. In the long term, it would be better to [run the importer in a worker thread](https://github.com/personalizedrefrigerator/joplin/tree/wip/run-onenote-importer-in-worker) (or similar).

# Testing

Windows 11:
- Import a large 3+ GiB OneNote file.
- Verify that the "window is unresponsive" dialog is not shown.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->