### PR TITLE
Desktop, Mobile: Fixes #15425: In-editor rendering: Render URLs when the link text is empty

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1120,6 +1120,8 @@ packages/editor/CodeMirror/extensions/rendering/replaceDividers.js
 packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.js
 packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.test.js
 packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.js
+packages/editor/CodeMirror/extensions/rendering/replaceLinks.test.js
+packages/editor/CodeMirror/extensions/rendering/replaceLinks.js
 packages/editor/CodeMirror/extensions/rendering/types.js
 packages/editor/CodeMirror/extensions/rendering/utils/makeBlockReplaceExtension.js
 packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.js

--- a/.gitignore
+++ b/.gitignore
@@ -1097,6 +1097,8 @@ packages/editor/CodeMirror/extensions/rendering/replaceDividers.js
 packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.js
 packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.test.js
 packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.js
+packages/editor/CodeMirror/extensions/rendering/replaceLinks.test.js
+packages/editor/CodeMirror/extensions/rendering/replaceLinks.js
 packages/editor/CodeMirror/extensions/rendering/types.js
 packages/editor/CodeMirror/extensions/rendering/utils/makeBlockReplaceExtension.js
 packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.js

--- a/packages/editor/CodeMirror/extensions/rendering/renderingExtension.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderingExtension.ts
@@ -6,12 +6,14 @@ import replaceDividers from './replaceDividers';
 import replaceFormatCharacters from './replaceFormatCharacters';
 import replaceInlineHtml from './replaceInlineHtml';
 import renderTables from './renderTables';
