### PR TITLE
Desktop: Fixes #15346: Fix fatal startup crash when sync target upgrade is required

### DIFF
--- a/packages/app-desktop/gui/Root_UpgradeSyncTarget.tsx
+++ b/packages/app-desktop/gui/Root_UpgradeSyncTarget.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useEffect } from 'react';
 import useSyncTargetUpgrade, { SyncTargetUpgradeResult } from '@joplin/lib/services/synchronizer/gui/useSyncTargetUpgrade';
 
-const { render } = require('react-dom');
+import { createRoot } from 'react-dom/client';
 const ipcRenderer = require('electron').ipcRenderer;
 import Setting from '@joplin/lib/models/Setting';
 import restart from '../services/restart';
@@ -101,4 +101,5 @@ function Root_UpgradeSyncTarget() {
 	);
 }
 
-render(<Root_UpgradeSyncTarget />, document.getElementById('react-root'));
+const root = createRoot(document.getElementById('react-root'));
+root.render(<Root_UpgradeSyncTarget />);


### PR DESCRIPTION
Fixes #15346

The `Root_UpgradeSyncTarget` entry point was still calling the legacy `render` export from `react-dom`, which was removed in React 19. As a result, any user whose profile required a sync target upgrade hit a fatal `TypeError` at renderer startup and could not open the app. This change migrates the file to the React 18+ `createRoot` API from `react-dom/client`, matching the pattern already used in `Root.tsx` since the React 19 upgrade.