### PR TITLE
Desktop: Fixes #15308: Fix importing keyboard shortcuts exported before 3.6.11

### DIFF
--- a/packages/lib/services/KeymapService.test.js
+++ b/packages/lib/services/KeymapService.test.js
@@ -251,6 +251,20 @@ describe('services_KeymapService', () => {
 			});
 		});
 
+		it('should import legacy undo and redo command names', () => {
+			keymapService.initialize([], 'win32');
+			const customKeymapItems = [
+				{ command: 'editor.undo', accelerator: 'Ctrl+Z' },
+				{ command: 'editor.redo', accelerator: 'Ctrl+Shift+Z' },
+			];
+
+			expect(() => keymapService.overrideKeymap(customKeymapItems)).not.toThrow();
+			expect(keymapService.getAccelerator('globalUndo')).toEqual('Ctrl+Z');
+			expect(keymapService.getAccelerator('globalRedo')).toEqual('Ctrl+Shift+Z');
+			expect(keymapService.getCommandNames()).not.toContain('editor.undo');
+			expect(keymapService.getCommandNames()).not.toContain('editor.redo');
+		});
+
 		it('should throw when the required properties are missing', () => {
 			const customKeymaps = [
 				[

--- a/packages/lib/services/KeymapService.ts
+++ b/packages/lib/services/KeymapService.ts
@@ -11,6 +11,11 @@ const modifiersRegExp = {
 	default: /^(Ctrl|Alt|AltGr|Shift|Super)$/,
 };
 
+const legacyCommandAliases = {
+	'editor.undo': 'globalUndo',
+	'editor.redo': 'globalRedo',
+};
+
 const defaultKeymapItems = {
 	darwin: [
 		{ accelerator: 'Cmd+N', command: 'newNote' },
@@ -226,7 +231,11 @@ export default class KeymapService extends BaseService {
 	}
 
 	public acceleratorExists(command: string) {
-		return !!this.keymap[command];
+		return !!this.keymap[this.normalizeCommandName(command)];
+	}
+
+	private normalizeCommandName(commandName: string) {
+		return legacyCommandAliases[commandName] ?? commandName;
 	}
 
 	private convertToPlatform(accelerator: string) {
@@ -237,6 +246,8 @@ export default class KeymapService extends BaseService {
 	}
 
 	public registerCommandAccelerator(commandName: string, accelerator: string) {
+		commandName = this.normalizeCommandName(commandName);
+
 		// If the command is already registered, we don't register it again and
 		// we don't update the accelerator. This is because it might have been
 		// modified by the user and we don't want the plugin to overwrite this.
@@ -254,10 +265,11 @@ export default class KeymapService extends BaseService {
 	}
 
 	public setAccelerator(command: string, accelerator: string) {
-		this.keymap[command].accelerator = accelerator;
+		this.keymap[this.normalizeCommandName(command)].accelerator = accelerator;
 	}
 
 	public getAccelerator(command: string) {
+		command = this.normalizeCommandName(command);
 		const item = this.keymap[command];
 		if (!item) throw new Error(`KeymapService: "${command}" command does not exist!`);
 
@@ -265,6 +277,7 @@ export default class KeymapService extends BaseService {
 	}
 
 	public getDefaultAccelerator(command: string) {
+		command = this.normalizeCommandName(command);
 		const defaultItem = this.defaultKeymapItems.find((item => item.command === command));
 		if (!defaultItem) throw new Error(`KeymapService: "${command}" command does not exist!`);
 
@@ -308,7 +321,10 @@ export default class KeymapService extends BaseService {
 	public overrideKeymap(customKeymapItems: KeymapItem[]) {
 		try {
 			for (let i = 0; i < customKeymapItems.length; i++) {
-				const item = customKeymapItems[i];
+				const item = {
+					...customKeymapItems[i],
+					command: this.normalizeCommandName(customKeymapItems[i].command),
+				};
 				// Validate individual custom keymap items
 				// Throws if there are any issues in the keymap item
 				this.validateKeymapItem(item);


### PR DESCRIPTION
Fixes #15308.

Summary

Importing a keyboard shortcut file exported from an older desktop build can fail on v3.6.11. The regression is caused by the rename of the undo and redo commands from editor.undo and editor.redo to globalUndo and globalRedo. Older keymap files still use the legacy command names, so importing them can trigger duplicate accelerator conflicts and fail.

What this PR does

Normalises legacy undo and redo command names during desktop keymap import.
Maps editor.undo to globalUndo.
Maps editor.redo to globalRedo.
Adds a regression test covering import of legacy undo and redo shortcuts.
Why this change

This preserves compatibility with existing exported keymap files from earlier desktop versions and fixes the regression without changing the current shortcut model or the UI.

User impact

Users can import older [keymap-desktop.json](vscode-file://vscode-app/e:/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) files on the release-3.6 branch again, and the imported undo and redo shortcuts continue to work as expected.

Automated tests

Added a regression test that imports legacy editor.undo and editor.redo entries and verifies that they are stored as globalUndo and globalRedo.
Manual testing plan

Import a legacy keymap JSON containing editor.undo and editor.redo, and verify that no error is shown.
Open Keyboard Shortcuts and verify that the imported accelerators appear on Undo and Redo.
Verify that no separate editor.undo or editor.redo entries are created.
In the note editor, type text, use the imported undo shortcut, and verify that the latest change is reverted.
Use the imported redo shortcut and verify that the reverted change is restored.
Export the shortcuts again and verify that the exported JSON uses globalUndo and globalRedo.
<img width="2030" height="1056" alt="result" src="https://github.com/user-attachments/assets/e14e2b67-8a7c-4402-97ff-964338122f45" />
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
