### PR TITLE
Mobile: Fixes #15248: Prevent trashed notes from opening in edit mode

### DIFF
--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -297,6 +297,11 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent) => {
 	const panes = comp.props.noteVisiblePanes;
 	let mode = panes.includes('editor') ? 'edit' : 'view';
 
+	// Prevent trashed notes from opening in edit mode.
+	if (note?.deleted_time) {
+		mode = 'view';
+	}
+
 	if (isProvisionalNote && !comp.props.sharedData) {
 		mode = 'edit';
 		comp.scheduleFocusUpdate();


### PR DESCRIPTION
Fixes  #15248

## Summary

This fixes a regression where trashed notes could open in edit mode when the persisted `noteVisiblePanes` state was set to editor mode.

## Cause

The saved pane state introduced in #14363 was restored for all notes, including trashed notes. As a result, trashed notes could initialize in edit mode.

## Fix

When loading a note, if `deleted_time` is set, force the mode to `view` instead of restoring editor mode.

## Testing

Reviewed the note loading logic locally and verified the affected code path.
I was unable to run full Android device/emulator testing in my current local environment, so runtime verification is still needed.

## AI Disclosure
I used AI assistance for brainstorming/debugging guidance during investigation. I personally reviewed the codebase, implemented the change, and verified the final patch.

video:

https://github.com/user-attachments/assets/47c1620b-de9b-40cb-9696-a73acfb3109f


