### PR TITLE
Fix: Secondary window loses note focus when note moved to different notebook

### DIFF
--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -211,7 +211,7 @@ export default class BaseApplication {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public async refreshNotes(state: any, useSelectedNoteId = false, noteHash = '') {
+	public async refreshNotes(state: any, useSelectedNoteId = false, noteHash = '', windowId: string = null) {
 		let parentType = state.notesParentType;
 		let parentId = null;
 
@@ -279,12 +279,12 @@ export default class BaseApplication {
 			notes: notes,
 			notesSource: source,
 		});
-
 		if (useSelectedNoteId) {
 			this.store().dispatch({
 				type: 'NOTE_SELECT',
 				id: state.selectedNoteIds && state.selectedNoteIds.length ? state.selectedNoteIds[0] : null,
 				hash: noteHash,
+				windowId: windowId,
 			});
 		} else {
 			const lastSelectedNoteIds = stateUtils.lastSelectedNoteIds(state);
@@ -311,9 +311,11 @@ export default class BaseApplication {
 			this.store().dispatch({
 				type: 'NOTE_SELECT',
 				id: selectedNoteId,
+				windowId: windowId,
 			});
 		}
 	}
+
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private resourceFetcher_downloadComplete(event: any) {
@@ -545,10 +547,10 @@ export default class BaseApplication {
 				refreshNotes = true;
 			}
 		}
-
 		if (refreshNotes) {
-			await this.refreshNotes(newState, refreshNotesUseSelectedNoteId, refreshNotesHash);
+			await this.refreshNotes(newState, refreshNotesUseSelectedNoteId, refreshNotesHash, action.windowId ?? null);
 		}
+
 
 		if (action.type === 'NOTE_UPDATE_ONE') {
 			if (!action.changedFields.length ||


### PR DESCRIPTION
## Summary

When a note open in a secondary window is moved to a different notebook via the main window, the secondary window incorrectly loses focus and goes blank (or switches to a different note).

## Root Cause

`refreshNotes()` in `BaseApplication.ts` dispatches `NOTE_SELECT` without a `windowId`, causing it to affect all windows including secondary ones. When the main window's folder changes due to a note move, it triggers a note refresh that overwrites the secondary window's selected note.

## Fix

Pass `windowId` through `refreshNotes()` and include it in the `NOTE_SELECT` dispatch, so the action only affects the window that triggered the folder/note change.

## Testing

1. Open a note in a secondary window (right-click → Open in new window)
2. Move that note to a different notebook from the main window
3. Before fix: secondary window goes blank
4. After fix: secondary window correctly keeps displaying the note

Fixes #11728