### PR TITLE
Desktop: Fixes #15194: Fix positioning of nested ink containers

### DIFF
--- a/packages/onenote-converter/renderer/src/page/content.rs
+++ b/packages/onenote-converter/renderer/src/page/content.rs
@@ -7,7 +7,7 @@ use parser::contents::Content;
 impl<'a> Renderer<'a> {
     pub(crate) fn render_contents(&mut self, contents: &[Content]) -> Result<String> {
         let mut result = vec![];
-        let mut ink_builder = InkBuilder::new(false);
+        let mut ink_builder = InkBuilder::new(true);
 
         for content in contents {
             if !matches!(content, Content::Ink(_)) {

--- a/packages/onenote-converter/renderer/src/page/ink.rs
+++ b/packages/onenote-converter/renderer/src/page/ink.rs
@@ -126,7 +126,7 @@ impl InkBuilder {
 
         // The size of previous embedded ink determines the position of the next
         if self.embedded {
-            self.offset = (self.offset.0 + width_px, self.offset.1);
+            self.offset = (self.offset.0 + display_size_px.0, self.offset.1);
         }
     }
 

--- a/packages/onenote-converter/renderer/src/page/ink.rs
+++ b/packages/onenote-converter/renderer/src/page/ink.rs
@@ -11,18 +11,14 @@ struct InkPart {
 
     /// Size of the ink
     content_size_px: Vec2,
-    /// x/y position of the element containing the ink
-    content_offset_px: Vec2,
     /// Size of the element containing the ink
     display_size_px: Vec2,
-    /// Ofset of the original bounding box for the element
-    display_offset_px: Vec2,
+    /// x/y position of the element containing the ink
+    offset_px: Vec2,
 }
 
 pub(crate) struct InkBuilder {
     parts: Vec<InkPart>,
-
-    offset: Vec2,
     embedded: bool,
 }
 
@@ -32,14 +28,12 @@ impl InkBuilder {
     pub(crate) fn new(embedded: bool) -> Self {
         Self {
             parts: vec![],
-            offset: (0.0, 0.0),
             embedded,
         }
     }
 
     fn reset(&mut self) {
         self.parts.clear();
-        self.offset = (0.0, 0.0);
     }
 
     pub(crate) fn push(&mut self, ink: &Ink, display_bounding_box: Option<&InkBoundingBox>) {
@@ -95,20 +89,8 @@ impl InkBuilder {
         let display_y_min = display_bounding_box.map(|bb| bb.y()).unwrap_or_default();
         let display_x_min = display_bounding_box.map(|bb| bb.x()).unwrap_or_default();
 
-        let top_px = (y_min - display_y_min) / Self::SVG_SCALING_FACTOR
-            + offset_vertical * 48.0
-            + self.offset.1;
-        let left_px = (x_min - display_x_min) / Self::SVG_SCALING_FACTOR
-            + offset_horizontal * 48.0
-            + self.offset.0;
-
-        let display_offset_px = if let Some(ink_bbox) = display_bounding_box {
-            let display_offset_x = ink_bbox.x() / Self::SVG_SCALING_FACTOR;
-            let display_offset_y = ink_bbox.y() / Self::SVG_SCALING_FACTOR;
-            (display_offset_x, display_offset_y)
-        } else {
-            (left_px, top_px)
-        };
+        let top_px = (y_min - display_y_min) / Self::SVG_SCALING_FACTOR + offset_vertical * 48.0;
+        let left_px = (x_min - display_x_min) / Self::SVG_SCALING_FACTOR + offset_horizontal * 48.0;
 
         let translate = (
             left_px * Self::SVG_SCALING_FACTOR - x_min,
@@ -118,16 +100,10 @@ impl InkBuilder {
         let path = self.render_ink_path(strokes, scale, translate);
         self.parts.push(InkPart {
             content: path,
-            content_offset_px: (left_px, top_px),
             content_size_px: (width_px, height_px),
-            display_offset_px,
             display_size_px,
-        });
-
-        // The size of previous embedded ink determines the position of the next
-        if self.embedded {
-            self.offset = (self.offset.0 + display_size_px.0, self.offset.1);
-        }
+            offset_px: (left_px, top_px),
+        })
     }
 
     pub(crate) fn finish(&mut self) -> String {
@@ -145,33 +121,25 @@ impl InkBuilder {
         let path = self.parts.iter().map(|part| &part.content).join("");
 
         let (offset, content_size, display_size) = {
-            let mut min_content = (f32::INFINITY, f32::INFINITY);
-            let mut min_display = (f32::INFINITY, f32::INFINITY);
+            let mut offset = (f32::INFINITY, f32::INFINITY);
             let mut max_content = (f32::NEG_INFINITY, f32::NEG_INFINITY);
             let mut max_display = (f32::NEG_INFINITY, f32::NEG_INFINITY);
 
             for item in self.parts.iter() {
-                let item_offset = item.content_offset_px;
+                let item_offset = item.offset_px;
 
-                min_content.0 = min_content.0.min(item_offset.0);
-                min_content.1 = min_content.1.min(item_offset.1);
-                min_display.0 = min_display.0.min(item.display_offset_px.0);
-                min_display.1 = min_display.1.min(item.display_offset_px.1);
-
+                offset.0 = offset.0.min(item_offset.0);
+                offset.1 = offset.1.min(item_offset.1);
                 max_content.0 = max_content.0.max(item_offset.0 + item.content_size_px.0);
                 max_content.1 = max_content.1.max(item_offset.1 + item.content_size_px.1);
-                max_display.0 = max_display
-                    .0
-                    .max(item.display_offset_px.0 + item.display_size_px.0);
-                max_display.1 = max_display
-                    .1
-                    .max(item.display_offset_px.1 + item.display_size_px.1);
+                max_display.0 = max_display.0.max(item_offset.0 + item.display_size_px.0);
+                max_display.1 = max_display.1.max(item_offset.1 + item.display_size_px.1);
             }
 
-            let content_size = (max_content.0 - min_content.0, max_content.1 - min_content.1);
-            let display_size = (max_display.0 - min_display.0, max_display.1 - min_display.1);
+            let content_size = (max_content.0 - offset.0, max_content.1 - offset.1);
+            let display_size = (max_display.0 - offset.0, max_display.1 - offset.1);
 
-            (min_content, content_size, display_size)
+            (offset, content_size, display_size)
         };
 
         let offset = round_svg_vec(offset);

--- a/packages/onenote-converter/renderer/src/page/ink.rs
+++ b/packages/onenote-converter/renderer/src/page/ink.rs
@@ -11,10 +11,12 @@ struct InkPart {
 
     /// Size of the ink
     content_size_px: Vec2,
+    /// x/y position of the element containing the ink
+    content_offset_px: Vec2,
     /// Size of the element containing the ink
     display_size_px: Vec2,
-    /// x/y position of the element containing the ink
-    offset_px: Vec2,
+    /// Ofset of the original bounding box for the element
+    display_offset_px: Vec2,
 }
 
 pub(crate) struct InkBuilder {
@@ -93,8 +95,20 @@ impl InkBuilder {
         let display_y_min = display_bounding_box.map(|bb| bb.y()).unwrap_or_default();
         let display_x_min = display_bounding_box.map(|bb| bb.x()).unwrap_or_default();
 
-        let top_px = (y_min - display_y_min) / Self::SVG_SCALING_FACTOR + offset_vertical * 48.0 + self.offset.1;
-        let left_px = (x_min - display_x_min) / Self::SVG_SCALING_FACTOR + offset_horizontal * 48.0 + self.offset.0;
+        let top_px = (y_min - display_y_min) / Self::SVG_SCALING_FACTOR
+            + offset_vertical * 48.0
+            + self.offset.1;
+        let left_px = (x_min - display_x_min) / Self::SVG_SCALING_FACTOR
+            + offset_horizontal * 48.0
+            + self.offset.0;
+
+        let display_offset_px = if let Some(ink_bbox) = display_bounding_box {
+            let display_offset_x = ink_bbox.x() / Self::SVG_SCALING_FACTOR;
+            let display_offset_y = ink_bbox.y() / Self::SVG_SCALING_FACTOR;
+            (display_offset_x, display_offset_y)
+        } else {
+            (left_px, top_px)
+        };
 
         let translate = (
             left_px * Self::SVG_SCALING_FACTOR - x_min,
@@ -104,9 +118,10 @@ impl InkBuilder {
         let path = self.render_ink_path(strokes, scale, translate);
         self.parts.push(InkPart {
             content: path,
+            content_offset_px: (left_px, top_px),
             content_size_px: (width_px, height_px),
+            display_offset_px,
             display_size_px,
-            offset_px: (left_px, top_px),
         });
 
         // The size of previous embedded ink determines the position of the next
@@ -130,25 +145,33 @@ impl InkBuilder {
         let path = self.parts.iter().map(|part| &part.content).join("");
 
         let (offset, content_size, display_size) = {
-            let mut offset = (f32::INFINITY, f32::INFINITY);
+            let mut min_content = (f32::INFINITY, f32::INFINITY);
+            let mut min_display = (f32::INFINITY, f32::INFINITY);
             let mut max_content = (f32::NEG_INFINITY, f32::NEG_INFINITY);
             let mut max_display = (f32::NEG_INFINITY, f32::NEG_INFINITY);
 
             for item in self.parts.iter() {
-                let item_offset = item.offset_px;
+                let item_offset = item.content_offset_px;
 
-                offset.0 = offset.0.min(item_offset.0);
-                offset.1 = offset.1.min(item_offset.1);
+                min_content.0 = min_content.0.min(item_offset.0);
+                min_content.1 = min_content.1.min(item_offset.1);
+                min_display.0 = min_display.0.min(item.display_offset_px.0);
+                min_display.1 = min_display.1.min(item.display_offset_px.1);
+
                 max_content.0 = max_content.0.max(item_offset.0 + item.content_size_px.0);
                 max_content.1 = max_content.1.max(item_offset.1 + item.content_size_px.1);
-                max_display.0 = max_display.0.max(item_offset.0 + item.display_size_px.0);
-                max_display.1 = max_display.1.max(item_offset.1 + item.display_size_px.1);
+                max_display.0 = max_display
+                    .0
+                    .max(item.display_offset_px.0 + item.display_size_px.0);
+                max_display.1 = max_display
+                    .1
+                    .max(item.display_offset_px.1 + item.display_size_px.1);
             }
 
-            let content_size = (max_content.0 - offset.0, max_content.1 - offset.1);
-            let display_size = (max_display.0 - offset.0, max_display.1 - offset.1);
+            let content_size = (max_content.0 - min_content.0, max_content.1 - min_content.1);
+            let display_size = (max_display.0 - min_display.0, max_display.1 - min_display.1);
 
-            (offset, content_size, display_size)
+            (min_content, content_size, display_size)
         };
 
         let offset = round_svg_vec(offset);

--- a/packages/onenote-converter/renderer/src/page/ink.rs
+++ b/packages/onenote-converter/renderer/src/page/ink.rs
@@ -19,6 +19,8 @@ struct InkPart {
 
 pub(crate) struct InkBuilder {
     parts: Vec<InkPart>,
+
+    offset: Vec2,
     embedded: bool,
 }
 
@@ -28,12 +30,14 @@ impl InkBuilder {
     pub(crate) fn new(embedded: bool) -> Self {
         Self {
             parts: vec![],
+            offset: (0.0, 0.0),
             embedded,
         }
     }
 
     fn reset(&mut self) {
         self.parts.clear();
+        self.offset = (0.0, 0.0);
     }
 
     pub(crate) fn push(&mut self, ink: &Ink, display_bounding_box: Option<&InkBoundingBox>) {
@@ -89,8 +93,8 @@ impl InkBuilder {
         let display_y_min = display_bounding_box.map(|bb| bb.y()).unwrap_or_default();
         let display_x_min = display_bounding_box.map(|bb| bb.x()).unwrap_or_default();
 
-        let top_px = (y_min - display_y_min) / Self::SVG_SCALING_FACTOR + offset_vertical * 48.0;
-        let left_px = (x_min - display_x_min) / Self::SVG_SCALING_FACTOR + offset_horizontal * 48.0;
+        let top_px = (y_min - display_y_min) / Self::SVG_SCALING_FACTOR + offset_vertical * 48.0 + self.offset.1;
+        let left_px = (x_min - display_x_min) / Self::SVG_SCALING_FACTOR + offset_horizontal * 48.0 + self.offset.0;
 
         let translate = (
             left_px * Self::SVG_SCALING_FACTOR - x_min,
@@ -103,7 +107,12 @@ impl InkBuilder {
             content_size_px: (width_px, height_px),
             display_size_px,
             offset_px: (left_px, top_px),
-        })
+        });
+
+        // The size of previous embedded ink determines the position of the next
+        if self.embedded {
+            self.offset = (self.offset.0 + width_px, self.offset.1);
+        }
     }
 
     pub(crate) fn finish(&mut self) -> String {


### PR DESCRIPTION
# Problem

Nested ink containers were positioned incorrectly when imported into Joplin.

See #15194.

# Solution

Import ink within outline elements as embedded ink.

# Testing

With this change, the 1s and 0s in #15194 that were previously mispositioned are now imported correctly:
|Before|After|
|------|-----|
|<img width="853" height="674" alt="table of 1s and 0s has several misplaced numbers" src="https://github.com/user-attachments/assets/497e834f-bf65-4aec-8ca0-e70013ebf0d9" />| <img width="853" height="674" alt="previously-misplaced numbers are shown in the correct rows" src="https://github.com/user-attachments/assets/d8a566b3-ce42-4342-9f39-b958e6e02996" /> |


This also fixes an ink positioning issue mentioned in https://github.com/laurent22/joplin/pull/15178 (from the test notebook provided in [comment](https://github.com/laurent22/joplin/issues/14211#issuecomment-3828805793)):
| Before | After |
|--------|-------|
| <img width="448" height="277" alt="screenshot: 'h' in 'homophony' is vertically offset, 'tal' in 'total' is offset" src="https://github.com/user-attachments/assets/cb02416f-081b-47f2-bcaa-49bb32980c95" /> | <img width="311" height="269" alt="screenshot: total and homophony are rendered correctly" src="https://github.com/user-attachments/assets/e17119e0-ef20-4726-be1e-9766882ef70e" /> |



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->