### PR TITLE
All: Fix inability to cancel the sync during the deletion step

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -579,7 +579,9 @@ export default class Synchronizer {
 			if (syncSteps.indexOf('delete_remote') >= 0) {
 				await syncDeleteStep(
 					syncTargetId,
-					this.cancelling,
+					() => {
+						return this.cancelling();
+					},
 					(action, local, logSyncOperation, message, actionCount) => {
 						this.logSyncOperation(action, local, logSyncOperation, message, actionCount);
 					},

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -579,7 +579,7 @@ export default class Synchronizer {
 			if (syncSteps.indexOf('delete_remote') >= 0) {
 				await syncDeleteStep(
 					syncTargetId,
-					this.cancelling(),
+					this.cancelling,
 					(action, local, logSyncOperation, message, actionCount) => {
 						this.logSyncOperation(action, local, logSyncOperation, message, actionCount);
 					},

--- a/packages/lib/services/synchronizer/utils/syncDeleteStep.ts
+++ b/packages/lib/services/synchronizer/utils/syncDeleteStep.ts
@@ -7,10 +7,10 @@ import time from '../../../time';
 import resourceRemotePath from './resourceRemotePath';
 import { ApiCallFunction, LogSyncOperationFunction, SyncAction } from './types';
 
-export default async (syncTargetId: number, cancelling: boolean, logSyncOperation: LogSyncOperationFunction, apiCall: ApiCallFunction, dispatch: Dispatch) => {
+export default async (syncTargetId: number, cancelling: ()=> boolean, logSyncOperation: LogSyncOperationFunction, apiCall: ApiCallFunction, dispatch: Dispatch) => {
 	const deletedItems = await BaseItem.deletedItems(syncTargetId);
 	for (let i = 0; i < deletedItems.length; i++) {
-		if (cancelling) break;
+		if (cancelling()) break;
 
 		const item = deletedItems[i];
 		const path = BaseItem.systemPath(item.item_id);


### PR DESCRIPTION
There is a historic bug whereby there is an inability to cancel the sync during the deletion step. This is because the result of the cancelling() function is passed to the syncDeleteStep function, rather than a function which returns the live value of the cancelling() function. This PR corrects this.

### Testing

Behaviour before code change:

https://github.com/user-attachments/assets/e90300f9-1f7d-4062-b88a-6c98b597cd09

Behaviour after code change:

https://github.com/user-attachments/assets/258297af-648d-4852-95e1-9e7c8113e155