### PR TITLE
Desktop: Fixes #15425: Prevent links with empty title from disappearing in the Markdown editor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1093,6 +1093,7 @@ packages/editor/CodeMirror/extensions/rendering/replaceBackslashEscapes.js
 packages/editor/CodeMirror/extensions/rendering/replaceBulletLists.js
 packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.js
 packages/editor/CodeMirror/extensions/rendering/replaceDividers.js
+packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.test.js
 packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.js
 packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.test.js
 packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.js

--- a/.gitignore
+++ b/.gitignore
@@ -1066,6 +1066,7 @@ packages/editor/CodeMirror/extensions/rendering/replaceBackslashEscapes.js
 packages/editor/CodeMirror/extensions/rendering/replaceBulletLists.js
 packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.js
 packages/editor/CodeMirror/extensions/rendering/replaceDividers.js
+packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.test.js
 packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.js
 packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.test.js
 packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.js

--- a/packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.test.ts
@@ -1,0 +1,60 @@
+import { EditorSelection } from '@codemirror/state';
+import createTestEditor from '../../testing/createTestEditor';
+import replaceFormatCharacters from './replaceFormatCharacters';
+import waitFor from '@joplin/lib/testing/waitFor';
+
+describe('replaceFormatCharacters', () => {
+	jest.retryTimes(2);
+
+	test('should hide link syntax for links with title', async () => {
+		const markdown = '\n\n[title](https://example.com)\n\n';
+		const editor = await createTestEditor(
+			markdown,
+			EditorSelection.cursor(0),
+			['Link', 'URL'],
+			[replaceFormatCharacters],
+		);
+
+		await waitFor(() => {
+			// Brackets, parens, and the URL should be hidden — only the title remains visible.
+			expect(editor.contentDOM.textContent).not.toContain('https://example.com');
+			expect(editor.contentDOM.textContent).toContain('title');
+		});
+	});
+
+	test.each([
+		'[](https://example.com)',
+		'[ ](https://example.com)',
+		'[   ](https://example.com)',
+	])('should show only the URL when title is empty or whitespace-only and cursor is elsewhere (%s)', async (link) => {
+		// Regression test for https://github.com/laurent22/joplin/issues/15425
+		const markdown = `\n\n${link}\n\n`;
+		const editor = await createTestEditor(
+			markdown,
+			EditorSelection.cursor(0),
+			['Link', 'URL'],
+			[replaceFormatCharacters],
+		);
+
+		await waitFor(() => {
+			// Only the URL is visible on the link's line — no brackets, no
+			// parens, no leading whitespace from the empty title.
+			const linkLine = editor.contentDOM.textContent.split('\n').find(line => line.includes('example.com'));
+			expect(linkLine).toBe('https://example.com');
+		});
+	});
+
+	test('should reveal full link syntax for links with empty title when cursor is on the link', async () => {
+		const markdown = '[](https://example.com)';
+		const editor = await createTestEditor(
+			markdown,
+			EditorSelection.cursor(markdown.indexOf('(') + 1),
+			['Link', 'URL'],
+			[replaceFormatCharacters],
+		);
+
+		await waitFor(() => {
+			expect(editor.contentDOM.textContent).toContain('[](https://example.com)');
+		});
+	});
+});

--- a/packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.ts
@@ -15,13 +15,27 @@ const shouldFullReplace = (node: SyntaxNodeRef, state: EditorState) => {
 	if ((node.name === 'URL' || node.name === 'LinkMark') && getParentName() === 'Link') {
 		const parent = node.node.parent!;
 		const parentContent = state.sliceDoc(parent.from, parent.to);
+
+		// If the link has no title (e.g. [](https://example.com) or [  ](...)),
+		// keep the URL visible so the link doesn't disappear entirely. The
+		// brackets/parens are still hidden.
+		// See https://github.com/laurent22/joplin/issues/15425
+		const linkMarks = parent.getChildren('LinkMark');
+		const openingBracket = linkMarks.find(mark => state.sliceDoc(mark.from, mark.to) === '[');
+		const firstClosingBracket = linkMarks.find(mark => state.sliceDoc(mark.from, mark.to) === ']');
+		const hasEmptyTitle = !!openingBracket && !!firstClosingBracket
+			&& state.sliceDoc(openingBracket.to, firstClosingBracket.from).trim() === '';
+		if (hasEmptyTitle && node.name === 'URL') {
+			return false;
+		}
+
 		if (node.name === 'LinkMark') {
 			if (isReferenceLink(parentContent)) {
 				return !!resolveReferenceFromLink(parentContent, state);
 			}
 		} else if (node.name === 'URL') {
 			// Find all closing link marks
-			const closingBracketNodes = parent.getChildren('LinkMark').filter(mark => {
+			const closingBracketNodes = linkMarks.filter(mark => {
 				const isClosingBracket = state.sliceDoc(mark.from, mark.to) === ']';
 				return isClosingBracket;
 			});
@@ -82,6 +96,18 @@ const replaceFormatCharacters = [
 				// Include the space in the hidden region, if it's available
 				if (state.doc.sliceString(node.to, node.to + 1) === ' ') {
 					return [node.from, node.to + 1];
+				}
+			}
+
+			// For empty/whitespace-only link titles, extend the opening [ to
+			// cover the whitespace through the closing ], so the whitespace
+			// isn't visible (and isn't underlined as part of the link).
+			// See https://github.com/laurent22/joplin/issues/15425
+			if (node.name === 'LinkMark' && node.node.parent?.name === 'Link' && state.sliceDoc(node.from, node.to) === '[') {
+				const parent = node.node.parent;
+				const closingBracket = parent.getChildren('LinkMark').find(mark => state.sliceDoc(mark.from, mark.to) === ']');
+				if (closingBracket && node.to < closingBracket.from && state.sliceDoc(node.to, closingBracket.from).trim() === '') {
+					return [node.from, closingBracket.from];
 				}
 			}
 


### PR DESCRIPTION
Previously, a Markdown link with no title (e.g. `[](https://example.com)`) would disappear entirely when the cursor moved off it, because the editor was hiding both the link syntax and the URL — leaving nothing visible.

Now, when a link has an empty or whitespace-only title, the URL itself is shown when the cursor is elsewhere, and the full `[](...)` syntax is revealed when the cursor is on the link.