### PR TITLE
Desktop: Fixes #15386: Fixed highlight text button.

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/ActionPanel.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/ActionPanel.tsx
@@ -33,6 +33,8 @@ const baseStyle = (colors: WhiteboardThemeColors): CSSProperties => ({
 	fontSize: 12,
 	height: 36,
 	color: colors.textColor,
+	userSelect: 'none',
+	WebkitUserSelect: 'none',
 });
 
 const captionStyle = (colors: WhiteboardThemeColors): CSSProperties => ({
@@ -78,6 +80,8 @@ const buttonBase = (colors: WhiteboardThemeColors): CSSProperties => ({
 	alignItems: 'center',
 	gap: 4,
 	whiteSpace: 'nowrap',
+	userSelect: 'none',
+	WebkitUserSelect: 'none',
 });
 
 interface ActionButtonProps {


### PR DESCRIPTION
## Summary

Fixes issue #15386.

This PR prevents accidental text selection when interacting with the whiteboard action panel controls in the desktop app when clicking max zoom in and out.

The change adds `userSelect: 'none'` and `WebkitUserSelect: 'none'` to the whiteboard `ActionPanel` container and action button base styles. 

## Testing
Tested manually on Joplin Desktop(DEV):
1. Opened a note with the whiteboard editor.
2. Interacted with the whiteboard action panel.
3. Clicked and double-clicked action panel buttons.
4. Dragged around the action panel area.
5. Max zoom in and out.

## Recording of Test

https://github.com/user-attachments/assets/4f436edf-ba21-4e6a-87ce-35259bddb00f



