### PR TITLE
Mobile: Fixes #13437: Fix conflicts notebook has low contrast when selected

### DIFF
--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -117,10 +117,6 @@ const useStyles = (themeId: number) => {
 			sidebarIcon: sidebarIconStyle,
 			folderButton: folderButtonStyle,
 			folderButtonText: folderButtonTextStyle,
-			conflictFolderButtonText: {
-				...folderButtonTextStyle,
-				color: theme.colorError,
-			},
 			folderButtonSelected: {
 				...folderButtonStyle,
 				backgroundColor: theme.selectedColor,
@@ -197,6 +193,12 @@ const FolderItem: React.FC<FolderItemProps> = props => {
 				paddingRight: 10,
 				backgroundColor: props.selected ? theme.selectedColor : undefined,
 			},
+			conflictFolderButtonText: {
+				color: theme.colorError,
+			},
+			conflictFolderButtonSelectedText: {
+				color: theme.colorErrorSelected,
+			},
 		});
 	}, [props.selected, props.depth, props.themeId]);
 	const baseStyles = props.styles;
@@ -268,7 +270,18 @@ const FolderItem: React.FC<FolderItemProps> = props => {
 	// depth is specified with an accessibilityLabel:
 	const folderDepthDescription = props.depth > 0 ? _('(level %d)', props.depth) : '';
 	const accessibilityLabel = `${folderTitle}  ${folderDepthDescription}`.trim();
-	const folderButtonTextStyle = props.folder.id === Folder.conflictFolderId() ? baseStyles.conflictFolderButtonText : baseStyles.folderButtonText;
+	const isConflictFolder = props.folder.id === Folder.conflictFolderId();
+	const textStyle = useMemo(() => {
+		const result: TextStyle[] = [baseStyles.folderButtonText];
+		if (isConflictFolder) {
+			result.push(styles.conflictFolderButtonText);
+			if (props.selected) {
+				result.push(styles.conflictFolderButtonSelectedText);
+			}
+		}
+		return result;
+	}, [styles, props.selected, isConflictFolder, baseStyles.folderButtonText]);
+
 	return (
 		<View key={props.folder.id} style={styles.buttonWrapper}>
 			<TouchableRipple
@@ -284,7 +297,7 @@ const FolderItem: React.FC<FolderItemProps> = props => {
 					{renderFolderIcon(props.folder.id, folderIcon)}
 					<Text
 						numberOfLines={1}
-						style={folderButtonTextStyle}
+						style={textStyle}
 						accessibilityLabel={accessibilityLabel}
 					>
 						{folderTitle}

--- a/packages/lib/services/style/themeToCss.test.ts
+++ b/packages/lib/services/style/themeToCss.test.ts
@@ -88,6 +88,7 @@ const expected = `
 	--joplin-color-correct: green;
 	--joplin-color-error: red;
 	--joplin-color-error2: #ff6c6c;
+	--joplin-color-error-selected: #d00000;
 	--joplin-color-faded: #7C8B9E;
 	--joplin-color-warn: rgb(228,86,0);
 	--joplin-color-warn2: #ffcb81;

--- a/packages/lib/services/style/themeToCss.test.ts
+++ b/packages/lib/services/style/themeToCss.test.ts
@@ -11,6 +11,7 @@ const input: Theme = {
 	oddBackgroundColor: '#eeeeee',
 	color: '#32373F', // For regular text
 	colorError: 'red',
+	colorErrorSelected: '#d00000',
 	colorCorrect: 'green',
 	colorWarn: 'rgb(228,86,0)',
 	colorWarnUrl: '#155BDA',

--- a/packages/lib/themes/dark.ts
+++ b/packages/lib/themes/dark.ts
@@ -21,6 +21,7 @@ const theme: Theme = {
 	dividerColor: '#555555',
 	selectedColor: '#616161',
 	urlColor: 'rgb(166,166,255)',
+	colorErrorSelected: '#FFD7D7',
 
 	// Color scheme "2" is used for the sidebar. It's white text over
 	// dark blue background.

--- a/packages/lib/themes/light.ts
+++ b/packages/lib/themes/light.ts
@@ -18,6 +18,7 @@ const theme: Theme = {
 	dividerColor: '#dddddd',
 	selectedColor: '#e5e5e5',
 	urlColor: '#155BDA',
+	colorErrorSelected: '#d00000',
 
 	// Color scheme "2" is used for the sidebar. It's white text over
 	// dark blue background.

--- a/packages/lib/themes/type.ts
+++ b/packages/lib/themes/type.ts
@@ -13,6 +13,7 @@ export interface Theme {
 	oddBackgroundColor: string;
 	color: string; // For regular text
 	colorError: string;
+	colorErrorSelected: string; // On a selectedColor background
 	colorCorrect: string;
 	colorWarn: string;
 	colorWarnUrl: string; // For URL displayed over a warningBackgroundColor


### PR DESCRIPTION
# Problem

On mobile in dark mode, the conflicts folder text has low 1.81:1 contrast with the selection background:
<img width="300" alt="screenshot: Selected conflicts folder in dark mode" src="https://github.com/user-attachments/assets/d4e39ada-6e09-49dc-bfc2-df43dd4374cd" />

In light mode, the conflicts folder header has 3.17:1 contrast (when selected), which is also low:
<img width="300" alt="screenshot: Selected conflicts folder in light mode" src="https://github.com/user-attachments/assets/fb6dd9c2-a1ea-4cc1-9887-2e8630a9542e" />

# Solution

When the "conflicts" folders list entry is selected, use a color with greater contrast.

Fixes #13437.

# Testing (web)

**Light mode**: The Chromium developer tools list 4.52:1 contrast:

<img width="300" alt="screenshot: Conflicts heading" src="https://github.com/user-attachments/assets/9d4f14ad-9b63-4d7f-92f4-60f7b6df5157" /><img width="300" alt="screenshot: Conflicts heading, Chrome devtools listing 4.52:1 contrast" src="https://github.com/user-attachments/assets/947d8681-d5d1-4908-b871-21bef6e3ab5d" />

**Default dark mode**: The Chromium developer tools list 4.7:1 contrast:

<img width="300" alt="screenshot: Conflicts heading, dark mode" src="https://github.com/user-attachments/assets/f548ffe8-ed74-41d9-a031-e44f81d329fc" /><img width="300" alt="screenshot: Conflicts heading, dark mode, Chrome devtools listing 4.7:1 contrast" src="https://github.com/user-attachments/assets/12976e0c-fbbc-4a79-bc2f-e1518de785a3" />


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->