### PR TITLE
Mobile: Resolves #15313: Remove old workaround for S3 and Dropbox sync to improve performance

### DIFF
--- a/packages/app-mobile/utils/shim-init-react/shimInitShared.ts
+++ b/packages/app-mobile/utils/shim-init-react/shimInitShared.ts
@@ -19,12 +19,6 @@ const shimInitShared = () => {
 		return Buffer.byteLength(string, 'utf-8');
 	};
 
-	shim.Buffer = Buffer;
-
-	shim.stringByteLength = function(string) {
-		return Buffer.byteLength(string, 'utf-8');
-	};
-
 	shim.httpAgent = () => null;
 
 	shim.fetch = async function(url, options = null) {

--- a/packages/lib/file-api-driver-amazon-s3.js
+++ b/packages/lib/file-api-driver-amazon-s3.js
@@ -299,9 +299,6 @@ class FileApiDriverAmazonS3 {
 		const remotePath = this.makePath_(path);
 		if (!options) options = {};
 
-		// See https://github.com/facebook/react-native/issues/14445#issuecomment-352965210
-		if (typeof content === 'string') content = shim.Buffer.from(content, 'utf8');
-
 		try {
 			if (options.source === 'file') {
 				await this.s3UploadFileFrom(options.path, remotePath);

--- a/packages/lib/file-api-driver-dropbox.js
+++ b/packages/lib/file-api-driver-dropbox.js
@@ -182,9 +182,6 @@ class FileApiDriverDropbox {
 	}
 
 	async put(path, content, options = null) {
-		// See https://github.com/facebook/react-native/issues/14445#issuecomment-352965210
-		if (typeof content === 'string') content = shim.Buffer.from(content, 'utf8');
-
 		try {
 			await this.api().exec(
 				'POST',

--- a/packages/lib/file-api-driver.test.ts
+++ b/packages/lib/file-api-driver.test.ts
@@ -18,6 +18,14 @@ describe('file-api-driver', () => {
 		expect(content).toBe('testing');
 	}));
 
+	it('should preserve unicode content when uploading text files', (async () => {
+		// U+D800~U+DFFF are not guaranteed because they are not valid in UTF-8
+		const content = '中文にっぽんご한국어😀\0\r\nenglish 01234567890';
+		await fileApi().put('unicode.txt', content);
+		const uploadedContent = await fileApi().get('unicode.txt');
+		expect(uploadedContent).toBe(content);
+	}));
+
 	it('should get a file info', (async () => {
 		await fileApi().put('test1.txt', 'testing');
 		await fileApi().mkdir('sub');

--- a/packages/lib/file-api-driver.test.ts
+++ b/packages/lib/file-api-driver.test.ts
@@ -18,14 +18,6 @@ describe('file-api-driver', () => {
 		expect(content).toBe('testing');
 	}));
 
-	it('should preserve unicode content when uploading text files', (async () => {
-		// U+D800~U+DFFF are not guaranteed because they are not valid in UTF-8
-		const content = '中文にっぽんご한국어😀\0\r\nenglish 01234567890';
-		await fileApi().put('unicode.txt', content);
-		const uploadedContent = await fileApi().get('unicode.txt');
-		expect(uploadedContent).toBe(content);
-	}));
-
 	it('should get a file info', (async () => {
 		await fileApi().put('test1.txt', 'testing');
 		await fileApi().mkdir('sub');

--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -692,8 +692,6 @@ function shimInit(options: ShimInitOptions = null) {
 		return Buffer.byteLength(string, 'utf-8');
 	};
 
-	shim.Buffer = Buffer;
-
 	shim.openUrl = url => {
 		// Returns true if it opens the file successfully; returns false if it could
 		// not find the file.

--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -427,9 +427,6 @@ const shim = {
 	},
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	Buffer: null as any,
-
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	openUrl: (_url: string): any => {
 		throw new Error('Not implemented: openUrl');
 	},


### PR DESCRIPTION
Resolves #15313
This PR removes the conversion from string to utf-8 buffer in `put()` methods of S3/Dropbox file api driver, which can increase the performance on mobile platform.

---
# Performance Analysis

`.put()` calls `fetch()` in RN in the end. `fetch()` processes string data and binary data in different ways.

## Call `fetch()` on string
`JS string` --1--> `native bytes` --2--> `network`
1. `JS string` -> `{string: body}` in JS, then native turns that string body into request bytes.
  - [`convertRequestBody.js#L28-L30`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/Libraries/Network/convertRequestBody.js#L28-L30)
  - Android: [`RCTNetworking.android.js#L72-L90`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/Libraries/Network/RCTNetworking.android.js#L72-L90), [`NetworkingModule.kt#L360-L398`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt#L360-L398), iOS: [`RCTNetworking.ios.js#L42-L54`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/Libraries/Network/RCTNetworking.ios.js#L42-L54), [`RCTNetworking.mm#L416-L418`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/Libraries/Network/RCTNetworking.mm#L416-L418)
2. Native request bytes are sent through the platform networking stack.
  - Android: [`NetworkingModule.kt#L472-L477`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt#L472-L477), iOS: [`RCTNetworking.mm#L332-L339`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/Libraries/Network/RCTNetworking.mm#L332-L339), [`RCTNetworking.mm#L689-L709`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/Libraries/Network/RCTNetworking.mm#L689-L709)

## Call `fetch()` on binary data
  `JS bytes` --1--> `base64 string` --2--> `native decode` --3--> `native bytes` --4--> `network`
1. `JS bytes` -> `{base64: binaryToBase64(body)}` -> `base64 string`.
  - [`convertRequestBody.js#L38-L41`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/Libraries/Network/convertRequestBody.js#L38-L41)
  - Android: [`binaryToBase64.js#L15-L28`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/Libraries/Utilities/binaryToBase64.js#L15-L28), iOS: [`binaryToBase64.js#L15-L28`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/Libraries/Utilities/binaryToBase64.js#L15-L28)
2. The base64 string is passed from JS into the native networking module.
  - Android: [`RCTNetworking.android.js#L72-L90`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/Libraries/Network/RCTNetworking.android.js#L72-L90), iOS: [`RCTNetworking.ios.js#L42-L54`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/Libraries/Network/RCTNetworking.ios.js#L42-L54)
3. Native decodes the base64 string and rebuilds the request bytes/body.
  - Android: [`NetworkingModule.kt#L400-L428`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt#L400-L428), iOS: [`RCTNetworking.mm#L420-L423`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/Libraries/Network/RCTNetworking.mm#L420-L423)
4. Native request bytes are sent through the platform networking stack.
  - Android: [`NetworkingModule.kt#L472-L477`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt#L472-L477), iOS: [`RCTNetworking.mm#L332-L339`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/Libraries/Network/RCTNetworking.mm#L332-L339), [`RCTNetworking.mm#L689-L709`](https://github.com/facebook/react-native/blob/cddf8a7536de12db889e35e946281cfaf327197a/packages/react-native/Libraries/Network/RCTNetworking.mm#L689-L709)

In summary, passing binary content to `fetch()` has more overhead.

---
# Test
I tested the sync to Dropbox on an Android device and it works. Notes with unicode text can be synced to Dropbox, and newly installed Joplin client can fetch the note content via sync.

<details><summary>Screenshot</summary>

<img width="100%" height="100%" alt="image" src="https://github.com/user-attachments/assets/6c19ee6a-e3ba-43c6-a31a-9a6f2d39a9e9" />

</details> 