### PR TITLE
Desktop: Upgrade Electron to v40.9.2

### DIFF
--- a/packages/app-desktop/gui/NewWindowOrIFrame.tsx
+++ b/packages/app-desktop/gui/NewWindowOrIFrame.tsx
@@ -44,12 +44,6 @@ const useDocument = (
 			setDoc(iframeElement?.contentWindow?.document);
 		} else if (mode === WindowMode.NewWindow) {
 			openedWindow = window.open('about:blank');
-
-			// Starting from Electron 41, secondary about:blank windows open in Quirks Mode, which breaks
-			// TinyMCE. As a workaround, use `document.write` to set the doctype (enabling standards mode):
-			openedWindow.document.write('<!DOCTYPE html><html><head></head><body></body></html>');
-			openedWindow.document.close();
-
 			setDoc(openedWindow.document);
 
 			// .onbeforeunload and .onclose events don't seem to fire when closed by a user -- rely on polling

--- a/packages/app-desktop/gui/NewWindowOrIFrame.tsx
+++ b/packages/app-desktop/gui/NewWindowOrIFrame.tsx
@@ -44,6 +44,12 @@ const useDocument = (
 			setDoc(iframeElement?.contentWindow?.document);
 		} else if (mode === WindowMode.NewWindow) {
 			openedWindow = window.open('about:blank');
+
+			// Starting from Electron 41, secondary about:blank windows open in Quirks Mode, which breaks
+			// TinyMCE. As a workaround, use `document.write` to set the doctype (enabling standards mode):
+			openedWindow.document.write('<!DOCTYPE html><html><head></head><body></body></html>');
+			openedWindow.document.close();
+
 			setDoc(openedWindow.document);
 
 			// .onbeforeunload and .onclose events don't seem to fire when closed by a user -- rely on polling

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -168,7 +168,7 @@
     "color": "3.2.1",
     "compare-versions": "6.1.1",
     "debounce": "1.2.1",
-    "electron": "40.8.3",
+    "electron": "40.9.2",
     "electron-builder": "24.13.3",
     "electron-updater": "6.6.8",
     "electron-window-state": "5.0.3",

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -168,7 +168,7 @@
     "color": "3.2.1",
     "compare-versions": "6.1.1",
     "debounce": "1.2.1",
-    "electron": "41.3.0",
+    "electron": "40.9.2",
     "electron-builder": "24.13.3",
     "electron-updater": "6.6.8",
     "electron-window-state": "5.0.3",

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -168,7 +168,7 @@
     "color": "3.2.1",
     "compare-versions": "6.1.1",
     "debounce": "1.2.1",
-    "electron": "40.9.2",
+    "electron": "41.3.0",
     "electron-builder": "24.13.3",
     "electron-updater": "6.6.8",
     "electron-window-state": "5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12714,7 +12714,7 @@ __metadata:
     color: "npm:3.2.1"
     compare-versions: "npm:6.1.1"
     debounce: "npm:1.2.1"
-    electron: "npm:40.9.2"
+    electron: "npm:41.3.0"
     electron-builder: "npm:24.13.3"
     electron-updater: "npm:6.6.8"
     electron-window-state: "npm:5.0.3"
@@ -29720,16 +29720,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:40.9.2":
-  version: 40.9.2
-  resolution: "electron@npm:40.9.2"
+"electron@npm:41.3.0":
+  version: 41.3.0
+  resolution: "electron@npm:41.3.0"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^24.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/573fde53d250df8e1035c90e239c6ffc4d359d9ffb9303fe3f0863ac6c3d8175ff1afd5188b42f0f3fa4ed0af63be525c30f843d62db3fbf82fa71e4ecd15bdb
+  checksum: 10/ec6eb7d6a865f94ce8c1856d3cdea7fb654c8d8eaa08d20a8558f559a004cbc056bf88cc7d78bf5fe82502fefe3e29017b368c15109c5f5c1d6294a5720de4af
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12714,7 +12714,7 @@ __metadata:
     color: "npm:3.2.1"
     compare-versions: "npm:6.1.1"
     debounce: "npm:1.2.1"
-    electron: "npm:41.3.0"
+    electron: "npm:40.9.2"
     electron-builder: "npm:24.13.3"
     electron-updater: "npm:6.6.8"
     electron-window-state: "npm:5.0.3"
@@ -29720,16 +29720,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:41.3.0":
-  version: 41.3.0
-  resolution: "electron@npm:41.3.0"
+"electron@npm:40.9.2":
+  version: 40.9.2
+  resolution: "electron@npm:40.9.2"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^24.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/ec6eb7d6a865f94ce8c1856d3cdea7fb654c8d8eaa08d20a8558f559a004cbc056bf88cc7d78bf5fe82502fefe3e29017b368c15109c5f5c1d6294a5720de4af
+  checksum: 10/573fde53d250df8e1035c90e239c6ffc4d359d9ffb9303fe3f0863ac6c3d8175ff1afd5188b42f0f3fa4ed0af63be525c30f843d62db3fbf82fa71e4ecd15bdb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12714,7 +12714,7 @@ __metadata:
     color: "npm:3.2.1"
     compare-versions: "npm:6.1.1"
     debounce: "npm:1.2.1"
-    electron: "npm:40.8.3"
+    electron: "npm:40.9.2"
     electron-builder: "npm:24.13.3"
     electron-updater: "npm:6.6.8"
     electron-window-state: "npm:5.0.3"
@@ -29720,16 +29720,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:40.8.3":
-  version: 40.8.3
-  resolution: "electron@npm:40.8.3"
+"electron@npm:40.9.2":
+  version: 40.9.2
+  resolution: "electron@npm:40.9.2"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^24.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/6d53f8a359de40c6b5c11c8b2b253f1b59db45a3c6dff6edd78a47af02c382ec67143a7f695f6e63c49d85f6bae39ad337b6b5f4cf73056a789f6e272a945dc5
+  checksum: 10/573fde53d250df8e1035c90e239c6ffc4d359d9ffb9303fe3f0863ac6c3d8175ff1afd5188b42f0f3fa4ed0af63be525c30f843d62db3fbf82fa71e4ecd15bdb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

Upgrades Electron to 40.9.2 ([changes from v40.8.3](https://releases.electronjs.org/release/compare/v40.8.3/v40.9.2)).


# Testing

## Linux (Fedora 43 + GNOME)

With a release build of Joplin (AppImage):
- [x] Print to PDF works.
- [x] It's possible to print an embedded PDF to file from the PDF viewer.
- [x] It's possible to open a note in a new window and edit it.
- [x] It's possible to edit a note in an external editor.
- [x] It's possible to create a backup using the `:CreateBackup` command (the "backup completed" dialog is shown).
- [x] It's possible to edit a note in the Rich Text Editor.
- [x] Switching the OS theme to dark also switches the Joplin theme.
- [x] It's possible to right-click > export a note as PDF.
- [x] An alarm set on a to-do note shows a notification at the set time.
- [x] Spellcheck: Works in the Markdown editor and Rich Text Editor
   - Note: Does not work in dev mode, but this does not seem to be a regression.
- [x] The Orca screen reader can read/interact with the main Joplin window.

## Windows 11

With a release build of Joplin:
- [x] Print to PDF works.
- [x] The NVDA screen reader can read the content of the Joplin window.
- [x] It's possible to print an embedded PDF to file from the PDF viewer.
- [x] It's possible to open a note in a new window and edit it.
- [x] It's possible to edit a note in an external editor.
- [x] It's possible to create a backup using the `:CreateBackup` command (the "backup completed" dialog is shown).
- [x] It's possible to edit a note in the Rich Text Editor.
- [x] It's possible to right-click > export a note as PDF.
- [x] An alarm set on a to-do note shows a notification at the set time.
- [x] Spellcheck: Works in the Markdown editor and Rich Text Editor

## MacOS (x86_64)

With a release build of Joplin:
- [x] A sync with Joplin Cloud completes successfully.
- [x] File > print can be used to print to PDF.
- [x] It's possible to right-click > export a note as PDF.
- [x] An alarm set on a to-do note shows a notification at the set time.
- [x] Spellcheck works in the Markdown and Rich Text editors.
- [x] VoiceOver can read and interact with content in the main app window.



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->