### PR TITLE
Desktop: Fixes #15189: Fix Rich Text Editor fails to load in secondary windows

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -412,6 +412,7 @@ export default class ElectronAppWrapper {
 						action: 'allow',
 						overrideBrowserWindowOptions: {
 							webPreferences: {
+								nodeIntegration: false,
 								preload: resolve(__dirname, './utils/window/secondaryWindowPreload.js'),
 							},
 						},

--- a/packages/app-desktop/gui/NewWindowOrIFrame.tsx
+++ b/packages/app-desktop/gui/NewWindowOrIFrame.tsx
@@ -44,6 +44,12 @@ const useDocument = (
 			setDoc(iframeElement?.contentWindow?.document);
 		} else if (mode === WindowMode.NewWindow) {
 			openedWindow = window.open('about:blank');
+
+			// Required to support TinyMCE:
+			openedWindow.document.open();
+			openedWindow.document.write('<!DOCTYPE html><html><head></head><body></body></html>');
+			openedWindow.document.close();
+
 			setDoc(openedWindow.document);
 
 			// .onbeforeunload and .onclose events don't seem to fire when closed by a user -- rely on polling

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -16,6 +16,9 @@ import { menuItems } from '../../../utils/contextMenu';
 import isItemId from '@joplin/lib/models/utils/isItemId';
 import { extractResourceUrls } from '@joplin/lib/urlUtils';
 import { WindowIdContext } from '../../../../NewWindowOrIFrame';
+import Logger from '@joplin/utils/Logger';
+
+const logger = Logger.create('useContextMenu');
 
 export type ResourceMarkupType = 'image' | 'file';
 
@@ -355,11 +358,19 @@ const useContextMenu = (props: ContextMenuProps) => {
 
 		// Prepend the event listener so that it gets called before
 		// the listener that shows the default menu.
-		targetWindow.webContents.prependListener('context-menu', onContextMenu);
+		try {
+			targetWindow.webContents.prependListener('context-menu', onContextMenu);
+		} catch (error) {
+			logger.warn('Error registering menu', error);
+		}
 
 		return () => {
-			if (!targetWindow.isDestroyed()) {
-				targetWindow.webContents.off('context-menu', onContextMenu);
+			try {
+				if (!targetWindow.isDestroyed()) {
+					targetWindow.webContents.off('context-menu', onContextMenu);
+				}
+			} catch (error) {
+				logger.warn('Error removing menu listener', error);
 			}
 		};
 	}, [

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -370,6 +370,8 @@ const useContextMenu = (props: ContextMenuProps) => {
 					targetWindow.webContents.off('context-menu', onContextMenu);
 				}
 			} catch (error) {
+				// This can happen if the window closes after the isDestroyed check, but before webContents.off
+				// finishes running.
 				logger.warn('Error removing menu listener', error);
 			}
 		};

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
@@ -160,7 +160,11 @@ export default function(editor: Editor, plugins: PluginStates, dispatch: Dispatc
 			}
 		};
 
-		targetWindow.webContents.prependListener('context-menu', onElectronContextMenu);
+		try {
+			targetWindow.webContents.prependListener('context-menu', onElectronContextMenu);
+		} catch (error) {
+			logger.error('Failed to register context menu', error);
+		}
 		editor.on('contextmenu', onBrowserContextMenu);
 
 		return () => {
@@ -171,7 +175,9 @@ export default function(editor: Editor, plugins: PluginStates, dispatch: Dispatc
 					targetWindow.webContents.off('context-menu', onElectronContextMenu);
 				}
 			} catch (error) {
-				logger.warn('Error removing context menu listener', error);
+				// This can happen if the window closes after the isDestroyed check, but before webContents.off
+				// finishes running.
+				logger.error('Error removing context menu listener', error);
 			}
 		};
 	}, [editor, plugins, dispatch, htmlToMd, mdToHtml, editDialog, windowId]);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
@@ -19,6 +19,9 @@ import { _ } from '@joplin/lib/locale';
 import type { MenuItem as MenuItemType } from 'electron';
 import isItemId from '@joplin/lib/models/utils/isItemId';
 import { WindowIdContext } from '../../../../NewWindowOrIFrame';
+import Logger from '@joplin/utils/Logger';
+
+const logger = Logger.create('useContextMenu');
 
 const Menu = bridge().Menu;
 const MenuItem = bridge().MenuItem;
@@ -162,8 +165,13 @@ export default function(editor: Editor, plugins: PluginStates, dispatch: Dispatc
 
 		return () => {
 			editor.off('contextmenu', onBrowserContextMenu);
-			if (!targetWindow.isDestroyed() && targetWindow?.webContents?.off) {
-				targetWindow.webContents.off('context-menu', onElectronContextMenu);
+
+			try {
+				if (!targetWindow.isDestroyed() && targetWindow?.webContents?.off) {
+					targetWindow.webContents.off('context-menu', onElectronContextMenu);
+				}
+			} catch (error) {
+				logger.warn('Error removing context menu listener', error);
 			}
 		};
 	}, [editor, plugins, dispatch, htmlToMd, mdToHtml, editDialog, windowId]);


### PR DESCRIPTION
# Problem

https://github.com/laurent22/joplin/pull/15035 removed a deprecated `document.write` call to fix a hang when closing secondary windows. The `document.write` call, however, was required to prevent the secondary window from opening in [compatibility mode](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Quirks_mode_and_standards_mode) (TinyMCE does not support compatibility mode).

# Solution

To fix the Rich Text Editor regression: Revert #15035.

To try to prevent https://github.com/laurent22/joplin/issues/14968 from returning:
1. Add `try`/`catch` guards that *may* prevent the secondary window crash/hang from occurring.
   - **Note**: The `try`/`catch` **do** fix an error overlay related to adding/removing context menu listeners observed while testing this pull request locally.
2. Set `nodeIntegration: false` when opening secondary windows: it doesn't need to be `true` (this was another potential crash/hang workaround I was looking into before creating https://github.com/laurent22/joplin/pull/15035).

# Testing

Fedora 43/Linux:
1. Open 20 secondary windows.
2. Close them all rapidly.
3. Verify that the app doesn't crash.
4. Repeat steps 1-3 for the Rich Text Editor.

[Screencast from 2026-04-23 16-15-02.webm](https://github.com/user-attachments/assets/1b7369c5-26f7-471f-9782-233db9af635c)

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->