### PR TITLE
Desktop: Fixes #15430: Importing from OneNote: Fix importing `.zip` files containing `.onetoc2` files

### DIFF
--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -127,7 +127,7 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			const notebookFilePath = join(unzipTempDirectory, notebookFile.path);
 			// In some cases, the OneNote zip file can include folders and other files
 			// that shouldn't be imported directly. Skip these:
-			if (!['.one', '.onepkg', '.onetoc2'].includes(extname(notebookFilePath).toLowerCase())) {
+			if (!['.one', '.onepkg'].includes(extname(notebookFilePath).toLowerCase())) {
 				logger.info('Skipping non-OneNote file:', notebookFile.path);
 				skippedFiles.push(notebookFile.path);
 				continue;


### PR DESCRIPTION
# Problem

Joplin's OneNote importer does not support `.onetoc2` files. However, since https://github.com/laurent22/joplin/pull/14605, `.onetoc2` files can be processed by the importer, which causes import errors (as in #15430).

# Solution

Don't process `.onetoc2` files.

# Testing

1. Download the `.zip` file provided in #15430.
2. Import the `.zip` file from Joplin.
3. Verify that the import completes successfully (without showing an error dialog).

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
