### PR TITLE
Desktop: Resolves #15132 Fix: Fix hang during postprocessing note while importing from OneNote

### DIFF
--- a/packages/lib/services/interop/InteropService_Importer_OneNote.postprocessHtml.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.postprocessHtml.test.ts
@@ -5,22 +5,29 @@ import Setting from '../../models/Setting';
 import shim from '../../shim';
 
 describe('InteropService_Importer_OneNote.postprocessHtml', () => {
-	it('should skip high-complexity HTML without reporting an import error', async () => {
-		const testImportDirectory = Setting.value('tempDir');
-		const onErrorCalls: string[] = [];
+	type ImporterInternals = {
+		postprocessGeneratedHtmlInFolder_: (baseFolder: string)=> Promise<void>;
+		getValidHtmlFiles_: (baseFolder: string)=> Promise<{ path: string }[]>;
+		buildIdMap_: (baseFolder: string)=> Promise<{ get: (id: string|null)=> { path: string }|null }>;
+	};
 
+	const setupImporterTest = async (testImportDirectory: string, onError?: (error: string|Error)=> void) => {
 		const importer = new InteropService_Importer_OneNote();
 		await importer.init(testImportDirectory, {
 			domParser: new DOMParser(),
 			xmlSerializer: new XMLSerializer(),
-			onError: (error: string|Error) => onErrorCalls.push(String(error)),
+			...(onError && { onError }),
 		});
 
-		const importerWithInternals = importer as unknown as {
-			postprocessGeneratedHtmlInFolder_: (baseFolder: string)=> Promise<void>;
-			getValidHtmlFiles_: (baseFolder: string)=> Promise<{ path: string }[]>;
-			buildIdMap_: (baseFolder: string)=> Promise<{ get: (id: string|null)=> { path: string }|null }>;
-		};
+		const importerWithInternals = importer as unknown as ImporterInternals;
+		return { importer, importerWithInternals };
+	};
+
+	it('should skip high-complexity HTML without reporting an import error', async () => {
+		const testImportDirectory = Setting.value('tempDir');
+		const onErrorCalls: string[] = [];
+
+		const { importer, importerWithInternals } = await setupImporterTest(testImportDirectory, (error: string|Error) => onErrorCalls.push(String(error)));
 
 		const getValidHtmlFilesSpy = jest.spyOn(importerWithInternals, 'getValidHtmlFiles_').mockResolvedValue([{ path: 'high-complexity.html' }]);
 		const buildIdMapSpy = jest.spyOn(importerWithInternals, 'buildIdMap_').mockResolvedValue({ get: () => null });
@@ -40,18 +47,9 @@ describe('InteropService_Importer_OneNote.postprocessHtml', () => {
 
 	it('should still extract svgs for high-complexity HTML when skipping remaining postprocessing', async () => {
 		const testImportDirectory = Setting.value('tempDir');
+		const onErrorCalls: string[] = [];
 
-		const importer = new InteropService_Importer_OneNote();
-		await importer.init(testImportDirectory, {
-			domParser: new DOMParser(),
-			xmlSerializer: new XMLSerializer(),
-		});
-
-		const importerWithInternals = importer as unknown as {
-			postprocessGeneratedHtmlInFolder_: (baseFolder: string)=> Promise<void>;
-			getValidHtmlFiles_: (baseFolder: string)=> Promise<{ path: string }[]>;
-			buildIdMap_: (baseFolder: string)=> Promise<{ get: (id: string|null)=> { path: string }|null }>;
-		};
+		const { importer, importerWithInternals } = await setupImporterTest(testImportDirectory, (error: string|Error) => onErrorCalls.push(String(error)));
 
 		const svgMarkup = '<svg><path d="M0 0 L10 10" /></svg>'.repeat(20);
 		const htmlWithManySvgs = `<html><body>${svgMarkup}</body></html>`;
@@ -64,6 +62,7 @@ describe('InteropService_Importer_OneNote.postprocessHtml', () => {
 
 		await importerWithInternals.postprocessGeneratedHtmlInFolder_(testImportDirectory);
 
+		expect(onErrorCalls).toEqual([]);
 		expect(postprocessGeneratedHtmlSpy).not.toHaveBeenCalled();
 
 		const svgWriteCalls = writeFileSpy.mock.calls.filter(call => String(call[0]).endsWith('.svg'));

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.postprocessHtml.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.postprocessHtml.test.ts
@@ -2,8 +2,42 @@ import '../../testing/test-utils';
 import '../../testing/dom-test-environment';
 import InteropService_Importer_OneNote from './InteropService_Importer_OneNote';
 import Setting from '../../models/Setting';
+import shim from '../../shim';
 
 describe('InteropService_Importer_OneNote.postprocessHtml', () => {
+	it('should skip high-complexity HTML without reporting an import error', async () => {
+		const testImportDirectory = Setting.value('tempDir');
+		const onErrorCalls: string[] = [];
+
+		const importer = new InteropService_Importer_OneNote();
+		await importer.init(testImportDirectory, {
+			domParser: new DOMParser(),
+			xmlSerializer: new XMLSerializer(),
+			onError: (error: string|Error) => onErrorCalls.push(String(error)),
+		});
+
+		const importerWithInternals = importer as unknown as {
+			postprocessGeneratedHtmlInFolder_: (baseFolder: string)=> Promise<void>;
+			getValidHtmlFiles_: (baseFolder: string)=> Promise<{ path: string }[]>;
+			buildIdMap_: (baseFolder: string)=> Promise<{ get: (id: string|null)=> { path: string }|null }>;
+		};
+
+		const getValidHtmlFilesSpy = jest.spyOn(importerWithInternals, 'getValidHtmlFiles_').mockResolvedValue([{ path: 'high-complexity.html' }]);
+		const buildIdMapSpy = jest.spyOn(importerWithInternals, 'buildIdMap_').mockResolvedValue({ get: () => null });
+		const postprocessGeneratedHtmlSpy = jest.spyOn(importer, 'postprocessGeneratedHtml_');
+		const readFileSpy = jest.spyOn(shim.fsDriver(), 'readFile').mockResolvedValue('x'.repeat(360000));
+
+		await importerWithInternals.postprocessGeneratedHtmlInFolder_(testImportDirectory);
+
+		expect(onErrorCalls).toEqual([]);
+		expect(postprocessGeneratedHtmlSpy).not.toHaveBeenCalled();
+
+		readFileSpy.mockRestore();
+		postprocessGeneratedHtmlSpy.mockRestore();
+		buildIdMapSpy.mockRestore();
+		getValidHtmlFilesSpy.mockRestore();
+	});
+
 	it.each([
 		{
 			label: 'when links are in an invalid/unsupported format',

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.postprocessHtml.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.postprocessHtml.test.ts
@@ -11,72 +11,89 @@ describe('InteropService_Importer_OneNote.postprocessHtml', () => {
 		buildIdMap_: (baseFolder: string)=> Promise<{ get: (id: string|null)=> { path: string }|null }>;
 	};
 
-	const setupImporterTest = async (testImportDirectory: string, onError?: (error: string|Error)=> void) => {
+	type RiskyHtmlTestContext = {
+		testImportDirectory: string;
+		onErrorCalls: string[];
+		importerWithInternals: ImporterInternals;
+		postprocessGeneratedHtmlSpy: jest.SpyInstance;
+		parseFromStringSpy: jest.SpyInstance;
+		readFileSpy: jest.SpyInstance;
+		writeFileSpy: jest.SpyInstance;
+		cleanup: ()=> void;
+	};
+
+	const setupRiskyHtmlTest = async (filePath: string, html: string): Promise<RiskyHtmlTestContext> => {
+		const testImportDirectory = Setting.value('tempDir');
+		const onErrorCalls: string[] = [];
+		const domParser = new DOMParser();
+		const parseFromStringSpy = jest.spyOn(domParser, 'parseFromString');
+
 		const importer = new InteropService_Importer_OneNote();
 		await importer.init(testImportDirectory, {
-			domParser: new DOMParser(),
+			domParser,
 			xmlSerializer: new XMLSerializer(),
-			...(onError && { onError }),
+			onError: (error: string|Error) => onErrorCalls.push(String(error)),
 		});
 
 		const importerWithInternals = importer as unknown as ImporterInternals;
-		return { importer, importerWithInternals };
+		const getValidHtmlFilesSpy = jest.spyOn(importerWithInternals, 'getValidHtmlFiles_').mockResolvedValue([{ path: filePath }]);
+		const buildIdMapSpy = jest.spyOn(importerWithInternals, 'buildIdMap_').mockResolvedValue({ get: () => null });
+		const postprocessGeneratedHtmlSpy = jest.spyOn(importer, 'postprocessGeneratedHtml_');
+		const readFileSpy = jest.spyOn(shim.fsDriver(), 'readFile').mockResolvedValue(html);
+		const writeFileSpy = jest.spyOn(shim.fsDriver(), 'writeFile').mockResolvedValue();
+
+		const cleanup = () => {
+			writeFileSpy.mockRestore();
+			readFileSpy.mockRestore();
+			postprocessGeneratedHtmlSpy.mockRestore();
+			buildIdMapSpy.mockRestore();
+			getValidHtmlFilesSpy.mockRestore();
+			parseFromStringSpy.mockRestore();
+		};
+
+		return {
+			testImportDirectory,
+			onErrorCalls,
+			importerWithInternals,
+			postprocessGeneratedHtmlSpy,
+			parseFromStringSpy,
+			readFileSpy,
+			writeFileSpy,
+			cleanup,
+		};
 	};
 
 	it('should skip high-complexity HTML without reporting an import error', async () => {
-		const testImportDirectory = Setting.value('tempDir');
-		const onErrorCalls: string[] = [];
+		const context = await setupRiskyHtmlTest('high-complexity.html', 'x'.repeat(360000));
 
-		const { importer, importerWithInternals } = await setupImporterTest(testImportDirectory, (error: string|Error) => onErrorCalls.push(String(error)));
+		await context.importerWithInternals.postprocessGeneratedHtmlInFolder_(context.testImportDirectory);
 
-		const getValidHtmlFilesSpy = jest.spyOn(importerWithInternals, 'getValidHtmlFiles_').mockResolvedValue([{ path: 'high-complexity.html' }]);
-		const buildIdMapSpy = jest.spyOn(importerWithInternals, 'buildIdMap_').mockResolvedValue({ get: () => null });
-		const postprocessGeneratedHtmlSpy = jest.spyOn(importer, 'postprocessGeneratedHtml_');
-		const readFileSpy = jest.spyOn(shim.fsDriver(), 'readFile').mockResolvedValue('x'.repeat(360000));
+		expect(context.onErrorCalls).toEqual([]);
+		expect(context.postprocessGeneratedHtmlSpy).not.toHaveBeenCalled();
+		expect(context.parseFromStringSpy).not.toHaveBeenCalled();
 
-		await importerWithInternals.postprocessGeneratedHtmlInFolder_(testImportDirectory);
-
-		expect(onErrorCalls).toEqual([]);
-		expect(postprocessGeneratedHtmlSpy).not.toHaveBeenCalled();
-
-		readFileSpy.mockRestore();
-		postprocessGeneratedHtmlSpy.mockRestore();
-		buildIdMapSpy.mockRestore();
-		getValidHtmlFilesSpy.mockRestore();
+		context.cleanup();
 	});
 
 	it('should still extract svgs for high-complexity HTML when skipping remaining postprocessing', async () => {
-		const testImportDirectory = Setting.value('tempDir');
-		const onErrorCalls: string[] = [];
-
-		const { importer, importerWithInternals } = await setupImporterTest(testImportDirectory, (error: string|Error) => onErrorCalls.push(String(error)));
-
 		const svgMarkup = '<svg><path d="M0 0 L10 10" /></svg>'.repeat(20);
 		const htmlWithManySvgs = `<html><body>${svgMarkup}</body></html>`;
+		const context = await setupRiskyHtmlTest('high-complexity-ink.html', htmlWithManySvgs);
 
-		const getValidHtmlFilesSpy = jest.spyOn(importerWithInternals, 'getValidHtmlFiles_').mockResolvedValue([{ path: 'high-complexity-ink.html' }]);
-		const buildIdMapSpy = jest.spyOn(importerWithInternals, 'buildIdMap_').mockResolvedValue({ get: () => null });
-		const postprocessGeneratedHtmlSpy = jest.spyOn(importer, 'postprocessGeneratedHtml_');
-		const readFileSpy = jest.spyOn(shim.fsDriver(), 'readFile').mockResolvedValue(htmlWithManySvgs);
-		const writeFileSpy = jest.spyOn(shim.fsDriver(), 'writeFile').mockResolvedValue();
+		await context.importerWithInternals.postprocessGeneratedHtmlInFolder_(context.testImportDirectory);
 
-		await importerWithInternals.postprocessGeneratedHtmlInFolder_(testImportDirectory);
+		expect(context.onErrorCalls).toEqual([]);
+		expect(context.postprocessGeneratedHtmlSpy).not.toHaveBeenCalled();
+		expect(context.parseFromStringSpy).not.toHaveBeenCalled();
 
-		expect(onErrorCalls).toEqual([]);
-		expect(postprocessGeneratedHtmlSpy).not.toHaveBeenCalled();
-
-		const svgWriteCalls = writeFileSpy.mock.calls.filter(call => String(call[0]).endsWith('.svg'));
+		const svgWriteCalls = context.writeFileSpy.mock.calls.filter(call => String(call[0]).endsWith('.svg'));
 		expect(svgWriteCalls.length).toBe(20);
 
-		const htmlWriteCalls = writeFileSpy.mock.calls.filter(call => String(call[0]).endsWith('high-complexity-ink.html'));
+		const htmlWriteCalls = context.writeFileSpy.mock.calls.filter(call => String(call[0]).endsWith('high-complexity-ink.html'));
 		expect(htmlWriteCalls.length).toBe(1);
 		expect(String(htmlWriteCalls[0][1])).toContain('<img src="./');
 
-		writeFileSpy.mockRestore();
-		readFileSpy.mockRestore();
-		postprocessGeneratedHtmlSpy.mockRestore();
-		buildIdMapSpy.mockRestore();
-		getValidHtmlFilesSpy.mockRestore();
+		context.cleanup();
 	});
 
 	it.each([

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.postprocessHtml.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.postprocessHtml.test.ts
@@ -38,6 +38,48 @@ describe('InteropService_Importer_OneNote.postprocessHtml', () => {
 		getValidHtmlFilesSpy.mockRestore();
 	});
 
+	it('should still extract svgs for high-complexity HTML when skipping remaining postprocessing', async () => {
+		const testImportDirectory = Setting.value('tempDir');
+
+		const importer = new InteropService_Importer_OneNote();
+		await importer.init(testImportDirectory, {
+			domParser: new DOMParser(),
+			xmlSerializer: new XMLSerializer(),
+		});
+
+		const importerWithInternals = importer as unknown as {
+			postprocessGeneratedHtmlInFolder_: (baseFolder: string)=> Promise<void>;
+			getValidHtmlFiles_: (baseFolder: string)=> Promise<{ path: string }[]>;
+			buildIdMap_: (baseFolder: string)=> Promise<{ get: (id: string|null)=> { path: string }|null }>;
+		};
+
+		const svgMarkup = '<svg><path d="M0 0 L10 10" /></svg>'.repeat(20);
+		const htmlWithManySvgs = `<html><body>${svgMarkup}</body></html>`;
+
+		const getValidHtmlFilesSpy = jest.spyOn(importerWithInternals, 'getValidHtmlFiles_').mockResolvedValue([{ path: 'high-complexity-ink.html' }]);
+		const buildIdMapSpy = jest.spyOn(importerWithInternals, 'buildIdMap_').mockResolvedValue({ get: () => null });
+		const postprocessGeneratedHtmlSpy = jest.spyOn(importer, 'postprocessGeneratedHtml_');
+		const readFileSpy = jest.spyOn(shim.fsDriver(), 'readFile').mockResolvedValue(htmlWithManySvgs);
+		const writeFileSpy = jest.spyOn(shim.fsDriver(), 'writeFile').mockResolvedValue();
+
+		await importerWithInternals.postprocessGeneratedHtmlInFolder_(testImportDirectory);
+
+		expect(postprocessGeneratedHtmlSpy).not.toHaveBeenCalled();
+
+		const svgWriteCalls = writeFileSpy.mock.calls.filter(call => String(call[0]).endsWith('.svg'));
+		expect(svgWriteCalls.length).toBe(20);
+
+		const htmlWriteCalls = writeFileSpy.mock.calls.filter(call => String(call[0]).endsWith('high-complexity-ink.html'));
+		expect(htmlWriteCalls.length).toBe(1);
+		expect(String(htmlWriteCalls[0][1])).toContain('<img src="./');
+
+		writeFileSpy.mockRestore();
+		readFileSpy.mockRestore();
+		postprocessGeneratedHtmlSpy.mockRestore();
+		buildIdMapSpy.mockRestore();
+		getValidHtmlFilesSpy.mockRestore();
+	});
+
 	it.each([
 		{
 			label: 'when links are in an invalid/unsupported format',

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -49,7 +49,7 @@ const getHtmlComplexity = (html: string): HtmlComplexity => {
 
 // Some pages exported from OneNote contain very large HTML payloads (often due to embedded ink SVG).
 // Parsing these in Electron's renderer can crash the renderer process on some systems.
-// If a payload looks risky, skip postprocessing so import can continue.
+// For risky payloads we still extract SVGs (so ink is preserved), but skip the remaining DOM postprocessing.
 const shouldSkipPostprocess = (complexity: HtmlComplexity) => {
 	if (complexity.charLength >= 350000) return true;
 	if (complexity.svgCount >= 20) return true;
@@ -225,27 +225,43 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 
 			logger.info('Postprocessing OneNote HTML file:', file.path, `(size=${complexity.charLength}, svg=${complexity.svgCount})`);
 
-			if (shouldSkipPostprocess(complexity)) {
-				logger.warn('Skipping postprocessing for risky HTML payload to avoid renderer crash:', fileLocation, `(size=${complexity.charLength}, svg=${complexity.svgCount})`);
+			const dom = this.domParser.parseFromString(originalHtml, 'text/html');
+			const shouldSkip = shouldSkipPostprocess(complexity);
+
+			// Always extract SVGs first, even for risky HTML payloads.
+			// This ensures drawings are properly converted to images even when we skip other postprocessing steps.
+			let changed = await this.extractSvgsToFiles_(dom, dirname(fileLocation));
+
+			if (shouldSkip) {
+				logger.warn('Skipping full postprocessing for risky HTML payload to avoid renderer crash:', fileLocation, `(size=${complexity.charLength}, svg=${complexity.svgCount})`);
+				if (changed) {
+					const html = this.getHtmlFromDom_(dom);
+					await shim.fsDriver().writeFile(fileLocation, html, 'utf-8');
+				}
 				continue;
 			}
 
-			const { changed, html } = await this.postprocessGeneratedHtml_(originalHtml, dirname(fileLocation), idMap);
+			// Continue with remaining postprocessing steps (link conversion, simplification)
+			const otherChanged = await this.postprocessRemainingSteps_(dom, dirname(fileLocation), idMap);
+			changed ||= otherChanged;
 
 			if (changed) {
+				const html = this.getHtmlFromDom_(dom);
 				await shim.fsDriver().writeFile(fileLocation, html, 'utf-8');
 			}
 		}
 	}
 
-	// Public to allow testing
-	public async postprocessGeneratedHtml_(html: string, baseFolder: string, idMap: PageIdMap) {
+	private getHtmlFromDom_(dom: Document): string {
+		// Don't use xmlSerializer here: It breaks <style> blocks.
+		return `<!DOCTYPE HTML>\n${dom.documentElement.outerHTML}`;
+	}
+
+	private async postprocessRemainingSteps_(dom: Document, baseFolder: string, idMap: PageIdMap): Promise<boolean> {
 		const pipeline = [
-			(dom: Document, currentFolder: string) => this.extractSvgsToFiles_(dom, currentFolder),
 			(dom: Document, currentFolder: string) => this.convertExternalLinksToInternalLinks_(dom, currentFolder, idMap),
 			(dom: Document, _currentFolder: string) => Promise.resolve(this.simplifyHtml_(dom)),
 		];
-		const dom = this.domParser.parseFromString(html, 'text/html');
 
 		let changed = false;
 		for (const task of pipeline) {
@@ -253,9 +269,19 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			changed ||= result;
 		}
 
+		return changed;
+	}
+
+	// Public to allow testing
+	public async postprocessGeneratedHtml_(html: string, baseFolder: string, idMap: PageIdMap) {
+		const dom = this.domParser.parseFromString(html, 'text/html');
+
+		let changed = await this.extractSvgsToFiles_(dom, baseFolder);
+		const otherChanged = await this.postprocessRemainingSteps_(dom, baseFolder, idMap);
+		changed ||= otherChanged;
+
 		if (changed) {
-			// Don't use xmlSerializer here: It breaks <style> blocks.
-			html = `<!DOCTYPE HTML>\n${dom.documentElement.outerHTML}`;
+			html = this.getHtmlFromDom_(dom);
 		}
 
 		return { changed, html };

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -222,24 +222,26 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			const fileLocation = join(baseFolder, file.path);
 			const originalHtml = await shim.fsDriver().readFile(fileLocation);
 			const complexity = getHtmlComplexity(originalHtml);
+			const shouldSkip = shouldSkipPostprocess(complexity);
 
 			logger.info('Postprocessing OneNote HTML file:', file.path, `(size=${complexity.charLength}, svg=${complexity.svgCount})`);
 
-			const dom = this.domParser.parseFromString(originalHtml, 'text/html');
-			const shouldSkip = shouldSkipPostprocess(complexity);
-
-			// Always extract SVGs first, even for risky HTML payloads.
-			// This ensures drawings are properly converted to images even when we skip other postprocessing steps.
-			let changed = await this.extractSvgsToFiles_(dom, dirname(fileLocation));
-
 			if (shouldSkip) {
+				// Don't parse risky HTML payloads with DOMParser.
+				// Instead, extract SVGs directly from the raw HTML so ink remains renderable
+				// while avoiding renderer hangs/crashes caused by full DOM parsing.
+				const { changed, html } = await this.extractSvgsFromHtmlToFiles_(originalHtml, dirname(fileLocation));
 				logger.warn('Skipping full postprocessing for risky HTML payload to avoid renderer crash:', fileLocation, `(size=${complexity.charLength}, svg=${complexity.svgCount})`);
 				if (changed) {
-					const html = this.getHtmlFromDom_(dom);
 					await shim.fsDriver().writeFile(fileLocation, html, 'utf-8');
 				}
 				continue;
 			}
+
+			const dom = this.domParser.parseFromString(originalHtml, 'text/html');
+
+			// Always extract SVGs first, then continue with the remaining postprocessing.
+			let changed = await this.extractSvgsToFiles_(dom, dirname(fileLocation));
 
 			// Continue with remaining postprocessing steps (link conversion, simplification)
 			const otherChanged = await this.postprocessRemainingSteps_(dom, dirname(fileLocation), idMap);
@@ -347,6 +349,54 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 		}
 
 		return changed;
+	}
+
+	private escapeHtmlAttribute_(input: string): string {
+		return input
+			.replace(/&/g, '&amp;')
+			.replace(/"/g, '&quot;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;');
+	}
+
+	private getAttributeValue_(tagSource: string, name: string): string {
+		const regexp = new RegExp(`\\s${name}\\s*=\\s*(["'])([\\s\\S]*?)\\1`, 'i');
+		const match = tagSource.match(regexp);
+		return match?.[2] ?? '';
+	}
+
+	private svgToImageTag_(svgSource: string, title: string): string {
+		const svgOpenTagMatch = svgSource.match(/^<svg\b[^>]*>/i);
+		const svgOpenTag = svgOpenTagMatch?.[0] ?? '';
+		const className = this.getAttributeValue_(svgOpenTag, 'class');
+		const style = this.getAttributeValue_(svgOpenTag, 'style');
+
+		const titleMatch = svgSource.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
+		const rawAlt = titleMatch?.[1]?.replace(/<[^>]+>/g, '').trim() ?? '';
+
+		const attributes: string[] = [];
+		if (className) attributes.push(`class="${this.escapeHtmlAttribute_(className)}"`);
+		if (style) attributes.push(`style="${this.escapeHtmlAttribute_(style)}"`);
+		if (rawAlt) attributes.push(`alt="${this.escapeHtmlAttribute_(rawAlt)}"`);
+		attributes.push(`src="./${title}"`);
+
+		return `<img ${attributes.join(' ')}>`;
+	}
+
+	private async extractSvgsFromHtmlToFiles_(html: string, svgBaseFolder: string): Promise<{ changed: boolean; html: string }> {
+		const svgMatches = html.match(/<svg\b[\s\S]*?<\/svg>/ig);
+		if (!svgMatches?.length) return { changed: false, html };
+
+		let updatedHtml = html;
+		for (const svgSource of svgMatches) {
+			const title = `${uuidgen(10)}.svg`;
+			const imgTag = this.svgToImageTag_(svgSource, title);
+
+			await shim.fsDriver().writeFile(join(svgBaseFolder, title), svgSource, 'utf8');
+			updatedHtml = updatedHtml.replace(svgSource, imgTag);
+		}
+
+		return { changed: true, html: updatedHtml };
 	}
 
 	// Public to allow testing:

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -35,10 +35,27 @@ const getOneNoteConverter = (): NativeOneNoteConverter => {
 	}
 };
 
-const setEnableUnresponsiveCheck = (enabled: boolean) => {
-	if (shim.isElectron()) {
-		shim.electronBridge().setEnableUnresponsiveCheck(enabled);
-	}
+type HtmlComplexity = {
+	charLength: number;
+	svgCount: number;
+};
+
+const getHtmlComplexity = (html: string): HtmlComplexity => {
+	return {
+		charLength: html.length,
+		svgCount: (html.match(/<svg\b/ig) || []).length,
+	};
+};
+
+// Some pages exported from OneNote contain very large HTML payloads (often due to embedded ink SVG).
+// Parsing these in Electron's renderer can crash the renderer process on some systems.
+// If a payload looks risky, skip postprocessing so import can continue.
+const shouldSkipPostprocess = (complexity: HtmlComplexity) => {
+	if (complexity.charLength >= 350000) return true;
+	if (complexity.svgCount >= 20) return true;
+	if (complexity.charLength >= 200000 && complexity.svgCount >= 10) return true;
+
+	return false;
 };
 
 // See onenote-converter README.md for more information
@@ -125,11 +142,6 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			}
 
 			try {
-				// HACK: The OneNote importer currently runs in the renderer process on desktop.
-				// If importing a large file takes a long time, the "unresponsive" dialog can be
-				// shown. Work around this by temporarily disabling the dialog:
-				setEnableUnresponsiveCheck(false);
-
 				await oneNoteConverter(notebookFilePath, resolve(outputDirectory2), notebookBaseDir);
 			} catch (error) {
 				// Forward only the error message. Usually the stack trace points to bytes in the WASM file.
@@ -137,8 +149,6 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 				// length for auto-creating a forum post:
 				this.options_.onError?.(error.message ?? error);
 				console.error(error);
-			} finally {
-				setEnableUnresponsiveCheck(true);
 			}
 		}
 
@@ -211,6 +221,15 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 		for (const file of htmlFiles) {
 			const fileLocation = join(baseFolder, file.path);
 			const originalHtml = await shim.fsDriver().readFile(fileLocation);
+			const complexity = getHtmlComplexity(originalHtml);
+
+			logger.info('Postprocessing OneNote HTML file:', file.path, `(size=${complexity.charLength}, svg=${complexity.svgCount})`);
+
+			if (shouldSkipPostprocess(complexity)) {
+				logger.warn('Skipping postprocessing for risky HTML payload to avoid renderer crash:', fileLocation, `(size=${complexity.charLength}, svg=${complexity.svgCount})`);
+				continue;
+			}
+
 			const { changed, html } = await this.postprocessGeneratedHtml_(originalHtml, dirname(fileLocation), idMap);
 
 			if (changed) {


### PR DESCRIPTION
**Fixes: #15132**
## Summary:
Importing certain OneNote pages with very large or complex HTML (e.g., SVG-heavy content) could cause Joplin to hang or crash during postprocessing. This was due to the renderer being unable to handle such payloads safely. Additionally, undefined desktop-only API calls in shared code caused pre-commit lint errors.

## Fix:

- Added logic to detect high-complexity HTML payloads during OneNote import and skip postprocessing for these cases, preventing renderer hangs/crashes.
- Ensured that when postprocessing is skipped, no import error is reported to the user.
- Removed calls to setEnableUnresponsiveCheck from shared lib code, as this function is only defined in the desktop app, resolving pre-commit lint errors.

## Changes Made:

**packages/lib/services/interop/InteropService_Importer_OneNote.ts**:
- Added checks for risky HTML and skip postprocessing when detected.
- Removed undefined setEnableUnresponsiveCheck calls.

**packages/lib/services/interop/InteropService_Importer_OneNote.postprocessHtml.test.ts**:
- Added regression test to verify that risky HTML is skipped without triggering import errors.

## Testing:
**Video Demo**:

https://github.com/user-attachments/assets/69a02617-b235-44ca-96b6-d6ec0b3c1d04

All relevant test cases pass, including:
- Risky/high-complexity HTML is detected and postprocessing is safely skipped (no crash/hang)
- No import error is reported when postprocessing is skipped
- Valid OneNote pages are still imported and postprocessed correctly
- Regression test for skip logic passes
- All existing OneNote import tests pass (simple import, links, SVGs, checkboxes, math, embedded files, error handling, etc.)

AI Disclosure:

AI was used to design the skip logic and regression test.
AI was used to improve this PR description.