### PR TITLE
Server: Fix startup can fail after downgrading if an interrupted task no longer exists

### DIFF
--- a/packages/server/src/services/TaskService.test.ts
+++ b/packages/server/src/services/TaskService.test.ts
@@ -111,4 +111,22 @@ describe('TaskService', () => {
 		expect(stateAfter.running).toBe(0);
 	});
 
+	test('should not fail if an interrupted task no longer exists', async () => {
+		const service = newService();
+
+		const tasks = createDemoTasks();
+		await service.registerTasks(tasks);
+
+		// Use a task ID with no corresponding TaskId enum entry.
+		// This simulates a task that is no longer present after downgrading
+		// the server:
+		const nonExistentTaskId = 123456;
+		await models().taskState().save({
+			id: nonExistentTaskId,
+			task_id: nonExistentTaskId as TaskId,
+			running: 1,
+		}, { isNew: true });
+
+		await service.resetInterruptedTasks();
+	});
 });

--- a/packages/server/src/services/TaskService.ts
+++ b/packages/server/src/services/TaskService.ts
@@ -152,6 +152,10 @@ export default class TaskService extends BaseService {
 	}
 
 	private taskDisplayString(id: TaskId): string {
+		// If a task is no longer registered, but was in the past, we might still attempt to
+		// create a display string for it:
+		if (!(id in this.tasks_)) return `#${id} (unknown)`;
+
 		const task = this.taskById(id);
 		return `#${task.id} (${task.description})`;
 	}


### PR DESCRIPTION
# Problem

If the user upgrades Joplin Sever to a version that includes a new task, then downgrades while the task is running, the downgraded server can fail to start. This happens because `taskDisplayString` currently throws `No such task: ...` for unknown tasks and `taskDisplayString` is called while running `resetInterruptedTasks`.

Since `resetInterruptedTasks` is called on startup, an unrecognized interrupted task can prevent the server from starting.

# Solution

Add a fallback display string for nonexistent tasks.

# Testing

This pull request adds a new automated test that:
1. Creates a task state entry with a task ID that does not correspond to a current task type (123456).
2. Calls `resetInterruptedTasks`.

Previously, step 2 failed with `No such task: 123456`. With the other changes from this pull request, the test passes.


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
