### PR TITLE
Android: Fixes #14548: Accessibility: Fix tab ordering in the note viewer screen

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -7,7 +7,7 @@ import NoteBodyViewer from '../../NoteBodyViewer/NoteBodyViewer';
 import checkPermissions from '../../../utils/checkPermissions';
 import NoteEditor from '../../NoteEditor/NoteEditor';
 import * as React from 'react';
-import { Keyboard, View, TextInput, StyleSheet, Linking, Share, NativeSyntheticEvent, useWindowDimensions, ViewStyle, TextStyle } from 'react-native';
+import { Keyboard, View, TextInput, StyleSheet, Linking, Share, NativeSyntheticEvent, useWindowDimensions } from 'react-native';
 import { Platform, PermissionsAndroid } from 'react-native';
 import { connect } from 'react-redux';
 import Note from '@joplin/lib/models/Note';
@@ -477,9 +477,8 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	public styles() {
 		const themeId = this.props.themeId;
 		const theme = themeStyle(themeId);
-		const isTodo = this.state.note.is_todo;
 
-		const cacheKey = [themeId, this.state.titleTextInputHeight, isTodo].join('_');
+		const cacheKey = [themeId, this.state.titleTextInputHeight].join('_');
 
 		if (this.styles_[cacheKey]) return this.styles_[cacheKey];
 		this.styles_ = {};
@@ -541,36 +540,25 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			flex: 0,
 			flexDirection: 'row',
 			flexBasis: 'auto',
+			paddingLeft: theme.marginLeft,
 			borderBottomColor: theme.dividerColor,
 			borderBottomWidth: 1,
 			maxHeight: '40%',
-			position: 'relative',
 		};
 
 		styles.titleContainerTodo = { ...styles.titleContainer };
 		styles.titleContainerTodo.paddingLeft = 0;
 
-		const checkboxWidth = 38;
-		styles.checkbox = {
-			position: 'absolute',
-			left: 0,
-			top: 0,
-			bottom: 0,
-			width: checkboxWidth,
-
-			zIndex: 2,
-		} satisfies ViewStyle;
-
 		styles.titleTextInput = {
 			flex: 1,
 			marginTop: 0,
-			paddingInlineStart: isTodo ? checkboxWidth : theme.marginLeft,
+			paddingLeft: 0,
 			color: theme.color,
 			fontWeight: 'bold',
 			fontSize: theme.fontSize,
 			paddingTop: 10, // Added for iOS (Not needed for Android??)
 			paddingBottom: 10, // Added for iOS (Not needed for Android??)
-		} satisfies TextStyle;
+		};
 
 		this.styles_[cacheKey] = StyleSheet.create(styles);
 		return this.styles_[cacheKey];
@@ -1812,6 +1800,12 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 						this.setState({ titleContainerWidth: width });
 					}
 				}}
+
+				// Making this focusable works around a tab ordering bug on Android
+				// See https://github.com/laurent22/joplin/issues/14548
+				focusable
+				// Since the group is focusable, it also needs a label (otherwise TalkBack reads "unlabelled"):
+				aria-label={_('Title')}
 			>
 				<TextWrapCalculator
 					textCompStyle={this.styles().titleTextInput}

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -7,7 +7,7 @@ import NoteBodyViewer from '../../NoteBodyViewer/NoteBodyViewer';
 import checkPermissions from '../../../utils/checkPermissions';
 import NoteEditor from '../../NoteEditor/NoteEditor';
 import * as React from 'react';
-import { Keyboard, View, TextInput, StyleSheet, Linking, Share, NativeSyntheticEvent, useWindowDimensions } from 'react-native';
+import { Keyboard, View, TextInput, StyleSheet, Linking, Share, NativeSyntheticEvent, useWindowDimensions, ViewStyle } from 'react-native';
 import { Platform, PermissionsAndroid } from 'react-native';
 import { connect } from 'react-redux';
 import Note from '@joplin/lib/models/Note';
@@ -477,8 +477,9 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	public styles() {
 		const themeId = this.props.themeId;
 		const theme = themeStyle(themeId);
+		const isTodo = this.state.note.is_todo;
 
-		const cacheKey = [themeId, this.state.titleTextInputHeight].join('_');
+		const cacheKey = [themeId, this.state.titleTextInputHeight, isTodo].join('_');
 
 		if (this.styles_[cacheKey]) return this.styles_[cacheKey];
 		this.styles_ = {};
@@ -540,19 +541,30 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			flex: 0,
 			flexDirection: 'row',
 			flexBasis: 'auto',
-			paddingLeft: theme.marginLeft,
 			borderBottomColor: theme.dividerColor,
 			borderBottomWidth: 1,
 			maxHeight: '40%',
+			position: 'relative',
 		};
 
 		styles.titleContainerTodo = { ...styles.titleContainer };
 		styles.titleContainerTodo.paddingLeft = 0;
 
