### PR TITLE
Web: Improve sync wizard help text when only one sync option is shown

### DIFF
--- a/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
+++ b/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
@@ -46,6 +46,11 @@ const styles = StyleSheet.create({
 		marginVertical: 6,
 		verticalAlign: 'middle',
 	},
+	callToAction: {
+		paddingTop: 4,
+		alignSelf: 'center',
+		fontWeight: 'bold',
+	},
 });
 
 const isAppJoplinCloud = () => {
@@ -61,7 +66,8 @@ const useShouldShowOtherButton = () => {
 interface SyncProviderProps {
 	title: string;
 	icon: ()=> React.ReactNode;
-	description: string;
+	description: string|null;
+	callToAction: string|null;
 	onPress: ()=> void;
 	featuresList: string[];
 	disabled: boolean;
@@ -86,6 +92,9 @@ const SyncProvider: React.FC<SyncProviderProps> = props => {
 					</View>
 				))}
 			</View>
+			{props.callToAction && <>
+				<Text style={styles.callToAction} variant='bodyMedium'>{props.callToAction}</Text>
+			</>}
 		</View>
 	</CardButton>;
 };
@@ -123,6 +132,7 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 
 	const showOther = useShouldShowOtherButton();
 
+	const isJoplinCloud = isAppJoplinCloud();
 	return <DismissibleDialog
 		themeId={themeId}
 		visible={visible}
@@ -132,14 +142,17 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 		heading={_('Synchronisation')}
 	>
 		<Text variant='bodyLarge' role='heading' style={styles.subheading}>{
-			isAppJoplinCloud()
-				? _('Sign in to Joplin Cloud to sync and manage your notes.')
+			isJoplinCloud
+				? _('You can synchronise your notes using Joplin Cloud, which also gives access to Joplin-specific features such as publishing notes or collaborating on notebooks with others.')
 				: _('Joplin can synchronise your notes using various providers. Select one from the list below.')
 		}</Text>
 		<View style={styles.syncProviderList}>
 			<SyncProvider
 				title={_('Joplin Cloud')}
-				description={_('Joplin\'s own sync service. Also gives access to Joplin-specific features such as publishing notes or collaborating on notebooks with others.')}
+				description={
+					isJoplinCloud ? null : _('Joplin\'s own sync service. Also gives access to Joplin-specific features such as publishing notes or collaborating on notebooks with others.')
+				}
+				callToAction={isJoplinCloud ? _('Synchronize your notes!') : null}
 				featuresList={[
 					_('Sync your notes'),
 					_('Publish notes to the internet'),
@@ -152,6 +165,7 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 			{showOther && <SyncProvider
 				title={_('Other')}
 				description={_('Select one of the other supported sync targets.')}
+				callToAction={null}
 				icon={() => <Icon size={iconSize} source='dots-horizontal-circle'/>}
 				featuresList={[]}
 				onPress={onSelectOtherTarget}

--- a/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
+++ b/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
@@ -132,7 +132,9 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 		heading={_('Synchronisation')}
 	>
 		<Text variant='bodyLarge' role='heading' style={styles.subheading}>{
-			_('Joplin can synchronise your notes using various providers. Select one from the list below.')
+			isAppJoplinCloud()
+				? _('Sign in to Joplin Cloud to sync your notes.')
+				: _('Joplin can synchronise your notes using various providers. Select one from the list below.')
 		}</Text>
 		<View style={styles.syncProviderList}>
 			<SyncProvider

--- a/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
+++ b/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
@@ -46,11 +46,6 @@ const styles = StyleSheet.create({
 		marginVertical: 6,
 		verticalAlign: 'middle',
 	},
-	callToAction: {
-		paddingTop: 4,
-		alignSelf: 'center',
-		fontWeight: 'bold',
-	},
 });
 
 const isAppJoplinCloud = () => {
@@ -67,7 +62,6 @@ interface SyncProviderProps {
 	title: string;
 	icon: ()=> React.ReactNode;
 	description: string|null;
-	callToAction: string|null;
 	onPress: ()=> void;
 	featuresList: string[];
 	disabled: boolean;
@@ -92,9 +86,6 @@ const SyncProvider: React.FC<SyncProviderProps> = props => {
 					</View>
 				))}
 			</View>
-			{props.callToAction && <>
-				<Text style={styles.callToAction} variant='bodyMedium'>{props.callToAction}</Text>
-			</>}
 		</View>
 	</CardButton>;
 };
@@ -148,11 +139,10 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 		}</Text>
 		<View style={styles.syncProviderList}>
 			<SyncProvider
-				title={_('Joplin Cloud')}
+				title={isJoplinCloud ? _('Synchronise with Joplin Cloud') : _('Joplin Cloud')}
 				description={
 					isJoplinCloud ? null : _('Joplin\'s own sync service. Also gives access to Joplin-specific features such as publishing notes or collaborating on notebooks with others.')
 				}
-				callToAction={isJoplinCloud ? _('Synchronize your notes!') : null}
 				featuresList={[
 					_('Sync your notes'),
 					_('Publish notes to the internet'),
@@ -165,7 +155,6 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 			{showOther && <SyncProvider
 				title={_('Other')}
 				description={_('Select one of the other supported sync targets.')}
-				callToAction={null}
 				icon={() => <Icon size={iconSize} source='dots-horizontal-circle'/>}
 				featuresList={[]}
 				onPress={onSelectOtherTarget}

--- a/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
+++ b/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
@@ -133,7 +133,7 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 	>
 		<Text variant='bodyLarge' role='heading' style={styles.subheading}>{
 			isAppJoplinCloud()
-				? _('Sign in to Joplin Cloud to sync your notes.')
+				? _('Sign in to Joplin Cloud to sync and manage your notes.')
 				: _('Joplin can synchronise your notes using various providers. Select one from the list below.')
 		}</Text>
 		<View style={styles.syncProviderList}>


### PR DESCRIPTION
# Problem

On `app.joplincloud.com`, only one option is shown in the sync wizard. However, the sync wizard still states 
> Joplin can synchronise your notes using various providers. Select one from the list below.

This label makes sense on the mobile app and when self-hosting the web app, but does not make sense on `app.joplincloud.com`.

# Solution

Update the sync wizard label.

# Screenshot

**Before**:
<img width="515" height="376" alt="Sync wizard dialog: Joplin can synchronize your notes using various providers. Select one from the list below" src="https://github.com/user-attachments/assets/4a3a6b52-f348-4d45-9f7d-b506916f3545" />


**After**:
<img width="520" height="343" alt="You can synchronise your notes using Joplin Cloud, which also gives access to Joplin-specific features such as publishing notes or collaborating on notebooks with others \\ synchronize with Joplin cloud, button" src="https://github.com/user-attachments/assets/cd033418-eab9-4d47-a771-4921644caf96" />



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title*z*: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
