### PR TITLE
 Restoring a folder from trash incorrectly modifies non-deleted notes causing spurious sync uploads

### DIFF
--- a/packages/lib/services/trash/restoreItems.test.ts
+++ b/packages/lib/services/trash/restoreItems.test.ts
@@ -88,6 +88,35 @@ describe('restoreItems', () => {
 		expect(noteReloaded.parent_id).toBe(folderReloaded2.id);
 	});
 
+	it('should not modify non-deleted notes when restoring a folder', async () => {
+		const folder = await Folder.save({});
+		const deletedNote = await Note.save({ parent_id: folder.id });
+		const nonDeletedNote = await Note.save({ parent_id: folder.id });
+
+		// Trash the folder WITHOUT trashing its children (deleteChildren: false).
+		// This leaves nonDeletedNote with deleted_time = 0 while the folder itself
+		// is in the trash — the exact condition that triggers the bug.
+		await Folder.delete(folder.id, { toTrash: true, deleteChildren: false });
+
+		// Manually trash only one note to simulate a note that was individually deleted
+		await Note.save({ id: deletedNote.id, deleted_time: Date.now() });
+
+		const nonDeletedNoteBefore = await Note.load(nonDeletedNote.id);
+		expect(nonDeletedNoteBefore.deleted_time).toBe(0); // confirm precondition
+
+		await restoreItems(ModelType.Folder, [await Folder.load(folder.id)]);
+
+		const nonDeletedNoteAfter = await Note.load(nonDeletedNote.id);
+
+		// The non-deleted note must be completely untouched
+		expect(nonDeletedNoteAfter.updated_time).toBe(nonDeletedNoteBefore.updated_time);
+		expect(nonDeletedNoteAfter.deleted_time).toBe(0);
+
+		// The deleted note must be restored
+		const deletedNoteAfter = await Note.load(deletedNote.id);
+		expect(deletedNoteAfter.deleted_time).toBe(0);
+	});
+
 	it('should restore a conflict', async () => {
 		const note = await Note.save({ is_conflict: 1, title: 'Test' });
 		await Note.delete(note.id, { toTrash: true });

--- a/packages/lib/services/trash/restoreItems.ts
+++ b/packages/lib/services/trash/restoreItems.ts
@@ -78,11 +78,11 @@ const restoreItems = async (itemType: ModelType, itemsOrIds: NoteEntity[] | Fold
 			await restoreItems(ModelType.Folder, deletedChildrenFolders);
 
 			const notes = await Folder.notes(item.id, {
-				fields: ['id', 'parent_id'],
+				fields: ['id', 'parent_id', 'deleted_time'],
 				includeDeleted: true,
 			});
-
-			await restoreItems(ModelType.Note, notes);
+			const deletedNotes = notes.filter(n => !!n.deleted_time);
+			await restoreItems(ModelType.Note, deletedNotes);
 		}
 	}
 };


### PR DESCRIPTION
## What

When restoring a folder from trash, `restoreItems()` was fetching all 
notes in the folder  including notes that were never deleted  and 
unconditionally writing `deleted_time: 0` and `updated_time: Date.now()` 
to every note.

This bumped `updated_time` on notes that were never in the trash, marking 
them dirty for sync and causing spurious uploads and potential conflicts 
on other devices.

## Why

The child-folder path already applied the correct filter:

```typescript
const deletedChildrenFolders = childrenFolders.filter(f => !!f.deleted_time);
await restoreItems(ModelType.Folder, deletedChildrenFolders);

But the notes path had no equivalent filter, and deleted_time was not even included in the fields list of the Folder.notes call, making filtering impossible.



##How
Two-line fix in 
restoreItems.tsTwo-line fix in 
restoreItems.ts
:

Add 'deleted_time' to the fields requested from Folder.notes
Filter notes to only deleted_time > 0 before the recursive call


##Testing
Added regression test: should not modify non-deleted notes when restoring a folder
All 7 tests in restoreItems.test.ts pass
Platforms affected
All (core library shared by Desktop, Mobile, CLI)




The platform prefix is All because the fix is in `@joplin/lib` which is shared across every app. Once you h