### PR TITLE
Server: Downgrade password reset log for non-existent users to info

### DIFF
--- a/packages/server/src/routes/index/password.ts
+++ b/packages/server/src/routes/index/password.ts
@@ -31,7 +31,11 @@ const subRoutes: Record<string, RouteHandler> = {
 			try {
 				await ctx.joplin.models.user().sendResetPasswordEmail(fields.email || '');
 			} catch (error) {
-				logger.warn(`Could not send reset email for ${fields.email}`, error);
+				if (error instanceof ErrorNotFound) {
+					logger.info(`Could not send reset email for ${fields.email}`, error);
+				} else {
+					logger.warn(`Could not send reset email for ${fields.email}`, error);
+				}
 			}
 
 			confirmationMessage = 'If we have an account that matches your email, you should receive an email with instructions on how to reset your password shortly.';


### PR DESCRIPTION
Password reset attempts for non-existent email addresses are now logged at info level instead of warn, since this is expected behavior (typos, wrong email). Other errors (e.g. email server issues) remain at warn level.