### PR TITLE
Android: Fixes #15363: Voice typing: Fix speech-to-text accuracy regression for non-English languages

### DIFF
--- a/packages/whisper-voice-typing/src/index.ts
+++ b/packages/whisper-voice-typing/src/index.ts
@@ -1,7 +1,7 @@
 import { NitroModules } from 'react-native-nitro-modules';
 import type { AudioRecorder, SessionOptions, WhisperSession, WhisperVoiceTyping } from './specs/Whisper.nitro';
 
-let WhisperVoiceTypingHybridObject: WhisperVoiceTyping|null = null;
+let WhisperVoiceTypingHybridObject: WhisperVoiceTyping|null = NitroModules.createHybridObject<WhisperVoiceTyping>('WhisperVoiceTyping');
 
 export type { SessionOptions };
 
@@ -27,7 +27,12 @@ export class Session {
 		}
 
 		this.recorder_ = NitroModules.createHybridObject<AudioRecorder>('AudioRecorder');
-		this.nativeSession_ = getVoiceTyping().openSession(this.options_);
+		this.nativeSession_ = getVoiceTyping().openSession({
+			...this.options_,
+
+			// Whisper.cpp doesn't support region specifiers (e.g. US in en_US). Remove them:
+			locale: this.options_.locale.replace(/_[a-z]+$/i, ''),
+		});
 		this.recorder_.start();
 	}
 


### PR DESCRIPTION
# Problem

The app locale was not correctly provided to Whisper. Whisper seems to have attempted to detect the language of the spoken text, with a reduction in transcription accuracy.

This is a regression from https://github.com/laurent22/joplin/pull/14232, which refactored the voice typing logic.

# Solution

Correctly format the language code.

Fixes #15363.

# Testing

Android 13 (dev mode):
1. Switch the app language to "Español (España)".
2. Start voice typing.
3. Say something in Spanish (e.g. "Estoy hablando en Español").
4. Verify that what was said is accurately transcribed.
5. Switch the app language to English.
6. Say something in English.
7. Verify that the speech was accurately transcribed.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
