### PR TITLE
Desktop, CLI: Fix potential unresolved promise race conditions when scheduling the sync

### DIFF
--- a/packages/app-cli/app/command-share.ts
+++ b/packages/app-cli/app/command-share.ts
@@ -11,6 +11,7 @@ import Folder from '@joplin/lib/models/Folder';
 import invitationRespond from '@joplin/lib/services/share/invitationRespond';
 import CommandService from '@joplin/lib/services/CommandService';
 import { substrWithEllipsis } from '@joplin/lib/string-utils';
+import time from '@joplin/lib/time';
 
 const logger = Logger.create('command-share');
 
@@ -248,7 +249,8 @@ class Command extends BaseCommand {
 
 			logger.info('Unsharing folder', folder.id);
 			await ShareService.instance().unshareFolder(folder.id);
-			await reg.scheduleSync();
+			await time.sleep(10);
+			await reg.scheduleSync(0);
 		};
 
 		if (args.command === 'add' || args.command === 'remove' || args.command === 'delete') {

--- a/packages/app-cli/app/command-share.ts
+++ b/packages/app-cli/app/command-share.ts
@@ -248,7 +248,7 @@ class Command extends BaseCommand {
 
 			logger.info('Unsharing folder', folder.id);
 			await ShareService.instance().unshareFolder(folder.id);
-			await reg.scheduleSync(0);
+			await reg.waitForSyncFinishedThenSync();
 		};
 
 		if (args.command === 'add' || args.command === 'remove' || args.command === 'delete') {

--- a/packages/app-cli/app/command-share.ts
+++ b/packages/app-cli/app/command-share.ts
@@ -11,7 +11,6 @@ import Folder from '@joplin/lib/models/Folder';
 import invitationRespond from '@joplin/lib/services/share/invitationRespond';
 import CommandService from '@joplin/lib/services/CommandService';
 import { substrWithEllipsis } from '@joplin/lib/string-utils';
-import time from '@joplin/lib/time';
 
 const logger = Logger.create('command-share');
 
@@ -249,7 +248,6 @@ class Command extends BaseCommand {
 
 			logger.info('Unsharing folder', folder.id);
 			await ShareService.instance().unshareFolder(folder.id);
-			await time.msleep(reg.defaultScheduleInterval());
 			await reg.scheduleSync(0);
 		};
 

--- a/packages/app-cli/app/command-share.ts
+++ b/packages/app-cli/app/command-share.ts
@@ -249,7 +249,7 @@ class Command extends BaseCommand {
 
 			logger.info('Unsharing folder', folder.id);
 			await ShareService.instance().unshareFolder(folder.id);
-			await time.sleep(10);
+			await time.msleep(reg.defaultScheduleInterval());
 			await reg.scheduleSync(0);
 		};
 

--- a/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
@@ -12,6 +12,7 @@ import KvStore from '@joplin/lib/services/KvStore';
 import ShareService from '@joplin/lib/services/share/ShareService';
 import LabelledPasswordInput from '../PasswordInput/LabelledPasswordInput';
 import shim from '@joplin/lib/shim';
+import time from '@joplin/lib/time';
 
 interface Props {
 	themeId: number;
@@ -23,6 +24,11 @@ enum Mode {
 	Set = 1,
 	Reset = 2,
 }
+
+const syncAfterDefaultInterval = async () => {
+	await time.msleep(reg.defaultScheduleInterval());
+	await reg.waitForSyncFinishedThenSync();
+};
 
 export default function(props: Props) {
 	const [status, setStatus] = useState(MasterPasswordStatus.NotSet);
@@ -78,7 +84,8 @@ export default function(props: Props) {
 				} else {
 					throw new Error(`Unknown mode: ${mode}`);
 				}
-				void reg.waitForSyncFinishedThenSync(reg.defaultScheduleInterval());
+				// We need to defer the sync, as enabling encryption may take a few seconds to complete
+				void syncAfterDefaultInterval();
 				onClose();
 			} catch (error) {
 				void shim.showErrorDialog(error.message);

--- a/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
@@ -78,7 +78,7 @@ export default function(props: Props) {
 				} else {
 					throw new Error(`Unknown mode: ${mode}`);
 				}
-				void reg.waitForSyncFinishedThenSync(null);
+				void reg.waitForSyncFinishedThenSync(reg.defaultScheduleInterval());
 				onClose();
 			} catch (error) {
 				void shim.showErrorDialog(error.message);

--- a/packages/lib/registry.ts
+++ b/packages/lib/registry.ts
@@ -4,7 +4,6 @@ import shim from './shim';
 import SyncTargetRegistry from './SyncTargetRegistry';
 import { AnyAction, Dispatch } from 'redux';
 import Synchronizer from './Synchronizer';
-import time from './time';
 
 class Registry {
 
@@ -102,7 +101,7 @@ class Registry {
 	// This can be used when some data has been modified and we want to make
 	// sure it gets synced. So we wait for the current sync operation to
 	// finish (if one is running), then we trigger a sync just after.
-	public waitForSyncFinishedThenSync = async (delay = 0) => {
+	public waitForSyncFinishedThenSync = async () => {
 		if (!Setting.value('sync.target')) {
 			this.logger().info('waitForSyncFinishedThenSync - cancelling because no sync target is selected.');
 			return;
@@ -112,8 +111,6 @@ class Registry {
 		try {
 			const synchronizer = await this.syncTarget().synchronizer();
 			await synchronizer.waitForSyncToFinish();
-			if (delay) await time.msleep(delay);
-			// delay must be 0, otherwise if you await the function, the promise will never resolve if another sync is scheduled during the delay
 			await this.scheduleSync(0);
 		} finally {
 			this.waitForReSyncCalls_.pop();

--- a/packages/lib/registry.ts
+++ b/packages/lib/registry.ts
@@ -4,6 +4,7 @@ import shim from './shim';
 import SyncTargetRegistry from './SyncTargetRegistry';
 import { AnyAction, Dispatch } from 'redux';
 import Synchronizer from './Synchronizer';
+import time from './time';
 
 class Registry {
 
@@ -81,6 +82,10 @@ class Registry {
 		}
 	}
 
+	public defaultScheduleInterval() {
+		return 1000 * 10;
+	}
+
 	public syncTarget = (syncTargetId: number = null) => {
 		if (syncTargetId === null) syncTargetId = Setting.value('sync.target');
 		if (this.syncTargets_[syncTargetId]) return this.syncTargets_[syncTargetId];
@@ -97,7 +102,7 @@ class Registry {
 	// This can be used when some data has been modified and we want to make
 	// sure it gets synced. So we wait for the current sync operation to
 	// finish (if one is running), then we trigger a sync just after.
-	public waitForSyncFinishedThenSync = async (delay: number | null = 0) => {
+	public waitForSyncFinishedThenSync = async (delay = 0) => {
 		if (!Setting.value('sync.target')) {
 			this.logger().info('waitForSyncFinishedThenSync - cancelling because no sync target is selected.');
 			return;
@@ -107,7 +112,9 @@ class Registry {
 		try {
 			const synchronizer = await this.syncTarget().synchronizer();
 			await synchronizer.waitForSyncToFinish();
-			await this.scheduleSync(delay);
+			if (delay) await time.msleep(delay);
+			// delay must be 0, otherwise if you await the function, the promise will never resolve if another sync is scheduled during the delay
+			await this.scheduleSync(0);
 		} finally {
 			this.waitForReSyncCalls_.pop();
 		}
@@ -118,7 +125,7 @@ class Registry {
 		this.schedSyncCalls_.push(true);
 
 		try {
-			if (delay === null) delay = 1000 * 10;
+			if (delay === null) delay = this.defaultScheduleInterval();
 			if (syncOptions === null) syncOptions = {};
 
 			// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied


### PR DESCRIPTION
When using the Registry.scheduleSync function, the function uses debounce logic to prevent excessive data usage when typing continuously. The function may return a promise containing the Synchronizer context object, when the function is awaited. Where the delay is specified as 0, the promise will always be resolved when the function is awaited. However, when specifying a delay greater than 0, due to the debounce logic which clears the timeout, if another sync is scheduled during the delay, the promise will never resolve, meaning a function which awaits the scheduleSync call may get stuck waiting.

There are only 2 places which await the scheduleSync function, which are in the change added in https://github.com/laurent22/joplin/pull/15118, and when unsharing a notebook in the CLI. This PR amends those usages so that they will invoke scheduleSync without a delay, and instead do an explicit wait prior to making the call, or use waitForSyncFinishedThenSync instead in the case of unsharing, as the hardcoded delay is not necessary

### Testing

I have tested changing the master password in the desktop UI, ensuring it behaves as per existing behaviour

**See video:**

https://github.com/user-attachments/assets/77e5a6de-ce31-4bc1-b057-90e2a1ed5d91
