### PR TITLE
Desktop: Fix#15147 editor disappearing when search is triggered with empty query

### DIFF
--- a/packages/app-desktop/gui/SearchBar/SearchBar.tsx
+++ b/packages/app-desktop/gui/SearchBar/SearchBar.tsx
@@ -132,6 +132,10 @@ function SearchBar(props: Props) {
 		if (props.isFocused || searchStarted) {
 			void onExitSearch();
 		} else {
+			if (!query || query.trim().length === 0) {
+				focus('SearchBar::onSearchButtonClick', props.inputRef.current);
+				return;
+			}
 			setSearchStarted(true);
 			focus('SearchBar::onSearchButtonClick', props.inputRef.current);
 			props.dispatch({
@@ -140,7 +144,7 @@ function SearchBar(props: Props) {
 			});
 		}
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied
-	}, [onExitSearch, props.isFocused, searchStarted]);
+	}, [onExitSearch, props.isFocused, searchStarted, query]);
 
 	useEffect(() => {
 		if (props.notesParentType !== 'Search') {

--- a/packages/app-desktop/gui/SearchBar/SearchBar.tsx
+++ b/packages/app-desktop/gui/SearchBar/SearchBar.tsx
@@ -132,7 +132,7 @@ function SearchBar(props: Props) {
 		if (props.isFocused || searchStarted) {
 			void onExitSearch();
 		} else {
-			if (!query || query.trim().length === 0) {
+			if (!query.trim()) {
 				focus('SearchBar::onSearchButtonClick', props.inputRef.current);
 				return;
 			}


### PR DESCRIPTION
Fixes #15147

Summary:
Fixes an issue where clicking the search button when the search input is small can cause the editor and notes pane to disappear.

Root cause:
Search mode was being activated even when the query was empty. This led to entering a search state with no results, which in certain layouts (e.g., when the sidebar is very narrow) caused the UI to collapse and the editor to disappear.

Fix:
Added a guard in `SearchBar.onSearchButtonClick` to prevent entering search mode when the query is empty or whitespace-only. In such cases, the input is focused without dispatching `FOCUS_SET`

Before the fix:

https://github.com/user-attachments/assets/49ac0612-d8ca-4204-a6e8-8c8b8c65106c





After the fix:

https://github.com/user-attachments/assets/03bb84a0-415a-4c46-b3d6-44bf8e230c88

