### PR TITLE
Chore: Sync fuzzer: Fix failure caused by invalid expected state

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1907,6 +1907,7 @@ packages/tools/fuzzer/ipc/Client.js
 packages/tools/fuzzer/ipc/ClientPool.js
 packages/tools/fuzzer/ipc/Server.js
 packages/tools/fuzzer/model/ActionTracker.js
+packages/tools/fuzzer/model/FolderRecord.test.js
 packages/tools/fuzzer/model/FolderRecord.js
 packages/tools/fuzzer/model/NoteRecord.js
 packages/tools/fuzzer/model/ResourceRecord.js

--- a/.gitignore
+++ b/.gitignore
@@ -1880,6 +1880,7 @@ packages/tools/fuzzer/ipc/Client.js
 packages/tools/fuzzer/ipc/ClientPool.js
 packages/tools/fuzzer/ipc/Server.js
 packages/tools/fuzzer/model/ActionTracker.js
+packages/tools/fuzzer/model/FolderRecord.test.js
 packages/tools/fuzzer/model/FolderRecord.js
 packages/tools/fuzzer/model/NoteRecord.js
 packages/tools/fuzzer/model/ResourceRecord.js

--- a/packages/tools/fuzzer/ActionRunner.ts
+++ b/packages/tools/fuzzer/ActionRunner.ts
@@ -218,18 +218,22 @@ const getActions = (context: FuzzContext, clientPool: ClientPool, client: Client
 
 	const undefinedId = (): ItemId|undefined => undefined;
 
-	addAction('newSubfolder', async ({ parentId, id }) => {
-		await client.createRandomFolder({ parentId, id, quiet: false });
+	addAction('newSubfolder', async ({ parentId, id, title }) => {
+		await client.createRandomFolder({ parentId, id, title, quiet: false });
 		return true;
 	}, {
 		parentId: selectOrCreateWriteableFolder,
 		id: undefinedId,
+		title: () => undefined,
 	});
 
-	addAction('newToplevelFolder', async ({ id }) => {
-		await client.createRandomFolder({ parentId: '', id, quiet: false });
+	addAction('newToplevelFolder', async ({ id, title }) => {
+		await client.createRandomFolder({ parentId: '', id, title, quiet: false });
 		return true;
-	}, { id: undefinedId });
+	}, {
+		id: undefinedId,
+		title: () => undefined,
+	});
 
 	addAction('newNote', async ({ parentId, id }) => {
 		await client.createRandomNote({ parentId, id });

--- a/packages/tools/fuzzer/ipc/Client.ts
+++ b/packages/tools/fuzzer/ipc/Client.ts
@@ -134,6 +134,10 @@ interface CreateRandomItemOptions extends CreateOrUpdateOptions {
 	quiet?: boolean;
 }
 
+interface CreateRandomFolderOptions extends CreateRandomItemOptions {
+	title?: string;
+}
+
 interface CreateOrUpdateManyOptions {
 	createProbability: number;
 	updateProbability: number;
@@ -763,12 +767,12 @@ class Client implements ActionableClient {
 		bar.complete();
 	}
 
-	public async createRandomFolder({ quiet, parentId, id }: CreateRandomItemOptions) {
+	public async createRandomFolder({ quiet, parentId, id, title }: CreateRandomFolderOptions) {
 		const titleLength = this.context_.randInt(1, 128);
 		const folder = {
 			parentId: parentId,
 			id: id ?? this.context_.randomId(),
-			title: this.context_.randomString(titleLength).replace(/\n/g, ' '),
+			title: title ?? this.context_.randomString(titleLength).replace(/\n/g, ' '),
 		};
 
 		await this.createFolder(folder, { quiet });
@@ -1177,15 +1181,17 @@ class Client implements ActionableClient {
 			}
 		};
 
-		const assertSameBodies = (actualSorted: NoteData[], expectedSorted: NoteData[], assertionLabel: string) => {
+		const assertStringPropertyMatches = <Key extends string, Entity extends Record<Key|'id', string>> (
+			key: Key, actualSorted: Entity[], expectedSorted: Entity[], assertionLabel: string,
+		) => {
 			if (actualSorted.length !== expectedSorted.length) {
 				throw new Error(`Input arrays have different lengths (in: ${assertionLabel})`);
 			}
 
 			const differentItems = [];
 			for (let i = 0; i < actualSorted.length; i++) {
-				const actualBody = actualSorted[i].body;
-				const expectedBody = expectedSorted[i].body;
+				const actualBody = actualSorted[i][key];
+				const expectedBody = expectedSorted[i][key];
 
 				if (actualBody !== expectedBody) {
 					differentItems.push([actualSorted[i], expectedSorted[i]]);
@@ -1196,11 +1202,11 @@ class Client implements ActionableClient {
 				const message = [`Some items have different bodies (in: ${assertionLabel})`];
 				for (const [actual, expected] of differentItems) {
 					message.push(`- item: ${actual.id}${actual.id !== expected.id ? ` (compare ${expected.id}) ` : ''}:`);
-					message.push(` ${hangingIndent(getDiffDebugMessage(actual.body, expected.body))}`);
+					message.push(` ${hangingIndent(getDiffDebugMessage(actual[key], expected[key]))}`);
 
-					// Only display full bodies for easy-to-inspect content:
-					const simpleBodyExp = /^[a-z0-9;.,!?[\]() \t\n"']{0,200}$/i;
-					if (actual.body.match(simpleBodyExp) && expected.body.match(simpleBodyExp)) {
+					// Only display the full value for easy-to-inspect content:
+					const simpleContentExp = /^[a-z0-9;.,!?[\]() \t\n"']{0,200}$/i;
+					if (actual[key].match(simpleContentExp) && expected[key].match(simpleContentExp)) {
 						message.push(`  actual:  ${JSON.stringify(actual)}`);
 						message.push(`  expected:${JSON.stringify(expected)}`);
 					}
@@ -1219,7 +1225,7 @@ class Client implements ActionableClient {
 			assertNoAdjacentEqualIds(notes, 'notes');
 			assertNoAdjacentEqualIds(expectedNotes, 'expectedNotes');
 			await assertSameIds(notes, expectedNotes, 'Note IDs should match');
-			assertSameBodies(notes, expectedNotes, 'should have the same note bodies');
+			assertStringPropertyMatches('body', notes, expectedNotes, 'should have the same note bodies');
 			assert.deepEqual(notes, expectedNotes, 'should have the same notes as the expected state');
 		};
 
@@ -1233,6 +1239,7 @@ class Client implements ActionableClient {
 			assertNoAdjacentEqualIds(folders, 'folders');
 			assertNoAdjacentEqualIds(expectedFolders, 'expectedFolders');
 			await assertSameIds(folders, expectedFolders, 'Folder IDs should match');
+			assertStringPropertyMatches('title', folders, expectedFolders, 'should have the same folder titles');
 			assert.deepEqual(folders, expectedFolders, 'should have the same folders as the expected state');
 		};
 

--- a/packages/tools/fuzzer/model/FolderRecord.test.ts
+++ b/packages/tools/fuzzer/model/FolderRecord.test.ts
@@ -1,0 +1,33 @@
+import FolderRecord from './FolderRecord';
+import Folder from '@joplin/lib/models/Folder';
+import { afterAllCleanUp, afterEachCleanUp, setupDatabase } from '@joplin/lib/testing/test-utils';
+const { shimInit } = require('@joplin/lib/shim-init-node');
+const sqlite3 = require('sqlite3');
+
+describe('FolderRecord', () => {
+	beforeAll(() => {
+		shimInit({ nodeSqlite: sqlite3 });
+	});
+	afterAll(afterAllCleanUp);
+	afterEach(afterEachCleanUp);
+
+	beforeEach(async () => {
+		await setupDatabase();
+	});
+
+	it('should remove leading /s from titles for consistency with the Folder model', async () => {
+		const record = new FolderRecord({
+			title: '//test',
+			id: '1234567890abcdef1234567890abcdef',
+			parentId: '',
+			childIds: [],
+			isShared: false,
+			sharedWith: [],
+			ownedByEmail: '',
+		});
+
+		const folder = await Folder.save({ title: '//test' }, { userSideValidation: true });
+		expect(record.title).toBe('test');
+		expect(record.title).toBe(folder.title);
+	});
+});

--- a/packages/tools/fuzzer/model/FolderRecord.ts
+++ b/packages/tools/fuzzer/model/FolderRecord.ts
@@ -33,6 +33,13 @@ const schema = {
 	],
 } satisfies BaseSchema;
 
+const normalizeFolderTitle = (title: string) => {
+	// Joplin removes / and \ from the beginning of folder titles.
+	// For consistency, this must be done in the fuzzer, too.
+	const illegalStartCharRegex = /^[/\\]+/;
+	return title.replace(illegalStartCharRegex, '');
+};
+
 export default class FolderRecord extends Serializable<typeof schema> implements FolderData {
 	public readonly parentId: ItemId;
 	public readonly id: ItemId;
@@ -48,7 +55,7 @@ export default class FolderRecord extends Serializable<typeof schema> implements
 
 		this.parentId = options.parentId;
 		this.id = options.id;
-		this.title = options.title;
+		this.title = normalizeFolderTitle(options.title);
 		this.childIds = options.childIds;
 		this.isShared_ = options.isShared ?? options.sharedWith.length > 0;
 		this.ownedByEmail = options.ownedByEmail;

--- a/packages/tools/fuzzer/utils/getBinaryDiffDebugMessage.ts
+++ b/packages/tools/fuzzer/utils/getBinaryDiffDebugMessage.ts
@@ -45,8 +45,8 @@ const getDiffDebugMessage = (actual: string, expected: string) => {
 		if (expectedBinary[i] !== actualBinary[i]) {
 			diffMessage.push(
 				'First binary difference at position', i, `(0x${i.toString(16)})`, ': ', expectedBinary[i], '!=', actualBinary[i], '(expected != actual)',
-				'\n\tContext: expected[i-3:i+5] = ', [...expectedBinary.slice(i - 3, i + 5)],
-				'\n\tContext: actual[i-3 : i+5] = ', [...actualBinary.slice(i - 3, i + 5)],
+				'\n\tContext: expected[i-3:i+5] = ', [...expectedBinary.slice(Math.max(i - 3, 0), i + 5)],
+				'\n\tContext: actual[i-3 : i+5] = ', [...actualBinary.slice(Math.max(i - 3, 0), i + 5)],
 				'\n\tactual.byteLength = ', actualBinary.length, ', expected.byteLength = ', expectedBinary.length,
 				'\n\n',
 			);

--- a/packages/tools/fuzzer/utils/getBinaryDiffDebugMessage.ts
+++ b/packages/tools/fuzzer/utils/getBinaryDiffDebugMessage.ts
@@ -62,8 +62,8 @@ const getDiffDebugMessage = (actual: string, expected: string) => {
 			diffMessage.push(
 				'Last binary difference (working from end)', ': ',
 				expectedBinary[indexExpected], '!=', actualBinary[indexActual], `(expected[${indexExpected}] != actual[${indexActual}])`,
-				'\n\tContext: expected[a-6:a+3] = ', [...expectedBinary.slice(indexExpected - 6, indexExpected + 3)],
-				'\n\tContext: actual[b-6 : b+3] = ', [...actualBinary.slice(indexActual - 6, indexActual + 3)],
+				'\n\tContext: expected[a-6:a+3] = ', [...expectedBinary.slice(Math.max(indexExpected - 6, 0), indexExpected + 3)],
+				'\n\tContext: actual[b-6 : b+3] = ', [...actualBinary.slice(Math.max(indexActual - 6, 0), indexActual + 3)],
 				'\n\twhere expected.byteLength = ', expectedBinary.byteLength, 'and actual.byteLength = ', actualBinary.byteLength,
 				'\n\n',
 			);


### PR DESCRIPTION
# Problem

Folders created by the data API cannot have titles that start with `/` or `\`. The sync fuzzer allowed such titles to exist. As a result, if a title was randomly generated by the fuzzer that started with one of these characters, the fuzzer would expect the title to start with `/` or `\` when retrieved from Joplin. However, due to [normalization done in `Folder.ts`](https://github.com/laurent22/joplin/blob/0b3372b00a192d2776ae307950080e67b6e4b5a8/packages/lib/models/Folder.ts#L1049), the title retrieved from Joplin would not start with `/` or `\`, causing a fuzzer failure.

# Solution

- Normalize folder titles when updating the fuzzer's expected state, to match the Joplin client's normalization logic.
- Update the sync fuzzer to simplify debugging similar future issues.

# Testing

Previously, the sync fuzzer would fail when given the following initial setup steps:
```json
{
	"clientCount": 2,
	"description": "Creates a folder starting with a '/' and checks state consistency",
	"actions": [
		["switchClient", { "id": 0 }],
		"sync",

		["switchClient", { "id": 1 }],
		["newToplevelFolder", { "id": "11111111111111111111111111111112", "title": "/test" }],
		"syncAndCheckState"
	]
}
```

With this change, the fuzzer no longer fails on the `syncAndCheckState` step when run with the above config.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
