### PR TITLE
Mobile: Fixes #15473: Fix long note titles hide "unpublish" in the publish notes dialog

### DIFF
--- a/packages/app-mobile/components/screens/ShareNoteDialog.tsx
+++ b/packages/app-mobile/components/screens/ShareNoteDialog.tsx
@@ -48,6 +48,8 @@ const useStyles = (themeId: number) => {
 			},
 			noteTitle: {
 				fontSize: theme.fontSize,
+				flexShrink: 1,
+				flexGrow: 1,
 			},
 		});
 	}, [themeId]);


### PR DESCRIPTION
# Problem

Long note titles pushed the "Unpublish" button offscreen in the "Publish Note" dialog.

# Solution

Adjust the note title styles to allow the title to shrink, when low on horizontal space.

Fixes #15473.

# Testing

## Screenshots –– iOS

| Before | After |
|--------|-------|
| <img width="320" height="610" alt="Screenshot: unpublish button is not visible in the publish note dialog" src="https://github.com/user-attachments/assets/626e9d02-4194-45c4-a77a-972f1d586325" /> | <img width="320" height="610" alt="unpublish button is visible" src="https://github.com/user-attachments/assets/3aeaade2-87b1-43f9-a798-c8d74c854de2" />



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
