### PR TITLE
Server, Desktop, Mobile: Fix XSS vulnerability in HTML notes

### DIFF
--- a/packages/renderer/htmlUtils.test.ts
+++ b/packages/renderer/htmlUtils.test.ts
@@ -96,4 +96,21 @@ describe('htmlUtils', () => {
 	])('should remove empty elements (case %#)', (before, expected) => {
 		expect(removeWrappingParagraphAndTrailingEmptyElements(before)).toBe(expected);
 	});
+
+	it.each([
+		[':/0123456789abcdef0123456789abcdef', true],
+		[':/0123456789abcdef0123456789abcdef/anchor', true],
+		['javascript:/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/;alert(1)', false],
+		['data:/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/;alert(1)', false],
+		['vbscript:/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', false],
+		[':/short', false],
+	])('should only allow resource-style URLs anchored to the start (input: %s)', (href, shouldKeep) => {
+		const output = htmlUtils.sanitizeHtml(`<a href="${href}">Click</a>`);
+		if (shouldKeep) {
+			expect(output).toContain(`href="${href}"`);
+		} else {
+			expect(output).not.toContain(`href="${href}"`);
+			expect(output).toContain('href="#"');
+		}
+	});
 });

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -183,7 +183,7 @@ class HtmlUtils {
 			url.startsWith('http://') ||
 			url.startsWith('mailto:') ||
 			url.startsWith('joplin://') ||
-			!!url.match(/:\/[0-9a-zA-Z]{32}/) ||
+			!!url.match(/^:\/[0-9a-zA-Z]{32}(\/.*)?$/) ||
 			// We also allow anchors but only with a specific set of a characters.
 			// Fixes https://github.com/laurent22/joplin/issues/8286
 			!!url.match(/^#[a-zA-Z0-9-]+$/)) return true;


### PR DESCRIPTION
A flaw in the link sanitizer for HTML-formatted notes allowed a specially crafted link to bypass the safety check and execute JavaScript when the link was opened. This is fixed by tightening the sanitizer so that only legitimate internal links match the resource-URL format.