### PR TITLE
Desktop: Fixes #15263: Preserve timestamps when converting HTML notes

### DIFF
--- a/packages/lib/commands/convertNoteToMarkdown.test.ts
+++ b/packages/lib/commands/convertNoteToMarkdown.test.ts
@@ -58,6 +58,35 @@ describe('convertNoteToMarkdown', () => {
 		}
 	});
 
+	it('should preserve user timestamps from the original note', async () => {
+		const folder = await Folder.save({ title: 'test_folder' });
+		const createdTime = new Date('2026-05-04T10:59:00Z').getTime();
+		const updatedTime = new Date('2026-05-04T10:59:00Z').getTime();
+		const userCreatedTime = new Date('2019-07-15T10:02:00Z').getTime();
+		const userUpdatedTime = new Date('2020-08-16T11:03:00Z').getTime();
+		const htmlNote = await Note.save({
+			title: 'test',
+			body: '<p>Hello</p>',
+			parent_id: folder.id,
+			markup_language: MarkupLanguage.Html,
+			created_time: createdTime,
+			updated_time: updatedTime,
+			user_created_time: userCreatedTime,
+			user_updated_time: userUpdatedTime,
+		}, { autoTimestamp: false });
+		state.selectedNoteIds = [htmlNote.id];
+
+		await convertHtmlToMarkdown.runtime().execute({ state, dispatch: jest.fn() });
+
+		const notes = await Note.previews(folder.id);
+		expect(notes).toHaveLength(1);
+		const markdownNote = await Note.load(notes[0].id);
+
+		expect(markdownNote.user_created_time).toBe(userCreatedTime);
+		expect(markdownNote.user_updated_time).toBe(userUpdatedTime);
+		expect(markdownNote.updated_time).toBeGreaterThan(updatedTime);
+	});
+
 	it('should generate action to trigger notification', async () => {
 		const folder = await Folder.save({ title: 'test_folder' });
 		const htmlNoteProperties = {

--- a/packages/lib/commands/convertNoteToMarkdown.ts
+++ b/packages/lib/commands/convertNoteToMarkdown.ts
@@ -47,8 +47,11 @@ export const runtime = (): CommandRuntime => {
 
 					newNote.body = markdownBody;
 					newNote.markup_language = MarkupLanguage.Markdown;
+					newNote.user_created_time = note.user_created_time;
+					newNote.user_updated_time = note.user_updated_time;
+					newNote.updated_time = Date.now();
 
-					await Note.save(newNote);
+					await Note.save(newNote, { autoTimestamp: false });
 					await Note.delete(note.id, { toTrash: true });
 					processedCount ++;
 


### PR DESCRIPTION
Fixes #15263

When converting an HTML note to Markdown, preserve the original note's
`user_created_time` and `user_updated_time`.

Previously, the conversion path duplicated the HTML note, and `Note.duplicate()`
reset the user timestamps. The new Markdown note was then saved with automatic
timestamps, causing both user-visible created and updated times to become the
conversion time.

This change restores the original user timestamps before saving the converted
Markdown note, while still allowing `updated_time` to be updated so the change
can sync normally.

Tests:
- `node .yarn/releases/yarn-4.12.0.cjs workspace @joplin/lib test commands/convertNoteToMarkdown.test.js --runInBand`
- `node .yarn/releases/yarn-4.12.0.cjs workspace @joplin/lib tsc`