### PR TITLE
iOS: Fixes #15311: Fix plugins fail to start

### DIFF
--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -130,7 +130,18 @@ export default class FsDriverRN extends FsDriverBase {
 		let output: any[] = [];
 		for (let i = 0; i < stats.length; i++) {
 			const stat = stats[i];
-			const relativePath = (isScoped ? stat.uri : stat.path).substr(path.length + 1);
+			let relativePath;
+			if (isScoped) {
+				relativePath = stat.uri;
+			} else {
+				relativePath = stat.path;
+				// Workaround: Paths returned by stat can include a leading /private/, when this isn't included
+				// in the original path variable:
+				if (stat.path.startsWith('/private/') && !path.startsWith('/private/')) {
+					relativePath = relativePath.replace(/^\/private/, '');
+				}
+				relativePath = relativePath.substring(path.length + 1);
+			}
 			const standardStat = this.rnfsStatToStd_(stat, relativePath);
 			output.push(standardStat);
 

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -8,7 +8,8 @@ import tarExtract from './tarExtract';
 import JoplinError from '@joplin/lib/JoplinError';
 const md5 = require('md5');
 import { resolve } from 'path';
-
+import Logger from '@joplin/utils/Logger';
+const logger = Logger.create('fs-driver-rn');
 
 const ANDROID_URI_PREFIX = 'content://';
 
@@ -135,11 +136,17 @@ export default class FsDriverRN extends FsDriverBase {
 				relativePath = stat.uri;
 			} else {
 				relativePath = stat.path;
-				// Workaround: Paths returned by stat can include a leading /private/, when this isn't included
+
+				// Workaround: Paths returned by RNFS.readDir can include a leading /private/, when this isn't included
 				// in the original path variable:
 				if (stat.path.startsWith('/private/') && !path.startsWith('/private/')) {
 					relativePath = relativePath.replace(/^\/private/, '');
 				}
+
+				if (!relativePath.startsWith(path)) {
+					logger.warn('readDirStats: Relative path does not start with original:', { relativePath, path });
+				}
+
 				relativePath = relativePath.substring(path.length + 1);
 			}
 			const standardStat = this.rnfsStatToStd_(stat, relativePath);

--- a/packages/app-mobile/utils/fs-driver/runOnDeviceTests.ts
+++ b/packages/app-mobile/utils/fs-driver/runOnDeviceTests.ts
@@ -300,9 +300,9 @@ const runOnDeviceTests = async () => {
 		await testAppendFile(tempDir);
 		await testReadWriteFileUtf8(tempDir);
 		await testReadFileChunkUtf8(tempDir);
-		await testTarCreateAndExtract(tempDir);
 		await testMd5File(tempDir);
 		await testReadDirStats(tempDir);
+		await testTarCreateAndExtract(tempDir);
 
 		logger.info('Done');
 	} catch (error) {

--- a/packages/app-mobile/utils/fs-driver/runOnDeviceTests.ts
+++ b/packages/app-mobile/utils/fs-driver/runOnDeviceTests.ts
@@ -253,6 +253,34 @@ const testMd5File = async (tempDir: string) => {
 	await expectToBe(await fsDriver.md5File(testFilePath), 'ba11ba1be5042133a71874731e3d42cd');
 };
 
+const testReadDirStats = async (tempDir: string) => {
+	logger.info('Testing fsDriver.readDirStats...');
+	const fsDriver = shim.fsDriver();
+
+	const parentDir = `${tempDir}/parent-dir`;
+	await fsDriver.mkdir(parentDir);
+	await expectToBe(await fsDriver.exists(parentDir), true);
+
+	await fsDriver.writeFile(`${parentDir}/file1.txt`, 'test', 'utf-8');
+	await fsDriver.writeFile(`${parentDir}/file2.txt`, 'test', 'utf-8');
+	await fsDriver.mkdir(`${parentDir}/dir1`);
+
+	const sortedDirectoryStats = async (directory: string) => {
+		return (await fsDriver.readDirStats(directory)).sort((a, b) => {
+			if (a.path < b.path) return -1;
+			if (a.path === b.path) return 0;
+			return 1;
+		});
+	};
+
+	const stats = await sortedDirectoryStats(parentDir);
+	await expectToBe(stats.length, 3);
+	await expectToBe(stats.map(s => s.path).join(';'), 'dir1;file1.txt;file2.txt');
+	await expectToBe(stats[0].isDirectory(), true);
+	await expectToBe(stats[1].isDirectory(), false);
+	await expectToBe(stats[2].isDirectory(), false);
+};
+
 // In the past, some fs-driver functionality has worked correctly on some devices and not others.
 // As such, we need to be able to run some tests on-device.
 const runOnDeviceTests = async () => {
@@ -270,6 +298,7 @@ const runOnDeviceTests = async () => {
 		await testReadFileChunkUtf8(tempDir);
 		await testTarCreateAndExtract(tempDir);
 		await testMd5File(tempDir);
+		await testReadDirStats(tempDir);
 
 		logger.info('Done');
 	} catch (error) {

--- a/packages/app-mobile/utils/fs-driver/runOnDeviceTests.ts
+++ b/packages/app-mobile/utils/fs-driver/runOnDeviceTests.ts
@@ -2,7 +2,7 @@ import Setting from '@joplin/lib/models/Setting';
 import shim from '@joplin/lib/shim';
 import uuid from '@joplin/lib/uuid';
 import { join } from 'path';
-import FsDriverBase from '@joplin/lib/fs-driver-base';
+import FsDriverBase, { ReadDirStatsOptions } from '@joplin/lib/fs-driver-base';
 import Logger from '@joplin/utils/Logger';
 import { Buffer } from 'buffer';
 import createFilesFromPathRecord from './testUtil/createFilesFromPathRecord';
@@ -264,21 +264,25 @@ const testReadDirStats = async (tempDir: string) => {
 	await fsDriver.writeFile(`${parentDir}/file1.txt`, 'test', 'utf-8');
 	await fsDriver.writeFile(`${parentDir}/file2.txt`, 'test', 'utf-8');
 	await fsDriver.mkdir(`${parentDir}/dir1`);
+	await fsDriver.writeFile(`${parentDir}/dir1/file3.txt`, 'test', 'utf-8');
 
-	const sortedDirectoryStats = async (directory: string) => {
-		return (await fsDriver.readDirStats(directory)).sort((a, b) => {
+	const sortedDirectoryStats = async (directory: string, options: ReadDirStatsOptions|undefined) => {
+		return (await fsDriver.readDirStats(directory, options)).sort((a, b) => {
 			if (a.path < b.path) return -1;
 			if (a.path === b.path) return 0;
 			return 1;
 		});
 	};
 
-	const stats = await sortedDirectoryStats(parentDir);
-	await expectToBe(stats.length, 3);
-	await expectToBe(stats.map(s => s.path).join(';'), 'dir1;file1.txt;file2.txt');
-	await expectToBe(stats[0].isDirectory(), true);
-	await expectToBe(stats[1].isDirectory(), false);
-	await expectToBe(stats[2].isDirectory(), false);
+	const nonRecursiveStats = await sortedDirectoryStats(parentDir, undefined);
+	await expectToBe(nonRecursiveStats.length, 3);
+	await expectToBe(nonRecursiveStats.map(s => s.path).join(';'), 'dir1;file1.txt;file2.txt');
+	await expectToBe(nonRecursiveStats[0].isDirectory(), true);
+	await expectToBe(nonRecursiveStats[1].isDirectory(), false);
+	await expectToBe(nonRecursiveStats[2].isDirectory(), false);
+
+	const recursiveStats = await sortedDirectoryStats(parentDir, { recursive: true });
+	await expectToBe(recursiveStats.map(s => s.path).join(';'), 'dir1;dir1/file3.txt;file1.txt;file2.txt');
 };
 
 // In the past, some fs-driver functionality has worked correctly on some devices and not others.


### PR DESCRIPTION
# Problem

In a release build on a physical iOS device, `fs-driver-rn`'s `readDirStats` could return paths to files that do not exist. This was caused by an issue related to how `fs-driver-rn` computes relative paths:
https://github.com/laurent22/joplin/blob/33aa43bd7d825bc10f440442b352b81f91690800/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts#L133

In this particular case, `RNFS.readDir` was called with a path similar to `/var/.../some/path` and returned stats with `stat.path` `/private/var/.../some/path`. The `stat.path.substr` then left part of the parent directories of the given path, producing invalid output.  

This was likely caused by a dependency upgrade (most likely in #14232).

> [!NOTE]
>
> This pull request should also fix issues related to importing JEX files on iOS.

# Solution

- Add an edge case to handle the `/var/` -> `/private/var` change. 
- Log a warning if `stat.path` does not start with `path`.
  - Note: A better long-term alternative would be to `throw` in this case. However, since this pull request targets `release-3.6`, I would prefer to avoid throwing.


Fixes #15311.

# Testing

1. Enable the startup tests in release mode by removing [this if statement](https://github.com/laurent22/joplin/blob/33aa43bd7d825bc10f440442b352b81f91690800/packages/app-mobile/utils/buildStartupTasks.ts#L482).
2. Build and run the app on a physical iOS 18 device.
3. Verify that the startup tests pass.
4. Install the RevealJS slides plugin.
5. Verify that the plugin loads.
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
