### PR TITLE
Desktop, Mobile: Fixes #15184: Add authentication button for Dropbox/OneDrive sync

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1006,6 +1006,7 @@ packages/app-mobile/utils/ipc/WebViewToRNMessenger.js
 packages/app-mobile/utils/lockToSingleInstance.js
 packages/app-mobile/utils/makeShowMessageBox.test.js
 packages/app-mobile/utils/makeShowMessageBox.js
+packages/app-mobile/utils/performSync.js
 packages/app-mobile/utils/pickDocument.js
 packages/app-mobile/utils/polyfills/bufferPolyfill.js
 packages/app-mobile/utils/polyfills/crypto-polyfill/index.js

--- a/.gitignore
+++ b/.gitignore
@@ -979,6 +979,7 @@ packages/app-mobile/utils/ipc/WebViewToRNMessenger.js
 packages/app-mobile/utils/lockToSingleInstance.js
 packages/app-mobile/utils/makeShowMessageBox.test.js
 packages/app-mobile/utils/makeShowMessageBox.js
+packages/app-mobile/utils/performSync.js
 packages/app-mobile/utils/pickDocument.js
 packages/app-mobile/utils/polyfills/bufferPolyfill.js
 packages/app-mobile/utils/polyfills/crypto-polyfill/index.js

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -7,6 +7,7 @@ import bridge from '../../services/bridge';
 import Setting, { AppType, SettingValueType, SyncStartupOperation } from '@joplin/lib/models/Setting';
 import EncryptionConfigScreen from '../EncryptionConfigScreen/EncryptionConfigScreen';
 import { reg } from '@joplin/lib/registry';
+import CommandService from '@joplin/lib/services/CommandService';
 const { connect } = require('react-redux');
 import { themeStyle } from '@joplin/lib/theme';
 import SyncTargetRegistry from '@joplin/lib/SyncTargetRegistry';
