### PR TITLE
Desktop: Fixes #15374: Markdown export merges colliding folders when the path contains a dot

### DIFF
--- a/packages/lib/fs-driver-base.ts
+++ b/packages/lib/fs-driver-base.ts
@@ -1,6 +1,6 @@
 import time from './time';
 import Setting from './models/Setting';
-import { filename, fileExtension } from './path-utils';
+import { basename, filename, fileExtension } from './path-utils';
 const md5 = require('md5');
 import resolvePathWithinDir from './utils/resolvePathWithinDir';
 import { Buffer } from 'buffer';
@@ -203,22 +203,37 @@ export default class FsDriverBase {
 			return reservedNames.includes(testName.toLowerCase());
 		};
 
-		const nameNoExt = filename(name, true);
-		let extension = fileExtension(name);
+		// Derive the stem and extension from the leaf path segment only.
+		// Computing them from the full path is unsafe because
+		// filename()/fileExtension() split on the last dot anywhere in the
+		// string: a dot in a parent directory name (e.g. ".../joplin-3.6/...")
+		// would otherwise push the deduplication suffix into the directory
+		// rather than the leaf filename, producing a bogus path and breaking
+		// deduplication.
+		// A trailing separator (a directory path such as "folder/") is stripped
+		// first and restored on the result, so deduplication still operates on
+		// the final segment.
+		const trailingSepMatch = name.match(/[/\\]+$/);
+		const trailingSep = trailingSepMatch ? trailingSepMatch[0] : '';
+		const trimmedName = name.slice(0, name.length - trailingSep.length);
+		const baseName = trimmedName ? basename(trimmedName) : '';
+		const dirPart = name.slice(0, name.length - baseName.length - trailingSep.length);
+		const nameNoExt = baseName ? filename(baseName) : '';
+		let extension = baseName ? fileExtension(baseName) : '';
 		if (extension) extension = `.${extension}`;
-		let nameToTry = nameNoExt + extension;
+		let nameToTry = `${dirPart}${nameNoExt}${extension}${trailingSep}`;
 		while (true) {
 			// Check if the filename does not exist in the filesystem and is not reserved
 			const exists = await this.exists(nameToTry) || isReserved(nameToTry);
 			if (!exists) return nameToTry;
 			if (!markdownSafe) {
-				nameToTry = `${nameNoExt} (${counter})${extension}`;
+				nameToTry = `${dirPart}${nameNoExt} (${counter})${extension}${trailingSep}`;
 			} else {
-				nameToTry = `${nameNoExt}-${counter}${extension}`;
+				nameToTry = `${dirPart}${nameNoExt}-${counter}${extension}${trailingSep}`;
 			}
 			counter++;
 			if (counter >= 1000) {
-				nameToTry = `${nameNoExt} (${new Date().getTime()})${extension}`;
+				nameToTry = `${dirPart}${nameNoExt} (${new Date().getTime()})${extension}${trailingSep}`;
 				await time.msleep(10);
 			}
 			if (counter >= 1100) throw new Error('Cannot find unique filename');

--- a/packages/lib/fsDriver.test.ts
+++ b/packages/lib/fsDriver.test.ts
@@ -42,4 +42,17 @@ describe('fsDriver', () => {
 			await shim.fsDriver().findUniqueFilename(join(supportDir, 'this-file-does-not-exist.txt'), [join(supportDir, 'some-other-file.txt')]),
 		).toBe(join(supportDir, 'this-file-does-not-exist.txt'));
 	});
+
+	it('should not insert the deduplication suffix into a parent directory that contains a dot in findUniqueFilename', async () => {
+		// Regression test: filename()/fileExtension() split on the last dot
+		// anywhere in the string, so a dot in a parent directory name must not
+		// push the "-1" deduplication suffix into the directory instead of the
+		// leaf filename. The leaf here has no extension, mirroring an exported
+		// folder name.
+		const dottedDir = join(supportDir, 'dir.with.dot');
+		const reserved = join(dottedDir, 'folder_');
+		expect(
+			await shim.fsDriver().findUniqueFilename(reserved, [reserved], true),
+		).toBe(join(dottedDir, 'folder_-1'));
+	});
 });


### PR DESCRIPTION
## Problem

Fixes #15374.

When exporting notes to Markdown, two folders whose titles sanitize to the
same on-disk name (for example `folder:` and `folder?`, which both become
`folder_`) are supposed to be disambiguated  the second should be exported
as `folder_-1`.

Instead, under certain conditions only a single `folder_` directory is
created and the notes from both folders are written into it. The note from
the second folder overwrites the first in the export path map, so **one note
is silently lost** from the export.

### Steps to reproduce

1. Create two folders whose titles differ only by characters that get
   sanitized, e.g. `folder:` and `folder?`.
2. Add one note to each folder.
3. Export to Markdown.

**Expected:** two directories  `folder_` and `folder_-1`  each with its note.
**Actual:** only `folder_` is created, containing only one of the two notes.

The bug triggers when the Joplin installation/checkout path itself contains a
`.` in one of its directory names (e.g. a build under `.../joplin-3.6/...`).
This is why the existing collision test passes in most environments but not
all.

## Cause

`findUniqueFilename()` in `packages/lib/fs-driver-base.ts` computed the
filename stem and extension from the **entire path string**, via
`filename(name, true)` and `fileExtension(name)`. Both helpers `split('.')`
on the whole input, so they treat the last dot *anywhere in the path* as the
extension separator.

When a parent directory contains a dot, the `-1` deduplication suffix is
appended after that dot  inside the directory name  instead of after the
leaf folder name:

wanted: /home/user/joplin-3.6/export/folder_-1
actual: /home/user/joplin-3-1.6/export/folder_   ← suffix in the wrong place



That path does not exist on disk and is not reserved, so it is returned
unchanged. Its `basename()` is still `folder_`, so both folders map to the
same export path and the second note overwrites the first.

## Solution

`findUniqueFilename()` now derives the stem and extension from the **leaf path
segment only** (via `basename()`), leaving the directory prefix untouched. A
trailing path separator (for directory paths such as `folder/`, which the HTML
exporter passes in) is stripped first and restored on the result, so
deduplication still operates on the final segment.

This fixes the Markdown exporter and also removes the same latent bug at the
note-path call site (previously masked because notes carry a real `.md`/
`.html` extension).

## Test plan

- Added a regression test in `fsDriver.test.ts` that calls
  `findUniqueFilename()` with a parent directory containing a dot, asserting
  the `-1` suffix lands on the leaf name. It **fails on the current code and
  passes with the fix**, deterministically, regardless of the checkout path.
- All affected suites pass (39 tests): `fsDriver`,
  `InteropService_Exporter_Md` (incl. the existing folder-collision test),
  `InteropService_Exporter_Md_frontmatter`, `InteropService_Exporter_Html`.

No UI changes  this is a logic fix in the export path, so there is nothing to
demonstrate visually