### PR TITLE
Chore: Trying to fix CI random failure

### DIFF
--- a/packages/default-plugins/buildDefaultPlugins.ts
+++ b/packages/default-plugins/buildDefaultPlugins.ts
@@ -104,7 +104,9 @@ const buildPlugin = async (pluginId: string, repositoryData: RepositoryData, out
 		await options.beforeInstall(buildDir, pluginId);
 
 		logStatus('Installing dependencies.');
-		await execCommand('npm install');
+		// `npm install` occasionally crashes on Windows CI with STATUS_STACK_BUFFER_OVERRUN
+		// (exit code 3221226505), hence the retry.
+		await execCommand('npm install --no-audit --no-fund --prefer-offline', { retryCount: 3 });
 
 		const jplFiles = await glob('publish/*.jpl');
 		logStatus(`Found built .jpl files: ${JSON.stringify(jplFiles)}`);

--- a/packages/utils/execCommand.ts
+++ b/packages/utils/execCommand.ts
@@ -10,6 +10,8 @@ interface ExecCommandOptions {
 	quiet?: boolean;
 	env?: Record<string, string | undefined>;
 	detached?: boolean;
+	// Number of times to retry the command if it fails. 0 (the default) means no retry.
+	retryCount?: number;
 }
 
 export default async (command: string | string[], options: ExecCommandOptions | null = null): Promise<string> => {
@@ -24,6 +26,7 @@ export default async (command: string | string[], options: ExecCommandOptions | 
 		showStderr: !detached,
 		quiet: false,
 		env: {},
+		retryCount: 0,
 		...options,
 	};
 
@@ -41,13 +44,29 @@ export default async (command: string | string[], options: ExecCommandOptions | 
 		}
 	}
 
-	const args: string[] = typeof command === 'string' ? splitCommandString(command) : command as string[];
-	const executableName = args[0];
-	args.splice(0, 1);
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Workaround for type definition conflicts. Expo currently overrides NodeJs.ProcessEnv, making NODE_ENV required. This changes the type of the "env" argument to execa.
-	const promise = execa(executableName, args, { env: options.env as any });
-	if (options.showStdout && promise.stdout) promise.stdout.pipe(process.stdout);
-	if (options.showStderr && promise.stderr) promise.stderr.pipe(process.stderr);
-	const result = await promise;
-	return result.stdout.trim();
+	const runOnce = async () => {
+		const args: string[] = typeof command === 'string' ? splitCommandString(command) : [...command as string[]];
+		const executableName = args[0];
+		args.splice(0, 1);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Workaround for type definition conflicts. Expo currently overrides NodeJs.ProcessEnv, making NODE_ENV required. This changes the type of the "env" argument to execa.
+		const promise = execa(executableName, args, { env: options.env as any });
+		if (options.showStdout && promise.stdout) promise.stdout.pipe(process.stdout);
+		if (options.showStderr && promise.stderr) promise.stderr.pipe(process.stderr);
+		const result = await promise;
+		return result.stdout.trim();
+	};
+
+	const maxAttempts = (options.retryCount ?? 0) + 1;
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			return await runOnce();
+		} catch (error) {
+			if (attempt === maxAttempts) throw error;
+			stdout.write(`Command failed (attempt ${attempt}/${maxAttempts}): ${error}. Retrying...\n`);
+			await new Promise(resolve => setTimeout(resolve, 5000 * attempt));
+		}
+	}
+
+	// Unreachable: the loop above either returns or throws.
+	throw new Error('execCommand: unreachable');
 };


