### PR TITLE
Desktop: Fixes #15385: Improve card content when associated note is deleted

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/FileNode.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/FileNode.tsx
@@ -253,6 +253,18 @@ const FileNode = ({ data, selected }: NodeProps<{ id: string; type: 'wbFile'; da
 			);
 		}
 
+		// Internal ref that didn't resolve to any item — the linked note or
+		// resource has been permanently deleted (locally or via sync). Show a
+		// placeholder rather than leaking the raw `:/<id>` string.
+		if (isInternal && resolved?.kind === 'unknown') {
+			return (
+				<>
+					<div style={headerStyle(colors)}>Deleted</div>
+					<div style={bodyStyle(colors)}>This note or resource no longer exists.</div>
+				</>
+			);
+		}
+
 		// Loading or external file path.
 		return (
 			<>


### PR DESCRIPTION
### Problem

With [#15305](https://github.com/laurent22/joplin/pull/15305), whiteboards were added to the desktop app, including the ability to "Promote" a text card into a real Joplin note. A promoted card is stored as a FileCanvasNode whose file field references the new note via :/<noteId>.

### Solution
When the linked note is permanently deleted (moved to the trash, then deleted from the trash), BaseItem.loadItemById returns null for that ID. The render path in FileNode.tsx then falls through to a generic fallback that prints node.file verbatim, so the card on the whiteboard ends up displaying the raw internal reference (e.g. :/eea7…) instead of a meaningful state.

See also: [#15305](https://github.com/laurent22/joplin/pull/15305)


<img width="452" height="283" alt="image" src="https://github.com/user-attachments/assets/9c85872c-2024-4ee1-9ba8-d7e01a344566" />
