### PR TITLE
Chore: Web: Fix startup failure

### DIFF
--- a/packages/whisper-voice-typing/src/index.ts
+++ b/packages/whisper-voice-typing/src/index.ts
@@ -1,7 +1,7 @@
 import { NitroModules } from 'react-native-nitro-modules';
 import type { AudioRecorder, SessionOptions, WhisperSession, WhisperVoiceTyping } from './specs/Whisper.nitro';
 
-let WhisperVoiceTypingHybridObject: WhisperVoiceTyping|null = NitroModules.createHybridObject<WhisperVoiceTyping>('WhisperVoiceTyping');
+let WhisperVoiceTypingHybridObject: WhisperVoiceTyping|null = null;
 
 export type { SessionOptions };
 


### PR DESCRIPTION
# Problem 

A change made while debugging a voice typing build issue was accidentally committed in https://github.com/laurent22/joplin/pull/15412. This change moved the voice typing native module initialization earlier in startup and breaks the web app.

(I've verified that this issue does not affect the iOS app).

# Solution

Switch back to lazy-initializing the voice typing module.

# Testing

**Web**: Rebuilt `packages/whisper-voice-typing` and started the web app in dev mode. Verified that the web app starts successfully.

**iOS**: Verified that a release build of the iOS app can start and that it's possible to create a note.

**Android**: Created a release build of the Android app. Verified that it's possible to use voice typing in English in the release build.
- See [comment](https://github.com/laurent22/joplin/pull/15415#discussion_r3242532327) for why Android testing needed to be done with a release build.


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
