### PR TITLE
Desktop: Importing from OneNote: Convert an ink-related import error to a warning

### DIFF
--- a/packages/onenote-converter/parser/src/one/property_set/ink_data_node.rs
+++ b/packages/onenote-converter/parser/src/one/property_set/ink_data_node.rs
@@ -3,7 +3,8 @@ use crate::one::property::{PropertyType, simple};
 use crate::one::property_set::PropertySetId;
 use crate::onestore::object::Object;
 use crate::shared::exguid::ExGuid;
-use parser_utils::errors::{ErrorKind, Result};
+use parser_utils::errors::Result;
+use parser_utils::log_warn;
 
 /// An ink data container.
 pub(crate) struct Data {
@@ -17,9 +18,10 @@ pub(crate) fn parse(object: &Object) -> Result<Data> {
     }
 
     let strokes =
-        ObjectReference::parse_vec(PropertyType::InkStrokes, object)?.ok_or_else(|| {
-            ErrorKind::MalformedOneNoteFileData("ink data node has no strokes".into())
-        })?;
+        ObjectReference::parse_vec(PropertyType::InkStrokes, object)?.unwrap_or_else(|| {
+            log_warn!("ink data node {:?} has no strokes", object.id());
+            vec![]
+        });
     let bounding_box = simple::parse_vec_i32(PropertyType::InkBoundingBox, object)?
         .filter(|values| values.len() == 4)
         .map(|values| [values[0], values[1], values[2], values[3]]);

--- a/packages/onenote-converter/parser/src/one/property_set/ink_data_node.rs
+++ b/packages/onenote-converter/parser/src/one/property_set/ink_data_node.rs
@@ -19,6 +19,8 @@ pub(crate) fn parse(object: &Object) -> Result<Data> {
 
     let strokes =
         ObjectReference::parse_vec(PropertyType::InkStrokes, object)?.unwrap_or_else(|| {
+            // It seems to be possible for an InkDataNode to have no associated InkStrokes object.
+            // See https://discourse.joplinapp.org/t/error-importing-notes-from-onenote/49671
             log_warn!("ink data node {:?} has no strokes", object.id());
             vec![]
         });


### PR DESCRIPTION
# Problem

A user has reported that it's possible to trigger the `ink data node has no strokes` error [on the Joplin forum](https://discourse.joplinapp.org/t/error-importing-notes-from-onenote/49671). Either:
1. There's a bug in the parser or ID resolution logic that prevents Joplin from finding the ink data node, or
2. It's possible for an ink data node to have no associated `InkStrokes` object.

(At the time of this writing, no test `.one` file has been provided).

# Solution

Convert the error to a warning: This pull request assumes that this isn't caused by a bug in the parser and that OneNote can create ink data nodes with no `InkStrokes` objects.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->