### PR TITLE
Desktop: Fixes #15132: Fix hang when importing certain OneNote files

### DIFF
--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -226,6 +226,7 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			(dom: Document, currentFolder: string) => this.convertExternalLinksToInternalLinks_(dom, currentFolder, idMap),
 			(dom: Document, _currentFolder: string) => Promise.resolve(this.simplifyHtml_(dom)),
 		];
+		html = html.replace(/[\u{00d8}]/ug, 'ø');
 		const dom = this.domParser.parseFromString(html, 'text/html');
 
 		let changed = false;

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -226,6 +226,8 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			(dom: Document, currentFolder: string) => this.convertExternalLinksToInternalLinks_(dom, currentFolder, idMap),
 			(dom: Document, _currentFolder: string) => Promise.resolve(this.simplifyHtml_(dom)),
 		];
+		// Workaround: \u00d8 seems to cause parseFromString to hang.
+		// See https://github.com/laurent22/joplin/issues/15132
 		html = html.replace(/\u{00d8}/ug, '&oslash;');
 		const dom = this.domParser.parseFromString(html, 'text/html');
 

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -226,7 +226,7 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			(dom: Document, currentFolder: string) => this.convertExternalLinksToInternalLinks_(dom, currentFolder, idMap),
 			(dom: Document, _currentFolder: string) => Promise.resolve(this.simplifyHtml_(dom)),
 		];
-		html = html.replace(/[\u{00d8}]/ug, 'ø');
+		html = html.replace(/\u{00d8}/ug, '&oslash;');
 		const dom = this.domParser.parseFromString(html, 'text/html');
 
 		let changed = false;

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -226,9 +226,10 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			(dom: Document, currentFolder: string) => this.convertExternalLinksToInternalLinks_(dom, currentFolder, idMap),
 			(dom: Document, _currentFolder: string) => Promise.resolve(this.simplifyHtml_(dom)),
 		];
-		// Workaround: \u00d8 seems to cause parseFromString to hang.
+		// Workaround: HTML read directly from the filesystem can cause parseFromString to hang.
+		// Force creation of a new string.
 		// See https://github.com/laurent22/joplin/issues/15132
-		html = html.replace(/\u{00d8}/ug, '&oslash;');
+		html = `${html} `.substring(0, html.length);
 		const dom = this.domParser.parseFromString(html, 'text/html');
 
 		let changed = false;

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -265,3 +265,4 @@ onestore
 macshot
 pdate
 coderabbitai
+oslash

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -265,4 +265,3 @@ onestore
 macshot
 pdate
 coderabbitai
-oslash


### PR DESCRIPTION
# Problem

A certain file, when read by `fs-extra`, causes certain native methods to hang (e.g. `new Blob`, `TextEncoder.encode`, etc). The issue occurs in Electron, but does not seem to occur in a NodeJS environment (see #15132).

# Solution

Create a new `String` before processing the imported HTML.

# Comparison with #15158

#15158 is an alternate fix for #15132. #15158 adjusts `fs-driver` to use `fs/promises` for reading files. If the issue is caused by `fs-extra`, the `fs-driver` change is more likely to fix similar issues in other parts of the codebase.

# Testing

Manual testing:
1. Import the ["Linguistics Basics"](https://github.com/laurent22/joplin/issues/14211#issuecomment-3828805793) file from [this issue report](https://github.com/laurent22/joplin/issues/14211#issuecomment-3828805793).
2. Verify that the import completes successfully.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->