### PR TITLE
Desktop: Add note to whiteboard via GotoAnything and update cursor style

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/WhiteboardSurface.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/WhiteboardSurface.tsx
@@ -32,6 +32,10 @@ import LinkNode from './nodes/LinkNode';
 import { ActionButton, ActionDivider, ActionInput, ActionPanel } from './ActionPanel';
 import { useWhiteboardContext } from './WhiteboardContext';
 import { whiteboardColors } from './theme';
+import { GotoAnythingOptions, UiType } from '../../../WindowCommandsAndDialogs/commands/gotoAnything';
+import { Mode } from '../../../../plugins/GotoAnything';
+import CommandService from '@joplin/lib/services/CommandService';
+import { ModelType } from '@joplin/lib/BaseModel';
 
 // `markerUnits: 'userSpaceOnUse'` keeps the arrowhead at an absolute size,
 // independent of the edge's stroke width. Without it, selected edges (which
@@ -169,6 +173,27 @@ const InnerSurface = ({ canvas, onChange }: Props) => {
 		});
 	}, [rf, addCanvasNode]);
 
+	const onAddNote = useCallback(async ()=> {
+		const options: GotoAnythingOptions = { mode: Mode.TitleOnly };
+		const result = await CommandService.instance().execute('gotoAnything', UiType.ControlledApi, options);
+		if (!result || result.type !== ModelType.Note) return;
+
+		const view = rf.getViewport();
+		const rect = containerRef.current?.getBoundingClientRect();
+		const cx = rect ? (rect.width / 2 - view.x) / view.zoom : 0;
+		const cy = rect ? (rect.height / 2 - view.y) / view.zoom : 0;
+
+		addCanvasNode({
+			id: generateId(),
+			type: 'file',
+			x: cx - 120,
+			y: cy - 80,
+			width: 200,
+			height: 100,
+			file: `:/${result.item.id}`,
+		});
+	}, [rf, addCanvasNode]);
+
 	// Selection summaries for the action panels.
 	const selectedEdges = useMemo(() => flowEdges.filter(e => e.selected), [flowEdges]);
 	const selectedNodes = useMemo(() => flowNodes.filter(n => n.selected), [flowNodes]);
@@ -292,6 +317,8 @@ const InnerSurface = ({ canvas, onChange }: Props) => {
 
 				<ActionPanel position="top-right">
 					<ActionButton onClick={onAddText} title={_('Add a text card')}>{_('+ Text')}</ActionButton>
+					<ActionDivider />
+					<ActionButton onClick={onAddNote} title={_('Add an existing note')}>{_('+ Note')}</ActionButton>
 				</ActionPanel>
 
 				{selectedEdges.length > 0 ? (

--- a/packages/app-desktop/plugins/GotoAnything.tsx
+++ b/packages/app-desktop/plugins/GotoAnything.tsx
@@ -229,6 +229,7 @@ class DialogComponent extends React.PureComponent<Props, State> {
 				borderBottomStyle: 'solid',
 				borderBottomColor: theme.dividerColor,
 				boxSizing: 'border-box',
+				cursor: 'pointer',
 			},
 			inputHelpWrapper: { display: 'flex', flexDirection: 'row', alignItems: 'center' },
 		};


### PR DESCRIPTION
### Description

This PR implements the ability to add notes directly to the Whiteboard canvas using the "Goto Anything" dialog. Additionally, it improves the UX of the Goto Anything dialog by adding a `cursor: pointer` style to clickable items.

**Changes included:**
- Integrated `gotoAnything` command inside the WhiteboardEditor (e.g., via the `+ Note` action button) to search and select existing notes.
- Automatically inserts the selected note as a `wbFile` (FileNode) on the Whiteboard canvas upon selection.
- Added `cursor: pointer` to the `GotoAnything` component items to indicate that they are clickable, improving accessibility and standard UI behavior.

### Testing
1. Open a note containing a Whiteboard.
2. Click the `+ Note` button (or invoke the action to add an existing note).
3. The Goto Anything dialog appears. Notice the cursor changes to a pointer when hovering over items.
4. Select a note from the dialog.
5. Verify that the selected note is successfully placed on the whiteboard as a card.

### Screen Recording
[Screencast From 2026-05-13 21-41-10.webm](https://github.com/user-attachments/assets/74b879c5-ec72-48a4-bbd9-213b04f9ede4)
