### PR TITLE
iOS: Fixes #15407: Fix JEX import on iOS

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { _ } from '@joplin/lib/locale';
 import Logger from '@joplin/utils/Logger';
 import { FunctionComponent } from 'react';
-import { join } from 'path';
+import { join, basename } from 'path';
 import { ConfigScreenStyles } from '../configScreenStyles';
 import InteropService from '@joplin/lib/services/interop/InteropService';
 import pickDocument from '../../../../utils/pickDocument';
@@ -64,8 +64,10 @@ const NoteImportButton: FunctionComponent<Props> = props => {
 			default: sourceFileUri,
 			ios: decodeURIComponent(sourceFileUri),
 		});
+		// Note: Don't use importFiles[0].fileName here: It can be null in some situations (e.g. on iOS)
+		const sourceFileName = basename(sourceFilePath);
 
-		const importTargetPath = join(await makeImportExportCacheDirectory(), importFiles[0].fileName);
+		const importTargetPath = join(await makeImportExportCacheDirectory(), sourceFileName);
 		setAfterCompleteListener(async (_success: boolean) => {
 			await shim.fsDriver().remove(importTargetPath);
 		});

--- a/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx
@@ -64,7 +64,7 @@ const NoteImportButton: FunctionComponent<Props> = props => {
 			default: sourceFileUri,
 			ios: decodeURIComponent(sourceFileUri),
 		});
-		// Note: Don't use importFiles[0].fileName here: It can be null in some situations (e.g. on iOS)
+		// Note: Don't use importFiles[0].fileName here: It is null on iOS and potentially in other cases
 		const sourceFileName = basename(sourceFilePath);
 
 		const importTargetPath = join(await makeImportExportCacheDirectory(), sourceFileName);

--- a/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx
@@ -64,7 +64,7 @@ const NoteImportButton: FunctionComponent<Props> = props => {
 			default: sourceFileUri,
 			ios: decodeURIComponent(sourceFileUri),
 		});
-		// Note: Don't use importFiles[0].fileName here: It is null on iOS and potentially in other cases
+		// importFiles[0].fileName can be null on iOS
 		const sourceFileName = importFiles[0].fileName ?? basename(sourceFilePath);
 
 		const importTargetPath = join(await makeImportExportCacheDirectory(), sourceFileName);

--- a/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx
@@ -65,7 +65,7 @@ const NoteImportButton: FunctionComponent<Props> = props => {
 			ios: decodeURIComponent(sourceFileUri),
 		});
 		// Note: Don't use importFiles[0].fileName here: It is null on iOS and potentially in other cases
-		const sourceFileName = basename(sourceFilePath);
+		const sourceFileName = importFiles[0].fileName ?? basename(sourceFilePath);
 
 		const importTargetPath = join(await makeImportExportCacheDirectory(), sourceFileName);
 		setAfterCompleteListener(async (_success: boolean) => {


### PR DESCRIPTION
# Problem

JEX import fails on iOS.

This seems to be a regression from https://github.com/laurent22/joplin/pull/13742, related to the use of `importedFiles[0].fileName`.

# Solution

Fall back to a file name computed from the path, when `importedFiles[0].fileName` is unavailable.

Fixes #15407.

# Testing

**iOS 18**:
1. Create and run a release iOS build.
2. Verify that it's possible to import a previously-created JEX export of the welcome notebook.
3. Verify that it's possible to import a local Markdown file using the TXT import function.

**Android (API 36)**:
1. Create a release build and start it.
2. Import a previously-created JEX file.
3. Verify that the JEX file imports successfully.
4. Import a .txt file using the TXT import button.
5. Verify that the .txt file imports successfully.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
