### PR TITLE
Desktop: Preserve leading/trailing whitespace on paste in Rich Text E…

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
@@ -57,6 +57,27 @@ describe('resourceHandling', () => {
 		}
 	});
 
+	it('should preserve leading and trailing whitespace when pasting', async () => {
+		const { markupToHtml, htmlToMd } = createTestMarkupConverters();
+
+		const normalizeHtmlEntities = (html: string) => {
+			return html
+				.replace(/&nbsp;|&#160;|&#xA0;/gi, ' ')
+				.replace(/&bull;|&#8226;|&#x2022;/gi, '•');
+		};
+
+		const testCases: [string, string][] = [
+			['&nbsp;&nbsp;&nbsp;Hello', '   Hello'],
+			['Hello&nbsp;&nbsp;&nbsp;', 'Hello   '],
+			['&nbsp;&nbsp;Hello&nbsp;&nbsp;', '  Hello  '],
+			['•&nbsp;', '• '],
+		];
+
+		for (const [html, expected] of testCases) {
+			const result = await processPastedHtml(html, htmlToMd, markupToHtml);
+			expect(normalizeHtmlEntities(result)).toBe(expected);
+		}
+	});
 	it('should preserve images pasted from the resource directory', async () => {
 		const { markupToHtml, htmlToMd } = createTestMarkupConverters();
 

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -247,6 +247,8 @@ export async function processPastedHtml(html: string, htmlToMd: HtmlToMarkdownHa
 	// inserted into the TinyMCE editor (using insertContent), they will be
 	// dropped. So here we convert them to regular spaces.
 	// https://stackoverflow.com/a/31790544/561309
+	const hasBoundaryWhitespace = /^(?:\s|&nbsp;|&#160;|&#xA0;)/i.test(html) || /(?:\s|&nbsp;|&#160;|&#xA0;)\s*$/i.test(html);
+
 	html = html.replace(/[\u202F\u00A0]/g, ' ');
 
 	html = await processImagesInPastedHtml(html);
@@ -276,7 +278,7 @@ export async function processPastedHtml(html: string, htmlToMd: HtmlToMarkdownHa
 	// Markdown. For example the content may have a dark background which would be supported by
 	// TinyMCE, but lost once the note is saved. So here we convert the HTML to Markdown then back
 	// to HTML to ensure that the content we paste will be handled correctly by the app.
-	if (htmlToMd && mdToHtml) {
+	if (htmlToMd && mdToHtml && !hasBoundaryWhitespace) {
 		const md = await htmlToMd(MarkupLanguage.Markdown, html, '', { preserveColorStyles: Setting.value('editor.pastePreserveColors') });
 		html = (await mdToHtml(MarkupLanguage.Markdown, md, markupRenderOptions({ bodyOnly: true }))).html;
 


### PR DESCRIPTION
## Summary

Fixes #15093 issue where leading and trailing whitespace is removed when pasting text in the Rich Text Editor.

---

## Problem

When pasting text that contains leading or trailing spaces (e.g., `"   Hello"` or `"• "`), the whitespace is stripped.

This happens because pasted HTML is converted to Markdown and back to HTML, and the Markdown conversion does not preserve boundary whitespace.

---

## Solution

- Detect boundary whitespace in pasted HTML (`&nbsp;`, `&#160;`, etc.)
- Skip HTML → Markdown → HTML conversion when such whitespace is present
- Allow the original HTML to pass through so spacing is preserved

This ensures that user intent (e.g., bullet spacing `"• "`) is respected.

---

## Changes

- Updated `processPastedHtml` to conditionally skip Markdown conversion when boundary whitespace is detected
- Added test coverage for:
  - Leading whitespace
  - Trailing whitespace
  - Both sides
  - Bullet + space (`• `)

---

## Before


https://github.com/user-attachments/assets/397e45be-d10b-4883-aea3-146d0485298f


---

## After


https://github.com/user-attachments/assets/ead803f2-8210-4902-b58a-aa499d45b86a


---

## Testing

### Automated Tests

- Added new test case in `resourceHandling.test.ts`
- All tests pass:
```
yarn test resourceHandling
```

### Manual Testing

1. Paste text with leading spaces → preserved  
2. Paste text with trailing spaces → preserved  
3. Paste `"• "` → space preserved  
4. Paste normal text → unchanged  
5. Paste formatted HTML → no regression observed  

---

## Notes

- The fix is scoped only to paste handling and does not modify global HTML ↔ Markdown conversion logic
- Existing behavior remains unchanged for normal paste scenarios