### PR TITLE
All: Refactor (native) Crypto module to improve mobile performance

### DIFF
--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -74,7 +74,7 @@
     "react-native-popup-menu": "0.17.0",
     "react-native-quick-actions": "0.3.13",
     "react-native-quick-base64": "2.2.2",
-    "react-native-quick-crypto": "1.0.19",
+    "react-native-quick-crypto": "1.1.2",
     "react-native-rsa-native": "2.0.5",
     "react-native-safe-area-context": "5.6.2",
     "react-native-securerandom": "1.0.1",

--- a/packages/app-mobile/services/e2ee/crypto.ts
+++ b/packages/app-mobile/services/e2ee/crypto.ts
@@ -1,4 +1,4 @@
-import { Crypto, CryptoBuffer, Digest, CipherAlgorithm, EncryptionResult, EncryptionParameters } from '@joplin/lib/services/e2ee/types';
+import { Crypto, CryptoBuffer, CryptoBufferEncoding, Digest, CipherAlgorithm, EncryptionResult, EncryptionParameters } from '@joplin/lib/services/e2ee/types';
 import QuickCrypto from 'react-native-quick-crypto';
 import type { CipherGCMOptions, CipherGCM, DecipherGCM } from 'crypto';
 import {
@@ -15,7 +15,7 @@ const digestNameMap: DigestNameMap = {
 	[Digest.sha512]: 'sha512',
 };
 
-const pbkdf2Raw = (password: string, salt: CryptoBuffer, iterations: number, keylen: number, digest: Digest): Promise<CryptoBuffer> => {
+const pbkdf2Raw = (password: string, salt: CryptoBuffer | ArrayBuffer, iterations: number, keylen: number, digest: Digest): Promise<CryptoBuffer> => {
 	return new Promise((resolve, reject) => {
 		QuickCrypto.pbkdf2(password, salt, iterations, keylen, digest, (error, result) => {
 			if (error) {
@@ -31,7 +31,7 @@ const encryptRaw = (data: CryptoBuffer, algorithm: CipherAlgorithm, key: CryptoB
 
 	const cipher = QuickCrypto.createCipheriv(algorithm, key, iv, { authTagLength: authTagLength } as CipherGCMOptions) as unknown as CipherGCM;
 
-	cipher.setAAD(associatedData, { plaintextLength: Buffer.byteLength(data) });
+	cipher.setAAD(associatedData, { plaintextLength: data.byteLength });
 
 	const encryptedData = [cipher.update(data), cipher.final()];
 	const authTag = cipher.getAuthTag();
@@ -39,14 +39,14 @@ const encryptRaw = (data: CryptoBuffer, algorithm: CipherAlgorithm, key: CryptoB
 	return Buffer.concat([encryptedData[0], encryptedData[1], authTag]);
 };
 
-const decryptRaw = (data: CryptoBuffer, algorithm: CipherAlgorithm, key: CryptoBuffer, iv: CryptoBuffer, authTagLength: number, associatedData: CryptoBuffer) => {
+const decryptRaw = (data: ArrayBuffer, algorithm: CipherAlgorithm, key: CryptoBuffer, iv: ArrayBuffer, authTagLength: number, associatedData: CryptoBuffer) => {
 
 	const decipher = QuickCrypto.createDecipheriv(algorithm, key, iv, { authTagLength: authTagLength } as CipherGCMOptions) as unknown as DecipherGCM;
 
-	const authTag = data.subarray(-authTagLength);
-	const encryptedData = data.subarray(0, data.byteLength - authTag.byteLength);
+	const authTag = new Uint8Array(data, data.byteLength - authTagLength, authTagLength);
+	const encryptedData = new Uint8Array(data, 0, data.byteLength - authTagLength);
 	decipher.setAuthTag(authTag);
-	decipher.setAAD(associatedData, { plaintextLength: Buffer.byteLength(data) });
+	decipher.setAAD(associatedData, { plaintextLength: data.byteLength });
 
 	try {
 		return Buffer.concat([decipher.update(encryptedData), decipher.final()]);
@@ -82,7 +82,7 @@ const crypto: Crypto = {
 
 		// Parameters in EncryptionParameters won't appear in result
 		const result: EncryptionResult = {
-			salt: salt.toString('base64'),
+			salt: crypto.bufferToString(salt, 'base64'),
 			iv: '',
 			ct: '', // cipherText
 		};
@@ -94,25 +94,29 @@ const crypto: Crypto = {
 		const key = await pbkdf2Raw(password, salt, encryptionParameters.iterationCount, encryptionParameters.keyLength, encryptionParameters.digestAlgorithm);
 		const encrypted = encryptRaw(data, encryptionParameters.cipherAlgorithm, key, iv, encryptionParameters.authTagLength, encryptionParameters.associatedData);
 
-		result.iv = iv.toString('base64');
-		result.ct = encrypted.toString('base64');
+		result.iv = crypto.bufferToString(iv, 'base64');
+		result.ct = crypto.bufferToString(encrypted, 'base64');
 
 		return result;
 	},
 
 	decrypt: async (password: string, data: EncryptionResult, encryptionParameters: EncryptionParameters) => {
 
-		const salt = Buffer.from(data.salt, 'base64');
-		const iv = Buffer.from(data.iv, 'base64');
+		const salt = QuickCrypto.binaryLikeToArrayBuffer(data.salt, 'base64');
+		const iv = QuickCrypto.binaryLikeToArrayBuffer(data.iv, 'base64');
 
 		const key = await pbkdf2Raw(password, salt, encryptionParameters.iterationCount, encryptionParameters.keyLength, encryptionParameters.digestAlgorithm);
-		const decrypted = decryptRaw(Buffer.from(data.ct, 'base64'), encryptionParameters.cipherAlgorithm, key, iv, encryptionParameters.authTagLength, encryptionParameters.associatedData);
+		const decrypted = decryptRaw(QuickCrypto.binaryLikeToArrayBuffer(data.ct, 'base64'), encryptionParameters.cipherAlgorithm, key, iv, encryptionParameters.authTagLength, encryptionParameters.associatedData);
 
 		return decrypted;
 	},
 
-	encryptString: async (password: string, salt: CryptoBuffer, data: string, encoding: BufferEncoding, encryptionParameters: EncryptionParameters) => {
-		return crypto.encrypt(password, salt, Buffer.from(data, encoding), encryptionParameters);
+	encryptString: async (password: string, salt: CryptoBuffer, data: string, encoding: CryptoBufferEncoding, encryptionParameters: EncryptionParameters) => {
+		return crypto.encrypt(password, salt, new Uint8Array(QuickCrypto.binaryLikeToArrayBuffer(data, encoding)), encryptionParameters);
+	},
+
+	bufferToString: (buffer: CryptoBuffer, encoding: CryptoBufferEncoding) => {
+		return QuickCrypto.ab2str(buffer.buffer, encoding, buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
 	},
 
 	generateNonce: generateNonceShared,

--- a/packages/lib/services/e2ee/EncryptionService.ts
+++ b/packages/lib/services/e2ee/EncryptionService.ts
@@ -1,4 +1,4 @@
-import { CipherAlgorithm, Digest, MasterKeyEntity } from './types';
+import { CipherAlgorithm, CryptoBuffer, Digest, MasterKeyEntity } from './types';
 import Logger from '@joplin/utils/Logger';
 import shim from '../../shim';
 import Setting from '../../models/Setting';
@@ -76,7 +76,7 @@ export default class EncryptionService {
 	public defaultFileEncryptionMethod_ = EncryptionMethod.FileV1; // public because used in tests
 	private defaultMasterKeyEncryptionMethod_ = EncryptionMethod.KeyV1;
 
-	private encryptionNonce_: Uint8Array = null;
+	private encryptionNonce_: CryptoBuffer = null;
 
 	private headerTemplates_ = {
 		// Template version 1
@@ -538,32 +538,32 @@ export default class EncryptionService {
 		const sjcl = shim.sjclModule;
 		const crypto = shim.crypto;
 		if (method === EncryptionMethod.KeyV1) {
-			return (await crypto.decrypt(key, JSON.parse(cipherText), {
+			return crypto.bufferToString(await crypto.decrypt(key, JSON.parse(cipherText), {
 				cipherAlgorithm: CipherAlgorithm.AES_256_GCM,
 				authTagLength: 16,
 				digestAlgorithm: Digest.sha512,
 				keyLength: 32,
 				associatedData: emptyUint8Array,
 				iterationCount: 220000,
-			})).toString('hex');
+			}), 'hex');
 		} else if (method === EncryptionMethod.FileV1) {
-			return (await crypto.decrypt(key, JSON.parse(cipherText), {
+			return crypto.bufferToString(await crypto.decrypt(key, JSON.parse(cipherText), {
 				cipherAlgorithm: CipherAlgorithm.AES_256_GCM,
 				authTagLength: 16,
 				digestAlgorithm: Digest.sha512,
 				keyLength: 32,
 				associatedData: emptyUint8Array,
 				iterationCount: 3,
-			})).toString('base64');
+			}), 'base64');
 		} else if (method === EncryptionMethod.StringV1) {
-			return (await crypto.decrypt(key, JSON.parse(cipherText), {
+			return crypto.bufferToString(await crypto.decrypt(key, JSON.parse(cipherText), {
 				cipherAlgorithm: CipherAlgorithm.AES_256_GCM,
 				authTagLength: 16,
 				digestAlgorithm: Digest.sha512,
 				keyLength: 32,
 				associatedData: emptyUint8Array,
 				iterationCount: 3,
-			})).toString('utf16le');
+			}), 'utf16le');
 		} else if (this.isValidSjclEncryptionMethod(method)) {
 			try {
 				const output = sjcl.json.decrypt(key, cipherText);

--- a/packages/lib/services/e2ee/crypto.ts
+++ b/packages/lib/services/e2ee/crypto.ts
@@ -1,4 +1,4 @@
-import { Crypto, CryptoBuffer, Digest, EncryptionResult, EncryptionParameters } from './types';
+import { Crypto, CryptoBuffer, CryptoBufferEncoding, Digest, EncryptionResult, EncryptionParameters } from './types';
 import { webcrypto } from 'crypto';
 import { Buffer } from 'buffer';
 import {
@@ -70,7 +70,7 @@ const crypto: Crypto = {
 
 		// Parameters in EncryptionParameters won't appear in result
 		const result: EncryptionResult = {
-			salt: salt.toString('base64'),
+			salt: crypto.bufferToString(salt, 'base64'),
 			iv: '',
 			ct: '', // cipherText
 		};
@@ -82,8 +82,8 @@ const crypto: Crypto = {
 		const key = await pbkdf2Raw(password, salt, encryptionParameters.iterationCount, encryptionParameters.keyLength, encryptionParameters.digestAlgorithm);
 		const encrypted = await encryptRaw(data, key, iv, encryptionParameters.authTagLength, encryptionParameters.associatedData);
 
-		result.iv = iv.toString('base64');
-		result.ct = encrypted.toString('base64');
+		result.iv = crypto.bufferToString(iv, 'base64');
+		result.ct = crypto.bufferToString(encrypted, 'base64');
 
 		return result;
 	},
@@ -99,8 +99,13 @@ const crypto: Crypto = {
 		return decrypted;
 	},
 
-	encryptString: async (password: string, salt: CryptoBuffer, data: string, encoding: BufferEncoding, encryptionParameters: EncryptionParameters) => {
+	encryptString: async (password: string, salt: CryptoBuffer, data: string, encoding: CryptoBufferEncoding, encryptionParameters: EncryptionParameters) => {
 		return crypto.encrypt(password, salt, Buffer.from(data, encoding), encryptionParameters);
+	},
+
+	bufferToString: (buffer: CryptoBuffer, encoding: CryptoBufferEncoding) => {
+		if (Buffer.isBuffer(buffer)) return buffer.toString(encoding);
+		return Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength).toString(encoding);
 	},
 
 	generateNonce: generateNonceShared,

--- a/packages/lib/services/e2ee/cryptoShared.ts
+++ b/packages/lib/services/e2ee/cryptoShared.ts
@@ -11,7 +11,7 @@ export const setRandomBytesImplementation = (implementation: RandomBytesImplemen
 	randomBytesImplementation = implementation;
 };
 
-export const generateNonce = async (nonce: Uint8Array) => {
+export const generateNonce = async (nonce: CryptoBuffer) => {
 	const randomLength = nonce.length - nonceTimestampLength - nonceCounterLength;
 	if (randomLength < 1) {
 		throw new Error(`Nonce length should be greater than ${(nonceTimestampLength + nonceCounterLength) * 8} bits`);
@@ -35,7 +35,7 @@ export const generateNonce = async (nonce: Uint8Array) => {
 	return nonce;
 };
 
-export const increaseNonce = async (nonce: Uint8Array) => {
+export const increaseNonce = async (nonce: CryptoBuffer) => {
 	const end = nonce.length - nonceCounterLength;
 	let i = nonce.length;
 	while (i-- > end) {

--- a/packages/lib/services/e2ee/cryptoTestUtils.ts
+++ b/packages/lib/services/e2ee/cryptoTestUtils.ts
@@ -110,7 +110,7 @@ export async function testStringPerformance(method: EncryptionMethod, dataSize: 
 
 		const crypto = shim.crypto;
 
-		const content = (await crypto.randomBytes(dataSize / 2)).toString('hex');
+		const content = crypto.bufferToString(await crypto.randomBytes(dataSize / 2), 'hex');
 		const folder = await Folder.save({ title: 'folder' });
 		const note = await Note.save({ title: 'encrypted note', body: content, parent_id: folder.id });
 
@@ -174,7 +174,7 @@ export async function testFilePerformance(method: EncryptionMethod, dataSize: nu
 		const encryptedPath = `${Setting.value('tempDir')}/testData.crypted`;
 		const decryptedPath = `${Setting.value('tempDir')}/testData.decrypted`;
 		await fsDriver.writeFile(sourcePath, '');
-		await fsDriver.appendFile(sourcePath, (await crypto.randomBytes(dataSize)).toString('base64'), 'base64');
+		await fsDriver.appendFile(sourcePath, crypto.bufferToString(await crypto.randomBytes(dataSize), 'base64'), 'base64');
 
 		let encryptTime = 0.0;
 		let decryptTime = 0.0;

--- a/packages/lib/services/e2ee/cryptoTestUtils.ts
+++ b/packages/lib/services/e2ee/cryptoTestUtils.ts
@@ -91,6 +91,32 @@ export async function checkDecryptTestData(data: DecryptTestData, options: Check
 	}
 }
 
+const checkBufferToString = () => {
+	const crypto = shim.crypto;
+	const data = new Uint8Array([
+		0xaa, 0xbb, 0xcc, 0xdd,
+		0x00, 0x01, 0x02, 0x03, 0xfc, 0xfd, 0xfe, 0xff, 0x3d, 0xd8, 0x41, 0x00, 0x3e, 0xd8, 0x17, 0xdd, 0x00, 0xdc,
+		0x11, 0x22, 0x33, 0x44,
+	]);
+	const view = data.subarray(4, 22);
+
+	// cSpell:disable
+	const testCases = {
+		hex: '00010203fcfdfeff3dd841003ed817dd00dc',
+		base64: 'AAECA/z9/v892EEAPtgX3QDc',
+		utf16le: '\u0100\u0302\uFDFC\uFFFE\uD83DA\uD83E\uDD17\uDC00',
+	} as const;
+	// cSpell:enable
+
+	for (const encoding in testCases) {
+		const actual = crypto.bufferToString(view, encoding as keyof typeof testCases);
+		const expected = testCases[encoding as keyof typeof testCases];
+		if (actual !== expected) {
+			throw new Error(`bufferToString(${encoding}) failed. Expected: ${expected}. Got: ${actual}.`);
+		}
+	}
+};
+
 export async function testStringPerformance(method: EncryptionMethod, dataSize: number, count: number, options: CheckTestDataOptions = null) {
 	options = {
 		throwOnError: false,
@@ -248,6 +274,9 @@ export const runIntegrationTests = async (silent = false, testPerformance = fals
 	serviceInstance = EncryptionService.instance();
 	BaseItem.encryptionService_ = EncryptionService.instance();
 	setEncryptionEnabled(true);
+
+	log('Testing bufferToString...');
+	checkBufferToString();
 
 	log('Decrypting using known data...');
 	for (const testLabel in decryptTestData) {

--- a/packages/lib/services/e2ee/types.ts
+++ b/packages/lib/services/e2ee/types.ts
@@ -44,17 +44,20 @@ export type PublicKeyCryptoProvider = Record<PublicKeyAlgorithm, PublicKeyCrypto
 
 export interface Crypto {
 	randomBytes(size: number): Promise<CryptoBuffer>;
-	digest(algorithm: Digest, data: Uint8Array): Promise<CryptoBuffer>;
-	generateNonce(nonce: Uint8Array): Promise<Uint8Array>;
-	increaseNonce(nonce: Uint8Array): Promise<Uint8Array>;
+	digest(algorithm: Digest, data: CryptoBuffer): Promise<CryptoBuffer>;
+	generateNonce(nonce: CryptoBuffer): Promise<CryptoBuffer>;
+	increaseNonce(nonce: CryptoBuffer): Promise<CryptoBuffer>;
 	encrypt(password: string, salt: CryptoBuffer, data: CryptoBuffer, options: EncryptionParameters): Promise<EncryptionResult>;
-	decrypt(password: string, data: EncryptionResult, options: EncryptionParameters): Promise<Buffer>;
-	encryptString(password: string, salt: CryptoBuffer, data: string, encoding: BufferEncoding, options: EncryptionParameters): Promise<EncryptionResult>;
+	decrypt(password: string, data: EncryptionResult, options: EncryptionParameters): Promise<CryptoBuffer>;
+	encryptString(password: string, salt: CryptoBuffer, data: string, encoding: CryptoBufferEncoding, options: EncryptionParameters): Promise<EncryptionResult>;
+	bufferToString(buffer: CryptoBuffer, encoding: CryptoBufferEncoding): string;
 }
 
-export interface CryptoBuffer extends Uint8Array {
-	toString(encoding?: BufferEncoding, start?: number, end?: number): string;
-}
+// Reject views backed by SharedArrayBuffer
+// https://github.com/nodejs/node/issues/59688 (see `Web Cryptography` row)
+export type CryptoBuffer = Uint8Array<ArrayBuffer>;
+// For EncryptionMethod.KeyV1/FileV1/StringV1
+export type CryptoBufferEncoding = 'hex' | 'base64' | 'utf16le';
 
 // A subset of react-native-quick-crypto.HashAlgorithm, supported by Web Crypto API
 export enum Digest {
@@ -81,6 +84,6 @@ export interface EncryptionParameters {
 	authTagLength: number; // in bytes
 	digestAlgorithm: Digest;
 	keyLength: number; // in bytes
-	associatedData: Uint8Array;
+	associatedData: CryptoBuffer;
 	iterationCount: number;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12435,7 +12435,7 @@ __metadata:
     react-native-popup-menu: "npm:0.17.0"
     react-native-quick-actions: "npm:0.3.13"
     react-native-quick-base64: "npm:2.2.2"
-    react-native-quick-crypto: "npm:1.0.19"
+    react-native-quick-crypto: "npm:1.1.2"
     react-native-rsa-native: "npm:2.0.5"
     react-native-safe-area-context: "npm:5.6.2"
     react-native-securerandom: "npm:1.0.1"
@@ -49264,9 +49264,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-quick-crypto@npm:1.0.19":
-  version: 1.0.19
-  resolution: "react-native-quick-crypto@npm:1.0.19"
+"react-native-quick-crypto@npm:1.1.2":
+  version: 1.1.2
+  resolution: "react-native-quick-crypto@npm:1.1.2"
   dependencies:
     "@craftzdog/react-native-buffer": "npm:6.1.0"
     events: "npm:3.3.0"
@@ -49279,14 +49279,14 @@ __metadata:
     expo-build-properties: "*"
     react: "*"
     react-native: "*"
-    react-native-nitro-modules: ">=0.29.1"
+    react-native-nitro-modules: ">=0.31.2"
     react-native-quick-base64: ">=2.1.0"
   peerDependenciesMeta:
     expo:
       optional: true
     expo-build-properties:
       optional: true
-  checksum: 10/73a6ac9e3c11d297ff72e4b5ae07b194c5f12ca8dc5d8f160feaf1c73ebf05acbd66effdb04e76b4accefd4782e267daa69e0ef6bf97d2196f854f7d1225e1c6
+  checksum: 10/f3abae21395e6bd342f3fdeaf55b3e244115fc062e96213ca97ab1b57b5e52c6f830e35ceb56ed00ef9f217fc531c7eeb4887220fc7cf45a1d69d6a421e7fc30
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR refactors `Crypto` module to use the fast buffer/string conversion feature in `react-native-quick-crypto`. Specifically:

- Bump `react-native-quick-crypto` to 1.1.2 to use the new `ab2str()` API
- Add `Crypto.bufferToString()` as a wrapper to `QuickCrypto.ab2str()` on mobile
- Replace `Buffer.from()`/`toString()` with `QuickCrypto.binaryLikeToArrayBuffer()`/`Crypto.bufferToString()` on mobile
- Replace the interface of `CryptoBuffer` from `Uint8Array`+`toString()` to `Uint8Array<ArrayBuffer>`
- Unify the input/output data type of `Crypto` module to `CryptoBuffer`
- Add `CryptoBufferEncoding`
- Add test for `Crypto.bufferToString()`