+		const checkboxWidth = 32;
+		styles.checkbox = {
+			position: 'absolute',
+			left: 0,
+			top: 0,
+			bottom: 0,
+			width: checkboxWidth,
+
+			zIndex: 2,
+		} satisfies ViewStyle;
+
 		styles.titleTextInput = {
 			flex: 1,
 			marginTop: 0,
-			paddingLeft: 0,
+			paddingLeft: theme.marginLeft + (isTodo ? checkboxWidth : 0),
 			color: theme.color,
 			fontWeight: 'bold',
 			fontSize: theme.fontSize,

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -7,7 +7,7 @@ import NoteBodyViewer from '../../NoteBodyViewer/NoteBodyViewer';
 import checkPermissions from '../../../utils/checkPermissions';
 import NoteEditor from '../../NoteEditor/NoteEditor';
 import * as React from 'react';
-import { Keyboard, View, TextInput, StyleSheet, Linking, Share, NativeSyntheticEvent, useWindowDimensions, ViewStyle } from 'react-native';
+import { Keyboard, View, TextInput, StyleSheet, Linking, Share, NativeSyntheticEvent, useWindowDimensions, ViewStyle, TextStyle } from 'react-native';
 import { Platform, PermissionsAndroid } from 'react-native';
 import { connect } from 'react-redux';
 import Note from '@joplin/lib/models/Note';
@@ -564,13 +564,13 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		styles.titleTextInput = {
 			flex: 1,
 			marginTop: 0,
-			paddingLeft: (isTodo ? checkboxWidth : theme.marginLeft),
+			paddingInlineStart: isTodo ? checkboxWidth : theme.marginLeft,
 			color: theme.color,
 			fontWeight: 'bold',
 			fontSize: theme.fontSize,
 			paddingTop: 10, // Added for iOS (Not needed for Android??)
 			paddingBottom: 10, // Added for iOS (Not needed for Android??)
-		};
+		} satisfies TextStyle;
 
 		this.styles_[cacheKey] = StyleSheet.create(styles);
 		return this.styles_[cacheKey];

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -550,7 +550,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		styles.titleContainerTodo = { ...styles.titleContainer };
 		styles.titleContainerTodo.paddingLeft = 0;
 
-		const checkboxWidth = 32;
+		const checkboxWidth = 38;
 		styles.checkbox = {
 			position: 'absolute',
 			left: 0,
@@ -564,7 +564,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		styles.titleTextInput = {
 			flex: 1,
 			marginTop: 0,
-			paddingLeft: theme.marginLeft + (isTodo ? checkboxWidth : 0),
+			paddingLeft: (isTodo ? checkboxWidth : theme.marginLeft),
 			color: theme.color,
 			fontWeight: 'bold',
 			fontSize: theme.fontSize,

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -1803,7 +1803,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 
 				// Making this focusable works around a tab ordering bug on Android
 				// See https://github.com/laurent22/joplin/issues/14548
-				focusable
+				accessible={Platform.OS === 'android'}
 				// Since the group is focusable, it also needs a label (otherwise TalkBack reads "unlabelled"):
 				aria-label={_('Title')}
 			>


### PR DESCRIPTION
# Problem

Pressing <kbd>tab</kbd> with focus on the note title did not move focus to the note body. Instead, focus cycled through other focusable buttons in the app. This is a regression from the v3.5 release.

**Note**: #14548 affects external keyboard focus, but does not seem to affect screen reader focus.

# Solution

This pull request implements a workaround: The note title input row is marked as [`focusable`](https://reactnative.dev/docs/view#focusable-android). This fixes the focus order issue reported in #14548, but makes the title container focusable, adding a new `View` to the focus order.

Fixes #14548.

> [!NOTE]
>
> This change is currently only applied on Android: At least in an iOS simulator, the <kbd>tab</kbd> key inserts a tab character, rather than moves focus. Since I'm unsure whether #14548 affects hardware iOS devices and the workaround adds an extra view to the focus order, the change is currently Android-specific

# Testing

## Web (regression testing)


Tab focus continues to visit the note title and completion checkbox:

https://github.com/user-attachments/assets/90103856-c325-4b97-80ed-d3ab047c4493

## iOS (regression testing)

With VoiceOver enabled, focus can visit the note title and completion checkbox.

<!--
https://github.com/user-attachments/assets/6990ceef-9fd0-4726-aec6-f313bf97ff22

**Note/known issue:** Since testing was done on an iOS simulator, focus skips the note editor WebView.
-->

**Edit**: Removed iOS screen recording: The VoiceOver focus indicator and output were not captured by the recording.

## Android

Moving focus from the title input to the note body, then to the checkbox input:

https://github.com/user-attachments/assets/aa3a4596-ad73-4a83-b588-7f96df16ff8c


Moving TalkBack focus from the title input to the note body, then back to the title input:

https://github.com/user-attachments/assets/8a16fcbf-422b-4615-92ec-255d65349422



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->