### PR TITLE
Desktop: Display inline error instead of smalltalk dialog for invalid master password

### DIFF
--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -54,6 +54,7 @@ export const EncryptionConfigScreen = (props: Props) => {
 	const [pendingEnableEncryption, setPendingEnableEncryption] = useState(false);
 	const [enableEncryptionPromptVisible, setEnableEncryptionPromptVisible] = useState(false);
 	const [enableEncryptionPassword, setEnableEncryptionPassword] = useState('');
+	const [enableEncryptionError, setEnableEncryptionError] = useState('');
 	const [disableEncryptionPromptVisible, setDisableEncryptionPromptVisible] = useState(false);
 	const disablePromptPromiseRef = useRef<(value: boolean)=> void>(null);
 	const promptPromiseRef = useRef<(password: string | null)=> void>(null);
@@ -285,19 +286,13 @@ export const EncryptionConfigScreen = (props: Props) => {
 
 			// Wait for the custom React Dialog to resolve
 			setEnableEncryptionPassword('');
+			setEnableEncryptionError('');
 			setEnableEncryptionPromptVisible(true);
 			newPassword = await new Promise<string | null>((resolve) => {
 				promptPromiseRef.current = resolve;
 			});
 
 			if (newPassword === null) return; // User cancelled
-		}
-
-		if (hasMasterPassword && newEnabled) {
-			if (!(await masterPasswordIsValid(newPassword))) {
-				await dialogs.alert('Invalid password. Please try again. If you have forgotten your password you will need to reset it.');
-				return;
-			}
 		}
 
 		try {
@@ -339,12 +334,19 @@ export const EncryptionConfigScreen = (props: Props) => {
 			if (promptPromiseRef.current) promptPromiseRef.current(null);
 		};
 
-		const onDialogButtonRowClick = (event: { buttonName: string }) => {
+		const onDialogButtonRowClick = async (event: { buttonName: string }) => {
 			if (event.buttonName === 'cancel') {
 				onClose();
 				return;
 			}
 			if (event.buttonName === 'ok') {
+				if (hasMasterPassword) {
+					if (!(await masterPasswordIsValid(enableEncryptionPassword))) {
+						setEnableEncryptionError(_('Invalid password. Please try again. If you have forgotten your password you will need to reset it.'));
+						return;
+					}
+				}
+				setEnableEncryptionError('');
 				setEnableEncryptionPromptVisible(false);
 				if (promptPromiseRef.current) promptPromiseRef.current(enableEncryptionPassword);
 			}
@@ -352,6 +354,7 @@ export const EncryptionConfigScreen = (props: Props) => {
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Required because PasswordInput's ChangeEventHandler type is incorrect
 		const onPasswordInputChange = (event: any) => {
+			setEnableEncryptionError('');
 			setEnableEncryptionPassword(event.target.value);
 		};
 
@@ -371,6 +374,11 @@ export const EncryptionConfigScreen = (props: Props) => {
 							onChange={onPasswordInputChange}
 						/>
 					</div>
+					{enableEncryptionError && (
+						<div style={{ ...theme.textStyle, color: theme.colorError, marginTop: 10 }}>
+							{enableEncryptionError}
+						</div>
+					)}
 				</>
 			),
 			onClose,

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -375,7 +375,7 @@ export const EncryptionConfigScreen = (props: Props) => {
 						/>
 					</div>
 					{enableEncryptionError && (
-						<div style={{ ...theme.textStyle, color: theme.colorError, marginTop: 10 }}>
+						<div style={{ ...theme.textStyle, color: theme.colorError, marginTop: 10, marginBottom: 10 }}>
 							{enableEncryptionError}
 						</div>
 					)}


### PR DESCRIPTION
### What is the purpose of this pull request?
Currently, when a user enters an incorrect master password in the encryption config screen, the application displays a jarring system-style/smalltalk alert dialog.

This PR improves the user experience by replacing the popup dialog with a localized inline error message directly beneath the password input. This provides a clean, polished UI without entirely taking the user out of their current context.

### Question for Reviewers:
As the smalltalk dialog was replaced with the <Dialog> component for both the enable and disable prompts to maintain uniformity, I decided to replace the error-showing smalltalk dialog with an inline error while enabling encryption.

Would you prefer this inline error approach, or should I instead keep a separate error popup but just change it from smalltalk to a standard <Dialog> component here as well?

### Changes

- Removed the `dialogs.alert()` call for incorrect passwords during the enable-encryption flow.
- Utilized `setEnableEncryptionError()` to set a localized inline error string `(_('Invalid password. Please try again. If you have forgotten your password you will need to reset it.'))`.
- The error now gracefully renders in red text directly inside the Encryption Config dialog, guiding the user to try again.

### Testing

1. Open the desktop application and navigate to Tools -> Options -> Encryption.
2. Attempt to enable encryption.
3. Enter an incorrect master password in the prompt.
4. Verify that an inline error message appears instead of a separate popup alert.

### Before:
https://github.com/user-attachments/assets/49ea42d1-eb29-4200-ad75-6ee57eb499bb


### After:

1] Dark Mode:

https://github.com/user-attachments/assets/282bdce6-eb62-47d7-9ce5-62ef83fa7a34

2] Light Mode:

https://github.com/user-attachments/assets/42abc75d-3ff7-4206-be6a-ed47cc731e13

