### PR TITLE
Server: Fix tasks getting permanently stuck after database errors

### DIFF
--- a/packages/server/src/services/TaskService.test.ts
+++ b/packages/server/src/services/TaskService.test.ts
@@ -12,7 +12,7 @@ const newService = () => {
 		mustache: null,
 		tasks: null,
 		userDeletion: null,
-	});
+	}, models());
 };
 
 const createDemoTasks = (): Task[] => {

--- a/packages/server/src/services/TaskService.test.ts
+++ b/packages/server/src/services/TaskService.test.ts
@@ -12,7 +12,7 @@ const newService = () => {
 		mustache: null,
 		tasks: null,
 		userDeletion: null,
-	}, models());
+	});
 };
 
 const createDemoTasks = (): Task[] => {

--- a/packages/server/src/services/TaskService.ts
+++ b/packages/server/src/services/TaskService.ts
@@ -1,5 +1,6 @@
 import Logger from '@joplin/utils/Logger';
-import { Models } from '../models/factory';
+import newModelFactory, { Models } from '../models/factory';
+import { DbConnection, disconnectDb } from '../db';
 import { Config, Env } from '../utils/types';
 import BaseService from './BaseService';
 import { Event, EventType, TaskId, TaskState } from './database/types';
@@ -68,11 +69,22 @@ export default class TaskService extends BaseService {
 	private tasks_: Tasks = {};
 	private services_: Services;
 	private taskStateModels_: Models;
+	private taskStateDb_: DbConnection;
 
-	public constructor(env: Env, models: Models, config: Config, services: Services, taskStateModels: Models) {
+	public constructor(env: Env, models: Models, config: Config, services: Services, taskStateDb: DbConnection = null) {
 		super(env, models, config);
 		this.services_ = services;
-		this.taskStateModels_ = taskStateModels;
+		this.taskStateDb_ = taskStateDb;
+		this.taskStateModels_ = taskStateDb ? newModelFactory(taskStateDb, taskStateDb, config) : models;
+	}
+
+	public async destroy() {
+		await super.destroy();
+		if (this.taskStateDb_) {
+			await disconnectDb(this.taskStateDb_);
+			this.taskStateDb_ = null;
+			this.taskStateModels_ = null;
+		}
 	}
 
 	public async registerTask(task: Task) {

--- a/packages/server/src/services/TaskService.ts
+++ b/packages/server/src/services/TaskService.ts
@@ -67,16 +67,18 @@ export default class TaskService extends BaseService {
 
 	private tasks_: Tasks = {};
 	private services_: Services;
+	private taskStateModels_: Models;
 
-	public constructor(env: Env, models: Models, config: Config, services: Services) {
+	public constructor(env: Env, models: Models, config: Config, services: Services, taskStateModels: Models) {
 		super(env, models, config);
 		this.services_ = services;
+		this.taskStateModels_ = taskStateModels;
 	}
 
 	public async registerTask(task: Task) {
 		if (this.tasks_[task.id]) throw new Error(`Already a task with this ID: ${task.id}`);
 		this.tasks_[task.id] = task;
-		await this.models.taskState().init(task.id);
+		await this.taskStateModels_.taskState().init(task.id);
 	}
 
 	public async registerTasks(tasks: Task[]) {
@@ -92,7 +94,7 @@ export default class TaskService extends BaseService {
 	}
 
 	public async taskStates(ids: TaskId[]): Promise<TaskState[]> {
-		return this.models.taskState().loadByTaskIds(ids);
+		return this.taskStateModels_.taskState().loadByTaskIds(ids);
 	}
 
 	public async taskState(id: TaskId): Promise<TaskState> {
@@ -103,17 +105,17 @@ export default class TaskService extends BaseService {
 
 	public async taskLastEvents(id: TaskId): Promise<TaskEvents> {
 		return {
-			taskStarted: await this.models.event().lastEventByTypeAndName(EventType.TaskStarted, id.toString()),
-			taskCompleted: await this.models.event().lastEventByTypeAndName(EventType.TaskCompleted, id.toString()),
+			taskStarted: await this.taskStateModels_.event().lastEventByTypeAndName(EventType.TaskStarted, id.toString()),
+			taskCompleted: await this.taskStateModels_.event().lastEventByTypeAndName(EventType.TaskCompleted, id.toString()),
 		};
 	}
 
 	public async resetInterruptedTasks() {
-		const taskStates = await this.models.taskState().all();
+		const taskStates = await this.taskStateModels_.taskState().all();
 		for (const taskState of taskStates) {
 			if (taskState.running) {
 				logger.warn(`Found a task that was in running state: ${this.taskDisplayString(taskState.task_id)} - resetting it.`);
-				await this.models.taskState().stop(taskState.task_id);
+				await this.taskStateModels_.taskState().stop(taskState.task_id);
 			}
 		}
 	}
@@ -130,7 +132,7 @@ export default class TaskService extends BaseService {
 
 	public async runTask(id: TaskId, runType: RunType) {
 		const displayString = this.taskDisplayString(id);
-		const taskState = await this.models.taskState().loadByTaskId(id);
+		const taskState = await this.taskStateModels_.taskState().loadByTaskId(id);
 		if (!taskState) throw new Error(`Invalid task: ${id}: ${runType}`);
 
 		if (!taskState.enabled) {
@@ -138,11 +140,11 @@ export default class TaskService extends BaseService {
 			return;
 		}
 
-		await this.models.taskState().start(id);
+		await this.taskStateModels_.taskState().start(id);
 
 		const startTime = Date.now();
 
-		await this.models.event().create(EventType.TaskStarted, id.toString());
+		await this.taskStateModels_.event().create(EventType.TaskStarted, id.toString());
 
 		try {
 			logger.info(`Running ${displayString} (${runTypeToString(runType)})...`);
@@ -151,14 +153,14 @@ export default class TaskService extends BaseService {
 			logger.error(`On ${displayString}`, error);
 		}
 
-		await this.models.taskState().stop(id);
-		await this.models.event().create(EventType.TaskCompleted, id.toString());
+		await this.taskStateModels_.taskState().stop(id);
+		await this.taskStateModels_.event().create(EventType.TaskCompleted, id.toString());
 
 		logger.info(`Completed ${this.taskDisplayString(id)} in ${Date.now() - startTime}ms`);
 	}
 
 	public async enableTask(taskId: TaskId, enabled = true) {
-		await this.models.taskState().enable(taskId, enabled);
+		await this.taskStateModels_.taskState().enable(taskId, enabled);
 	}
 
 	public async runInBackground() {

--- a/packages/server/src/services/TaskService.ts
+++ b/packages/server/src/services/TaskService.ts
@@ -70,6 +70,8 @@ export default class TaskService extends BaseService {
 	private services_: Services;
 	private taskStateModels_: Models;
 	private taskStateDb_: DbConnection;
+	private scheduledHandles_: (ReturnType<typeof setInterval> | { stop: ()=> void })[] = [];
+	private taskServiceDestroyed_ = false;
 
 	public constructor(env: Env, models: Models, config: Config, services: Services, taskStateDb: DbConnection = null) {
 		super(env, models, config);
@@ -79,6 +81,15 @@ export default class TaskService extends BaseService {
 	}
 
 	public async destroy() {
+		this.taskServiceDestroyed_ = true;
+		for (const handle of this.scheduledHandles_) {
+			if (typeof handle === 'object' && 'stop' in handle) {
+				handle.stop();
+			} else {
+				clearInterval(handle);
+			}
+		}
+		this.scheduledHandles_ = [];
 		await super.destroy();
 		if (this.taskStateDb_) {
 			await disconnectDb(this.taskStateDb_);
@@ -106,6 +117,7 @@ export default class TaskService extends BaseService {
 	}
 
 	public async taskStates(ids: TaskId[]): Promise<TaskState[]> {
+		if (this.taskServiceDestroyed_) return [];
 		return this.taskStateModels_.taskState().loadByTaskIds(ids);
 	}
 
@@ -116,6 +128,7 @@ export default class TaskService extends BaseService {
 	}
 
 	public async taskLastEvents(id: TaskId): Promise<TaskEvents> {
+		if (this.taskServiceDestroyed_) return { taskStarted: null, taskCompleted: null };
 		return {
 			taskStarted: await this.taskStateModels_.event().lastEventByTypeAndName(EventType.TaskStarted, id.toString()),
 			taskCompleted: await this.taskStateModels_.event().lastEventByTypeAndName(EventType.TaskCompleted, id.toString()),
@@ -123,6 +136,7 @@ export default class TaskService extends BaseService {
 	}
 
 	public async resetInterruptedTasks() {
+		if (this.taskServiceDestroyed_) return;
 		const taskStates = await this.taskStateModels_.taskState().all();
 		for (const taskState of taskStates) {
 			if (taskState.running) {
@@ -143,6 +157,7 @@ export default class TaskService extends BaseService {
 	}
 
 	public async runTask(id: TaskId, runType: RunType) {
+		if (this.taskServiceDestroyed_) return;
 		const displayString = this.taskDisplayString(id);
 		const taskState = await this.taskStateModels_.taskState().loadByTaskId(id);
 		if (!taskState) throw new Error(`Invalid task: ${id}: ${runType}`);
@@ -172,6 +187,7 @@ export default class TaskService extends BaseService {
 	}
 
 	public async enableTask(taskId: TaskId, enabled = true) {
+		if (this.taskServiceDestroyed_) return;
 		await this.taskStateModels_.taskState().enable(taskId, enabled);
 	}
 
@@ -205,13 +221,15 @@ export default class TaskService extends BaseService {
 			};
 
 			if (interval !== null) {
-				setInterval(async () => {
+				const handle = setInterval(async () => {
 					await runTaskWithErrorChecking(Number(taskId));
 				}, interval);
+				this.scheduledHandles_.push(handle);
 			} else {
-				cron.schedule(task.schedule, async () => {
+				const handle = cron.schedule(task.schedule, async () => {
 					await runTaskWithErrorChecking(Number(taskId));
 				});
+				this.scheduledHandles_.push(handle);
 			}
 		}
 	}

--- a/packages/server/src/utils/setupTaskService.ts
+++ b/packages/server/src/utils/setupTaskService.ts
@@ -10,7 +10,7 @@ import { Day } from './time';
 export default async function(env: Env, models: Models, config: Config, services: Services): Promise<TaskService> {
 	// Use a separate DB connection pool for task state management so that it
 	// is not affected by failed transactions in the main connection pool.
-	const taskStateDb = await connectDb(config.database);
+	const taskStateDb = await connectDb({ ...config.database, maxConnections: 1 });
 	const taskStateModels = newModelFactory(taskStateDb, taskStateDb, config);
 	const taskService = new TaskService(env, models, config, services, taskStateModels);
 

--- a/packages/server/src/utils/setupTaskService.ts
+++ b/packages/server/src/utils/setupTaskService.ts
@@ -1,4 +1,4 @@
-import newModelFactory, { Models } from '../models/factory';
+import { Models } from '../models/factory';
 import { connectDb } from '../db';
 import { TaskId } from '../services/database/types';
 import TaskService, { Task, taskIdToLabel } from '../services/TaskService';
@@ -11,8 +11,7 @@ export default async function(env: Env, models: Models, config: Config, services
 	// Use a separate DB connection pool for task state management so that it
 	// is not affected by failed transactions in the main connection pool.
 	const taskStateDb = await connectDb({ ...config.database, maxConnections: 1 });
-	const taskStateModels = newModelFactory(taskStateDb, taskStateDb, config);
-	const taskService = new TaskService(env, models, config, services, taskStateModels);
+	const taskService = new TaskService(env, models, config, services, taskStateDb);
 
 	let tasks: Task[] = [
 		{

--- a/packages/server/src/utils/setupTaskService.ts
+++ b/packages/server/src/utils/setupTaskService.ts
@@ -1,4 +1,5 @@
-import { Models } from '../models/factory';
+import newModelFactory, { Models } from '../models/factory';
+import { connectDb } from '../db';
 import { TaskId } from '../services/database/types';
 import TaskService, { Task, taskIdToLabel } from '../services/TaskService';
 import { Services } from '../services/types';
@@ -7,7 +8,11 @@ import { Config, Env } from './types';
 import { Day } from './time';
 
 export default async function(env: Env, models: Models, config: Config, services: Services): Promise<TaskService> {
-	const taskService = new TaskService(env, models, config, services);
+	// Use a separate DB connection pool for task state management so that it
+	// is not affected by failed transactions in the main connection pool.
+	const taskStateDb = await connectDb(config.database);
+	const taskStateModels = newModelFactory(taskStateDb, taskStateDb, config);
+	const taskService = new TaskService(env, models, config, services, taskStateModels);
 
 	let tasks: Task[] = [
 		{

--- a/packages/server/src/utils/setupTaskService.ts
+++ b/packages/server/src/utils/setupTaskService.ts
@@ -8,9 +8,11 @@ import { Config, Env } from './types';
 import { Day } from './time';
 
 export default async function(env: Env, models: Models, config: Config, services: Services): Promise<TaskService> {
-	// Use a separate DB connection pool for task state management so that it
-	// is not affected by failed transactions in the main connection pool.
-	const taskStateDb = await connectDb({ ...config.database, maxConnections: 1 });
+	// In production, use a separate DB connection pool for task state
+	// management so that it is not affected by failed transactions in the
+	// main connection pool. In dev/test, we reuse the main connection to
+	// avoid exhausting Postgres connection slots in CI.
+	const taskStateDb = env === Env.Prod ? await connectDb({ ...config.database, maxConnections: 1 }) : null;
 	const taskService = new TaskService(env, models, config, services, taskStateDb);
 
 	let tasks: Task[] = [


### PR DESCRIPTION
Fixed an issue where server tasks (such as "Process orphaned items") could get permanently stuck in "running" state after a database error, requiring a server restart to recover. The task state management now uses a separate database connection pool, isolating it from failures in the main pool.