### PR TITLE
Desktop: Fixes #15297: Rich Text Editor: Fix find/replace dialog fails to scroll to the next match

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -896,30 +896,6 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 					editor.addShortcut('Meta+Shift+8', '', () => editor.execCommand('InsertUnorderedList'));
 					editor.addShortcut('Meta+Shift+9', '', () => editor.execCommand('InsertJoplinChecklist'));
 
-					// Override ScrollIntoView to scroll to the cursor's character position
-					// instead of the start of the paragraph.
-					// See: https://github.com/laurent22/joplin/issues/14143
-					editor.on('ScrollIntoView', (event) => {
-						const sel = editor.getDoc().getSelection();
-						if (!sel || sel.rangeCount === 0) return;
-
-						const rect = sel.getRangeAt(0).getBoundingClientRect();
-						const win = editor.getWin();
-						const viewHeight = win.innerHeight;
-
-						if (rect.top < 0) {
-							win.scrollBy(0, rect.top);
-						} else if (rect.bottom > viewHeight) {
-							win.scrollBy(0, rect.bottom - viewHeight);
-						} else if (rect.top === 0 && rect.height === 0) {
-							// Handles edge case where rect is not rendered
-							// See: https://stackoverflow.com/a/14384220/5757550
-							return;
-						}
-						event.preventDefault();
-						return;
-					});
-
 					// TODO: remove event on unmount?
 					editor.on('drop', (event) => {
 						// Prevent the message "Dropped file type is not supported" from showing up.


### PR DESCRIPTION
# Problem

The next match button in the Rich Text Editor's find/replace dialog no longer scrolls to the next match.

**Note:** This pull request targets `release-3.6`.

# Solution

Revert #14669's changes to the Rich Text Editor's scrolling logic.

Fixes #15297. **Re-opens #14143.**

# Testing plan

1. Open the Rich Text Editor.
2. Search for a term that has an onscreen match and an offscreen match.
3. Press the next button.
4. Verify that the editor scrolls to the previously-offscreen match.

Screen recording:

[Screencast from 2026-05-08 13-00-03.webm](https://github.com/user-attachments/assets/eecf28fc-f7bd-4eb3-ba89-32219e96f2a4)


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
