### PR TITLE
Desktop: Fixes #15258: Show sync error state in sidebar button

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -438,6 +438,7 @@ packages/app-desktop/gui/SearchBar/SearchBar.js
 packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.js
 packages/app-desktop/gui/ShareNoteDialog.js
 packages/app-desktop/gui/Sidebar/FolderAndTagList.js
+packages/app-desktop/gui/Sidebar/Sidebar.test.js
 packages/app-desktop/gui/Sidebar/Sidebar.js
 packages/app-desktop/gui/Sidebar/commands/focusElementSideBar.js
 packages/app-desktop/gui/Sidebar/commands/index.js
@@ -460,6 +461,7 @@ packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.js
 packages/app-desktop/gui/Sidebar/listItemComponents/NoteCount.js
 packages/app-desktop/gui/Sidebar/listItemComponents/TagItem.js
 packages/app-desktop/gui/Sidebar/styles/index.js
+packages/app-desktop/gui/Sidebar/synchronizeButtonState.js
 packages/app-desktop/gui/Sidebar/types.js
 packages/app-desktop/gui/SsoLoginScreen/SsoLoginScreen.js
 packages/app-desktop/gui/StatusScreen/StatusScreen.js

--- a/.gitignore
+++ b/.gitignore
@@ -415,6 +415,7 @@ packages/app-desktop/gui/SearchBar/SearchBar.js
 packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.js
 packages/app-desktop/gui/ShareNoteDialog.js
 packages/app-desktop/gui/Sidebar/FolderAndTagList.js
+packages/app-desktop/gui/Sidebar/Sidebar.test.js
 packages/app-desktop/gui/Sidebar/Sidebar.js
 packages/app-desktop/gui/Sidebar/commands/focusElementSideBar.js
 packages/app-desktop/gui/Sidebar/commands/index.js
@@ -437,6 +438,7 @@ packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.js
 packages/app-desktop/gui/Sidebar/listItemComponents/NoteCount.js
 packages/app-desktop/gui/Sidebar/listItemComponents/TagItem.js
 packages/app-desktop/gui/Sidebar/styles/index.js
+packages/app-desktop/gui/Sidebar/synchronizeButtonState.js
 packages/app-desktop/gui/Sidebar/types.js
 packages/app-desktop/gui/SsoLoginScreen/SsoLoginScreen.js
 packages/app-desktop/gui/StatusScreen/StatusScreen.js

--- a/packages/app-desktop/gui/Sidebar/Sidebar.test.ts
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.test.ts
@@ -1,0 +1,46 @@
+import synchronizeButtonState from './synchronizeButtonState';
+
+type SyncReport = {
+	completedTime: number;
+	errors: Error[];
+};
+
+describe('Sidebar', () => {
+	test('should show a success icon when sync completed without errors and nothing is pending', () => {
+		const syncReport: SyncReport = {
+			completedTime: 123,
+			errors: [],
+		};
+
+		const buttonState = synchronizeButtonState('sync', false, syncReport);
+
+		expect(buttonState.iconName).toBe('fas fa-check');
+		expect(buttonState.className).toContain('-synced');
+	});
+
+	test('should show an error icon when the last sync report contains errors', () => {
+		const syncReport: SyncReport = {
+			completedTime: 123,
+			errors: [new Error('Fail-safe triggered')],
+		};
+
+		const buttonState = synchronizeButtonState('sync', false, syncReport);
+
+		expect(buttonState.iconName).toBe('fas fa-exclamation-triangle');
+		expect(buttonState.className).toContain('-error');
+		expect(buttonState.className).not.toContain('-synced');
+	});
+
+	test('should keep the cancel button state while synchronization is active', () => {
+		const syncReport: SyncReport = {
+			completedTime: 123,
+			errors: [new Error('Fail-safe triggered')],
+		};
+
+		const buttonState = synchronizeButtonState('cancel', false, syncReport);
+
+		expect(buttonState.iconName).toBe('icon-sync');
+		expect(buttonState.className).toContain('-syncing');
+		expect(buttonState.className).not.toContain('-error');
+	});
+});

