### PR TITLE
Mobile: Add notebook sort options in config screen

### DIFF
--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -153,7 +153,7 @@ const generalMiddleware = (store: any) => (next: any) => async (action: any) => 
 
 	const result = next(action);
 	const newState: AppState = store.getState();
-	let doRefreshFolders = false;
+	let doRefreshFolders: boolean | string = false;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	await reduxSharedMiddleware(store, next, action, storeDispatch as any);
@@ -248,9 +248,17 @@ const generalMiddleware = (store: any) => (next: any) => async (action: any) => 
 		Setting.setValue('noteVisiblePanes', newState.noteVisiblePanes);
 	}
 
+	if (action.type === 'SETTING_UPDATE_ONE' && action.key.indexOf('folders.sortOrder') === 0) {
+		doRefreshFolders = 'now';
+	}
+
 	if (doRefreshFolders) {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		await scheduleRefreshFolders((action: any) => storeDispatch(action), newState.selectedFolderId);
+		if (doRefreshFolders === 'now') {
+			await refreshFolders(storeDispatch, newState.selectedFolderId);
+		} else {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			await scheduleRefreshFolders((action: any) => storeDispatch(action), newState.selectedFolderId);
+		}
 	}
 
 	return result;

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -312,12 +312,6 @@ const buildStartupTasks = (
 			Setting.setValue('welcome.enabled', false);
 		}
 
-		// Note: for now we hard-code the folder sort order as we need to
-		// create a UI to allow customisation (started in branch mobile_add_sidebar_buttons)
-		Setting.setValue('folders.sortOrder.field', 'title');
-		Setting.setValue('folders.sortOrder.reverse', false);
-
-
 		reg.logger().info(`Sync target: ${Setting.value('sync.target')}`);
 
 		setLocale(Setting.value('locale'));

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1390,7 +1390,7 @@ class Setting extends BaseModel {
 		// TODO: This is currently specific to the mobile app
 		const sectionNameToSummary: Record<string, string> = {
 			'general': _('Language, date format'),
-			'appearance': _('Themes'),
+			'appearance': _('Themes, notebook sort order'),
 			'sync': _('Sync, encryption, proxy'),
 			'joplinCloud': _('Email To Note, login information'),
 			'editor': _('Typography, spellcheck, layout'),

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -907,7 +907,8 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			type: SettingItemType.String,
 			isEnum: true,
 			public: true,
-			appTypes: [AppType.Cli],
+			appTypes: [AppType.Cli, AppType.Mobile],
+			section: 'appearance',
 			label: () => _('Sort notebooks by'),
 			options: () => {
 				const Folder = require('../Folder').default;
@@ -921,7 +922,24 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			},
 			storage: SettingStorage.File,
 		},
-		'folders.sortOrder.reverse': { value: false, type: SettingItemType.Bool, storage: SettingStorage.File, isGlobal: true, public: true, label: () => _('Reverse sort order'), appTypes: [AppType.Cli] },
+		'folders.sortOrder.reverse': {
+			value: false,
+			type: SettingItemType.Bool,
+			storage: SettingStorage.File,
+			isGlobal: true,
+			public: true,
+			section: 'appearance',
+			label: () => {
+				if (mobilePlatform) {
+					// For config screen on mobile, there is no sections for notebooks
+					// Explicitly mark it as an option for notebook order
+					return _('Reverse notebook sort order');
+				} else {
+					return _('Reverse sort order');
+				}
+			},
+			appTypes: [AppType.Cli, AppType.Mobile],
+		},
 		trackLocation: { value: true, type: SettingItemType.Bool, section: 'note', storage: SettingStorage.File, isGlobal: true, public: true, label: () => _('Save geo-location with notes') },
 
 		'editor.usePlainText': {


### PR DESCRIPTION
Users cannot change the sort behaviors of notebooks on mobile, so I added `Sort notebooks by` and `Reverse notebook sort order` in the `Appearance` config section for `folders.sortOrder.field` and `folders.sortOrder.reverse`.

The comments in `packages/app-mobile/utils/buildStartupTasks.ts` shows these UI items should be added in sidebar, but I cannot find the git branch mention in them, so I guess they are deprecated.
https://github.com/laurent22/joplin/blob/0492849066292acf17905d4cfa702fea16e5aae6/packages/app-mobile/utils/buildStartupTasks.ts#L315-L316

Changes in `packages/app-mobile/root.tsx` are copied from `packages/lib/BaseApplication.ts` with necessary modifications to make the changes take effect in time.
https://github.com/laurent22/joplin/blob/0492849066292acf17905d4cfa702fea16e5aae6/packages/lib/BaseApplication.ts#L571-L576

I changed the text of `folders.sortOrder.field` from `Reverse sort order` to `Reverse notebook sort order` on mobile, because there are other config items in the `Appearance` section.