@@ -300,6 +301,27 @@ class ConfigScreenComponent extends React.Component<any, any> {
 							onClick={this.checkSyncConfig_}
 						/>
 						{statusComp}
+					</div>,
+				);
+			}
+
+			if (settings['sync.target'] === SyncTargetRegistry.nameToId('dropbox')
+				|| settings['sync.target'] === SyncTargetRegistry.nameToId('onedrive')) {
+				const syncTargetLabel = SyncTargetRegistry.idToMetadata(settings['sync.target']).label;
+				settingComps.push(
+					<div key="auth_oauth_description" style={{ ...theme.textStyle, marginBottom: 10 }}>
+						{_('After selecting %s, click "Sign in" to authenticate.', syncTargetLabel)}
+					</div>,
+				);
+				settingComps.push(
+					<div key="auth_oauth_button" style={this.rowStyle_}>
+						<Button
+							title={_('Sign in')}
+							level={ButtonLevel.Primary}
+							onClick={() => {
+								void CommandService.instance().execute('synchronize');
+							}}
+						/>
 					</div>,
 				);
 			}

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -318,7 +318,19 @@ class ConfigScreenComponent extends React.Component<any, any> {
 						<Button
 							title={_('Sign in')}
 							level={ButtonLevel.Primary}
-							onClick={() => {
+							onClick={async () => {
+								// Save settings first so reg.syncTarget() uses the correct target
+								await shared.saveSettings(this);
+
+								// Re-navigate to Config with the sync section selected so that
+								// pressing "Back" from the auth screen returns here instead of
+								// the General section.
+								this.props.dispatch({
+									type: 'NAV_GO',
+									routeName: 'Config',
+									props: { defaultSection: 'sync' },
+								});
+
 								void CommandService.instance().execute('synchronize');
 							}}
 						/>

--- a/packages/app-desktop/gui/SyncWizard/Dialog.tsx
+++ b/packages/app-desktop/gui/SyncWizard/Dialog.tsx
@@ -182,9 +182,9 @@ export default function(props: Props) {
 
 	const onSelectButtonClick = useCallback(async (name: SyncTargetInfoName) => {
 		const routes = {
-			'dropbox': { name: 'DropboxLogin', target: 7 },
-			'onedrive': { name: 'OneDriveLogin', target: 3 },
-			'joplinCloud': { name: 'JoplinCloudLogin', target: 10 },
+			'dropbox': { name: 'DropboxLogin', target: 7, shouldRestoreSyncSection: true },
+			'onedrive': { name: 'OneDriveLogin', target: 3, shouldRestoreSyncSection: true },
+			'joplinCloud': { name: 'JoplinCloudLogin', target: 10, shouldRestoreSyncSection: false },
 		};
 		const route = routes[name];
 		if (!route) return; // throw error??
@@ -192,6 +192,15 @@ export default function(props: Props) {
 		Setting.setValue('sync.target', route.target);
 		await Setting.saveAll();
 		closeDialog();
+
+		if (route.shouldRestoreSyncSection) {
+			props.dispatch({
+				type: 'NAV_GO',
+				routeName: 'Config',
+				props: { defaultSection: 'sync' },
+			});
+		}
+
 		props.dispatch({
 			type: 'NAV_GO',
 			routeName: route.name,

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -144,6 +144,7 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 	private onAuthenticateOAuth_ = async () => {
 		// Save any unsaved settings first (e.g. the sync target selection itself)
 		await this.saveButton_press();
+		await NavService.go('Config', { sectionName: 'sync' });
 		await performSync(false, this.props.dispatch);
 	};
 
@@ -392,6 +393,7 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 	public sectionToComponent(key: string, section: SettingMetadataSection, settings: any, isSelected: boolean) {
 		const settingComps: ReactElement[] = [];
 		const advancedSettingComps: ReactElement[] = [];
+		let syncOauthButtonsAdded = false;
 
 		const headerTitle = Setting.sectionNameToLabel(section.name);
 		const sectionDescription = Setting.sectionDescription(key, AppType.Mobile);
@@ -445,6 +447,23 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 				relatedText.push(options.description);
 			}
 			addSettingComponent(this.renderButton(key, title, clickHandler, options), relatedText);
+		};
+
+		const addSyncOauthComponents = () => {
+			const currentSyncTargetId = settings['sync.target'];
+			if (currentSyncTargetId === SyncTargetRegistry.nameToId('dropbox')
+				|| currentSyncTargetId === SyncTargetRegistry.nameToId('onedrive')) {
+				const syncTargetLabel = SyncTargetRegistry.idToMetadata(currentSyncTargetId).label;
+				addSettingButton(
+					'auth_oauth_button',
+					_('Sign in'),
+					this.onAuthenticateOAuth_,
+					{ description: _('After selecting %s, tap "Sign in" to authenticate.', syncTargetLabel) },
+				);
+			}
+
+			addSettingButton('sync_wizard_button', _('Open Sync Wizard...'), this.onShowSyncWizard_);
+			syncOauthButtonsAdded = true;
 		};
 
 		const styleSheet = this.styles().styleSheet;
@@ -519,6 +538,14 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 				relatedText,
 				md,
 			);
+
+			if (section.name === 'sync' && md.key === 'sync.mobileWifiOnly') {
+				addSyncOauthComponents();
+			}
+		}
+
+		if (section.name === 'sync' && !syncOauthButtonsAdded) {
+			addSyncOauthComponents();
 		}
 
 		if (section.name === 'plugins') {
@@ -573,20 +600,7 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 		}
 
 		if (section.name === 'sync') {
-			addSettingButton('sync_wizard_button', _('Open Sync Wizard...'), this.onShowSyncWizard_);
 			addSettingButton('e2ee_config_button', _('Encryption Config'), this.e2eeConfig_);
-
-			const currentSyncTargetId = settings['sync.target'];
-			if (currentSyncTargetId === SyncTargetRegistry.nameToId('dropbox')
-				|| currentSyncTargetId === SyncTargetRegistry.nameToId('onedrive')) {
-				const syncTargetLabel = SyncTargetRegistry.idToMetadata(currentSyncTargetId).label;
-				addSettingButton(
-					'auth_oauth_button',
-					_('Sign in'),
-					this.onAuthenticateOAuth_,
-					{ description: _('After selecting %s, tap "Sign in" to authenticate.', syncTargetLabel) },
-				);
-			}
 		}
 
 		if (section.name === 'joplinCloud') {

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -41,6 +41,7 @@ import { UpdateSettingValueCallback } from './types';
 import Folder from '@joplin/lib/models/Folder';
 import { FolderEntity } from '@joplin/lib/services/database/types';
 import { substrWithEllipsis } from '@joplin/lib/string-utils';
+import performSync from '../../../utils/performSync';
 
 interface ConfigScreenState {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -138,6 +139,12 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 			type: 'SYNC_WIZARD_VISIBLE_CHANGE',
 			visible: true,
 		});
+	};
+
+	private onAuthenticateOAuth_ = async () => {
+		// Save any unsaved settings first (e.g. the sync target selection itself)
+		await this.saveButton_press();
+		await performSync(false, this.props.dispatch);
 	};
 
 	private saveButton_press = async () => {
@@ -568,6 +575,18 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 		if (section.name === 'sync') {
 			addSettingButton('sync_wizard_button', _('Open Sync Wizard...'), this.onShowSyncWizard_);
 			addSettingButton('e2ee_config_button', _('Encryption Config'), this.e2eeConfig_);
+
+			const currentSyncTargetId = settings['sync.target'];
+			if (currentSyncTargetId === SyncTargetRegistry.nameToId('dropbox')
+				|| currentSyncTargetId === SyncTargetRegistry.nameToId('onedrive')) {
+				const syncTargetLabel = SyncTargetRegistry.idToMetadata(currentSyncTargetId).label;
+				addSettingButton(
+					'auth_oauth_button',
+					_('Sign in'),
+					this.onAuthenticateOAuth_,
+					{ description: _('After selecting %s, tap "Sign in" to authenticate.', syncTargetLabel) },
+				);
+			}
 		}
 
 		if (section.name === 'joplinCloud') {

--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -6,14 +6,13 @@ import { connect } from 'react-redux';
 import Icon from './Icon';
 import Folder from '@joplin/lib/models/Folder';
 import Synchronizer from '@joplin/lib/Synchronizer';
+import performSync from '../utils/performSync';
 import NavService from '@joplin/lib/services/NavService';
 import { _ } from '@joplin/lib/locale';
 import { themeStyle } from './global-style';
 import { buildFolderTree, isFolderSelected, renderFolders } from '@joplin/lib/components/shared/side-menu-shared';
 import { FolderEntity, FolderIcon, FolderIconType } from '@joplin/lib/services/database/types';
 import { AppState } from '../utils/types';
-import Setting from '@joplin/lib/models/Setting';
-import { reg } from '@joplin/lib/registry';
 import { ProfileConfig } from '@joplin/lib/services/profileConfig/types';
 import { getTrashFolderIcon, getTrashFolderId } from '@joplin/lib/services/trash';
 import restoreItems from '@joplin/lib/services/trash/restoreItems';
@@ -513,62 +512,14 @@ const SideMenuContentComponent = (props: Props) => {
 		});
 	};
 
-	const performSync = useCallback(async () => {
-		const action = props.syncStarted ? 'cancel' : 'start';
-
-		if (!Setting.value('sync.target')) {
-			props.dispatch({
-				type: 'SIDE_MENU_CLOSE',
-			});
-
-			props.dispatch({
-				type: 'SYNC_WIZARD_VISIBLE_CHANGE',
-				visible: true,
-			});
-
-			return 'init';
-		}
-
-		if (!(await reg.syncTarget().isAuthenticated())) {
-			if (reg.syncTarget().authRouteName()) {
-				props.dispatch({
-					type: 'NAV_GO',
-					routeName: reg.syncTarget().authRouteName(),
-				});
-				return 'auth';
-			}
-
-			reg.logger().error('Not authenticated with sync target - please check your credentials.');
-			return 'error';
-		}
-
-		let sync = null;
-		try {
-			sync = await reg.syncTarget().synchronizer();
-		} catch (error) {
-			reg.logger().error('Could not initialise synchroniser: ');
-			reg.logger().error(error);
-			error.message = `Could not initialise synchroniser: ${error.message}`;
-			props.dispatch({
-				type: 'SYNC_REPORT_UPDATE',
-				report: { errors: [error] },
-			});
-			return 'error';
-		}
-
-		if (action === 'cancel') {
-			void sync.cancel();
-			return 'cancel';
-		} else {
-			void reg.scheduleSync(0);
-			return 'sync';
-		}
+	const performSyncCallback = useCallback(async () => {
+		return performSync(props.syncStarted, props.dispatch);
 	}, [props.syncStarted, props.dispatch]);
 
 	const synchronize_press = useCallback(async () => {
-		const actionDone = await performSync();
+		const actionDone = await performSyncCallback();
 		if (actionDone === 'auth') props.dispatch({ type: 'SIDE_MENU_CLOSE' });
-	}, [performSync, props.dispatch]);
+	}, [performSyncCallback, props.dispatch]);
 
 
 	const renderFolderItem = (folder: FolderEntity, hasChildren: boolean, depth: number) => {

--- a/packages/app-mobile/utils/performSync.ts
+++ b/packages/app-mobile/utils/performSync.ts
@@ -1,0 +1,54 @@
+import { Dispatch } from 'redux';
+import Setting from '@joplin/lib/models/Setting';
+import { reg } from '@joplin/lib/registry';
+
+// Shared sync trigger logic used by both the side menu and the config screen.
+// Replicates the behavior of the desktop `synchronize` command: if not
+// authenticated it navigates to the sync target's auth route; otherwise it
+// schedules a sync (or cancels one in progress).
+const performSync = async (syncStarted: boolean, dispatch: Dispatch): Promise<string> => {
+	const action = syncStarted ? 'cancel' : 'start';
+
+	if (!Setting.value('sync.target')) {
+		dispatch({ type: 'SIDE_MENU_CLOSE' });
+		dispatch({ type: 'SYNC_WIZARD_VISIBLE_CHANGE', visible: true });
+		return 'init';
+	}
+
+	if (!(await reg.syncTarget().isAuthenticated())) {
+		if (reg.syncTarget().authRouteName()) {
+			dispatch({
+				type: 'NAV_GO',
+				routeName: reg.syncTarget().authRouteName(),
+			});
+			return 'auth';
+		}
+
+		reg.logger().error('Not authenticated with sync target - please check your credentials.');
+		return 'error';
+	}
+
+	let sync = null;
+	try {
+		sync = await reg.syncTarget().synchronizer();
+	} catch (error) {
+		reg.logger().error('Could not initialise synchroniser: ');
+		reg.logger().error(error);
+		error.message = `Could not initialise synchroniser: ${error.message}`;
+		dispatch({
+			type: 'SYNC_REPORT_UPDATE',
+			report: { errors: [error] },
+		});
+		return 'error';
+	}
+
+	if (action === 'cancel') {
+		void sync.cancel();
+		return 'cancel';
+	} else {
+		void reg.scheduleSync(0);
+		return 'sync';
+	}
+};
+
+export default performSync;


### PR DESCRIPTION
## AI Disclosure

AI tooling was used during the development of this PR. It helped in finding related files and assisted in the implementation of the feature. All changes were reviewed, tested, and validated manually.

## Summary

This pull request improves the user experience when selecting Dropbox or OneDrive as a synchronization target.

Currently, after selecting Dropbox or OneDrive in the synchronization settings, there is no visible indication of how to proceed with authentication. Users must manually click the "Sync" button to trigger the sign-in flow, which is not obvious or discoverable.

This PR adds a clear **"Sign in"** button in the synchronization settings screen for both mobile and desktop applications.

---

## Problem

Steps to reproduce:

1. Open Settings → Synchronization
2. Select Dropbox or OneDrive as the sync target
3. Save settings

### Current behavior

* No indication of how to authenticate
* No button or instruction shown
* User must know to press "Sync" manually

---

## Solution

* Add an **"Sign in" button** that appears only when:

  * Sync target = Dropbox
  * Sync target = OneDrive

* When clicked:

  * Triggers the same logic as pressing the "Sync" button
  * Starts the authentication flow (no new logic introduced)

* Helper text added:

  * Desktop: _"After selecting [Dropbox/OneDrive], click "Sign in" to authenticate."_
  * Mobile: _"After selecting [Dropbox/OneDrive], tap "Sign in" to authenticate."_

---

## Screenshots

### Mobile

https://github.com/user-attachments/assets/1f3e88db-0caa-43b9-83d6-8a2aaa8aca8f

### Desktop

https://github.com/user-attachments/assets/067a84d4-0128-4d35-95e6-4427f3223ada

## Testing

* Verified that:

  * Button appears only for Dropbox and OneDrive
  * Clicking button triggers authentication flow
  * Other sync targets remain unchanged
  * No regression in sync functionality