+import replaceLinks from './replaceLinks';
 
 export default (tableEditingEnabled = true) => {
 	return [
 		replaceCheckboxes,
 		replaceBulletLists,
 		replaceFormatCharacters,
+		replaceLinks,
 		replaceBackslashEscapes,
 		replaceDividers,
 		addFormattingClasses,

--- a/packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.ts
@@ -1,44 +1,12 @@
 import makeInlineReplaceExtension from './utils/makeInlineReplaceExtension';
 import { SyntaxNodeRef } from '@lezer/common';
 import { EditorState } from '@codemirror/state';
-import referenceLinkStateField, { isReferenceLink, resolveReferenceFromLink } from '../links/referenceLinksStateField';
 import { Decoration } from '@codemirror/view';
 
 const shouldFullReplace = (node: SyntaxNodeRef, state: EditorState) => {
-	const getParentName = () => node.node.parent?.name;
 	const getNodeStartLine = () => state.doc.lineAt(node.from);
 
 	if (['HeaderMark', 'CodeMark', 'EmphasisMark', 'StrikethroughMark', 'HighlightMarker', 'InsertMarker'].includes(node.name)) {
-		return true;
-	}
-
-	if ((node.name === 'URL' || node.name === 'LinkMark') && getParentName() === 'Link') {
-		const parent = node.node.parent!;
-		const parentContent = state.sliceDoc(parent.from, parent.to);
-		if (node.name === 'LinkMark' && isReferenceLink(parentContent)) {
-			return !!resolveReferenceFromLink(parentContent, state);
-		}
-
-		// Find all closing link marks
-		const closingBracketNodes = parent.getChildren('LinkMark').filter(mark => {
-			const isClosingBracket = state.sliceDoc(mark.from, mark.to) === ']';
-			return isClosingBracket;
-		});
-
-		// URLs can only be hidden if after the last ].
-		const isUrl = node.name === 'URL';
-		const lastClosingBracketIdx = closingBracketNodes.length > 0 ? closingBracketNodes[closingBracketNodes.length - 1].from : null;
-		if (!lastClosingBracketIdx || isUrl && node.from < lastClosingBracketIdx) {
-			return false;
-		}
-		// Avoid fully hiding links
-		const hasEmptyLabel = state.sliceDoc(
-			Math.max(0, lastClosingBracketIdx - 1), lastClosingBracketIdx,
-		) === '[';
-		if (hasEmptyLabel) {
-			return false;
-		}
-
 		return true;
 	}
 
@@ -52,9 +20,6 @@ const shouldFullReplace = (node: SyntaxNodeRef, state: EditorState) => {
 const hideDecoration = Decoration.replace({});
 
 const replaceFormatCharacters = [
-	// Dependency
-	referenceLinkStateField,
-
 	makeInlineReplaceExtension({
 		getRevealStrategy: (node) => {
 			if (node.name === 'QuoteMark') {

--- a/packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.ts
@@ -15,30 +15,30 @@ const shouldFullReplace = (node: SyntaxNodeRef, state: EditorState) => {
 	if ((node.name === 'URL' || node.name === 'LinkMark') && getParentName() === 'Link') {
 		const parent = node.node.parent!;
 		const parentContent = state.sliceDoc(parent.from, parent.to);
-		if (node.name === 'LinkMark') {
-			if (isReferenceLink(parentContent)) {
-				return !!resolveReferenceFromLink(parentContent, state);
-			}
-		} else if (node.name === 'URL') {
-			// Find all closing link marks
-			const closingBracketNodes = parent.getChildren('LinkMark').filter(mark => {
-				const isClosingBracket = state.sliceDoc(mark.from, mark.to) === ']';
-				return isClosingBracket;
-			});
-
-			// URLs can only be hidden if after the last ].
-			const lastClosingBracketIdx = closingBracketNodes.length > 0 ? closingBracketNodes[closingBracketNodes.length - 1].from : null;
-			if (!lastClosingBracketIdx || node.from < lastClosingBracketIdx) {
-				return false;
-			}
-			// Avoid fully hiding links
-			const hasEmptyLabel = state.sliceDoc(
-				Math.max(0, lastClosingBracketIdx - 1), lastClosingBracketIdx,
-			) === '[';
-			if (hasEmptyLabel) {
-				return false;
-			}
+		if (node.name === 'LinkMark' && isReferenceLink(parentContent)) {
+			return !!resolveReferenceFromLink(parentContent, state);
 		}
+
+		// Find all closing link marks
+		const closingBracketNodes = parent.getChildren('LinkMark').filter(mark => {
+			const isClosingBracket = state.sliceDoc(mark.from, mark.to) === ']';
+			return isClosingBracket;
+		});
+
+		// URLs can only be hidden if after the last ].
+		const isUrl = node.name === 'URL';
+		const lastClosingBracketIdx = closingBracketNodes.length > 0 ? closingBracketNodes[closingBracketNodes.length - 1].from : null;
+		if (!lastClosingBracketIdx || isUrl && node.from < lastClosingBracketIdx) {
+			return false;
+		}
+		// Avoid fully hiding links
+		const hasEmptyLabel = state.sliceDoc(
+			Math.max(0, lastClosingBracketIdx - 1), lastClosingBracketIdx,
+		) === '[';
+		if (hasEmptyLabel) {
+			return false;
+		}
+
 		return true;
 	}
 

--- a/packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.ts
@@ -31,6 +31,13 @@ const shouldFullReplace = (node: SyntaxNodeRef, state: EditorState) => {
 			if (!lastClosingBracketIdx || node.from < lastClosingBracketIdx) {
 				return false;
 			}
+			// Avoid fully hiding links
+			const hasEmptyLabel = state.sliceDoc(
+				Math.max(0, lastClosingBracketIdx - 1), lastClosingBracketIdx,
+			) === '[';
+			if (hasEmptyLabel) {
+				return false;
+			}
 		}
 		return true;
 	}

--- a/packages/editor/CodeMirror/extensions/rendering/replaceLinks.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceLinks.test.ts
@@ -1,0 +1,32 @@
+import createTestEditor from '../../testing/createTestEditor';
+import { EditorSelection } from '@codemirror/state';
+import replaceLinks from './replaceLinks';
+
+describe('replaceLinks', () => {
+	it.each([
+		{
+			label: 'should not hide link Markdown when the label is empty',
+			markup: 'test: [](https://example.com)',
+			expectedText: 'test: [](https://example.com)',
+
+			expectedSyntaxTags: ['URL', 'LinkMark', 'Link'],
+		},
+		{
+			label: 'should hide link Markdown when a title is present',
+			markup: 'test: [test](https://example.com)',
+			expectedText: 'test: test',
+
+			expectedSyntaxTags: ['URL', 'LinkMark', 'Link'],
+		},
+		{
+			label: 'should not hide URLs with no label section',
+			markup: 'test: https://example.com',
+			expectedText: 'test: https://example.com',
+
+			expectedSyntaxTags: ['URL'],
+		},
+	])('$label', async ({ markup, expectedText, expectedSyntaxTags }) => {
+		const editor = await createTestEditor(markup, EditorSelection.cursor(0), expectedSyntaxTags, [replaceLinks]);
+		expect(editor.contentDOM.textContent).toBe(expectedText);
+	});
+});

--- a/packages/editor/CodeMirror/extensions/rendering/replaceLinks.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceLinks.test.ts
@@ -12,6 +12,13 @@ describe('replaceLinks', () => {
 			expectedSyntaxTags: ['URL', 'LinkMark', 'Link'],
 		},
 		{
+			label: 'should not hide whitespace-only links',
+			markup: 'test: [ ](https://example.com)',
+			expectedText: 'test: [ ](https://example.com)',
+
+			expectedSyntaxTags: ['URL', 'LinkMark', 'Link'],
+		},
+		{
 			label: 'should hide link Markdown when a title is present',
 			markup: 'test: [test](https://example.com)',
 			expectedText: 'test: test',

--- a/packages/editor/CodeMirror/extensions/rendering/replaceLinks.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceLinks.ts
@@ -29,11 +29,12 @@ const shouldFullReplace = (node: SyntaxNodeRef, state: EditorState) => {
 		return false;
 	}
 
+	const label = state.sliceDoc(
+		parent.from, lastClosingBracketIdx,
+	).replace(/^\[/, '');
+
 	// Links with an empty label shouldn't be hidden
-	const hasEmptyLabel = state.sliceDoc(
-		Math.max(0, lastClosingBracketIdx - 1), lastClosingBracketIdx,
-	) === '[';
-	if (hasEmptyLabel) {
+	if (label.trim() === '') {
 		return false;
 	}
 

--- a/packages/editor/CodeMirror/extensions/rendering/replaceLinks.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceLinks.ts
@@ -1,0 +1,60 @@
+import makeInlineReplaceExtension from './utils/makeInlineReplaceExtension';
+import { SyntaxNodeRef } from '@lezer/common';
+import { EditorState } from '@codemirror/state';
+import referenceLinkStateField, { isReferenceLink, resolveReferenceFromLink } from '../links/referenceLinksStateField';
+import { Decoration } from '@codemirror/view';
+
+const shouldFullReplace = (node: SyntaxNodeRef, state: EditorState) => {
+	const isUrl = node.name === 'URL';
+	const isLinkMark = node.name === 'LinkMark';
+	if (!isUrl && !isLinkMark) return false;
+
+	const parent = node.node.parent;
+	if (parent?.name !== 'Link') return false;
+
+	const parentContent = state.sliceDoc(parent.from, parent.to);
+	if (isLinkMark && isReferenceLink(parentContent)) {
+		return !!resolveReferenceFromLink(parentContent, state);
+	}
+
+	// Find all closing link marks
+	const closingBracketNodes = parent.getChildren('LinkMark').filter(mark => {
+		const isClosingBracket = state.sliceDoc(mark.from, mark.to) === ']';
+		return isClosingBracket;
+	});
+
+	// URLs can only be hidden if after the last ].
+	const lastClosingBracketIdx = closingBracketNodes.length > 0 ? closingBracketNodes[closingBracketNodes.length - 1].from : null;
+	if (!lastClosingBracketIdx || isUrl && node.from < lastClosingBracketIdx) {
+		return false;
+	}
+
+	// Links with an empty label shouldn't be hidden
+	const hasEmptyLabel = state.sliceDoc(
+		Math.max(0, lastClosingBracketIdx - 1), lastClosingBracketIdx,
+	) === '[';
+	if (hasEmptyLabel) {
+		return false;
+	}
+
+	return true;
+};
+
+const hideDecoration = Decoration.replace({});
+
+const replaceLinks = [
+	// Dependency
+	referenceLinkStateField,
+
+	makeInlineReplaceExtension({
+		getRevealStrategy: () => 'active',
+		createDecoration: (node, state) => {
+			if (shouldFullReplace(node, state)) {
+				return hideDecoration;
+			}
+			return null;
+		},
+	}),
+];
+
+export default replaceLinks;


### PR DESCRIPTION
# Problem

When in-editor Markdown rendering is enabled, links are invisible when the link text is empty. For example, `[](https://example.com/)` was invisible when rendered in the editor.

# Solution

Don't hide link markup when the label text is empty.

Fixes #15425.



# Testing

## Screenshots

For the following note content:
```markdown
[](http://example.com)... 
[test](http://example.com)...

Reference link: [ref link]

[ref link]: http://example.com/
```

- With in-editor rendering enabled:
  <img width="433" height="145" alt="screenshot: First link ([](http://example.com/)) renders as link Markdown, others are rendered as links" src="https://github.com/user-attachments/assets/b5367feb-501a-4a1d-b86b-ea51b51cafdb" />
- With in-editor rendering disabled:
  <img width="433" height="145" alt="screenshot: All links render as Markdown" src="https://github.com/user-attachments/assets/3c022771-487a-4ad3-98b5-cd4354cc26ea" />


## Automated testing

This pull request adds new automated tests for link rendering to `renderLinks.test.ts`.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
