### PR TITLE
Mobile: Fixes #13134: Fix Android IME text corruption by upgrading @codemirror/view to 6.39.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,8 @@
   },
   "packageManager": "yarn@4.12.0",
   "resolutions": {
+    "@codemirror/view": "6.39.9",
+    "@codemirror/state": "6.5.4",
     "react-native-camera@4.2.1": "patch:react-native-camera@npm%3A4.2.1#./.yarn/patches/react-native-camera-npm-4.2.1-24b2600a7e.patch",
     "eslint": "patch:eslint@8.57.1#./.yarn/patches/eslint-npm-8.39.0-d92bace04d.patch",
     "app-builder-lib@24.4.0": "patch:app-builder-lib@npm%3A24.4.0#./.yarn/patches/app-builder-lib-npm-24.4.0-05322ff057.patch",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -38,7 +38,7 @@
     "@codemirror/lint": "6.9.2",
     "@codemirror/search": "6.5.8",
     "@codemirror/state": "6.5.4",
-    "@codemirror/view": "6.35.0",
+    "@codemirror/view": "6.39.9",
     "@joplin/fork-uslug": "^2.0.0",
     "@lezer/common": "1.5.0",
     "@lezer/highlight": "1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7984,7 +7984,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/state@npm:6.5.4, @codemirror/state@npm:^6.0.0, @codemirror/state@npm:^6.4.0":
+"@codemirror/state@npm:6.5.4":
   version: 6.5.4
   resolution: "@codemirror/state@npm:6.5.4"
   dependencies:
@@ -7993,14 +7993,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/view@npm:6.35.0, @codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.17.0, @codemirror/view@npm:^6.23.0, @codemirror/view@npm:^6.27.0, @codemirror/view@npm:^6.35.0":
-  version: 6.35.0
-  resolution: "@codemirror/view@npm:6.35.0"
+"@codemirror/view@npm:6.39.9":
+  version: 6.39.9
+  resolution: "@codemirror/view@npm:6.39.9"
   dependencies:
-    "@codemirror/state": "npm:^6.4.0"
+    "@codemirror/state": "npm:^6.5.0"
+    crelt: "npm:^1.0.6"
     style-mod: "npm:^4.1.0"
     w3c-keyname: "npm:^2.2.4"
-  checksum: 10/edf9cb81cf2c5d80cc852f924d2d86299bf30aa009cf36afb370a8e2b4b0d03ceeda2de9a809c06aa8c06fcf1c8ba0d857c3d5292813808742446435d2ed533c
+  checksum: 10/9e86b35f31fd4f8b4c2fe608fa6116ddc71261acd842c405de41de1f752268c47ea8e0c400818b4d0481a629e1f773dda9e6f0d24d38ed6a9f6b3d58b2dff669
   languageName: node
   linkType: hard
 
@@ -12522,7 +12523,7 @@ __metadata:
     "@codemirror/lint": "npm:6.9.2"
     "@codemirror/search": "npm:6.5.8"
     "@codemirror/state": "npm:6.5.4"
-    "@codemirror/view": "npm:6.35.0"
+    "@codemirror/view": "npm:6.39.9"
     "@joplin/fork-uslug": "npm:^2.0.0"
     "@joplin/lib": "npm:~3.6"
     "@joplin/utils": "npm:~3.6"
@@ -26253,7 +26254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crelt@npm:^1.0.0":
+"crelt@npm:^1.0.0, crelt@npm:^1.0.6":
   version: 1.0.6
   resolution: "crelt@npm:1.0.6"
   checksum: 10/5ed326ca6bd243b1dba6b943f665b21c2c04be03271824bc48f20dba324b0f8233e221f8c67312526d24af2b1243c023dc05a41bd8bd05d1a479fd2c72fb39c3


### PR DESCRIPTION
### PR Summary
Fixes #13134

Aknowledged regression caused due to #15007

On Android, typing in the markdown editor near certain characters (like +) caused text corruption , characters would disappear, duplicate, or be inserted at the wrong position. This was a known bug in @codemirror/view that was fixed upstream in versions 6.39.6 and 6.39.7 (specifically "Fix composing on boundary of decoration causing garbled text" and "Fix document mangled during composition").

Upgrading from 6.35.0 to 6.39.9 picks up those fixes. I bisected various versions after 6.35 and  found a rendering regression starting at 6.39.10 where content flickers or fails to render during slow scrolling and direction changes. Version 6.39.9 does not have this regression.

The root package.json resolutions block is also updated to pin @codemirror/view and @codemirror/state to prevent nested dependency conflicts across workspaces.

### Testing:
Tested the changes manually 
**Before:**

https://github.com/user-attachments/assets/fb96eb7d-bdaa-4b76-91c9-0f9a62ad794c


**After:**

https://github.com/user-attachments/assets/75eb8460-1d39-44f2-99a0-aebabb6a0347

### Scrolling Test:
https://drive.google.com/file/d/1eJb7_ia6GeAkO8Wc52l9F1gTt05hp4Ks/view?usp=sharing