### PR TITLE
Mobile: Add setting to choose the default view / edit state

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -163,6 +163,7 @@ describe('screens/Note', () => {
 		await setupDatabaseAndSynchronizer(1);
 		await setupDatabaseAndSynchronizer(0);
 		await switchClient(0);
+		Setting.setValue('editor.mobile.defaultEditState', 'view');
 
 		store = createMockReduxStore();
 		setupGlobalStore(store);
@@ -377,13 +378,15 @@ describe('screens/Note', () => {
 	it.each([
 		[['viewer']],
 		[['editor']],
-	])('should initialize in the correct mode when noteVisiblePanes is %j', async (panes) => {
+	])('should initialize in the correct mode when noteVisiblePanes is %j, when default edit state is set to last', async (panes) => {
+		Setting.setValue('editor.mobile.defaultEditState', 'last');
 		const { unmount } = await setupNoteWithPanes(panes);
 		await expectToBeEditing(panes.includes('editor'));
 		unmount();
 	});
 
-	it('should show edit button', async () => {
+	it('should show edit button when in view mode', async () => {
+		Setting.setValue('editor.mobile.defaultEditState', 'last');
 		const { unmount } = await setupNoteWithPanes(['viewer']);
 		const editButton = await screen.findByLabelText('Edit');
 		expect(editButton).toBeVisible();
@@ -393,7 +396,8 @@ describe('screens/Note', () => {
 	it.each([
 		[['viewer']],
 		[['editor']],
-	])('should switch modes when toggle button is pressed', async (panes) => {
+	])('should switch modes when toggle button is pressed, when default edit state is set to last', async (panes) => {
+		Setting.setValue('editor.mobile.defaultEditState', 'last');
 		const initialEditing = panes.includes('editor');
 		const expectedEditing = !initialEditing;
 		const { unmount } = await setupNoteWithPanes(panes);
@@ -450,7 +454,9 @@ describe('screens/Note', () => {
 	it.each([
 		[['viewer']],
 		[['editor']],
-	])('should preserve noteVisiblePanes state when leaving and returning to the same note', async (panes) => {
+	])('should preserve noteVisiblePanes state when leaving and returning to the same note, when default edit state is set to last', async (panes) => {
+		Setting.setValue('editor.mobile.defaultEditState', 'last');
+
 		const firstRender = await setupNoteWithPanes(panes);
 		await expectToBeEditing(panes.includes('editor'));
 		// Navigate away
@@ -480,7 +486,9 @@ describe('screens/Note', () => {
 	it.each([
 		[['viewer']],
 		[['editor']],
-	])('should preserve noteVisiblePanes state when navigating from note 1 to note 2', async (panes) => {
+	])('should preserve noteVisiblePanes state when navigating from note 1 to note 2, when default edit state is set to last', async (panes) => {
+		Setting.setValue('editor.mobile.defaultEditState', 'last');
+
 		// Open note 1
 		await act(async () => {
 			store.dispatch({

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -297,6 +297,11 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent) => {
 	const panes = comp.props.noteVisiblePanes;
 	let mode = panes.includes('editor') ? 'edit' : 'view';
 
+	// Override the mode if the default state is not last
+	const defaultState = Setting.value('editor.mobile.defaultEditState');
+	if (defaultState === 'view') mode = 'view';
+	if (defaultState === 'edit') mode = 'edit';
+
 	// Prevent trashed notes from opening in edit mode.
 	if (note?.deleted_time) {
 		mode = 'view';

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1301,7 +1301,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 					subType: SettingItemSubType.FontFamily,
 				},
 		'editor.mobile.defaultEditState': {
-			value: 'last',
+			value: 'view',
 			type: SettingItemType.String,
 			isEnum: true,
 			section: 'editor',

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1300,6 +1300,23 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 					isGlobal: true,
 					subType: SettingItemSubType.FontFamily,
 				},
+		'editor.mobile.defaultEditState': {
+			value: 'last',
+			type: SettingItemType.String,
+			isEnum: true,
+			section: 'editor',
+			public: true,
+			appTypes: [AppType.Mobile],
+			label: () => _('Default view / edit state'),
+			options: () => {
+				return {
+					view: _('View mode'),
+					edit: _('Edit mode'),
+					last: _('Last used'),
+				};
+			},
+			storage: SettingStorage.File,
+		},
 		'style.editor.monospaceFontFamily': {
 			value: '',
 			type: SettingItemType.String,


### PR DESCRIPTION
Joplin 3.6 changed the behaviour for how the view / edit state of notes on mobile is managed. Originally, notes would always open in view mode and had to be switched to edit mode via a floating button. This was changed to be a toggle button in the note header, and the behaviour was altered so that the previously set view / edit mode is remembered when re-opening or switching between notes. While this is good for users which use the rich text editor, or use the markdown rendering in the markdown editor, for users who use the markdown editor without rendering enabled, this makes a poorer user experience, due to the need to always switch back to view mode after editing, if they want to see the rendered content whenever they open notes.

This PR adds a new 'Default view / edit state' setting under the editor configuration section on mobile, with the option to always open notes in view / edit mode, or the last used state. The default option for a new profile is the last used state.

This is targeted at release-3.6 as per discussion with Laurent.

### Testing

Screenshots of the new setting:

<img width="303" alt="shot1" src="https://github.com/user-attachments/assets/1c738586-a8f1-43a7-bf16-b571852f7ff4" />
<img width="304" alt="shot2" src="https://github.com/user-attachments/assets/ef493668-47bb-4654-be63-70169ce10cdf" />

Video demonstrating opening notes in each mode, and verifying that notes in the trash will always open in view mode regardless of the setting:

https://github.com/user-attachments/assets/987a51e5-6395-4cee-ae86-71507af6d19f

Additionally, I verified when the setting is set to view mode, new notes and todos will still open in edit mode upon creation

