### PR TITLE
Chore: Fixes #13644: Fuzzer: Fix fuzzer failure caused by invalid expected state

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1927,6 +1927,7 @@ packages/tools/fuzzer/utils/openDebugSession.js
 packages/tools/fuzzer/utils/randomId.test.js
 packages/tools/fuzzer/utils/randomId.js
 packages/tools/fuzzer/utils/randomString.js
+packages/tools/fuzzer/utils/removeInvalidUtf8.js
 packages/tools/fuzzer/utils/retryWithCount.js
 packages/tools/generate-database-types.js
 packages/tools/generate-images.js

--- a/.gitignore
+++ b/.gitignore
@@ -1900,6 +1900,7 @@ packages/tools/fuzzer/utils/openDebugSession.js
 packages/tools/fuzzer/utils/randomId.test.js
 packages/tools/fuzzer/utils/randomId.js
 packages/tools/fuzzer/utils/randomString.js
+packages/tools/fuzzer/utils/removeInvalidUtf8.js
 packages/tools/fuzzer/utils/retryWithCount.js
 packages/tools/generate-database-types.js
 packages/tools/generate-images.js

--- a/packages/tools/fuzzer/ipc/Client.ts
+++ b/packages/tools/fuzzer/ipc/Client.ts
@@ -28,6 +28,7 @@ import { substrWithEllipsis } from '@joplin/lib/string-utils';
 import hangingIndent from '../utils/hangingIndent';
 import { readFile, writeFile } from 'fs/promises';
 import { hasOwnProperty } from '@joplin/utils/object';
+import removeInvalidUtf8 from '../utils/removeInvalidUtf8';
 
 const logger = Logger.create('Client');
 
