### PR TITLE
Server: Fixes #15395: Static asset resolution fails on Windows due to backslash path separators

### DIFF
--- a/packages/server/src/routes/default.ts
+++ b/packages/server/src/routes/default.ts
@@ -9,6 +9,7 @@ import { localFileFromUrl } from '../utils/joplinUtils';
 import { homeUrl, loginUrl } from '../utils/urlUtils';
 import * as mime from '@joplin/lib/mime-utils';
 import { hasOwnProperty } from '@joplin/utils/object';
+import { toForwardSlashes } from '@joplin/utils/path';
 
 const publicDir = `${dirname(dirname(__dirname))}/public`;
 
@@ -34,7 +35,7 @@ async function findLocalFile(path: string): Promise<string> {
 	const appFilePath = await localFileFromUrl(path);
 	if (appFilePath) return appFilePath;
 
-	let localPath = normalize(path);
+	let localPath = toForwardSlashes(normalize(path));
 	if (localPath.indexOf('..') >= 0) throw new ErrorNotFound(`Cannot resolve path: ${path}`);
 
 	if (hasOwnProperty(pathToFileMap, path)) return pathToFileMap[path];


### PR DESCRIPTION
Fixes #15395 

Summary
On Windows, normalize() from Node can return paths with \. The server code compares URL-style paths with /, so some static files like icons may not be found.

Change
In `packages/server/src/routes/default.ts`, `findLocalFile()` now does `toForwardSlashes(normalize(path))` using toForwardSlashes from `packages/utils/path.ts`, so the rest of the logic always sees forward slashes.

How I tested
I ran Joplin Server on Windows, opened the a page that contains icons, and checked that icons are showing.