### PR TITLE
Desktop: Fixes #15278: Stop embedded media playback when viewer is hidden

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
@@ -639,6 +639,15 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 	});
 
 	useEffect(() => {
+		if (!props.visiblePanes.includes('viewer')) {
+			setRenderedBody(defaultRenderedBody());
+			setRenderedBodyContentKey(null);
+		} else if (renderedBodyContentKey && renderedBodyContentKey !== props.contentKey) {
+			setRenderedBody(defaultRenderedBody());
+		}
+	}, [props.contentKey, props.visiblePanes, renderedBodyContentKey]);
+
+	useEffect(() => {
 		let cancelled = false;
 
 		// When a new note is loaded (contentKey is different), we want the note to be displayed

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
@@ -194,6 +194,15 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 	});
 
 	useEffect(() => {
+		if (!props.visiblePanes.includes('viewer')) {
+			setRenderedBody(defaultRenderedBody());
+			setRenderedBodyContentKey(null);
+		} else if (renderedBodyContentKey && renderedBodyContentKey !== props.contentKey) {
+			setRenderedBody(defaultRenderedBody());
+		}
+	}, [props.contentKey, props.visiblePanes, renderedBodyContentKey]);
+
+	useEffect(() => {
 		let cancelled = false;
 
 		// When a new note is loaded (contentKey is different), we want the note to be displayed


### PR DESCRIPTION
This updates the Markdown viewer lifecycle so that rendered viewer content is cleared when the viewer is hidden or when switching to another note.

Previously, embedded media such as YouTube iframes could continue playing after hiding the viewer or selecting another note, because the previous rendered HTML stayed mounted in the viewer iframe.

Testing:

- Added a YouTube link to a note.
- Opened the Markdown viewer and started playback.
- Switched to another note and confirmed playback stops.
- Started playback again, hid the viewer, and confirmed playback stops.
- Re-opened the viewer and confirmed the current note renders normally.
- Ran yarn workspace @joplin/app-desktop tsc.