### PR DESCRIPTION
```
2026-05-17T06:02:05.6656684Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Building plugin io.github.jackgruber.backup at C:\Users\RUNNER~1\AppData\Local\Temp\default-plugin-buildmt1WuW
2026-05-17T06:02:05.6660510Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Cloning from repository https://github.com/JackGruber/***-plugin-backup.git
2026-05-17T06:02:05.6667005Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: > git clone -- https://github.com/JackGruber/***-plugin-backup.git D:\a\***\***\packages\default-plugins\plugin-sources\io.github.jackgruber.backup
2026-05-17T06:02:05.7235844Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Cloning into 'D:\a\***\***\packages\default-plugins\plugin-sources\io.github.jackgruber.backup'...
2026-05-17T06:02:06.2809090Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Switching to commit 2c3da7056e7ac39c86c2051a4fdb99d9534dd0a1
2026-05-17T06:02:06.2810604Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: > git switch master
2026-05-17T06:02:06.3566334Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Already on 'master'
2026-05-17T06:02:06.3587695Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Your branch is up to date with 'origin/master'.
2026-05-17T06:02:06.3646609Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: > git checkout 2c3da7056e7ac39c86c2051a4fdb99d9534dd0a1
2026-05-17T06:02:06.4365096Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Note: switching to '2c3da7056e7ac39c86c2051a4fdb99d9534dd0a1'.
2026-05-17T06:02:06.4368516Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:
2026-05-17T06:02:06.4371072Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: You are in 'detached HEAD' state. You can look around, make experimental
2026-05-17T06:02:06.4373979Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: changes and commit them, and you can discard any commits you make in this
2026-05-17T06:02:06.4376698Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: state without impacting any branches by switching back to a branch.
2026-05-17T06:02:06.4378943Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:
2026-05-17T06:02:06.4381154Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: If you want to create a new branch to retain commits you create, you may
2026-05-17T06:02:06.4383713Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: do so (now or later) by using -c with the switch command. Example:
2026-05-17T06:02:06.4386663Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:
2026-05-17T06:02:06.4388599Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:   git switch -c
2026-05-17T06:02:06.4390841Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:
2026-05-17T06:02:06.4392680Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Or undo this operation with:
2026-05-17T06:02:06.4395233Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:
2026-05-17T06:02:06.4396658Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:   git switch -
2026-05-17T06:02:06.4397756Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:
2026-05-17T06:02:06.4399514Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Turn off this advice by setting config variable advice.detachedHead to false
2026-05-17T06:02:06.4400824Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:
2026-05-17T06:02:06.4402022Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: HEAD is now at 2c3da70 bump version 1.5.1
2026-05-17T06:02:06.4448930Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: > git rev-parse --verify HEAD^{commit}
2026-05-17T06:02:06.4921716Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: 2c3da7056e7ac39c86c2051a4fdb99d9534dd0a1
2026-05-17T06:02:06.4964496Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Copying repository files...
2026-05-17T06:02:06.5651068Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Initializing repository.
2026-05-17T06:02:06.5653767Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: > git init . -b main
2026-05-17T06:02:06.6307198Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Initialized empty Git repository in C:/Users/runneradmin/AppData/Local/Temp/default-plugin-buildmt1WuW/.git/
2026-05-17T06:02:06.6352008Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Running before-patch hook.
2026-05-17T06:02:06.6355755Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Applying patch.
2026-05-17T06:02:06.6358859Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: > git apply D:\a\***\***\packages\default-plugins\plugin-patches\io.github.jackgruber.backup.diff
2026-05-17T06:02:06.6864229Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Installing dependencies.
2026-05-17T06:02:06.6865939Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: > npm install
2026-05-17T06:02:10.6191238Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Error: Command failed with exit code 3221226505: npm install
2026-05-17T06:02:10.6195121Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:     at makeError (D:\a\***\***\packages\utils\node_modules\execa\lib\error.js:60:11)
2026-05-17T06:02:10.6205458Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:     at handlePromise (D:\a\***\***\packages\utils\node_modules\execa\index.js:118:26)
2026-05-17T06:02:10.6220409Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:     at processTicksAndRejections (node:internal/process/task_queues:104:5)
2026-05-17T06:02:10.6349300Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:     at async exports.default (D:\a\***\***\packages\utils\execCommand.ts:51:17)
2026-05-17T06:02:10.6420767Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:     at async buildPlugin (D:\a\***\***\packages\default-plugins\buildDefaultPlugins.ts:107:3)
2026-05-17T06:02:10.6456150Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:     at async buildDefaultPlugins (D:\a\***\***\packages\default-plugins\buildDefaultPlugins.ts:29:4)
2026-05-17T06:02:10.6498984Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:     at async fn (D:\a\***\***\packages\app-desktop\gulpfile.ts:48:4) {
2026-05-17T06:02:10.6528754Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:   shortMessage: 'Command failed with exit code 3221226505: npm install',
2026-05-17T06:02:10.6539901Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:   command: 'npm install',
2026-05-17T06:02:10.6554791Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:   escapedCommand: 'npm install',
2026-05-17T06:02:10.6562873Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:   exitCode: 3221226505,
2026-05-17T06:02:10.6577529Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:   signal: undefined,
2026-05-17T06:02:10.6587352Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:   signalDescription: undefined,
2026-05-17T06:02:10.6602580Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:   stdout: '',
2026-05-17T06:02:10.6610829Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:   stderr: '',
2026-05-17T06:02:10.6622703Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:   failed: true,
2026-05-17T06:02:10.6632728Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:   timedOut: false,
2026-05-17T06:02:10.6650571Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:   isCanceled: false,
2026-05-17T06:02:10.6665084Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:   killed: false
2026-05-17T06:02:10.6673783Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: }
2026-05-17T06:02:10.6692080Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Build directory C:\Users\RUNNER~1\AppData\Local\Temp\default-plugin-buildmt1WuW
2026-05-17T06:02:10.6704371Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Input is not from a TTY -- not waiting for input.
2026-05-17T06:02:10.9695187Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: Removed build directory
2026-05-17T06:02:10.9698137Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: [06:02:10] 'buildDefaultPlugins' errored after 5.31 s
2026-05-17T06:02:10.9701056Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: [06:02:10] Error: Command failed with exit code 3221226505: npm install
2026-05-17T06:02:10.9704014Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:     at makeError (D:\a\***\***\packages\utils\node_modules\execa\lib\error.js:60:11)
2026-05-17T06:02:10.9706881Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:     at handlePromise (D:\a\***\***\packages\utils\node_modules\execa\index.js:118:26)
2026-05-17T06:02:10.9709613Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:     at processTicksAndRejections (node:internal/process/task_queues:104:5)
2026-05-17T06:02:10.9711449Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:     at async exports.default (D:\a\***\***\packages\utils\execCommand.ts:51:17)
2026-05-17T06:02:10.9713566Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:     at async buildPlugin (D:\a\***\***\packages\default-plugins\buildDefaultPlugins.ts:107:3)
2026-05-17T06:02:10.9715411Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:     at async buildDefaultPlugins (D:\a\***\***\packages\default-plugins\buildDefaultPlugins.ts:29:4)
2026-05-17T06:02:10.9717056Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]:     at async fn (D:\a\***\***\packages\app-desktop\gulpfile.ts:48:4)
2026-05-17T06:02:10.9718551Z ➤ YN0000: │ root@workspace:. STDOUT [@***/app-desktop]: [06:02:10] 'build' errored after 6.81 s
2026-05-17T06:02:11.0161735Z ➤ YN0000: │ root@workspace:. STDOUT The command failed in workspace @***/app-desktop@workspace:packages/app-desktop with exit code 1
2026-05-17T06:02:11.0165107Z ➤ YN0000: │ root@workspace:. STDOUT The command failed for workspaces that are depended upon by other workspaces; can't satisfy the dependency graph
2026-05-17T06:02:11.0167234Z ➤ YN0000: │ root@workspace:. STDOUT Failed with errors in 3m 50s
2026-05-17T06:02:11.1458722Z ➤ YN0000: │ root@workspace:. STDERR [06:02:11] 'build' errored after 4.07 min
2026-05-17T06:02:11.1465223Z ➤ YN0000: │ root@workspace:. STDERR [06:02:11] Error: Command failed with exit code 1: yarn run buildSequential
```