### PR TITLE
Fixed a bug about using relative addresses as profile paths, which resulted in KaTeX's original text being displayed on the right side

### DIFF
--- a/packages/lib/determineBaseAppDirs.ts
+++ b/packages/lib/determineBaseAppDirs.ts
@@ -1,12 +1,18 @@
 import { homedir } from 'os';
 import { toSystemSlashes } from './path-utils';
+import { dirname, isAbsolute } from 'path';
 
 export default (profileFromArgs: string, appName: string, altInstanceId: string) => {
 	let profileDir = '';
 	let homeDir = '';
 
 	if (profileFromArgs) {
-		profileDir = profileFromArgs;
+		if (isAbsolute(profileFromArgs)) {
+			profileDir = profileFromArgs;
+		}
+		else {
+			profileDir = `${dirname(process.execPath)}/${profileFromArgs}`;
+		}
 		homeDir = profileDir;
 	} else if (process && process.env && process.env.PORTABLE_EXECUTABLE_DIR) {
 		profileDir = `${process.env.PORTABLE_EXECUTABLE_DIR}/JoplinProfile`;

--- a/packages/lib/determineBaseAppDirs.ts
+++ b/packages/lib/determineBaseAppDirs.ts
@@ -9,8 +9,7 @@ export default (profileFromArgs: string, appName: string, altInstanceId: string)
 	if (profileFromArgs) {
 		if (isAbsolute(profileFromArgs)) {
 			profileDir = profileFromArgs;
-		}
-		else {
+		} else {
 			profileDir = `${dirname(process.execPath)}/${profileFromArgs}`;
 		}
 		homeDir = profileDir;


### PR DESCRIPTION
Fixed a bug about using relative addresses as profile paths, which resulted in KaTeX's original text being displayed on the right side