### PR TITLE
All: Fixes #15318: Fixed RotatingLogs.cleanActiveLogFile() crash on fresh install

### DIFF
--- a/packages/lib/RotatingLogs.ts
+++ b/packages/lib/RotatingLogs.ts
@@ -15,7 +15,7 @@ export default class RotatingLogs {
 
 	public async cleanActiveLogFile() {
 		const stats: Stat = await this.fsDriver().stat(this.logFileFullpath());
-		if (!stats) return; // log.txt doesn't exist yet (e.g. fresh install) — nothing to rotate
+		if (!stats) return;
 		if (stats.size >= this.maxFileSize) {
 			const newLogFile: string = this.logFileFullpath(this.getNameToNonActiveLogFile());
 			await this.fsDriver().move(this.logFileFullpath(), newLogFile);

--- a/packages/lib/RotatingLogs.ts
+++ b/packages/lib/RotatingLogs.ts
@@ -15,6 +15,7 @@ export default class RotatingLogs {
 
 	public async cleanActiveLogFile() {
 		const stats: Stat = await this.fsDriver().stat(this.logFileFullpath());
+		if (!stats) return; // log.txt doesn't exist yet (e.g. fresh install) — nothing to rotate
 		if (stats.size >= this.maxFileSize) {
 			const newLogFile: string = this.logFileFullpath(this.getNameToNonActiveLogFile());
 			await this.fsDriver().move(this.logFileFullpath(), newLogFile);


### PR DESCRIPTION
<!--
Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md
-->

## Description

Fixes #15318

This PR addresses an edge-case crash that happens on fresh installations (or after clearing profile data). 

**Issue:** `RotatingLogs.cleanActiveLogFile()` calls `this.fsDriver().stat()` and subsequently reads `.size` without validating the return object. In Joplin's Node `fs-driver`, `stat()` returns `null` for non-existent files. As a result, when the app launches and `log.txt` hasn't been created yet, this process throws a `TypeError: Cannot read properties of null (reading 'size')`.

**Fix:** Added an explicit `null` guard before checking file size, matching the validation already used elsewhere in the `RotatingLogs` service. 

## Testing

1. Deleted `log.txt` from the Joplin profile directory.
2. Verified that the app starts successfully without throwing an unhandled exception during log rotation checks.
