### PR TITLE
Desktop, Cli: Fixes #15374: Fix Markdown export folder paths with dot in parent path

### DIFF
--- a/packages/lib/fs-driver-base.ts
+++ b/packages/lib/fs-driver-base.ts
@@ -1,6 +1,6 @@
 import time from './time';
 import Setting from './models/Setting';
-import { basename, filename, fileExtension } from './path-utils';
+import { basename, filename, fileExtension, rtrimSlashes } from './path-utils';
 const md5 = require('md5');
 import resolvePathWithinDir from './utils/resolvePathWithinDir';
 import { Buffer } from 'buffer';
@@ -198,6 +198,7 @@ export default class FsDriverBase {
 			return reservedNames.includes(testName.toLowerCase());
 		};
 
+		name = rtrimSlashes(name);
 		const baseName = basename(name);
 		const pathPrefix = name.substring(0, name.length - baseName.length);
 		const nameNoExt = pathPrefix + filename(baseName);

--- a/packages/lib/fs-driver-base.ts
+++ b/packages/lib/fs-driver-base.ts
@@ -1,6 +1,6 @@
 import time from './time';
 import Setting from './models/Setting';
-import { filename, fileExtension } from './path-utils';
+import { basename, filename, fileExtension } from './path-utils';
 const md5 = require('md5');
 import resolvePathWithinDir from './utils/resolvePathWithinDir';
 import { Buffer } from 'buffer';
@@ -198,8 +198,10 @@ export default class FsDriverBase {
 			return reservedNames.includes(testName.toLowerCase());
 		};
 
-		const nameNoExt = filename(name, true);
-		let extension = fileExtension(name);
+		const baseName = basename(name);
+		const pathPrefix = name.substring(0, name.length - baseName.length);
+		const nameNoExt = pathPrefix + filename(baseName);
+		let extension = fileExtension(baseName);
 		if (extension) extension = `.${extension}`;
 		let nameToTry = nameNoExt + extension;
 		while (true) {

--- a/packages/lib/fsDriver.test.ts
+++ b/packages/lib/fsDriver.test.ts
@@ -42,4 +42,12 @@ describe('fsDriver', () => {
 			await shim.fsDriver().findUniqueFilename(join(supportDir, 'this-file-does-not-exist.txt'), [join(supportDir, 'some-other-file.txt')]),
 		).toBe(join(supportDir, 'this-file-does-not-exist.txt'));
 	});
+
+	it('should append markdown-safe suffixes to the leaf name when parent directories contain dots', async () => {
+		const folderPath = join(supportDir, 'parent.with.dot', 'folder_');
+
+		expect(
+			await shim.fsDriver().findUniqueFilename(folderPath, [folderPath], true),
+		).toBe(join(supportDir, 'parent.with.dot', 'folder_-1'));
+	});
 });

--- a/packages/lib/services/interop/InteropService_Exporter_Md.test.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Md.test.ts
@@ -530,6 +530,36 @@ describe('interop/InteropService_Exporter_Md', () => {
 		expect(await shim.fsDriver().exists(`${exportDir()}/${expectedPaths[1]}`)).toBe(true);
 	});
 
+	it('should handle folders that collide after sanitization when the export path contains a dot', async () => {
+		const exporter = new InteropService_Exporter_Md();
+		await exporter.init(`${exportDir()}/parent.with.dot/export`);
+
+		const { items, queue } = createExportItems();
+
+		const folder1 = await Folder.save({ title: 'folder:' });
+		const folder2 = await Folder.save({ title: 'folder?' });
+		const note1 = await Note.save({ title: 'note1', parent_id: folder1.id });
+		const note2 = await Note.save({ title: 'note2', parent_id: folder2.id });
+		queue(BaseModel.TYPE_FOLDER, folder1.id);
+		queue(BaseModel.TYPE_FOLDER, folder2.id);
+		queue(BaseModel.TYPE_NOTE, note1);
+		queue(BaseModel.TYPE_NOTE, note2);
+
+		await exporter.prepareForProcessingItemType(BaseModel.TYPE_FOLDER, items);
+		await exporter.prepareForProcessingItemType(BaseModel.TYPE_NOTE, items);
+
+		await exporter.processItem(Folder.modelType(), folder1);
+		await exporter.processItem(Folder.modelType(), folder2);
+		await exporter.processItem(Note.modelType(), note1);
+		await exporter.processItem(Note.modelType(), note2);
+
+		expect(exporter.context().notePaths[note1.id]).toBe('folder_/note1.md');
+		expect(exporter.context().notePaths[note2.id]).toBe('folder_-1/note2.md');
+
+		expect(await shim.fsDriver().exists(`${exportDir()}/parent.with.dot/export/folder_/note1.md`)).toBe(true);
+		expect(await shim.fsDriver().exists(`${exportDir()}/parent.with.dot/export/folder_-1/note2.md`)).toBe(true);
+	});
+
 	it('should handle filenames that contain slashes', (async () => {
 		const folder = await Folder.save({ title: 'testing' });
 		const note = await Note.save({ title: 'mynote', parent_id: folder.id });


### PR DESCRIPTION
Fixes #15374

This PR fixes a Markdown export bug when two folder names become the same safe filename.


The problem happens because `findUniqueFilename()` receives a full path. It then uses filename and extension logic on the whole path string. When a parent folder contains a dot, such as `joplin-3.6`, that dot can be treated like a file extension separator.

Because of this, the `-1` suffix can be added to the parent directory name, not to the exported folder name. 

This PR fixes `findUniqueFilename()` so it only checks the last part of the path.

Before, it used `filename(name)` and `fileExtension(name)` on the full path. If a parent folder had a dot, like `joplin-3.6`, the code could think `.6` was the file extension.

Now it first gets `baseName`, which is only the file or folder name. It keeps the parent path in `pathPrefix`, then adds the suffix only to the final name. This stops `-1` from being added to the parent folder.