@@ -737,8 +738,8 @@ class Client implements ActionableClient {
 				const append = this.context_.randomString(this.context_.randInt(0, 5000));
 
 				let body = keep + append;
-				// Only keep unicode that can be represented as UTF-8
-				body = new TextDecoder().decode(new TextEncoder().encode(body));
+				// Only keep unicode that can be represented as UTF-8 to prevent false-positive fuzzer failures
+				body = removeInvalidUtf8(body);
 
 				await this.updateNote({
 					...targetNote,

--- a/packages/tools/fuzzer/ipc/Client.ts
+++ b/packages/tools/fuzzer/ipc/Client.ts
@@ -126,6 +126,7 @@ const cliProcessPromptString = 'command> ';
 
 interface CreateOrUpdateOptions {
 	quiet?: boolean;
+	message?: string;
 }
 
 interface CreateRandomItemOptions extends CreateOrUpdateOptions {
@@ -729,15 +730,23 @@ class Client implements ActionableClient {
 
 				await this.createRandomNote({ parentId, quiet: true });
 			},
-			update: async (targetNote: NoteData) => {
+			update: async (targetNote: NoteData, step: number) => {
 				const keep = targetNote.body.substring(
 					0, this.context_.randInt(0, targetNote.body.length),
 				);
 				const append = this.context_.randomString(this.context_.randInt(0, 5000));
+
+				let body = keep + append;
+				// Only keep unicode that can be represented as UTF-8
+				body = new TextDecoder().decode(new TextEncoder().encode(body));
+
 				await this.updateNote({
 					...targetNote,
-					body: keep + append,
-				}, { quiet: true });
+					body,
+				}, {
+					quiet: true,
+					message: `sub-step: ${step}: keep: ${keep.length}, append: ${append.length}`,
+				});
 			},
 			delete: async (targetNote: NoteData) => {
 				await this.deleteNote(targetNote.id, { quiet: true });
@@ -757,7 +766,7 @@ class Client implements ActionableClient {
 
 			const actionId = this.context_.randomFrom(actionKeys, actionWeights);
 			if (actionId) {
-				await actions[actionId](targetNote);
+				await actions[actionId](targetNote, i);
 			}
 		}
 		bar.complete();
@@ -865,12 +874,12 @@ class Client implements ActionableClient {
 		await this.assertNoteMatchesState_(note);
 	}
 
-	public async updateNote(note: NoteData, { quiet = false }: CreateOrUpdateOptions = { }) {
+	public async updateNote(note: NoteData, { message, quiet = false }: CreateOrUpdateOptions = { }) {
 		if (!quiet) {
 			logger.info('Update note', note.id, 'in', `${note.parentId}/${this.label}`);
 		}
 
-		await this.tracker_.updateNote(note);
+		await this.tracker_.updateNote(note, { message });
 		await this.execApiCommand_('PUT', `/notes/${encodeURIComponent(note.id)}`, {
 			title: note.title,
 			body: note.body,

--- a/packages/tools/fuzzer/model/ActionTracker.ts
+++ b/packages/tools/fuzzer/model/ActionTracker.ts
@@ -537,7 +537,7 @@ class ActionTracker extends Serializable<typeof schema> {
 				this.checkRep_();
 				return Promise.resolve();
 			},
-			updateNote: (data: NoteData) => {
+			updateNote: (data: NoteData, options = {}) => {
 				assertWriteable(data.parentId);
 
 				const oldItem = this.idToItem_.get(data.id) as NoteData;
@@ -557,7 +557,11 @@ class ActionTracker extends Serializable<typeof schema> {
 					});
 
 				removeChild(oldItem.parentId, data.id);
-				updateItem(data.id, new NoteRecord(data), `updated (changed fields: ${JSON.stringify(changedFields)})`);
+				updateItem(
+					data.id,
+					new NoteRecord(data),
+					`updated (changed fields: ${JSON.stringify(changedFields)})${options?.message ? `, ${options.message}` : ''}`,
+				);
 				addChild(data.parentId, data.id);
 				updateResourceReferences(oldItem, data);
 

--- a/packages/tools/fuzzer/types.ts
+++ b/packages/tools/fuzzer/types.ts
@@ -37,6 +37,10 @@ export interface ShareOptions {
 	readOnly: boolean;
 }
 
+export interface UpdateNoteOptions {
+	message?: string;
+}
+
 export interface ActionableClient {
 	createFolder(data: FolderData): Promise<void>;
 	shareFolder(id: ItemId, shareWith: Client, options: ShareOptions): Promise<void>;
@@ -45,7 +49,7 @@ export interface ActionableClient {
 	deleteFolder(id: ItemId): Promise<void>;
 	deleteNote(id: ItemId): Promise<void>;
 	createNote(data: NoteData): Promise<void>;
-	updateNote(data: NoteData): Promise<void>;
+	updateNote(data: NoteData, options?: UpdateNoteOptions): Promise<void>;
 	attachResource(note: NoteData, resource: ResourceData): Promise<NoteData>;
 	createResource(resource: ResourceData): Promise<void>;
 	moveItem(itemId: ItemId, newParentId: ItemId): Promise<void>;

--- a/packages/tools/fuzzer/utils/getBinaryDiffDebugMessage.ts
+++ b/packages/tools/fuzzer/utils/getBinaryDiffDebugMessage.ts
@@ -14,7 +14,7 @@ const getDiffDebugMessage = (actual: string, expected: string) => {
 			inExpected.add(expected.charAt(i));
 		}
 
-		const unexpected = new Set<string>();
+		const unexpected = new Set();
 		for (let i = 0; i < actual.length; i++) {
 			const char = actual.charAt(i);
 			if (!inExpected.has(char)) {
@@ -24,10 +24,7 @@ const getDiffDebugMessage = (actual: string, expected: string) => {
 
 		if (unexpected.size) {
 			diffMessage.push('Characters found in actual that were not in the expected state:\n');
-			const unexpectedArray = [...unexpected];
-			diffMessage.push('  ', JSON.stringify(unexpectedArray));
-			const firstIndex = actual.indexOf(unexpectedArray[0]);
-			diffMessage.push('  (first at index ', firstIndex, ')\n\n');
+			diffMessage.push('  ', JSON.stringify([...unexpected]), '\n\n');
 		}
 	}
 

--- a/packages/tools/fuzzer/utils/getBinaryDiffDebugMessage.ts
+++ b/packages/tools/fuzzer/utils/getBinaryDiffDebugMessage.ts
@@ -14,7 +14,7 @@ const getDiffDebugMessage = (actual: string, expected: string) => {
 			inExpected.add(expected.charAt(i));
 		}
 
-		const unexpected = new Set();
+		const unexpected = new Set<string>();
 		for (let i = 0; i < actual.length; i++) {
 			const char = actual.charAt(i);
 			if (!inExpected.has(char)) {
@@ -24,7 +24,10 @@ const getDiffDebugMessage = (actual: string, expected: string) => {
 
 		if (unexpected.size) {
 			diffMessage.push('Characters found in actual that were not in the expected state:\n');
-			diffMessage.push('  ', JSON.stringify([...unexpected]), '\n\n');
+			const unexpectedArray = [...unexpected];
+			diffMessage.push('  ', JSON.stringify(unexpectedArray));
+			const firstIndex = actual.indexOf(unexpectedArray[0]);
+			diffMessage.push('  (first at index ', firstIndex, ')\n\n');
 		}
 	}
 

--- a/packages/tools/fuzzer/utils/randomString.ts
+++ b/packages/tools/fuzzer/utils/randomString.ts
@@ -1,3 +1,5 @@
+import removeInvalidUtf8 from './removeInvalidUtf8';
+
 type OnRandomInt = (low: number, high: number)=> number;
 
 const randomString = (nextRandomInteger: OnRandomInt) => (length: number) => {
@@ -14,7 +16,7 @@ const randomString = (nextRandomInteger: OnRandomInt) => (length: number) => {
 	text = text.replace(/\p{C}/ug, '-'); // Other control characters
 
 	// Remove invalid UTF-8
-	text = new TextDecoder().decode(new TextEncoder().encode(text));
+	text = removeInvalidUtf8(text);
 
 	// Attempt to work around issues related to unexpected differences in items when reading from
 	// the Joplin client: Remove certain invalid unicode:

--- a/packages/tools/fuzzer/utils/removeInvalidUtf8.ts
+++ b/packages/tools/fuzzer/utils/removeInvalidUtf8.ts
@@ -1,0 +1,3 @@
+
+const removeInvalidUtf8 = (text: string) => new TextDecoder().decode(new TextEncoder().encode(text));
+export default removeInvalidUtf8;


### PR DESCRIPTION
# Problem

- With the default state, the sync fuzzer failed after 418 steps, due to use of `\ud854`, which, on its own, is an [isolated surrogate pair code point](https://www.unicode.org/charts/PDF/UD800.pdf) and is converted to `�` when encoded as UTF-8.
- This issue was difficult to debug, because it occurred in a "createOrUpdateMany" step. The last modification for the note pointed to the `createOrUpdateMany` step (418), but not the the particular sub-step within.

See #13644.

# Solution

- Avoid creating isolated surrogate pair code points when trimming/appending to notes.
- Improve debug output to help diagnose similar future issues: Add additional debug information to the change log for each note so that the particular sub-step of a `createOrUpdateMany` can be determined.

# Test plan

1. Restore the fuzzer from a snapshot previously taken just before step 418.
2. Verify that the fuzzer no longer fails at the end of step 418.

<!--
AI-Use-Disclosure: Not assisted
-->
