### PR TITLE
Android: Fixes #15205: Fix images fail to be resized

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -870,7 +870,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 				outputPath: targetPath,
 				maxWidth: dimensions.width,
 				maxHeight: dimensions.height,
-				quality: 85,
+				quality: 0.85,
 				format: mimeType === 'image/png' ? 'PNG' : 'JPEG',
 			});
 			return true;

--- a/packages/app-mobile/utils/image/resizeImage.ts
+++ b/packages/app-mobile/utils/image/resizeImage.ts
@@ -15,6 +15,7 @@ interface Options {
 	maxWidth: number;
 	maxHeight: number;
 	format: OutputFormat;
+	// A number from 0 to 100, where 100 is least compressed.
 	quality: number;
 }
 

--- a/packages/app-mobile/utils/image/resizeImage.ts
+++ b/packages/app-mobile/utils/image/resizeImage.ts
@@ -78,7 +78,7 @@ const resizeImage = async (options: Options) => {
 		const final = await context.renderAsync();
 		const saved = await final.saveAsync({
 			format: options.format === 'PNG' ? SaveFormat.PNG : SaveFormat.JPEG,
-			compress: options.quality,
+			compress: options.quality / 100,
 		});
 
 		const resizedImagePath = saved.uri;

--- a/packages/app-mobile/utils/image/resizeImage.ts
+++ b/packages/app-mobile/utils/image/resizeImage.ts
@@ -15,7 +15,7 @@ interface Options {
 	maxWidth: number;
 	maxHeight: number;
 	format: OutputFormat;
-	// A number from 0 to 100, where 100 is least compressed.
+	// A number from 0 to 1, where 1 is least compressed.
 	quality: number;
 }
 
@@ -79,7 +79,7 @@ const resizeImage = async (options: Options) => {
 		const final = await context.renderAsync();
 		const saved = await final.saveAsync({
 			format: options.format === 'PNG' ? SaveFormat.PNG : SaveFormat.JPEG,
-			compress: options.quality / 100,
+			compress: options.quality,
 		});
 
 		const resizedImagePath = saved.uri;


### PR DESCRIPTION
# Problem

Images failed to resize because of an invalid parameter value in `resizeImage`. `compress` was set to 85 but *should* range from 0 to 1 (per the Expo [documentation](https://docs.expo.dev/versions/latest/sdk/imagemanipulator/#saveoptions)).

# Solution

Set `quality` to 0.85, rather than 85.

**Note**: The [`.toBlob`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob) API used on web also seems to expect a quality from 0 to 1. It was also provided 85.

Fixes #15205.

# Testing

Android 16 emulator:
1. Open an existing note.
2. Click "Attach", then "Attach file".
3. Choose a large image.
4. Verify that the "You are about to attach a large image" dialog is shown.
5. Click "Yes".
6. Verify that the image has been attached.

Web (MacOS/Chromium):
1. Open a note.
2. Take a screenshot of the entire screen.
3. Save the screenshot, then copy-paste it into Joplin.
4. Verify that the "You are about to attach a large image" dialog is shown.
5. Click "Yes".
6. Verify that the image attaches to the note successfully.
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->