--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
 import { themeStyle } from '@joplin/lib/theme';
 import { Dispatch } from 'redux';
 import FolderAndTagList from './FolderAndTagList';
+import synchronizeButtonState from './synchronizeButtonState';
 
 
 interface Props {
@@ -24,23 +25,16 @@ interface Props {
 	syncPending: boolean;
 	syncReportIsVisible: boolean;
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- The generated report does not currently have a type
-const syncCompletedWithoutError = (syncReport: any) => {
-	return syncReport.completedTime && (!syncReport.errors || !syncReport.errors.length);
-};
-
 const SidebarComponent = (props: Props) => {
 	const renderSynchronizeButton = (type: string) => {
 		const label = type === 'sync' ? _('Synchronise') : _('Cancel');
-		const nothingToSync = type === 'sync' && !props.syncPending && syncCompletedWithoutError(props.syncReport);
-		const iconName = nothingToSync ? 'fas fa-check' : 'icon-sync';
+		const buttonState = synchronizeButtonState(type, props.syncPending, props.syncReport);
 
 		return (
 			<StyledSynchronizeButton
 				level={ButtonLevel.SidebarSecondary}
-				className={`sidebar-sync-button ${type === 'sync' ? '' : '-syncing'} ${nothingToSync ? '-synced' : ''}`}
-				iconName={iconName}
+				className={buttonState.className}
+				iconName={buttonState.iconName}
 				key="sync_button"
 				title={label}
 				onClick={() => {

--- a/packages/app-desktop/gui/Sidebar/styles/index.ts
+++ b/packages/app-desktop/gui/Sidebar/styles/index.ts
@@ -91,6 +91,17 @@ export const StyledShareIcon = styled.i`
 
 export const StyledSynchronizeButton = styled(Button)`
 	width: 100%;
+
+	&.-error,
+	&.-error:hover,
+	&.-error:active {
+		border-color: ${(props: StyleProps) => props.theme.colorError2};
+		color: ${(props: StyleProps) => props.theme.colorError2};
+
+		.icon {
+			color: ${(props: StyleProps) => props.theme.colorError2};
+		}
+	}
 `;
 
 export const StyledAddButton = styled(Button)`

--- a/packages/app-desktop/gui/Sidebar/synchronizeButtonState.ts
+++ b/packages/app-desktop/gui/Sidebar/synchronizeButtonState.ts
@@ -1,0 +1,32 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- The generated report does not currently have a type
+const syncCompletedWithoutError = (syncReport: any) => {
+	return syncReport.completedTime && (!syncReport.errors || !syncReport.errors.length);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- The generated report does not currently have a type
+const syncReportHasErrors = (syncReport: any) => {
+	return !!(syncReport.errors && syncReport.errors.length);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- The generated report does not currently have a type
+const synchronizeButtonState = (type: string, syncPending: boolean, syncReport: any) => {
+	const nothingToSync = type === 'sync' && !syncPending && syncCompletedWithoutError(syncReport);
+	const hasErrors = type === 'sync' && syncReportHasErrors(syncReport);
+
+	let iconName = 'icon-sync';
+	if (nothingToSync) iconName = 'fas fa-check';
+	if (hasErrors) iconName = 'fas fa-exclamation-triangle';
+
+	const classNames = ['sidebar-sync-button'];
+	if (type !== 'sync') classNames.push('-syncing');
+	if (nothingToSync) classNames.push('-synced');
+	if (hasErrors) classNames.push('-error');
+
+	return {
+		className: classNames.join(' '),
+		iconName,
+		nothingToSync,
+	};
+};
+
+export default synchronizeButtonState;


### PR DESCRIPTION
1. Start Joplin Desktop with a test profile.
2. Configure a sync target that will fail, for example WebDAV with an invalid URL or wrong credentials.
3. Run synchronisation and wait until it fails.
4. Check the sync button in the left sidebar.

Before:
- the sidebar button keeps the normal sync icon

After:
- the sidebar button shows the error state with a warning icon
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
