### PR TITLE
Mobile: Fixes #15141: Fix incomplete rendering when scrolling long notes 

### DIFF
--- a/packages/app-mobile/contentScripts/markdownEditorBundle/contentScript.ts
+++ b/packages/app-mobile/contentScripts/markdownEditorBundle/contentScript.ts
@@ -124,6 +124,14 @@ export const createMainEditor = (props: EditorProps) => {
 		}
 	});
 
+	// Joplin uses WebView-level (external) scrolling, so cm-scroller.scrollTop is always 0
+	// and CodeMirror never updates its rendered viewport past the first screenful.
+	// Setting viewState.printing = true makes CodeMirror always use fullPixelRange,
+	// rendering the full document height instead of a virtualised viewport.
+	// viewState is the same object across normal dispatches (not recreated), so this persists.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(control.editor as any).viewState.printing = true;
+
 	mainEditor = control;
 	return control;
 };


### PR DESCRIPTION
Fixes #15141

### Problem
When scrolling through a long note in the markdown editor on mobile, parts of the note body would not render and would only refresh after scrolling further. The issue could be reproduced by scrolling far down a long note, scrolling back up partway, then scrolling slowly in either direction.

This is a regression from the @codemirror/view upgrade in Joplin 3.6. Joplin uses WebView-level scrolling, meaning the scroll happens outside of CodeMirror's control. CodeMirror tracks scroll position through its internal scroller element's scrollTop, which is always 0 in this setup. Because of this, CodeMirror always thinks the document has not been scrolled and only keeps the top portion rendered. Before the 6.32.0 upgrade this was accidentally masked, but the upgrade tightened the viewport calculation and made the blank regions persistent.

### Fix
Set `viewState.printing = true` on the editor after it is created. This makes CodeMirror render the full document height at all times rather than virtualising the viewport based on scroll position. The viewState object is reused across normal edits so the flag stays set for the lifetime of the editor.

### Edge cases
The main trade-off is performance on very long notes. With `viewState.printing = true`, CodeMirror renders the full document instead of just the visible portion, which means more DOM nodes and higher memory usage. For typical note lengths this is not a concern, but notes with thousands of lines or many embedded images may see a slower initial render
[ maybe this needs to be discussed]

### Test Plan
checked that all the existing markdown editor tests passes 

Tested Manually :
Uploaded in drive due to video's large size 
https://drive.google.com/file/d/1FXP-RlRFhSDR3QTDz4pUx_hWuXvocyTy/view?usp=sharing

### AI Assistance Disclosure:
AI was used to find the root cause by researching what change in @codemirror/view upgrade related to rendering and also used in improving wording in PR description