### PR TITLE
Server: Fixes #15373: Fixed published notes reusing disabled owner shares

### DIFF
--- a/packages/server/src/models/ShareModel.test.ts
+++ b/packages/server/src/models/ShareModel.test.ts
@@ -144,6 +144,29 @@ describe('ShareModel', () => {
 		expect(share1.id).toBe(share2.id);
 	});
 
+	test('should not reuse a disabled user share when publishing a shared note', async () => {
+		const { shareUser, note, session1, session2 } = await createShareWithNoteOwnedByRecipient();
+		const user1 = await models().user().load(session1.user_id);
+		const user2 = await models().user().load(session2.user_id);
+
+		const user2Share = await models().share().shareNote(user2, note.jop_id, '', false);
+		expect(user2Share.owner_id).toBe(user2.id);
+
+		await models().shareUser().delete(shareUser.id);
+		await models().user().save({
+			id: user2.id,
+			enabled: 0,
+		});
+		await models().share().updateSharedItems3();
+
+		const updatedNote = await models().item().load(note.id);
+		expect(updatedNote.owner_id).toBe(user1.id);
+
+		const user1Share = await models().share().shareNote(user1, note.jop_id, '', false);
+		expect(user1Share.id).not.toBe(user2Share.id);
+		expect(user1Share.owner_id).toBe(user1.id);
+	});
+
 	test('should delete a note that has been shared', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 

--- a/packages/server/src/models/ShareModel.ts
+++ b/packages/server/src/models/ShareModel.ts
@@ -136,6 +136,27 @@ export default class ShareModel extends BaseModel<Share> {
 			.first();
 	}
 
+	public async byItemAndRecursiveWithEnabledOwner(itemId: Uuid, recursive: boolean): Promise<Share | null> {
+		return this.db(this.tableName)
+			.select(this.selectFields(null, this.defaultFields, this.tableName))
+			.innerJoin('users', 'users.id', `${this.tableName}.owner_id`)
+			.innerJoin('user_items', 'user_items.user_id', `${this.tableName}.owner_id`)
+			.where(`${this.tableName}.item_id`, itemId)
+			.where(`${this.tableName}.recursive`, recursive ? 1 : 0)
+			.where('users.enabled', 1)
+			.where('user_items.item_id', itemId)
+			.first();
+	}
+
+	public async byUserItemAndRecursive(userId: Uuid, itemId: Uuid, recursive: boolean): Promise<Share | null> {
+		return this.db(this.tableName)
+			.select(this.defaultFields)
+			.where('owner_id', userId)
+			.where('item_id', itemId)
+			.where('recursive', recursive ? 1 : 0)
+			.first();
+	}
+
 	public async byUserId(userId: Uuid, type: ShareType): Promise<Share[]> {
 		const query1 = this
 			.db(this.tableName)
@@ -607,7 +628,10 @@ export default class ShareModel extends BaseModel<Share> {
 		const noteItem = await this.models().item().loadByJopId(owner.id, noteId);
 		if (!noteItem) throw new ErrorNotFound(`No such note: ${noteId}`);
 
-		const existingShare = await this.byItemAndRecursive(noteItem.id, recursive);
+		const existingShareForOwner = await this.byUserItemAndRecursive(owner.id, noteItem.id, recursive);
+		if (existingShareForOwner) return existingShareForOwner;
+
+		const existingShare = await this.byItemAndRecursiveWithEnabledOwner(noteItem.id, recursive);
 		if (existingShare) return existingShare;
 
 		const shareToSave: Share = {

--- a/packages/server/src/models/ShareModel.ts
+++ b/packages/server/src/models/ShareModel.ts
@@ -128,14 +128,6 @@ export default class ShareModel extends BaseModel<Share> {
 		return this.db(this.tableName).select(this.defaultFields).whereIn('item_id', itemIds);
 	}
 
-	public async byItemAndRecursive(itemId: Uuid, recursive: boolean): Promise<Share | null> {
-		return this.db(this.tableName)
-			.select(this.defaultFields)
-			.where('item_id', itemId)
-			.where('recursive', recursive ? 1 : 0)
-			.first();
-	}
-
 	public async byItemAndRecursiveWithEnabledOwner(itemId: Uuid, recursive: boolean): Promise<Share | null> {
 		return this.db(this.tableName)
 			.select(this.selectFields(null, this.defaultFields, this.tableName))


### PR DESCRIPTION
Fixes #15373 

When a user publishes a note, the server first looks for an existing share for that note.

Before this PR, the server could reuse a share owned by another user, even if that user account was disabled. Then the public link showed:

This account has been disabled
This PR changes the note sharing logic so the server does not reuse that share unless the share owner:

is enabled
still has the note in user_items
If the old share owner is disabled or no longer has the note, the server creates a new share for the current user.