### PR TITLE
Mobile: Fixes #15120: RTE heading links scroll to bottom instead of top in Editing mode

### DIFF
--- a/packages/editor/ProseMirror/utils/jumpToHash.ts
+++ b/packages/editor/ProseMirror/utils/jumpToHash.ts
@@ -8,11 +8,13 @@ const jumpToHash = (targetHash: string): Command => (state, dispatch, view) => {
 	}
 
 	let targetHeaderPos: number|null = null;
+	let targetHeadingNodePos: number|null = null;
 	forEachHeading(view.state.doc, (node, hash, pos) => {
 		if (hash === targetHash) {
 			// Subtract one to move the selection to the end of
 			// the node:
 			targetHeaderPos = pos + node.nodeSize - 1;
+			targetHeadingNodePos = pos;
 		}
 
 		return targetHeaderPos !== null;
@@ -21,11 +23,15 @@ const jumpToHash = (targetHash: string): Command => (state, dispatch, view) => {
 	if (targetHeaderPos !== null) {
 		const newSelection = TextSelection.create(state.doc, targetHeaderPos);
 		if (dispatch) {
-			dispatch(
-				state.tr.setSelection(newSelection)
-					.scrollIntoView(),
-			);
+			dispatch(state.tr.setSelection(newSelection));
 			if (view) {
+				// Use nodeDOM to get the heading element directly, then call native
+				// scrollIntoView with block:'start' so the heading appears at the top
+				// of the viewport, consistent with view mode behavior.
+				const headingDom = view.nodeDOM(targetHeadingNodePos);
+				if (headingDom instanceof Element) {
+					headingDom.scrollIntoView({ block: 'start' });
+				}
 				focus('jumpToHash', view);
 			}
 		}

--- a/packages/editor/ProseMirror/utils/jumpToHash.ts
+++ b/packages/editor/ProseMirror/utils/jumpToHash.ts
@@ -29,7 +29,7 @@ const jumpToHash = (targetHash: string): Command => (state, dispatch, view) => {
 				// scrollIntoView with block:'start' so the heading appears at the top
 				// of the viewport, consistent with view mode behavior.
 				const headingDom = view.nodeDOM(targetHeadingNodePos);
-				if (headingDom instanceof Element) {
+				if (headingDom instanceof Element && headingDom.scrollIntoView) {
 					headingDom.scrollIntoView({ block: 'start' });
 				}
 				focus('jumpToHash', view);

--- a/packages/editor/ProseMirror/utils/jumpToHash.ts
+++ b/packages/editor/ProseMirror/utils/jumpToHash.ts
@@ -23,14 +23,18 @@ const jumpToHash = (targetHash: string): Command => (state, dispatch, view) => {
 	if (targetHeaderPos !== null) {
 		const newSelection = TextSelection.create(state.doc, targetHeaderPos);
 		if (dispatch) {
-			dispatch(state.tr.setSelection(newSelection));
+			dispatch(
+				state.tr.setSelection(newSelection)
+					.scrollIntoView(),
+			);
 			if (view) {
-				// Use nodeDOM to get the heading element directly, then call native
-				// scrollIntoView with block:'start' so the heading appears at the top
-				// of the viewport, consistent with view mode behavior.
+				// Scroll the heading to the top of the viewport, consistent with view
+				// mode behavior. Uses window.scrollTo to avoid relying on scrollIntoView
+				// option support across WebView versions.
 				const headingDom = view.nodeDOM(targetHeadingNodePos);
-				if (headingDom instanceof Element && headingDom.scrollIntoView) {
-					headingDom.scrollIntoView({ block: 'start' });
+				if (headingDom instanceof Element) {
+					const rect = headingDom.getBoundingClientRect();
+					window.scrollTo(0, window.scrollY + rect.top);
 				}
 				focus('jumpToHash', view);
 			}


### PR DESCRIPTION
Fixes #15120
### Problem 
When you tap a heading link in the rich text editor on mobile, the note scrolls but the heading ends up at the bottom of the screen. This is inconsistent with view mode, where the same action brings the heading to the top

### Fix
The root cause was that ProseMirror's built-in `scrollIntoView()` uses a minimal-scroll strategy ; it only scrolls just enough to make the cursor visible, which naturally pushes the heading to the bottom. The fix grabs the actual heading DOM element using `view.nodeDOM()` and calls the native `scrollIntoView({ block: 'start' })` on it directly, which is exactly what the view mode does

### Test Plan
Tested Manually:

https://github.com/user-attachments/assets/08df0830-6827-44ad-8e3e-138cb60a524c

