### PR TITLE
Desktop: Resolves #15341: Fix TinyMCE toolbar alignment when resizing notes area

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -421,8 +421,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 		editorContainerDom.head.appendChild(element);
 		element.appendChild(editorContainerDom.createTextNode(`
 			.joplin-tinymce .tox-editor-header.tox-editor-header {
-				margin-left: ${styles.leftExtraToolbarContainer.width + styles.leftExtraToolbarContainer.padding * 2}px;
-				margin-right: ${styles.rightExtraToolbarContainer.width + styles.rightExtraToolbarContainer.padding * 2}px;
+				margin-left: ${styles.leftExtraToolbarContainer.width}px;
+				margin-right: ${styles.rightExtraToolbarContainer.width}px;
 				padding: 0;
 				box-shadow: none;
 			}
@@ -1678,12 +1678,24 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 	const containerId = useMemo(() => {
 		return `tinymce-container-${Math.ceil(Math.random() * 1000)}-${Date.now()}`;
 	}, []);
+
 	return (
 		<div style={styles.rootStyle} className="joplin-tinymce">
 			{renderDisabledOverlay()}
-			{renderLeftExtraToolbarButtons()}
-			{renderRightExtraToolbarButtons()}
-			<div style={{ width: '100%', height: '100%' }} id={containerId} ref={setEditorContainer}/>
+
+			<div style={styles.toolbarContainer}>
+				{renderLeftExtraToolbarButtons()}
+
+				<div style={styles.tinyMceToolbarContainer}/>
+
+				{renderRightExtraToolbarButtons()}
+			</div>
+
+			<div
+				style={styles.editorContainer}
+				id={containerId}
+				ref={setEditorContainer}
+			/>
 		</div>
 	);
 };

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.ts
@@ -5,17 +5,9 @@ import { buildStyle } from '@joplin/lib/theme';
 export default function styles(props: NoteBodyEditorProps) {
 	const leftExtraToolbarContainerWidth = props.watchedNoteFiles.length > 0 ? 120 : 80;
 	return buildStyle(['TinyMCE', props.style.width, props.style.height, leftExtraToolbarContainerWidth], props.themeId, theme => {
-		const extraToolbarContainer = {
-			boxSizing: 'content-box',
-			backgroundColor: theme.backgroundColor3,
-			display: 'flex',
-			flexDirection: 'row',
-			position: 'absolute',
-			height: theme.toolbarHeight,
-			zIndex: 2,
-			top: 0,
-			padding: theme.toolbarPadding,
-		};
+		const toolbarHeight = theme.toolbarHeight + theme.toolbarPadding * 2;
+		const leftExtraToolbarContainerTotalWidth = leftExtraToolbarContainerWidth + theme.toolbarPadding * 2;
+		const rightExtraToolbarContainerTotalWidth = 70 + theme.toolbarPadding + theme.mainPadding;
 
 		return {
 			disabledOverlay: {
@@ -37,18 +29,49 @@ export default function styles(props: NoteBodyEditorProps) {
 				width: props.style.width,
 				height: props.style.height,
 			},
-			leftExtraToolbarContainer: {
-				...extraToolbarContainer,
-				width: leftExtraToolbarContainerWidth,
+			toolbarContainer: {
+				position: 'absolute',
+				top: 0,
 				left: 0,
+				right: 0,
+				height: toolbarHeight,
+				display: 'flex',
+				alignItems: 'stretch',
+				zIndex: 10,
+				overflow: 'hidden',
+				pointerEvents: 'none',
+			},
+			leftExtraToolbarContainer: {
+				boxSizing: 'border-box',
+				display: 'flex',
+				flex: '0 0 auto',
+				width: leftExtraToolbarContainerTotalWidth,
+				position: 'static',
+				padding: theme.toolbarPadding,
+				backgroundColor: theme.backgroundColor3,
+				overflow: 'hidden',
+				pointerEvents: 'auto',
+			},
+			tinyMceToolbarContainer: {
+				flex: '1 1 auto',
+				minWidth: 0,
 			},
 			rightExtraToolbarContainer: {
-				...extraToolbarContainer,
-				alignItems: 'center',
-				justifyContent: 'flex-end',
-				width: 70,
-				right: 0,
+				boxSizing: 'border-box',
+				display: 'flex',
+				flex: '0 0 auto',
+				width: rightExtraToolbarContainerTotalWidth,
+				position: 'static',
+				padding: theme.toolbarPadding,
 				paddingRight: theme.mainPadding,
+				backgroundColor: theme.backgroundColor3,
+				overflow: 'hidden',
+				pointerEvents: 'auto',
+			},
+			editorContainer: {
+				width: '100%',
+				height: '100%',
+				boxSizing: 'border-box',
 			},
 			extraToolbarButton: {
 				display: 'flex',

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.ts
@@ -11,7 +11,7 @@ export default function styles(props: NoteBodyEditorProps) {
 
 		return {
 			disabledOverlay: {
-				zIndex: 10,
+				zIndex: 11,
 				position: 'absolute',
 				backgroundColor: theme.backgroundColor,
 				opacity: theme.appearance === ThemeAppearance.Light ? 0.7 : 0.9,


### PR DESCRIPTION
## Summary
Fixes the TinyMCE editor toolbar layout so Joplin’s extra toolbar buttons and TinyMCE’s toolbar render as a single aligned row without overlap.

While developing the plugin for Infinite Whiteboard, I noticed that shrinking the notes area caused the left and right toolbar sections to overlap each other and extend outside the toolbar boundaries. This happened because the extra toolbar sections were positioned independently.

To resolve this, I grouped the left and right toolbar sections into a single toolbar container, ensuring all toolbar elements stay within bounds and behave consistently when the notes area is resized, similar to the editor layout behavior.

## What Changed

- Wrapped the left and right extra toolbar buttons inside a single toolbar container.
- Refactored the toolbar layout to use flex so the left buttons, TinyMCE toolbar area, and right buttons stay properly aligned.
- Updated TinyMCE toolbar margins to reserve space for Joplin’s extra toolbar buttons and prevent overlap.
- Adjusted width calculations to avoid double-counting padding after layout changes.

## Why

Previously, Joplin’s extra toolbar buttons were positioned separately on the left and right while TinyMCE rendered its own toolbar independently underneath.

This made the toolbar layout harder to maintain and caused alignment issues when resizing the notes area, leading to overlapping sections and out-of-bound rendering.

The updated layout ensures:
- Joplin’s extra toolbar buttons remain within the toolbar boundaries
- TinyMCE’s toolbar stays properly centered between the left and right sections
- Toolbar behavior remains stable during editor resizing

## Testing

Attached videos demonstrating the toolbar behavior before and after the fix.

## Before:
[Screencast From 2026-05-11 14-34-22.webm](https://github.com/user-attachments/assets/2b23b430-332c-49f5-aaa0-4c19b6e07b6f)


## After:
[Screencast From 2026-05-11 15-06-42.webm](https://github.com/user-attachments/assets/9251a5d0-52e3-48bf-aa21-a1018e549450)
