### PR TITLE
Desktop: Fixes #15307: Note list: Don't detect checkbox-like markup in tables and paragraphs as checkboxes

### DIFF
--- a/packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.test.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.test.ts
@@ -141,23 +141,44 @@ describe('prepareViewProps', () => {
 		});
 	});
 
-	it('should return isComplete true when all checkboxes are checked', async () => {
+	it.each([
+		{
+			label: 'set isComplete to true when all checkboxes are checked',
+			body: '- [x] task 1\n- [X] task 2\n- [x] task 3',
+			expectedStatus: {
+				total: 3,
+				checked: 3,
+				percent: 100,
+				isComplete: true,
+			},
+		},
+		{
+			label: 'not recognise checkbox markup that isn\'t in a checklist',
+			body: 'This will not render as a checkbox: "- [x] task 1".',
+			expectedStatus: null,
+		},
+		{
+			label: 'recognise checkbox markup within block quotes',
+			body: '> > - [ ] This\n\n> - [ ] is\n> - [x] a test',
+			expectedStatus: {
+				total: 3,
+				checked: 1,
+				percent: 33,
+				isComplete: false,
+			},
+		},
+	])('should $label', async ({ body, expectedStatus }) => {
 		Setting.setValue('notes.showCheckboxCompletionChart', true);
 
 		const note = await Note.save({
 			title: 'test',
-			body: '- [x] task 1\n- [X] task 2\n- [x] task 3',
+			body,
 		});
 
 		const result = await prepare(['note.checkboxes'], note);
 		expect(result).toEqual({
 			note: {
-				checkboxes: {
-					total: 3,
-					checked: 3,
-					percent: 100,
-					isComplete: true,
-				},
+				checkboxes: expectedStatus,
 			},
 		});
 	});

--- a/packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.ts
@@ -16,8 +16,8 @@ const countCheckboxes = (body: string): CheckboxStats | null => {
 	if (!body) return null;
 
 	// Match unchecked: - [ ] and checked: - [x] or - [X]
-	const uncheckedMatches = body.match(/- \[ \]/g);
-	const checkedMatches = body.match(/- \[[xX]\]/g);
+	const uncheckedMatches = body.match(/\n[ \t>]*- \[ \]/g);
+	const checkedMatches = body.match(/\n[ \t>]*- \[[xX]\]/g);
 
 	const unchecked = uncheckedMatches ? uncheckedMatches.length : 0;
 	const checked = checkedMatches ? checkedMatches.length : 0;

--- a/packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.ts
@@ -16,8 +16,8 @@ const countCheckboxes = (body: string): CheckboxStats | null => {
 	if (!body) return null;
 
 	// Match unchecked: - [ ] and checked: - [x] or - [X]
-	const uncheckedMatches = body.match(/\n[ \t>]*- \[ \]/g);
-	const checkedMatches = body.match(/\n[ \t>]*- \[[xX]\]/g);
+	const uncheckedMatches = body.match(/(^|\n)[ \t>]*- \[ \]/g);
+	const checkedMatches = body.match(/(^|\n)[ \t>]*- \[[xX]\]/g);
 
 	const unchecked = uncheckedMatches ? uncheckedMatches.length : 0;
 	const checked = checkedMatches ? checkedMatches.length : 0;


### PR DESCRIPTION
# Problem

With https://github.com/laurent22/joplin/pull/14312, the fraction of complete vs incomplete checkboxes in each note is displayed in the note list. This fraction is determined using a regular expression. This expression allowed `- [ ]` checkbox markup to occur in the middle of paragraphs, in tables, and in other locations where the checkbox markup would not create a checkbox.

See also: https://github.com/laurent22/joplin/pull/14312


# Solution

Adjust the regular expression to only include checkboxes at the start of lines or within blockquotes.

Fixes #15307.

**Note:** As before, checkboxes in headers and checkboxes that use non-<kbd>-</kbd> starting characters are not counted.

# Testing

**Manual testing:** Checking/unchecking checkboxes in a note and checking the completion status shown in the note list:

[Manual testing: Note that includes checkboxes counted and not counted by the regex](https://github.com/user-attachments/assets/48f0e29a-e8ad-4bb6-be81-47458aa268cd)

**Automated testing**: This pull request adds a regression test.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
