### PR TITLE
Desktop: Fixes #15156: Inherit plugin enabled/disabled states when creating new profiles

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1647,10 +1647,12 @@ packages/lib/services/plugins/utils/validatePluginPlatforms.test.js
 packages/lib/services/plugins/utils/validatePluginPlatforms.js
 packages/lib/services/plugins/utils/validatePluginVersion.test.js
 packages/lib/services/plugins/utils/validatePluginVersion.js
+packages/lib/services/profileConfig/applyNewProfilePluginStates.js
 packages/lib/services/profileConfig/index.test.js
 packages/lib/services/profileConfig/index.js
 packages/lib/services/profileConfig/initProfile.js
 packages/lib/services/profileConfig/mergeGlobalAndLocalSettings.js
+packages/lib/services/profileConfig/seedNewProfilePluginStates.js
 packages/lib/services/profileConfig/splitGlobalAndLocalSettings.js
 packages/lib/services/profileConfig/types.js
 packages/lib/services/rest/Api.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -1620,10 +1620,12 @@ packages/lib/services/plugins/utils/validatePluginPlatforms.test.js
 packages/lib/services/plugins/utils/validatePluginPlatforms.js
 packages/lib/services/plugins/utils/validatePluginVersion.test.js
 packages/lib/services/plugins/utils/validatePluginVersion.js
+packages/lib/services/profileConfig/applyNewProfilePluginStates.js
 packages/lib/services/profileConfig/index.test.js
 packages/lib/services/profileConfig/index.js
 packages/lib/services/profileConfig/initProfile.js
 packages/lib/services/profileConfig/mergeGlobalAndLocalSettings.js
+packages/lib/services/profileConfig/seedNewProfilePluginStates.js
 packages/lib/services/profileConfig/splitGlobalAndLocalSettings.js
 packages/lib/services/profileConfig/types.js
 packages/lib/services/rest/Api.test.js

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/addProfile.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/addProfile.ts
@@ -1,12 +1,9 @@
 import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
 import { createNewProfile, saveProfileConfig } from '@joplin/lib/services/profileConfig';
+import seedNewProfilePluginStates from '@joplin/lib/services/profileConfig/seedNewProfilePluginStates';
 import Setting from '@joplin/lib/models/Setting';
-import shim from '@joplin/lib/shim';
-import Logger from '@joplin/utils/Logger';
 import restart from '../../../services/restart';
