### PR TITLE
All: Improved: Exclude user_data from note revisions

### DIFF
--- a/packages/lib/services/RevisionService.test.ts
+++ b/packages/lib/services/RevisionService.test.ts
@@ -501,6 +501,23 @@ describe('services/RevisionService', () => {
 		expect(revNote.user_updated_time).toBe(userUpdatedTime);
 	}));
 
+	it('should not track user_data in revisions', (async () => {
+		const n1_v0 = await Note.save({ title: 'hello' });
+		await Note.save({ id: n1_v0.id, title: 'hello world', user_data: '{"plugin":{"value":1}}' });
+		await revisionService().collectRevisions();
+
+		const revisions = await Revision.all();
+		expect(revisions.length).toBe(1);
+		const md = JSON.parse(revisions[0].metadata_diff);
+		expect(md.new.user_data).toBeUndefined();
+		expect(md.deleted).not.toContain('user_data');
+
+		// A user_data-only change should not create a revision.
+		await Note.save({ id: n1_v0.id, user_data: '{"plugin":{"value":2}}' });
+		await revisionService().collectRevisions();
+		expect((await Revision.all()).length).toBe(1);
+	}));
+
 	it('should not create a revision if there is already a recent one', (async () => {
 		const n1_v0 = await Note.save({ title: '' });
 		await Note.save({ id: n1_v0.id, title: 'hello' });

--- a/packages/lib/services/RevisionService.ts
+++ b/packages/lib/services/RevisionService.ts
@@ -65,7 +65,7 @@ export default class RevisionService extends BaseService {
 	}
 
 	private noteMetadata_(note: NoteEntity) {
-		const excludedFields = ['type_', 'title', 'body', 'created_time', 'updated_time', 'encryption_applied', 'encryption_cipher_text', 'is_conflict'];
+		const excludedFields = ['type_', 'title', 'body', 'created_time', 'updated_time', 'encryption_applied', 'encryption_cipher_text', 'is_conflict', 'user_data'];
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		const md: any = {};
 		for (const k in note) {


### PR DESCRIPTION
## summary

I noticed that whenever a plugin updates `user_data` (even a single char), the next revision collected for that note stores the entire new `user_data` blob, not a delta. plugins that write often accumulate full-size snapshots in revision history, especially with the default 90-day retention.

forum discussion (with the full case): https://discourse.joplinapp.org/t/exclude-user-data-from-note-revisions/49722

## change

add `user_data` to the existing `excludedFields` list in `RevisionService.noteMetadata_()`.

reasoning:

- `user_data` is plugin storage, not user-authored content
- reverting it from history has no clear meaning (plugins write to it programmatically)
- the existing list already covers similar non-content fields (encryption state, conflict flag, etc.)

## backward compatibility

- existing revisions still decode and apply normally.
- new revisions stop carrying `user_data`. an edit that *only* changes `user_data` won't create a revision (after a one-time transition revision recording the deletion, `metadata_diff` ends up empty and `Revision.isEmptyRevision` filters it out).
- restoring a pre-fix revision still recovers the historical `user_data`. restoring a post-fix revision creates a new note without it (plugins regenerate as needed).
- sync format unchanged. old Joplin versions handle the existing `deleted` array fine.

## tests

- added `should not track user_data in revisions` to `RevisionService.test.ts`. covers two cases: a mixed change excludes `user_data` from the diff; a user_data-only change produces no revision.
- full `RevisionService.test.ts` suite passes (27/27); `Revision.test.ts` suite also passes.
- manually verified in a live Joplin desktop dev build via the Web Clipper API: post-patch revisions for a note with active plugin user_data have `user_data` excluded from `metadata_diff.new` and `metadata_diff.deleted`; user_data-only changes produce no new revision.