### PR TITLE
Desktop,Mobile: Fixes #15467: In-editor rendering: Do not render empty inline HTML

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.test.ts
@@ -21,22 +21,24 @@ describe('replaceInlineHtml', () => {
 	jest.retryTimes(2);
 
 	test.each([
-		{ markdown: '<sup>Test</sup>', expectedDomTags: 'sup' },
-		{ markdown: '<strike>Test</strike>', expectedDomTags: 'strike' },
-		{ markdown: 'Test: <span style="color: red;">Test</span>', expectedDomTags: 'span[style]' },
-		{ markdown: 'Test: <span style="color: rgb(123, 0, 0);">Test</span>', expectedDomTags: 'span[style]' },
+		{ markdown: '<sup>Test</sup>', expectedDomTags: 'sup', expectedText: 'Test' },
+		{ markdown: '<strike>Test</strike>', expectedDomTags: 'strike', expectedText: 'Test' },
+		{ markdown: 'Test: <span style="color: red;">Test</span>', expectedDomTags: 'span[style]', expectedText: 'Test: Test' },
+		{ markdown: 'Test: <span style="color: rgb(123, 0, 0);">Test</span>', expectedDomTags: 'span[style]', expectedText: 'Test: Test' },
 		{
 			markdown: '<sup>Test *test*...</sup>',
 			expectedDomTags: 'sup',
+			expectedText: 'Test *test*...',
 			initialSyntaxTags: ['HTMLTag', 'Emphasis'],
 		},
-	])('should render inline HTML (case %#)', async ({ markdown, expectedDomTags: expectedTagsQuery, initialSyntaxTags }) => {
+	])('should render inline HTML (case %#)', async ({ markdown, expectedDomTags: expectedTagsQuery, expectedText, initialSyntaxTags }) => {
 		// Add additional newlines: Ensure that the cursor isn't initially on the same line as the content to be rendered:
 		const editor = await createEditor(`\n\n${markdown}\n\n`, initialSyntaxTags);
 
 		// Retry on failure to handle the case where the syntax tree is slow:
 		await waitFor(() => {
 			expect(editor.contentDOM.querySelector(expectedTagsQuery)).toBeTruthy();
+			expect(editor.contentDOM.textContent).toBe(expectedText);
 		});
 	});
 

--- a/packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.test.ts
@@ -77,4 +77,13 @@ describe('replaceInlineHtml', () => {
 			expect(editor.contentDOM.textContent).toContain('<strike>');
 		});
 	});
+
+	test('should not hide empty inline HTML tags', async () => {
+		const markdown = '<sup></sup>...';
+		const editor = await createEditorWithCursor(markdown, markdown.length);
+
+		await waitFor(() => {
+			expect(editor.contentDOM.textContent).toBe('<sup></sup>...');
+		});
+	});
 });

--- a/packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.ts
@@ -45,6 +45,33 @@ const createHtmlReplacementExtension = (tagName: string, onRenderContent: OnRend
 		return cursor;
 	};
 
+	const findOpeningTag = (closingTag: SyntaxNodeRef, state: EditorState) => {
+		const closingTagInfo = htmlNodeInfo(closingTag, state);
+		// Self-closing?
+		if (closingTagInfo.opening) {
+			return closingTag;
+		}
+
+		let cursor = closingTag.node.prevSibling;
+		let nestedTagCounter = 1;
+
+		// Find the matching opening tag
+		for (; !!cursor && nestedTagCounter > 0; cursor = cursor.prevSibling) {
+			const info = htmlNodeInfo(cursor, state);
+			if (info && isMatchingClosingTag(info)) {
+				nestedTagCounter ++;
+			} else if (info && isMatchingOpeningTag(info)) {
+				nestedTagCounter --;
+			}
+
+			if (nestedTagCounter === 0) {
+				break;
+			}
+		}
+
+		return cursor;
+	};
+
 	const selectionIntersectsRange = (selection: EditorSelection, from: number, to: number) => {
 		const rangeContains = (point: number) => point >= from && point <= to;
 		const selectionContains = (point: number) => point >= selection.main.from && point <= selection.main.to;
@@ -66,6 +93,14 @@ const createHtmlReplacementExtension = (tagName: string, onRenderContent: OnRend
 			const content = state.sliceDoc(node.to, closingTag.from);
 			if (!content.trim()) return null;
 			return [node.from, closingTag.to];
+		}
+
+		if (info.closing) {
+			const openingTag = findOpeningTag(node, state);
+			if (!openingTag) return null;
+			const content = state.sliceDoc(openingTag.to, node.from);
+			if (!content.trim()) return null;
+			return [openingTag.from, node.to];
 		}
 
 		return null;

--- a/packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.ts
@@ -45,33 +45,6 @@ const createHtmlReplacementExtension = (tagName: string, onRenderContent: OnRend
 		return cursor;
 	};
 
-	const findOpeningTag = (closingTag: SyntaxNodeRef, state: EditorState) => {
-		const closingTagInfo = htmlNodeInfo(closingTag, state);
-		// Self-closing?
-		if (closingTagInfo.opening) {
-			return closingTag;
-		}
-
-		let cursor = closingTag.node.prevSibling;
-		let nestedTagCounter = 1;
-
-		// Find the matching opening tag
-		for (; !!cursor && nestedTagCounter > 0; cursor = cursor.prevSibling) {
-			const info = htmlNodeInfo(cursor, state);
-			if (info && isMatchingClosingTag(info)) {
-				nestedTagCounter ++;
-			} else if (info && isMatchingOpeningTag(info)) {
-				nestedTagCounter --;
-			}
-
-			if (nestedTagCounter === 0) {
-				break;
-			}
-		}
-
-		return cursor;
-	};
-
 	const selectionIntersectsRange = (selection: EditorSelection, from: number, to: number) => {
 		const rangeContains = (point: number) => point >= from && point <= to;
 		const selectionContains = (point: number) => point >= selection.main.from && point <= selection.main.to;
@@ -90,13 +63,9 @@ const createHtmlReplacementExtension = (tagName: string, onRenderContent: OnRend
 		if (info.opening) {
 			const closingTag = findClosingTag(node, state);
 			if (!closingTag) return null;
+			const content = state.sliceDoc(node.to, closingTag.from);
+			if (!content.trim()) return null;
 			return [node.from, closingTag.to];
-		}
-
-		if (info.closing) {
-			const openingTag = findOpeningTag(node, state);
-			if (!openingTag) return null;
-			return [openingTag.from, node.to];
 		}
 
 		return null;


### PR DESCRIPTION
# Problem

When in-editor rendering was enabled, empty inline HTML tags caused issues with in-editor rendering.

# Solution

Disable in-editor rendering for inline HTML tags.

Fixes #15467.

# Testing

## Screen recordings



**Before**:

https://github.com/user-attachments/assets/f292a99d-8b69-47fc-b4e0-9e0648299e0f



**After**:

https://github.com/user-attachments/assets/557a4578-cc9b-4154-9148-a7916c3bf26b




<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
