### PR TITLE
Desktop: Importing from OneNote: Support large attachments

### DIFF
--- a/packages/onenote-converter/parser-utils/node_functions.js
+++ b/packages/onenote-converter/parser-utils/node_functions.js
@@ -28,6 +28,11 @@ function normalizeAndWriteFile(filePath, data) {
 	fs.writeFileSync(filePath, data);
 }
 
+function normalizeAndAppendFile(filePath, data) {
+	filePath = path.normalize(filePath);
+	fs.appendFileSync(filePath, data);
+}
+
 function fileReader(path) {
 	const fd = fs.openSync(path);
 	// TODO: When Node v20 is EOL, replace this with the { bigint: true }
@@ -66,6 +71,7 @@ module.exports = {
 	readDir,
 	removePrefix,
 	normalizeAndWriteFile,
+	normalizeAndAppendFile,
 	fileReader,
 	isWindows,
 };

--- a/packages/onenote-converter/parser-utils/src/file_api/api.rs
+++ b/packages/onenote-converter/parser-utils/src/file_api/api.rs
@@ -12,10 +12,13 @@ pub trait FileApiDriver: Send + Sync {
     fn read_dir(&self, path: &str) -> ApiResult<Vec<String>>;
     fn read_file(&self, path: &str) -> ApiResult<Vec<u8>>;
     fn write_file(&self, path: &str, data: &[u8]) -> ApiResult<()>;
-    fn stream_to_file(&self, path: &str, data: &mut dyn Read) -> ApiResult<()>;
     fn make_dir(&self, path: &str) -> ApiResult<()>;
     fn exists(&self, path: &str) -> ApiResult<bool>;
     fn open_file(&self, path: &str) -> ApiResult<Box<dyn FileHandle>>;
+
+    /// Writes data from `stream` to the file at `path`.
+    /// Note: If `stream.read` fails, the file may be left in a partially-written state.
+    fn stream_to_file(&self, path: &str, stream: &mut dyn Read) -> ApiResult<()>;
 
     // These functions correspond to the similarly-named
     // NodeJS path functions and should behave like the NodeJS

--- a/packages/onenote-converter/parser-utils/src/file_api/api.rs
+++ b/packages/onenote-converter/parser-utils/src/file_api/api.rs
@@ -12,6 +12,7 @@ pub trait FileApiDriver: Send + Sync {
     fn read_dir(&self, path: &str) -> ApiResult<Vec<String>>;
     fn read_file(&self, path: &str) -> ApiResult<Vec<u8>>;
     fn write_file(&self, path: &str, data: &[u8]) -> ApiResult<()>;
+    fn stream_to_file(&self, path: &str, data: &mut dyn Read) -> ApiResult<()>;
     fn make_dir(&self, path: &str) -> ApiResult<()>;
     fn exists(&self, path: &str) -> ApiResult<bool>;
     fn open_file(&self, path: &str) -> ApiResult<Box<dyn FileHandle>>;

--- a/packages/onenote-converter/parser-utils/src/file_api/native_driver.rs
+++ b/packages/onenote-converter/parser-utils/src/file_api/native_driver.rs
@@ -2,6 +2,7 @@ use super::ApiResult;
 use super::FileApiDriver;
 use super::FileHandle;
 use std::fs;
+use std::fs::File;
 use std::io::BufReader;
 use std::path;
 use std::path::Path;
@@ -44,6 +45,12 @@ impl FileApiDriver for FileApiDriverImpl {
 
     fn write_file(&self, path: &str, data: &[u8]) -> ApiResult<()> {
         fs::write(path, data)
+    }
+
+    fn stream_to_file(&self, path: &str, data: &mut dyn std::io::Read) -> ApiResult<()> {
+        let mut f = File::create(path)?;
+        std::io::copy(data, &mut f)?;
+        Ok(())
     }
 
     fn exists(&self, path: &str) -> ApiResult<bool> {

--- a/packages/onenote-converter/parser-utils/src/file_api/wasm_driver.rs
+++ b/packages/onenote-converter/parser-utils/src/file_api/wasm_driver.rs
@@ -157,7 +157,17 @@ impl FileApiDriver for FileApiDriverImpl {
         let mut buffer = vec![0; chunk_size];
 
         loop {
-            let size = data.read(&mut buffer)?;
+            let size = match data.read(&mut buffer) {
+                Ok(size) => size,
+                // Interrupted errors can be retried
+                Err(err) if err.kind() == std::io::ErrorKind::Interrupted => {
+                    continue;
+                }
+                Err(err) => {
+                    return Err(err);
+                }
+            };
+
             if size == 0 {
                 break;
             }

--- a/packages/onenote-converter/parser-utils/src/file_api/wasm_driver.rs
+++ b/packages/onenote-converter/parser-utils/src/file_api/wasm_driver.rs
@@ -149,6 +149,9 @@ impl FileApiDriver for FileApiDriverImpl {
     }
 
     fn stream_to_file(&self, path: &str, data: &mut dyn std::io::Read) -> ApiResult<()> {
+        // Create and clear the file. This is important for zero-size files
+        self.write_file(path, &[])?;
+
         let chunk_size = 2 * 1024 * 1024; // 2 MB
         let mut buffer = vec![0; chunk_size];
         loop {

--- a/packages/onenote-converter/parser-utils/src/file_api/wasm_driver.rs
+++ b/packages/onenote-converter/parser-utils/src/file_api/wasm_driver.rs
@@ -28,6 +28,9 @@ extern "C" {
     #[wasm_bindgen(js_name = normalizeAndWriteFile, catch)]
     fn write_file(path: &str, data: &[u8]) -> std::result::Result<JsValue, JsValue>;
 
+    #[wasm_bindgen(js_name = normalizeAndAppendFile, catch)]
+    fn append_file(path: &str, data: &[u8]) -> std::result::Result<JsValue, JsValue>;
+
     #[wasm_bindgen(js_name = isDirectory, catch)]
     fn is_directory(path: &str) -> std::result::Result<bool, JsValue>;
 
@@ -143,6 +146,22 @@ impl FileApiDriver for FileApiDriverImpl {
         } else {
             Ok(())
         }
+    }
+
+    fn stream_to_file(&self, path: &str, data: &mut dyn std::io::Read) -> ApiResult<()> {
+        let chunk_size = 2 * 1024 * 1024; // 2 MB
+        let mut buffer = vec![0; chunk_size];
+        loop {
+            let size = data.read(&mut buffer)?;
+            if size == 0 {
+                break;
+            }
+
+            if let Err(error) = append_file(path, &buffer[0..size]) {
+                return Err(handle_error(error, &format!("writing file {}", path)));
+            }
+        }
+        Ok(())
     }
 
     fn exists(&self, path: &str) -> ApiResult<bool> {

--- a/packages/onenote-converter/parser-utils/src/file_api/wasm_driver.rs
+++ b/packages/onenote-converter/parser-utils/src/file_api/wasm_driver.rs
@@ -152,8 +152,10 @@ impl FileApiDriver for FileApiDriverImpl {
         // Create and clear the file. This is important for zero-size files
         self.write_file(path, &[])?;
 
-        let chunk_size = 2 * 1024 * 1024; // 2 MB
+        let mut chunk_size = 1024 * 1024; // 1 MB
+        let max_chunk_size = 50 * 1024 * 1024;
         let mut buffer = vec![0; chunk_size];
+
         loop {
             let size = data.read(&mut buffer)?;
             if size == 0 {
@@ -162,6 +164,12 @@ impl FileApiDriver for FileApiDriverImpl {
 
             if let Err(error) = append_file(path, &buffer[0..size]) {
                 return Err(handle_error(error, &format!("writing file {}", path)));
+            }
+
+            // For performance, try to increase the chunk size
+            if size == chunk_size && chunk_size < max_chunk_size {
+                chunk_size = (chunk_size * 2).min(max_chunk_size);
+                buffer.resize(chunk_size, 0);
             }
         }
         Ok(())

--- a/packages/onenote-converter/parser-utils/src/reader.rs
+++ b/packages/onenote-converter/parser-utils/src/reader.rs
@@ -6,7 +6,7 @@ use bytes::Buf;
 use paste::paste;
 use std::{
     cell::RefCell,
-    io::{Read, Seek, SeekFrom},
+    io::{Cursor, Read, Seek, SeekFrom},
     mem,
     rc::Rc,
 };
@@ -163,11 +163,11 @@ impl<'a> Reader<'a> {
                 // data. Large data should generally use `ReaderData::File`.
                 Ok(ReaderDataRef::Vec(buffer[start..start + size].to_vec()))
             }
-            ReaderData::File(file) => Ok(ReaderDataRef::FilePointer {
+            ReaderData::File(file) => Ok(ReaderDataRef::FilePointer(ReaderFilePointer {
                 file: file.clone(),
                 offset: self.data_offset,
                 size,
-            }),
+            })),
         }
     }
 
@@ -258,32 +258,48 @@ impl<'a> From<&'a [u8]> for Reader<'a> {
 
 pub enum ReaderDataRef {
     Vec(Vec<u8>),
-    FilePointer {
-        file: ReaderFileHandle,
-        offset: u64,
-        size: usize,
-    },
+    FilePointer(ReaderFilePointer),
+}
+
+#[derive(Clone)]
+pub struct ReaderFilePointer {
+    file: ReaderFileHandle,
+    offset: u64,
+    size: usize,
+}
+
+impl Read for ReaderFilePointer {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let max_offset = self.offset + (self.size as u64);
+        let offset = self.offset;
+        if offset > max_offset {
+            return Ok(0);
+        }
+
+        let mut file = self.file.borrow_mut();
+        let original_offset = file.seek(SeekFrom::Current(0))?;
+        let read_result = (|| {
+            file.seek(SeekFrom::Start(offset))?;
+
+            file.read(buf)
+        })();
+        file.seek(SeekFrom::Start(original_offset))?;
+
+        match read_result {
+            Ok(size) => {
+                self.offset += size as u64;
+                Ok(size)
+            }
+            Err(err) => Err(err),
+        }
+    }
 }
 
 impl ReaderDataRef {
-    pub fn bytes(&self) -> Result<Vec<u8>> {
+    pub fn as_reader(&self) -> Result<Box<dyn Read>> {
         match self {
-            ReaderDataRef::Vec(slice) => Ok(slice.clone()),
-            ReaderDataRef::FilePointer { file, offset, size } => {
-                let mut file = file.borrow_mut();
-                let original_offset = file.seek(SeekFrom::Current(0))?;
-                let read_result = (|| {
-                    file.seek(SeekFrom::Start(*offset))?;
-
-                    let mut result = vec![0; *size];
-                    file.read_exact(&mut result)?;
-
-                    Ok(result)
-                })();
-                file.seek(SeekFrom::Start(original_offset))?;
-
-                read_result
-            }
+            ReaderDataRef::Vec(slice) => Ok(Box::new(Cursor::new(slice.to_vec()))),
+            ReaderDataRef::FilePointer(ptr) => Ok(Box::new(ptr.clone())),
         }
     }
 }

--- a/packages/onenote-converter/parser-utils/src/reader.rs
+++ b/packages/onenote-converter/parser-utils/src/reader.rs
@@ -280,7 +280,7 @@ pub struct ReaderFilePointer {
 impl Read for ReaderFilePointer {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let offset = self.start_offset;
-        if offset > self.end_offset {
+        if offset >= self.end_offset {
             return Ok(0);
         }
 

--- a/packages/onenote-converter/parser-utils/src/reader.rs
+++ b/packages/onenote-converter/parser-utils/src/reader.rs
@@ -345,7 +345,7 @@ mod test {
 
         reader.advance(2).unwrap();
 
-        // The data_ref should read from the offset from where it was created 
+        // The data_ref should read from the offset from where it was created
         let mut output = vec![];
         data_ref.read_to_end(&mut output).unwrap();
         assert_eq!(output, [2, 3, 4, 5]);

--- a/packages/onenote-converter/parser-utils/src/reader.rs
+++ b/packages/onenote-converter/parser-utils/src/reader.rs
@@ -165,8 +165,8 @@ impl<'a> Reader<'a> {
             }
             ReaderData::File(file) => Ok(ReaderDataRef::FilePointer(ReaderFilePointer {
                 file: file.clone(),
-                offset: self.data_offset,
-                size,
+                start_offset: self.data_offset,
+                end_offset: self.data_offset + (size as u64),
             })),
         }
     }
@@ -264,15 +264,14 @@ pub enum ReaderDataRef {
 #[derive(Clone)]
 pub struct ReaderFilePointer {
     file: ReaderFileHandle,
-    offset: u64,
-    size: usize,
+    start_offset: u64,
+    end_offset: u64,
 }
 
 impl Read for ReaderFilePointer {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let max_offset = self.offset + (self.size as u64);
-        let offset = self.offset;
-        if offset > max_offset {
+        let offset = self.start_offset;
+        if offset > self.end_offset {
             return Ok(0);
         }
 
@@ -287,7 +286,7 @@ impl Read for ReaderFilePointer {
 
         match read_result {
             Ok(size) => {
-                self.offset += size as u64;
+                self.start_offset += size as u64;
                 Ok(size)
             }
             Err(err) => Err(err),

--- a/packages/onenote-converter/parser-utils/src/reader.rs
+++ b/packages/onenote-converter/parser-utils/src/reader.rs
@@ -262,10 +262,10 @@ pub enum ReaderDataRef {
 }
 
 impl ReaderDataRef {
-    pub fn read(&self) -> Result<Box<dyn Read>> {
+    pub fn read(&self) -> Box<dyn Read> {
         match self {
-            ReaderDataRef::Vec(slice) => Ok(Box::new(Cursor::new(slice.to_vec()))),
-            ReaderDataRef::FilePointer(ptr) => Ok(Box::new(ptr.clone())),
+            ReaderDataRef::Vec(slice) => Box::new(Cursor::new(slice.to_vec())),
+            ReaderDataRef::FilePointer(ptr) => Box::new(ptr.clone()),
         }
     }
 }
@@ -332,6 +332,25 @@ mod test {
         reader.seek_relative(-2).unwrap();
         assert_eq!(reader.get_u8().unwrap(), 2);
         assert_eq!(reader.get_u8().unwrap(), 3);
+        assert_eq!(reader.get_u8().unwrap(), 4);
+    }
+
+    #[test]
+    fn should_read_from_offset() {
+        let data: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+        let mut reader = Reader::from(&data as &[u8]);
+
+        reader.advance(1).unwrap();
+        let mut data_ref = reader.as_data_ref(4).unwrap().read();
+
+        reader.advance(2).unwrap();
+
+        // The data_ref should read from the offset from where it was created 
+        let mut output = vec![];
+        data_ref.read_to_end(&mut output).unwrap();
+        assert_eq!(output, [2, 3, 4, 5]);
+
+        // Reading the data_ref should not affect the original reader
         assert_eq!(reader.get_u8().unwrap(), 4);
     }
 }

--- a/packages/onenote-converter/parser-utils/src/reader.rs
+++ b/packages/onenote-converter/parser-utils/src/reader.rs
@@ -275,6 +275,11 @@ impl Read for ReaderFilePointer {
             return Ok(0);
         }
 
+        // Don't read past the end of the region:
+        let remaining = self.end_offset - offset;
+        let maximum_buf_len = buf.len().min(remaining as usize);
+        let buf = &mut buf[0..maximum_buf_len];
+
         let mut file = self.file.borrow_mut();
         let original_offset = file.seek(SeekFrom::Current(0))?;
         let read_result = (|| {

--- a/packages/onenote-converter/parser-utils/src/reader.rs
+++ b/packages/onenote-converter/parser-utils/src/reader.rs
@@ -261,6 +261,15 @@ pub enum ReaderDataRef {
     FilePointer(ReaderFilePointer),
 }
 
+impl ReaderDataRef {
+    pub fn read(&self) -> Result<Box<dyn Read>> {
+        match self {
+            ReaderDataRef::Vec(slice) => Ok(Box::new(Cursor::new(slice.to_vec()))),
+            ReaderDataRef::FilePointer(ptr) => Ok(Box::new(ptr.clone())),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct ReaderFilePointer {
     file: ReaderFileHandle,
@@ -295,15 +304,6 @@ impl Read for ReaderFilePointer {
                 Ok(size)
             }
             Err(err) => Err(err),
-        }
-    }
-}
-
-impl ReaderDataRef {
-    pub fn as_reader(&self) -> Result<Box<dyn Read>> {
-        match self {
-            ReaderDataRef::Vec(slice) => Ok(Box::new(Cursor::new(slice.to_vec()))),
-            ReaderDataRef::FilePointer(ptr) => Ok(Box::new(ptr.clone())),
         }
     }
 }

--- a/packages/onenote-converter/parser/src/onenote/embedded_file.rs
+++ b/packages/onenote-converter/parser/src/onenote/embedded_file.rs
@@ -48,7 +48,7 @@ impl EmbeddedFile {
     }
 
     /// A reader over the file's binary data.
-    pub fn reader(&self) -> Result<Box<dyn Read>> {
+    pub fn read(&self) -> Result<Box<dyn Read>> {
         self.data.read()
     }
 

--- a/packages/onenote-converter/parser/src/onenote/embedded_file.rs
+++ b/packages/onenote-converter/parser/src/onenote/embedded_file.rs
@@ -1,3 +1,5 @@
+use std::io::Read;
+
 use crate::one::property::file_type::FileType;
 use crate::one::property_set::{embedded_file_container, embedded_file_node};
 use crate::onenote::note_tag::{NoteTag, parse_note_tags};
@@ -45,9 +47,9 @@ impl EmbeddedFile {
         &self.file_type
     }
 
-    /// The file's binary data.
-    pub fn data(&self) -> Result<Vec<u8>> {
-        self.data.load()
+    /// A reader over the file's binary data.
+    pub fn reader(&self) -> Result<Box<dyn Read>> {
+        self.data.read()
     }
 
     /// The max width of the embedded file's icon in half-inch increments.

--- a/packages/onenote-converter/parser/src/onenote/image.rs
+++ b/packages/onenote-converter/parser/src/onenote/image.rs
@@ -1,3 +1,5 @@
+use std::io::Read;
+
 use crate::one::property::layout_alignment::LayoutAlignment;
 use crate::one::property_set::{image_node, picture_container};
 use crate::onenote::iframe::{IFrame, parse_iframe};
@@ -49,11 +51,11 @@ pub struct Image {
 }
 
 impl Image {
-    /// The image's binary data.
+    /// Reads the image's binary data.
     ///
     /// If `None` this means that the image data hasn't been uploaded yet.
-    pub fn data(&self) -> Result<Option<Vec<u8>>> {
-        self.data.as_ref().map(|data| data.load()).transpose()
+    pub fn read(&self) -> Result<Option<Box<dyn Read>>> {
+        self.data.as_ref().map(|data| data.read()).transpose()
     }
 
     /// The image's file extension.

--- a/packages/onenote-converter/parser/src/shared/file_data_ref.rs
+++ b/packages/onenote-converter/parser/src/shared/file_data_ref.rs
@@ -31,7 +31,7 @@ impl FileDataLoader for Vec<u8> {
 
 impl FileDataLoader for ReaderDataRef {
     fn read(&self) -> Result<Box<dyn Read>> {
-        ReaderDataRef::read(self)
+        Ok(ReaderDataRef::read(self))
     }
 }
 

--- a/packages/onenote-converter/parser/src/shared/file_data_ref.rs
+++ b/packages/onenote-converter/parser/src/shared/file_data_ref.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::io::{Cursor, Read};
 use std::rc::Rc;
 
 use parser_utils::Result;
@@ -19,18 +20,18 @@ impl PartialEq for FileBlob {
 }
 
 pub trait FileDataLoader {
-    fn load(&self) -> Result<Vec<u8>>;
+    fn read(&self) -> Result<Box<dyn Read>>;
 }
 
 impl FileDataLoader for Vec<u8> {
-    fn load(&self) -> Result<Vec<u8>> {
-        Ok(self.clone())
+    fn read(&self) -> Result<Box<dyn Read>> {
+        Ok(Box::new(Cursor::new(self.clone())))
     }
 }
 
 impl FileDataLoader for ReaderDataRef {
-    fn load(&self) -> Result<Vec<u8>> {
-        self.bytes()
+    fn read(&self) -> Result<Box<dyn Read>> {
+        ReaderDataRef::as_reader(&self)
     }
 }
 
@@ -61,7 +62,7 @@ impl FileBlob {
         self.size
     }
 
-    pub fn load(&self) -> Result<Vec<u8>> {
-        self.loader.load()
+    pub fn read(&self) -> Result<Box<dyn Read>> {
+        self.loader.read()
     }
 }

--- a/packages/onenote-converter/parser/src/shared/file_data_ref.rs
+++ b/packages/onenote-converter/parser/src/shared/file_data_ref.rs
@@ -31,7 +31,7 @@ impl FileDataLoader for Vec<u8> {
 
 impl FileDataLoader for ReaderDataRef {
     fn read(&self) -> Result<Box<dyn Read>> {
-        ReaderDataRef::as_reader(self)
+        ReaderDataRef::read(self)
     }
 }
 

--- a/packages/onenote-converter/parser/src/shared/file_data_ref.rs
+++ b/packages/onenote-converter/parser/src/shared/file_data_ref.rs
@@ -31,7 +31,7 @@ impl FileDataLoader for Vec<u8> {
 
 impl FileDataLoader for ReaderDataRef {
     fn read(&self) -> Result<Box<dyn Read>> {
-        ReaderDataRef::as_reader(&self)
+        ReaderDataRef::as_reader(self)
     }
 }
 

--- a/packages/onenote-converter/renderer/src/page/embedded_file.rs
+++ b/packages/onenote-converter/renderer/src/page/embedded_file.rs
@@ -15,7 +15,7 @@ impl<'a> Renderer<'a> {
         let path = fs_driver().join(&self.output, &filename);
 
         log!("Rendering embedded file: {:?}", path);
-        let mut reader = file.reader()?;
+        let mut reader = file.read()?;
         fs_driver().stream_to_file(&path, &mut reader)?;
 
         let mut styles = StyleSet::new();

--- a/packages/onenote-converter/renderer/src/page/embedded_file.rs
+++ b/packages/onenote-converter/renderer/src/page/embedded_file.rs
@@ -13,8 +13,10 @@ impl<'a> Renderer<'a> {
             .section
             .to_unique_safe_filename(&self.output, file.filename())?;
         let path = fs_driver().join(&self.output, &filename);
+
         log!("Rendering embedded file: {:?}", path);
-        fs_driver().write_file(&path, &file.data()?)?;
+        let mut reader = file.reader()?;
+        fs_driver().stream_to_file(&path, &mut reader)?;
 
         let mut styles = StyleSet::new();
         if let Some(offset_x_half_inches) = file.offset_horizontal() {

--- a/packages/onenote-converter/renderer/src/page/image.rs
+++ b/packages/onenote-converter/renderer/src/page/image.rs
@@ -95,7 +95,7 @@ impl<'a> Renderer<'a> {
 fn read_file_start(reader: &mut Box<dyn Read>) -> Result<Vec<u8>> {
     let size: usize = 1024;
     let mut sub_reader = reader.by_ref().take(size as u64);
-    let mut bytes = vec![0; size];
+    let mut bytes = Vec::with_capacity(size);
     sub_reader.read_to_end(&mut bytes)?;
     Ok(bytes)
 }

--- a/packages/onenote-converter/renderer/src/page/image.rs
+++ b/packages/onenote-converter/renderer/src/page/image.rs
@@ -1,3 +1,5 @@
+use std::io::{ Cursor, Read };
+
 use crate::page::Renderer;
 use crate::utils::{AttributeSet, StyleSet, detect_png, px};
 use color_eyre::Result;
@@ -8,11 +10,16 @@ impl<'a> Renderer<'a> {
     pub(crate) fn render_image(&mut self, image: &Image) -> Result<String> {
         let mut content = String::new();
 
-        if let Some(data) = image.data()? {
-            let filename = self.determine_image_filename(image, &data)?;
+        if let Some(mut reader) = image.read()? {
+            let mut initial_bytes = vec![0;1024];
+            reader.read(&mut initial_bytes)?;
+
+            let filename = self.determine_image_filename(image, &initial_bytes)?;
             let path = fs_driver().join(&self.output, &filename);
             log!("Rendering image: {:?}", path);
-            fs_driver().write_file(&path, &data[..])?;
+
+            let mut reader = Cursor::new(initial_bytes).chain(reader);
+            fs_driver().stream_to_file(&path, &mut reader)?;
 
             let mut attrs = AttributeSet::new();
             let mut styles = StyleSet::new();

--- a/packages/onenote-converter/renderer/src/page/image.rs
+++ b/packages/onenote-converter/renderer/src/page/image.rs
@@ -11,8 +11,14 @@ impl<'a> Renderer<'a> {
         let mut content = String::new();
 
         if let Some(mut reader) = image.read()? {
-            let mut initial_bytes = vec![0; 1024];
-            reader.read(&mut initial_bytes)?;
+            // Read up to the first kilobyte so that determine_image_filename can do
+            // file type detection
+            let initial_bytes = {
+                let mut bytes = vec![0; 1024];
+                let read_length = reader.read(&mut bytes)?;
+                bytes.resize(read_length, 0);
+                bytes
+            };
 
             let filename = self.determine_image_filename(image, &initial_bytes)?;
             let path = fs_driver().join(&self.output, &filename);

--- a/packages/onenote-converter/renderer/src/page/image.rs
+++ b/packages/onenote-converter/renderer/src/page/image.rs
@@ -1,4 +1,4 @@
-use std::io::{ Cursor, Read };
+use std::io::{Cursor, Read};
 
 use crate::page::Renderer;
 use crate::utils::{AttributeSet, StyleSet, detect_png, px};
@@ -11,7 +11,7 @@ impl<'a> Renderer<'a> {
         let mut content = String::new();
 
         if let Some(mut reader) = image.read()? {
-            let mut initial_bytes = vec![0;1024];
+            let mut initial_bytes = vec![0; 1024];
             reader.read(&mut initial_bytes)?;
 
             let filename = self.determine_image_filename(image, &initial_bytes)?;

--- a/packages/onenote-converter/renderer/src/page/image.rs
+++ b/packages/onenote-converter/renderer/src/page/image.rs
@@ -13,18 +13,14 @@ impl<'a> Renderer<'a> {
         if let Some(mut reader) = image.read()? {
             // Read up to the first kilobyte so that determine_image_filename can do
             // file type detection
-            let initial_bytes = {
-                let mut bytes = vec![0; 1024];
-                let read_length = reader.read(&mut bytes)?;
-                bytes.resize(read_length, 0);
-                bytes
-            };
+            let image_start_bytes = read_file_start(&mut reader)?;
 
-            let filename = self.determine_image_filename(image, &initial_bytes)?;
+            let filename = self.determine_image_filename(image, &image_start_bytes)?;
             let path = fs_driver().join(&self.output, &filename);
             log!("Rendering image: {:?}", path);
 
-            let mut reader = Cursor::new(initial_bytes).chain(reader);
+            // Rebuild the reader so that the image start bytes are included in the file
+            let mut reader = Cursor::new(image_start_bytes).chain(reader);
             fs_driver().stream_to_file(&path, &mut reader)?;
 
             let mut attrs = AttributeSet::new();
@@ -94,4 +90,12 @@ impl<'a> Renderer<'a> {
             .to_unique_safe_filename(&self.output, &format!("image{}", ext))?;
         Ok(filename)
     }
+}
+
+fn read_file_start(reader: &mut Box<dyn Read>) -> Result<Vec<u8>> {
+    let size: usize = 1024;
+    let mut sub_reader = reader.by_ref().take(size as u64);
+    let mut bytes = vec![0; size];
+    sub_reader.read_to_end(&mut bytes)?;
+    Ok(bytes)
 }

--- a/packages/onenote-converter/renderer/tests/convert.rs
+++ b/packages/onenote-converter/renderer/tests/convert.rs
@@ -151,4 +151,10 @@ fn convert_printout() {
         rendered_file.contains("<img src=\"test4_1.pdf.png\""),
         "should import as a PNG"
     );
+
+    // Should correctly create the PNG
+    let png_data = fs::read(output_dir.join("Printout").join("test4_1.pdf.png"))
+        .expect("should read the PNG");
+    assert_eq!(png_data[0..4], [0x89, 0x50, 0x4E, 0x47], "PNG should have the correct initial bytes");
+    assert_eq!(png_data.len(), 14_005, "PNG should have the correct byte length");
 }

--- a/packages/onenote-converter/renderer/tests/convert.rs
+++ b/packages/onenote-converter/renderer/tests/convert.rs
@@ -153,8 +153,16 @@ fn convert_printout() {
     );
 
     // Should correctly create the PNG
-    let png_data = fs::read(output_dir.join("Printout").join("test4_1.pdf.png"))
-        .expect("should read the PNG");
-    assert_eq!(png_data[0..4], [0x89, 0x50, 0x4E, 0x47], "PNG should have the correct initial bytes");
-    assert_eq!(png_data.len(), 14_005, "PNG should have the correct byte length");
+    let png_data =
+        fs::read(output_dir.join("Printout").join("test4_1.pdf.png")).expect("should read the PNG");
+    assert_eq!(
+        png_data[0..4],
+        [0x89, 0x50, 0x4E, 0x47],
+        "PNG should have the correct initial bytes"
+    );
+    assert_eq!(
+        png_data.len(),
+        14_005,
+        "PNG should have the correct byte length"
+    );
 }


### PR DESCRIPTION
# Problem

`.one` files with large (e.g. multi-gigabyte) attachments failed to import. Previously, the `onenote-converter` package loaded full attachments into memory before writing them to disk.

# Solution

Read attachments in chunks.

Follow-up to https://github.com/laurent22/joplin/pull/15117.

# Testing

1. Attach a large (2.5-ish GiB) file to a note within OneNote.
2. Export the page containing the note to a `.one` file.
3. Import the `.one` file from Joplin.
4. Verify that Joplin imports the note successfully.


| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/0789ed51-9ad9-45f1-ac88-44f747b2b705"/> | <video src="https://github.com/user-attachments/assets/2a8c762a-187d-4ec3-a22d-1ea0a0509475"/> |




<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->