### PR TITLE
Desktop: Replace disable-confirm dialog(smalltalk dialog) with styled <Dialog> for uniformity

### DIFF
--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -58,6 +58,14 @@ export const EncryptionConfigScreen = (props: Props) => {
 	const disablePromptPromiseRef = useRef<(value: boolean)=> void>(null);
 	const promptPromiseRef = useRef<(password: string | null)=> void>(null);
 
+	// Cleanup on unmount to resolve pending promises if the user navigates away
+	useEffect(() => {
+		return () => {
+			if (disablePromptPromiseRef.current) disablePromptPromiseRef.current(false);
+			if (promptPromiseRef.current) promptPromiseRef.current(null);
+		};
+	}, []);
+
 	const wasMasterPasswordDialogOpen = useRef(props.masterPasswordDialogOpen);
 
 	const theme = useMemo(() => {

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -40,6 +40,15 @@ interface Props {
 	masterPasswordDialogOpen: boolean;
 }
 
+interface EncryptionDialogOptions{
+	className: string;
+	title: string;
+	content: React.ReactNode;
+	onClose: ()=> void;
+	onDialogButtonRowClick: (event: { buttonName: string })=> void;
+	okButtonDisabled?: boolean;
+}
+
 export const EncryptionConfigScreen = (props: Props) => {
 	const { inputPasswords, onInputPasswordChange } = useInputPasswords(props.passwords);
 	const [pendingEnableEncryption, setPendingEnableEncryption] = useState(false);
@@ -290,6 +299,24 @@ export const EncryptionConfigScreen = (props: Props) => {
 		}
 	}, [props.dispatch, props.masterPassword, props.masterPasswordDialogOpen]);
 
+	const renderEncryptionDialog = (options: EncryptionDialogOptions) => {
+		return (
+			<Dialog onCancel={options.onClose} className={options.className}>
+				<div className='dialog-root'>
+					<DialogTitle title={options.title}/>
+					<div className='dialog-content'>
+						{options.content}
+					</div>
+					<DialogButtonRow
+						themeId={props.themeId}
+						onClick={options.onDialogButtonRowClick}
+						okButtonDisabled={options.okButtonDisabled ?? false}
+					/>
+				</div>
+			</Dialog>
+		);
+	};
+
 	const renderEnableEncryptionDialog = () => {
 		if (!enableEncryptionPromptVisible) return null;
 
@@ -320,31 +347,28 @@ export const EncryptionConfigScreen = (props: Props) => {
 			setEnableEncryptionPassword(event.target.value);
 		};
 
-		return (
-			<Dialog onCancel={onClose} className="enable-encryption-dialog">
-				<div className="dialog-root">
-					<DialogTitle title={_('Enable encryption')}/>
-					<div className="dialog-content">
-						<div style={{ marginBottom: 16 }}>
-							{messageComps}
-						</div>
-						<div style={{ marginBottom: 16 }}>
-							<label style={{ ...theme.textStyle, marginBottom: 5, display: 'block' }} htmlFor="enable-encryption-password">{_('Password:')}</label>
-							<PasswordInput
-								inputId="enable-encryption-password"
-								value={enableEncryptionPassword}
-								onChange={onPasswordInputChange}
-							/>
-						</div>
+		return renderEncryptionDialog({
+			className: 'enable-encryption-dialog',
+			title: _('Enable encryption'),
+			content: (
+				<>
+					<div style={{ marginBottom: 16 }}>
+						{messageComps}
 					</div>
-					<DialogButtonRow
-						themeId={props.themeId}
-						onClick={onDialogButtonRowClick}
-						okButtonDisabled={!enableEncryptionPassword}
-					/>
-				</div>
-			</Dialog>
-		);
+					<div style={{ marginBottom: 16 }}>
+						<label style={{ ...theme.textStyle, marginBottom: 5, display: 'block' }} htmlFor="enable-encryption-password">{_('Password:')}</label>
+						<PasswordInput
+							inputId="enable-encryption-password"
+							value={enableEncryptionPassword}
+							onChange={onPasswordInputChange}
+						/>
+					</div>
+				</>
+			),
+			onClose,
+			onDialogButtonRowClick,
+			okButtonDisabled: !enableEncryptionPassword,
+		});
 	};
 
 	const renderDisableEncryptionDialog = () => {
@@ -367,27 +391,19 @@ export const EncryptionConfigScreen = (props: Props) => {
 			}
 		};
 
-		return (
-			<Dialog
-				onCancel={onClose}
-				className="disable-encryption-dialog"
-			>
-				<div className="dialog-root">
-					<DialogTitle title={_('Disable encryption')} />
-					<div className="dialog-content">
-						<div style={{ marginBottom: 16 }}>
-							<p style={theme.textStyle}>
-								{_('Disabling encryption means *all* your notes and attachments are going to be re-synchronised and sent unencrypted to the sync target. Do you wish to continue?')}
-							</p>
-						</div>
-					</div>
-					<DialogButtonRow
-						themeId={props.themeId}
-						onClick={onDialogButtonRowClick}
-					/>
+		return renderEncryptionDialog({
+			className: 'disable-encryption-dialog',
+			title: _('Disable encryption'),
+			content: (
+				<div style={{ marginBottom: 16 }}>
+					<p style={theme.textStyle}>
+						{_('Disabling encryption means *all* your notes and attachments are going to be re-synchronised and sent unencrypted to the sync target. Do you wish to continue?')}
+					</p>
 				</div>
-			</Dialog>
-		);
+			),
+			onClose,
+			onDialogButtonRowClick,
+		});
 	};
 
 	const renderEncryptionSection = () => {

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -45,6 +45,8 @@ export const EncryptionConfigScreen = (props: Props) => {
 	const [pendingEnableEncryption, setPendingEnableEncryption] = useState(false);
 	const [enableEncryptionPromptVisible, setEnableEncryptionPromptVisible] = useState(false);
 	const [enableEncryptionPassword, setEnableEncryptionPassword] = useState('');
+	const [disableEncryptionPromptVisible, setDisableEncryptionPromptVisible] = useState(false);
+	const disablePromptPromiseRef = useRef<(value: boolean)=> void>(null);
 	const promptPromiseRef = useRef<(password: string | null)=> void>(null);
 
 	const wasMasterPasswordDialogOpen = useRef(props.masterPasswordDialogOpen);
@@ -246,7 +248,10 @@ export const EncryptionConfigScreen = (props: Props) => {
 		let newPassword: string | null = '';
 
 		if (isEnabled) {
-			const answer = await dialogs.confirm(_('Disabling encryption means *all* your notes and attachments are going to be re-synchronised and sent unencrypted to the sync target. Do you wish to continue?'));
+			setDisableEncryptionPromptVisible(true);
+			const answer = await new Promise<boolean>((resolve) => {
+				disablePromptPromiseRef.current = resolve;
+			});
 			if (!answer) return;
 		} else {
 			if (shouldOpenMasterPasswordDialogForEnable({
@@ -336,6 +341,49 @@ export const EncryptionConfigScreen = (props: Props) => {
 						themeId={props.themeId}
 						onClick={onDialogButtonRowClick}
 						okButtonDisabled={!enableEncryptionPassword}
+					/>
+				</div>
+			</Dialog>
+		);
+	};
+
+	const renderDisableEncryptionDialog = () => {
+		if (!disableEncryptionPromptVisible) return null;
+
+		const onClose = () => {
+			setDisableEncryptionPromptVisible(false);
+			if (disablePromptPromiseRef.current) disablePromptPromiseRef.current(false);
+		};
+
+		const onDialogButtonRowClick = (event: { buttonName: string }) => {
+			if (event.buttonName === 'cancel') {
+				onClose();
+				return;
+			}
+
+			if (event.buttonName === 'ok') {
+				setDisableEncryptionPromptVisible(false);
+				if (disablePromptPromiseRef.current) disablePromptPromiseRef.current(true);
+			}
+		};
+
+		return (
+			<Dialog
+				onCancel={onClose}
+				className="disable-encryption-dialog"
+			>
+				<div className="dialog-root">
+					<DialogTitle title={_('Disable encryption')} />
+					<div className="dialog-content">
+						<div style={{ marginBottom: 16 }}>
+							<p style={theme.textStyle}>
+								{_('Disabling encryption means *all* your notes and attachments are going to be re-synchronised and sent unencrypted to the sync target. Do you wish to continue?')}
+							</p>
+						</div>
+					</div>
+					<DialogButtonRow
+						themeId={props.themeId}
+						onClick={onDialogButtonRowClick}
 					/>
 				</div>
 			</Dialog>
@@ -523,6 +571,7 @@ export const EncryptionConfigScreen = (props: Props) => {
 			{renderNonExistingMasterKeysSection()}
 			{renderAdvancedSection()}
 			{renderEnableEncryptionDialog()}
+			{renderDisableEncryptionDialog()}
 		</div>
 	);
 };

--- a/packages/app-desktop/main.scss
+++ b/packages/app-desktop/main.scss
@@ -286,18 +286,18 @@ Component-specific classes
 	padding-bottom: 20px;
 }
 
-.master-password-dialog .dialog-root, .enable-encryption-dialog .dialog-root {
+.master-password-dialog .dialog-root, .enable-encryption-dialog .dialog-root, .disable-encryption-dialog .dialog-root {
 	min-width: 500px;
 	max-width: 600px;
 }
 
-.master-password-dialog .dialog-content, .enable-encryption-dialog .dialog-content {
+.master-password-dialog .dialog-content, .enable-encryption-dialog .dialog-content, .disable-encryption-dialog .dialog-content {
 	background-color: var(--joplin-background-color3);
 	padding: 1em;
 	padding-bottom: 1px;
 }
 
-.master-password-dialog .current-password-wrapper, .enable-encryption-dialog .current-password-wrapper {
+.master-password-dialog .current-password-wrapper, .enable-encryption-dialog .current-password-wrapper, .disable-encryption-dialog .current-password-wrapper {
 	display: flex;
 	flex-direction: row;
 	align-items: center;


### PR DESCRIPTION
### Description

This pull request addresses the UI uniformity on the Desktop Encryption Configuration screen, building upon the consensus from #14739 (*Desktop: Replace smalltalk with React Dialog to add password visibility in encryption setup*). 

As the Master Password and Enable Encryption prompts are updated to use standard React `<Dialog>` components, the "Disable encryption" confirmation was still triggering a legacy OS-level `dialogs.confirm(...)` alert. As discussed in the previous PR, this change brings that final piece into structural styling alignment.

**Changes made:**
- Removed the legacy `dialogs.confirm(...)` alert used when a user toggles encryption off.
- Built a new `renderDisableEncryptionDialog` function utilizing the exact same `<Dialog>` architecture and SCSS styling overrides as the `enable-encryption-dialog` to ensure perfect visual consistency and viewport centering.
- Correctly wired the asynchronous Promise resolution logic behind the "Ok" and "Cancel" buttons to safely intercept the toggle and correctly pass the disable state to the `EncryptionService` when confirmed.

### Testing strategy

1. Navigate to Settings -> Encryption (on Desktop).
2. Toggle encryption **off**.
3. Verify that the new styled `<Dialog>` appears cleanly in the center of the screen matching the Enable Encryption dialog design.
4. Verify that pressing "Cancel" safely dismisses the prompt without executing the disable logic.
5. Verify that pressing "Ok" successfully resolves the promise bounds, dismisses the UI, and proceeds to disable E2EE sync.


### Before:
<img width="1857" height="859" alt="Screenshot From 2026-04-29 15-35-40" src="https://github.com/user-attachments/assets/08e9f2b3-115d-4a2e-a8a2-43389d401b82" />


### After:
Dark-Mode:
<img width="1857" height="411" alt="Screenshot From 2026-04-29 15-32-50" src="https://github.com/user-attachments/assets/92f7a93c-32dd-497f-8fab-53684855fcff" />


Light Mode: 
<img width="1857" height="411" alt="Screenshot From 2026-04-29 15-33-09" src="https://github.com/user-attachments/assets/16474c07-24f8-4b3f-86a1-ee95f5539589" />



### Video to verify changes:

https://github.com/user-attachments/assets/41753a7c-9b51-4a29-9a9f-0815d03ecab7


