### PR TITLE
Server: Add rate limiter on SAML auth code endpoint

### DIFF
--- a/packages/server/src/routes/api/login.ts
+++ b/packages/server/src/routes/api/login.ts
@@ -3,10 +3,11 @@ import Router from '../../utils/Router';
 import { redirect, SubPath } from '../../utils/routeUtils';
 import { generateRedirectHtml, getIdentityProvider, getServiceProvider } from '../../utils/saml';
 import { AppContext, RouteType, SamlPostResponse } from '../../utils/types';
-import { bodyFields } from '../../utils/requestUtils';
+import { bodyFields, userIp } from '../../utils/requestUtils';
 import { ErrorBadRequest, ErrorForbidden } from '../../utils/errors';
 import { cookieSet } from '../../utils/cookies';
 import defaultView from '../../utils/defaultView';
+import limiterLoginBruteForce from '../../utils/request/limiterLoginBruteForce';
 
 export const router = new Router(RouteType.Api);
 
@@ -71,6 +72,8 @@ router.post('api/saml', async (_path: SubPath, ctx: AppContext) => {
 });
 
 router.get('api/login_with_code/:id', async (path: SubPath, ctx: AppContext) => {
+	await limiterLoginBruteForce(userIp(ctx));
+
 	const code = path.id;
 	if (!code) {
 		throw new ErrorBadRequest();


### PR DESCRIPTION
The endpoint used to exchange a temporary SAML login code for a session token was not protected by the brute-force rate limiter that guards Joplin Server's other authentication endpoints. This change applies the same per-IP rate limit to the SAML auth code endpoint, bringing it in line with email/password login, web form login, and 2FA recovery.