### PR TITLE
Desktop, Mobile: Fix possible crash when creating a note or notebook with an excessively long title

### DIFF
--- a/packages/lib/BaseModel.test.ts
+++ b/packages/lib/BaseModel.test.ts
@@ -28,4 +28,19 @@ describe('BaseModel', () => {
 
 		expect(BaseModel.modelsByIds(items, ids)).toMatchObject(expectedMatchingItems);
 	});
+
+	test.each([
+		[0, false],
+		[12, false],
+		[4096, false],
+		[4097, true],
+		[100000, true],
+	])('userSideValidation should reject overly long titles (length: %d)', (length, shouldThrow) => {
+		const run = () => BaseModel.userSideValidation({ title: 'x'.repeat(length) });
+		if (shouldThrow) {
+			expect(run).toThrow(/title must be 4096 characters or less/);
+		} else {
+			expect(run).not.toThrow();
+		}
+	});
 });

--- a/packages/lib/BaseModel.ts
+++ b/packages/lib/BaseModel.ts
@@ -601,7 +601,7 @@ class BaseModel {
 		return query;
 	}
 
-	public static userSideValidation(o: { id?: string; user_updated_time?: number; user_created_time?: number }) {
+	public static userSideValidation(o: { id?: string; title?: string; user_updated_time?: number; user_created_time?: number }) {
 		if (o.id && !o.id.match(/^[a-f0-9]{32}$/)) {
 			throw new Error('Validation error: ID must a 32-characters lowercase hexadecimal string');
 		}
@@ -609,6 +609,11 @@ class BaseModel {
 		const timestamps = ['user_updated_time', 'user_created_time'] as const;
 		for (const k of timestamps) {
 			if ((k in o) && (typeof o[k] !== 'number' || isNaN(o[k]) || o[k] < 0)) throw new Error('Validation error: user_updated_time and user_created_time must be numbers greater than 0');
+		}
+
+		const maxTitleLength = 4096;
+		if (typeof o.title === 'string' && o.title.length > maxTitleLength) {
+			throw new Error(`Validation error: title must be ${maxTitleLength} characters or less`);
 		}
 	}
 


### PR DESCRIPTION
Joplin did not enforce a maximum length on note and notebook titles. As a result, entering or pasting an extremely long string into the title field — either directly in the app or via the local Web Clipper API — could cause the application to run out of memory and crash. In some cases the long title would also be saved, causing the app to crash again on the next launch.