### PR TITLE
Mobile: Add padding to the bottom of the viewer and editor 

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useEditorSettings.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useEditorSettings.ts
@@ -55,6 +55,7 @@ const useEditorSettings = (props: EditorSettingsProps) => {
 				marginLeft: 0,
 				marginRight: 0,
 				monospaceFont: settings.monospaceFont,
+				paddingBottom: 400,
 			},
 			automatchBraces: settings.automatchBraces,
 			autocompleteMarkup: settings.autocompleteMarkup,

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -100,7 +100,8 @@ function editorTheme(themeId: number) {
 		fontSize: estimatedFontSizeInEm,
 		fontFamily: fontFamilyFromSettings(),
 
-		// At least when the keyboard is open, iOS adds its own padding to the bottom of the note editor
+		// Avoid adding extra padding on iOS:
+		// When the keyboard is open, iOS adds its own padding to the bottom of the note editor.
 		paddingBottom: Platform.OS === 'ios' ? 0 : 150,
 	};
 }

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -99,7 +99,9 @@ function editorTheme(themeId: number) {
 		fontSizeUnits: 'em',
 		fontSize: estimatedFontSizeInEm,
 		fontFamily: fontFamilyFromSettings(),
-		paddingBottom: 150,
+
+		// At least when the keyboard is open, iOS adds its own padding to the bottom of the note editor
+		paddingBottom: Platform.OS === 'ios' ? 0 : 150,
 	};
 }
 

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -99,6 +99,7 @@ function editorTheme(themeId: number) {
 		fontSizeUnits: 'em',
 		fontSize: estimatedFontSizeInEm,
 		fontFamily: fontFamilyFromSettings(),
+		paddingBottom: 150,
 	};
 }
 

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -1678,7 +1678,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 					!note || !note.body.trim() ? null : (
 						<NoteBodyViewer
 							style={this.styles().noteBodyViewer}
-							paddingBottom={0}
+							paddingBottom={150}
 							noteBody={note.body}
 							noteMarkupLanguage={note.markup_language}
 							noteResources={this.state.noteResources}

--- a/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
@@ -136,6 +136,7 @@ const useSource = (props: UseSourceProps) => {
 				/* Increase the size of the editor to make it easier to focus the editor. */
 				.prosemirror-editor {
 					min-height: 75vh;
+					padding-bottom: ${Number(propsRef.current.settings.themeData.paddingBottom)}px;
 				}
 			`,
 			js: `

--- a/packages/editor/CodeMirror/theme.ts
+++ b/packages/editor/CodeMirror/theme.ts
@@ -103,7 +103,7 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 		'& .cm-content': {
 			fontFamily: theme.fontFamily,
 			...baseContentStyle,
-			paddingBottom: theme.isDesktop ? '400px' : undefined,
+			paddingBottom: `${theme.paddingBottom}px`,
 			marginLeft: `${theme.marginLeft}px`,
 			marginRight: `${theme.marginRight}px`,
 		},

--- a/packages/editor/testing/createEditorSettings.ts
+++ b/packages/editor/testing/createEditorSettings.ts
@@ -2,7 +2,7 @@ import { themeStyle } from '@joplin/lib/theme';
 import { EditorKeymap, EditorLanguageType, EditorSettings } from '../types';
 
 const createEditorSettings = (themeId: number) => {
-	const themeData = { themeId, ...themeStyle(themeId) };
+	const themeData = { themeId, paddingBottom: 0, ...themeStyle(themeId) };
 	const editorSettings: EditorSettings = {
 		markdownMarkEnabled: true,
 		markdownInsertEnabled: true,

--- a/packages/editor/types.ts
+++ b/packages/editor/types.ts
@@ -182,6 +182,7 @@ export interface EditorTheme extends Theme {
 	marginLeft?: number;
 	marginRight?: number;
 	listTabSize?: string;
+	paddingBottom: number;
 }
 
 export interface EditorSettings {


### PR DESCRIPTION
# Problem

Joplin v3.6 removes padding from the note viewer. Based on [discussion](https://discourse.joplinapp.org/t/android-pre-release-v3-6-is-now-available-updated-08-05-2026/48553/15?u=personalizedrefriger), it may make sense to restore this padding, while also adding similar padding to the note editors.

> [!NOTE]
>
> This pull request currently targets `release-3.6`.

# Solution

Add 150px of padding to the note viewer and editors on mobile.

# Screenshots (web app)

**Viewer**:
<img width="634" height="958" alt="screenshot: extra space present between the bottom of the note and the bottom of the screen" src="https://github.com/user-attachments/assets/d91a4fed-bd23-472c-b84d-8f208f02a84a" />

**Rich Text Editor**:
<img width="634" height="958" alt="screenshot: web app with Rich Text Editor open, note scrolled to end, with space between the end of the content and the maximum scroll position" src="https://github.com/user-attachments/assets/b4aeb737-8628-4c02-9b91-c6d2589440d8" />

**Markdown editor**:
<img width="634" height="958" alt="screenshot: web app with the Markdown editor open, note scrolled to end, with space between the end of the content and the maximum scroll position" src="https://github.com/user-attachments/assets/22069d95-d93b-4e2b-aeee-7870d37922b8" />

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
