### PR TITLE
Desktop: Fixes #15247: When a note is deleted, tags can still be added or removed 

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/StatusBar.tsx
+++ b/packages/app-desktop/gui/NoteEditor/StatusBar.tsx
@@ -58,7 +58,26 @@ const StatusBar: React.FC<Props> = props => {
 	function renderTagBar() {
 		const theme = themeStyle(props.themeId);
 		const noteIds = [props.noteId];
-		const instructions = <span onClick={() => { void CommandService.instance().execute('setTags', noteIds); }} style={{ ...theme.clickableTextStyle, whiteSpace: 'nowrap' }}>{_('Click to add tags...')}</span>;
+		const instructions = (
+			<span
+				onClick={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+
+					if (!props.setTagsToolbarButtonInfo.enabled) return;
+
+					void CommandService.instance().execute('setTags', noteIds);
+				}}
+				style={{
+					...theme.clickableTextStyle,
+					whiteSpace: 'nowrap',
+					opacity: props.setTagsToolbarButtonInfo.enabled ? 1 : 0.5,
+					cursor: props.setTagsToolbarButtonInfo.enabled ? 'pointer' : 'default',
+				}}
+			>
+				{_('Click to add tags...')}
+			</span>
+		);
 		const tagList = props.selectedNoteTags.length ? <TagList items={props.selectedNoteTags} /> : null;
 
 		return <div className='tag-bar'>

--- a/packages/app-desktop/gui/NoteEditor/StatusBar.tsx
+++ b/packages/app-desktop/gui/NoteEditor/StatusBar.tsx
@@ -60,7 +60,20 @@ const StatusBar: React.FC<Props> = props => {
 		const noteIds = [props.noteId];
 		const instructions = (
 			<span
+				role='button'
+				tabIndex={props.setTagsToolbarButtonInfo.enabled ? 0 : -1}
+				aria-disabled={!props.setTagsToolbarButtonInfo.enabled}
 				onClick={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+
+					if (!props.setTagsToolbarButtonInfo.enabled) return;
+
+					void CommandService.instance().execute('setTags', noteIds);
+				}}
+				onKeyDown={(e) => {
+					if (e.key !== 'Enter' && e.key !== ' ') return;
+
 					e.preventDefault();
 					e.stopPropagation();
 

--- a/packages/app-desktop/gui/NoteEditor/StatusBar.tsx
+++ b/packages/app-desktop/gui/NoteEditor/StatusBar.tsx
@@ -60,20 +60,8 @@ const StatusBar: React.FC<Props> = props => {
 		const noteIds = [props.noteId];
 		const instructions = (
 			<span
-				role='button'
-				tabIndex={props.setTagsToolbarButtonInfo.enabled ? 0 : -1}
 				aria-disabled={!props.setTagsToolbarButtonInfo.enabled}
 				onClick={(e) => {
-					e.preventDefault();
-					e.stopPropagation();
-
-					if (!props.setTagsToolbarButtonInfo.enabled) return;
-
-					void CommandService.instance().execute('setTags', noteIds);
-				}}
-				onKeyDown={(e) => {
-					if (e.key !== 'Enter' && e.key !== ' ') return;
-
 					e.preventDefault();
 					e.stopPropagation();
 


### PR DESCRIPTION
Fixes  #15247

## Summary

Fixes an issue where deleted notes in Trash still allowed opening the tag editor through the “Click to add tags...” link in the editor status bar.

## Changes

* Added a click guard to prevent executing the `setTags` command when tag editing is disabled
* Stopped click event propagation/default behavior for disabled state
* Updated the link appearance to visually match the disabled toolbar button

## Testing

Tested the following scenarios on Desktop (Windows):

1. Normal note: clicking “Click to add tags...” opens the tag editor.
2. Deleted note in Trash: clicking the text does nothing.
3. Restored note: clicking works again after restore.

video:



https://github.com/user-attachments/assets/08e56892-e314-4892-857c-d3bff9175588







