### PR TITLE
Server: Fix conditions for sending oversized account emails

### DIFF
--- a/packages/server/src/models/UserModel.test.ts
+++ b/packages/server/src/models/UserModel.test.ts
@@ -303,6 +303,25 @@ describe('UserModel', () => {
 		}
 	});
 
+	test('should not send emails when an account\'s size limit has been manually increased', async () => {
+		const { user: user1 } = await createUserAndSession(1);
+
+		const totalSize = Math.round(accountByType(AccountType.Basic).max_total_item_size * 0.85);
+		await models().user().save({
+			id: user1.id,
+			account_type: AccountType.Basic,
+			total_item_size: totalSize,
+			max_total_item_size: totalSize * 2,
+		});
+
+		const emailBeforeCount = (await models().email().all()).length;
+
+		await models().user().handleOversizedAccounts();
+
+		const emailAfterCount = (await models().email().all()).length;
+		expect(emailAfterCount).toBe(emailBeforeCount);
+	});
+
 	test('should get the user public key', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 		const { user: user2 } = await createUserAndSession(2);

--- a/packages/server/src/models/UserModel.ts
+++ b/packages/server/src/models/UserModel.ts
@@ -685,7 +685,6 @@ export default class UserModel extends BaseModel<User> {
 		await this.withTransaction(async () => {
 			for (const user of users) {
 				const maxTotalItemSize = getMaxTotalItemSize(user);
-				const account = accountByType(user.account_type);
 
 				if (user.total_item_size > maxTotalItemSize * alertLimitMax) {
 					await this.models().email().push({
@@ -699,7 +698,7 @@ export default class UserModel extends BaseModel<User> {
 					});
 
 					await this.models().userFlag().add(user.id, UserFlagType.AccountOverLimit);
-				} else if (maxTotalItemSize > account.max_total_item_size * alertLimit1) {
+				} else if (user.total_item_size > maxTotalItemSize * alertLimit1) {
 					await this.models().email().push({
 						...oversizedAccount1({
 							percentLimit: alertLimit1 * 100,


### PR DESCRIPTION
# Problem

Oversized account emails were sent in some cases for accounts with a storage limit set via `max_total_item_size`.

# Solution

Fix a logic error in an `if` statement. The `if` statement:
- previously checked that the **maximum account storage** was greater than 85% of the manually set maximum size.
  - Earlier filtering in an SQL query prevented this from triggering in some cases.
- now checks that the user's total used storage is greater than 85% of the maximum account storage.
  - This mirrors the condition on line 689.

# AI use disclosure

- The logic error was flagged by either Coderabbit or Claude Code during a code review.
- The code and test were written by me.

# Testing

## Automated testing

- This pull request adds a new automated test that verifies that an email is no longer sent for an account with `max_total_item_size` set.
  - This test fails if the changes to `UserItemModel` are reverted.
- An existing automated test (`should send emails and flag accounts when it is over the size limit`) covers the case where the email should be sent.
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->