-
-const logger = Logger.create('commands/addProfile');
 
 export const declaration: CommandDeclaration = {
 	name: 'addProfile',
@@ -27,22 +24,11 @@ export const runtime = (comp: any): CommandRuntime => {
 							const { newConfig, newProfile } = createNewProfile(context.state.profileConfig, answer);
 							newConfig.currentProfileId = newProfile.id;
 
-							// Inherit the plugin enabled/disabled state from the source profile.
-							// The plugin binaries live in a shared `${rootProfileDir}/plugins`
-							// directory, so without seeding `plugins.states` the new profile would
-							// default every installed plugin to enabled.
-							try {
-								const pluginStates = Setting.value('plugins.states');
-								const newProfileDir = `${Setting.value('rootProfileDir')}/profile-${newProfile.id}`;
-								await shim.fsDriver().mkdir(newProfileDir);
-								await shim.fsDriver().writeFile(
-									`${newProfileDir}/settings.json`,
-									JSON.stringify({ 'plugins.states': pluginStates }, null, '\t'),
-									'utf8',
-								);
-							} catch (error) {
-								logger.error('Could not seed plugin states for new profile:', error);
-							}
+							await seedNewProfilePluginStates(
+								Setting.value('rootProfileDir'),
+								newProfile.id,
+								Setting.value('plugins.states'),
+							);
 
 							await saveProfileConfig(`${Setting.value('rootProfileDir')}/profiles.json`, newConfig);
 							await restart();

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/addProfile.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/addProfile.ts
@@ -2,7 +2,11 @@ import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/
 import { _ } from '@joplin/lib/locale';
 import { createNewProfile, saveProfileConfig } from '@joplin/lib/services/profileConfig';
 import Setting from '@joplin/lib/models/Setting';
+import shim from '@joplin/lib/shim';
+import Logger from '@joplin/utils/Logger';
 import restart from '../../../services/restart';
+
+const logger = Logger.create('commands/addProfile');
 
 export const declaration: CommandDeclaration = {
 	name: 'addProfile',
@@ -22,6 +26,24 @@ export const runtime = (comp: any): CommandRuntime => {
 						if (answer) {
 							const { newConfig, newProfile } = createNewProfile(context.state.profileConfig, answer);
 							newConfig.currentProfileId = newProfile.id;
+
+							// Inherit the plugin enabled/disabled state from the source profile.
+							// The plugin binaries live in a shared `${rootProfileDir}/plugins`
+							// directory, so without seeding `plugins.states` the new profile would
+							// default every installed plugin to enabled. See issue #15156.
+							try {
+								const pluginStates = Setting.value('plugins.states');
+								const newProfileDir = `${Setting.value('rootProfileDir')}/profile-${newProfile.id}`;
+								await shim.fsDriver().mkdir(newProfileDir);
+								await shim.fsDriver().writeFile(
+									`${newProfileDir}/settings.json`,
+									JSON.stringify({ 'plugins.states': pluginStates }, null, '\t'),
+									'utf8',
+								);
+							} catch (error) {
+								logger.error('Could not seed plugin states for new profile:', error);
+							}
+
 							await saveProfileConfig(`${Setting.value('rootProfileDir')}/profiles.json`, newConfig);
 							await restart();
 						}

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/addProfile.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/addProfile.ts
@@ -30,7 +30,7 @@ export const runtime = (comp: any): CommandRuntime => {
 							// Inherit the plugin enabled/disabled state from the source profile.
 							// The plugin binaries live in a shared `${rootProfileDir}/plugins`
 							// directory, so without seeding `plugins.states` the new profile would
-							// default every installed plugin to enabled. See issue #15156.
+							// default every installed plugin to enabled.
 							try {
 								const pluginStates = Setting.value('plugins.states');
 								const newProfileDir = `${Setting.value('rootProfileDir')}/profile-${newProfile.id}`;

--- a/packages/app-mobile/components/ProfileSwitcher/ProfileEditor.tsx
+++ b/packages/app-mobile/components/ProfileSwitcher/ProfileEditor.tsx
@@ -6,6 +6,8 @@ import ScreenHeader from '../ScreenHeader';
 import { _ } from '@joplin/lib/locale';
 import { loadProfileConfig, saveProfileConfig } from '../../services/profiles';
 import { createNewProfile } from '@joplin/lib/services/profileConfig';
+import seedNewProfilePluginStates from '@joplin/lib/services/profileConfig/seedNewProfilePluginStates';
+import Setting from '@joplin/lib/models/Setting';
 import useProfileConfig from './useProfileConfig';
 const { TextInput } = require('react-native-paper');
 
@@ -51,6 +53,13 @@ export default (props: Props) => {
 		if (isNew) {
 			const profileConfig = await loadProfileConfig();
 			const result = createNewProfile(profileConfig, name);
+
+			await seedNewProfilePluginStates(
+				Setting.value('rootProfileDir'),
+				result.newProfile.id,
+				Setting.value('plugins.states'),
+			);
+
 			await saveProfileConfig(result.newConfig);
 		} else {
 			const newProfiles = profileConfig.profiles.map(p => {

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -10,6 +10,7 @@ import PoorManIntervals from '@joplin/lib/PoorManIntervals';
 import { parseNotesParent } from '@joplin/lib/reducer';
 import uuid from '@joplin/lib/uuid';
 import { loadKeychainServiceAndSettings } from '@joplin/lib/services/SettingUtils';
+import applyNewProfilePluginStates from '@joplin/lib/services/profileConfig/applyNewProfilePluginStates';
 import { setLocale } from '@joplin/lib/locale';
 import SyncTargetJoplinServer from '@joplin/lib/SyncTargetJoplinServer';
 import SyncTargetJoplinCloud from '@joplin/lib/SyncTargetJoplinCloud';
@@ -271,6 +272,8 @@ const buildStartupTasks = (
 		BaseItem.syncShareCache = parseShareCache(Setting.value('sync.shareCache'));
 
 		if (Setting.value('firstStart')) {
+			await applyNewProfilePluginStates(Setting.value('profileDir'));
+
 			const detectedLocale = shim.detectAndSetLocale(Setting);
 			reg.logger().info(`First start: detected locale as ${detectedLocale}`);
 

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -45,6 +45,7 @@ import RevisionService from './services/RevisionService';
 import ResourceService from './services/ResourceService';
 import DecryptionWorker from './services/DecryptionWorker';
 import { loadKeychainServiceAndSettings } from './services/SettingUtils';
+import applyNewProfilePluginStates from './services/profileConfig/applyNewProfilePluginStates';
 import MigrationService from './services/MigrationService';
 import ShareService from './services/share/ShareService';
 import handleSyncStartupOperation from './services/synchronizer/utils/handleSyncStartupOperation';
@@ -813,6 +814,7 @@ export default class BaseApplication {
 		}
 
 		if (Setting.value('firstStart')) {
+			await applyNewProfilePluginStates(Setting.value('profileDir'));
 
 			// detectAndSetLocale sets the locale to the system default locale.
 			// Not calling it when a new profile is created ensures that the

--- a/packages/lib/services/profileConfig/applyNewProfilePluginStates.ts
+++ b/packages/lib/services/profileConfig/applyNewProfilePluginStates.ts
@@ -32,8 +32,8 @@ export default async (profileDir: string) => {
 		try {
 			await shim.fsDriver().remove(seedPath);
 		} catch {
-			// Ignore removal errors; missing-file is harmless and any other failure
-			// will be retried on the next firstStart if one happens.
+			// Ignore removal errors; a stale seed file is harmless as `firstStart`
+			// is flipped to false right after, so it will never be read again.
 		}
 	}
 };

--- a/packages/lib/services/profileConfig/applyNewProfilePluginStates.ts
+++ b/packages/lib/services/profileConfig/applyNewProfilePluginStates.ts
@@ -1,0 +1,39 @@
+import Logger from '@joplin/utils/Logger';
+import shim from '../../shim';
+import Setting from '../../models/Setting';
+import { PluginSettings } from '../plugins/PluginService';
+
+const logger = Logger.create('applyNewProfilePluginStates');
+
+// Consumes the seed written by seedNewProfilePluginStates(): reads the file,
+// merges `{ enabled }` entries into `plugins.states`, persists via the normal
+// Setting pipeline (DB on every platform), and deletes the file.
+// Intended to be called once, inside the `firstStart` branch of the boot path.
+export default async (profileDir: string) => {
+	const seedPath = `${profileDir}/initial-plugin-states.json`;
+	try {
+		if (!(await shim.fsDriver().exists(seedPath))) return;
+
+		const raw = await shim.fsDriver().readFile(seedPath, 'utf8');
+		const seed = JSON.parse(raw) as Record<string, { enabled?: boolean }>;
+
+		const current: PluginSettings = Setting.value('plugins.states') || {};
+		const merged: PluginSettings = { ...current };
+		for (const pluginId of Object.keys(seed || {})) {
+			const existing = merged[pluginId] || ({} as PluginSettings[string]);
+			merged[pluginId] = { ...existing, enabled: Boolean(seed[pluginId]?.enabled) };
+		}
+
+		Setting.setValue('plugins.states', merged);
+		await Setting.saveAll();
+	} catch (error) {
+		logger.error('Could not apply initial plugin states for new profile:', error);
+	} finally {
+		try {
+			await shim.fsDriver().remove(seedPath);
+		} catch {
+			// Ignore removal errors; missing-file is harmless and any other failure
+			// will be retried on the next firstStart if one happens.
+		}
+	}
+};

--- a/packages/lib/services/profileConfig/seedNewProfilePluginStates.ts
+++ b/packages/lib/services/profileConfig/seedNewProfilePluginStates.ts
@@ -1,0 +1,30 @@
+import Logger from '@joplin/utils/Logger';
+import shim from '../../shim';
+import { PluginSettings } from '../plugins/PluginService';
+
+const logger = Logger.create('seedNewProfilePluginStates');
+
+// Writes a one-shot seed file `${rootProfileDir}/profile-${newProfileId}/initial-plugin-states.json`
+// containing only `{ [pluginId]: { enabled } }` for each plugin in the source profile.
+// Lifecycle flags (`deleted`, `hasBeenUpdated`) are intentionally dropped; a plugin
+// marked as deleted is treated as disabled. The file is consumed and deleted by
+// applyNewProfilePluginStates() inside the new profile's `firstStart` block.
+export default async (rootProfileDir: string, newProfileId: string, sourcePluginStates: PluginSettings) => {
+	try {
+		const seeded: Record<string, { enabled: boolean }> = {};
+		for (const pluginId of Object.keys(sourcePluginStates || {})) {
+			const state = sourcePluginStates[pluginId] || ({} as { enabled?: boolean; deleted?: boolean });
+			seeded[pluginId] = { enabled: Boolean(state.enabled) && !state.deleted };
+		}
+
+		const newProfileDir = `${rootProfileDir}/profile-${newProfileId}`;
+		await shim.fsDriver().mkdir(newProfileDir);
+		await shim.fsDriver().writeFile(
+			`${newProfileDir}/initial-plugin-states.json`,
+			JSON.stringify(seeded, null, '\t'),
+			'utf8',
+		);
+	} catch (error) {
+		logger.error('Could not seed plugin states for new profile:', error);
+	}
+};


### PR DESCRIPTION
Fixes #15156
### AI Disclosure
I used AI for code tracing and identifying that `plugins.states` is database-backed and tracing the `firstStart` boot path across desktop and mobile.

### Problem
New profiles inherit the shared plugin directory but start with an empty `settings.json`. Since `PluginService.pluginEnabled()` defaults to `true` for missing IDs, every installed plugin is enabled by default in the new profile, forcing users to manually re-disable unwanted plugins.

### Solution
Sentinel file approach using Joplin's existing `firstStart` gate. At profile creation, `seedNewProfilePluginStates` writes `initial-plugin-states.json` into the new profile directory. On first boot, `applyNewProfilePluginStates` reads it, applies via `Setting.setValue` + `Setting.saveAll`, then deletes it. Both helpers live in `packages/lib` so the fix works across desktop, mobile, and web.

### Test Plan
Disabled specific plugins in the source profile, created a new profile, confirmed states were correctly mirrored on both desktop and mobile.

## Desktop
### Before Video
https://www.loom.com/share/d8ec3c16c63e436d82be9d23e101c822

### After Video
https://www.loom.com/share/f68f31eac1534a11ab67eee1deb75c9f

## Mobile
### Before Video
https://github.com/user-attachments/assets/b94698e9-03c2-4613-b6a6-e598998821e4

### After Video
https://github.com/user-attachments/assets/81953ebd-0949-4d85-8c96-636b4347c1e1
