### PR TITLE
Mobile: Fix log screen auto-scroll loop when toggling errors

### DIFF
--- a/packages/app-mobile/components/screens/LogScreen.tsx
+++ b/packages/app-mobile/components/screens/LogScreen.tsx
@@ -163,6 +163,7 @@ class LogScreenComponent extends BaseScreenComponent<Props, State> {
 
 	private async refreshLogEntries(showErrorsOnly: boolean = null) {
 		if (showErrorsOnly === null) showErrorsOnly = this.state.showErrorsOnly;
+		const prevShowErrorsOnly = this.state.showErrorsOnly;
 
 		const limit = 1000;
 		const logEntries = await this.getLogEntries(showErrorsOnly, limit);
@@ -171,7 +172,7 @@ class LogScreenComponent extends BaseScreenComponent<Props, State> {
 			logEntries: logEntries,
 			showErrorsOnly: showErrorsOnly,
 		}, () => {
-			if (this.state.filter !== undefined) {
+			if (this.state.filter !== undefined || prevShowErrorsOnly !== showErrorsOnly) {
 				this.logListRef_.current?.scrollToOffset({ offset: 0, animated: false });
 			}
 		});


### PR DESCRIPTION
PR https://github.com/laurent22/joplin/pull/14757 fixed an issue on the log screen where there was an auto-scroll loop during search. However, this issue can occur when toggling the showing of 'errors only' as well. This PR addresses the issue in this scenario

### Testing

**Before:**

https://github.com/user-attachments/assets/2262a127-52eb-4b77-ade5-bc606f42223d

**After:**

https://github.com/user-attachments/assets/ee4377e4-2476-433b-98df-d4c2bc118eb3