### PR TITLE
Chore: Testing: Fix warnings logged while running ProseMirror tests

### DIFF
--- a/packages/editor/jest.setup.js
+++ b/packages/editor/jest.setup.js
@@ -29,8 +29,9 @@ document.createRange = () => {
 // By default, jsdom's window.scrollTo throws an unimplemented error
 window.scrollTo = (scrollX, scrollY) => {
 	if (typeof scrollX === 'object') {
-		scrollX = scrollX.left ?? 0;
-		scrollY = scrollX.top ?? 0;
+		const options = scrollX;
+		scrollX = options.left ?? 0;
+		scrollY = options.top ?? 0;
 	}
 
 	const target = document.scrollingElement ?? document.body;

--- a/packages/editor/jest.setup.js
+++ b/packages/editor/jest.setup.js
@@ -25,3 +25,14 @@ document.createRange = () => {
 	});
 	return result;
 };
+
+// By default, jsdom's window.scrollTo throws an unimplemented error
+window.scrollTo = (scroll) => {
+	const target = document.scrollingElement ?? document.body;
+	if (typeof scroll === 'number') {
+		target.scrollTop = scroll;
+	} else {
+		target.scrollTop = scroll.top;
+		target.scrollLeft = scroll.left;
+	}
+};

--- a/packages/editor/jest.setup.js
+++ b/packages/editor/jest.setup.js
@@ -27,12 +27,13 @@ document.createRange = () => {
 };
 
 // By default, jsdom's window.scrollTo throws an unimplemented error
-window.scrollTo = (scroll) => {
-	const target = document.scrollingElement ?? document.body;
-	if (typeof scroll === 'number') {
-		target.scrollTop = scroll;
-	} else {
-		target.scrollTop = scroll.top;
-		target.scrollLeft = scroll.left;
+window.scrollTo = (scrollX, scrollY) => {
+	if (typeof scrollX === 'object') {
+		scrollX = scrollX.left ?? 0;
+		scrollY = scrollX.top ?? 0;
 	}
+
+	const target = document.scrollingElement ?? document.body;
+	target.scrollTop = scrollY;
+	target.scrollLeft = scrollX;
 };


### PR DESCRIPTION
# Problem

"Not implemented" warnings related to `window.scrollTo` were logged while running ProseMirror tests.

# Solution

Override `window.scrollTo` when running Jest tests.


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
