### PR TITLE
Mobile: Fixes #15315: Installed plugins list shown incorrectly as empty

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx
@@ -49,6 +49,8 @@ const useLoadedPluginIds = () => {
 			setLoadedPluginIds(getLoadedPlugins());
 		});
 
+		setLoadedPluginIds(getLoadedPlugins());
+
 		return () => {
 			remove();
 		};


### PR DESCRIPTION
Fixes #15315

This PR fixes a React state race condition in `useLoadedPluginIds` on the mobile app. On mobile, plugins are loaded asynchronously in the background via `PluginRunnerWebView`. If the plugin loading finishes between the initial state render and the `useEffect` attaching the change listener, the UI misses the `plugins loaded` event and the `loadedPluginIds` state remains permanently empty. By checking and updating the state immediately after registering the listener, we guarantee that the UI correctly populates the list of installed plugins regardless of when the asynchronous background loading completes.