### PR TITLE
Desktop: Fixes #15278: Stop embedded media playback when viewer is hidden

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
@@ -54,6 +54,8 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 	rootRef.current = editorRoot;
 
 	const webviewRef = useRef(null);
+	const previousContentKeyRef = useRef(props.contentKey);
+	const wasViewerVisibleRef = useRef(props.visiblePanes.includes('viewer'));
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	const props_onChangeRef = useRef<Function>(null);
 	props_onChangeRef.current = props.onChange;
@@ -637,6 +639,19 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 		content: props.content,
 		onMessage: props.onMessage,
 	});
+
+	useEffect(() => {
+		const viewerVisible = props.visiblePanes.includes('viewer');
+		const viewerWasHidden = wasViewerVisibleRef.current && !viewerVisible;
+		const noteChanged = previousContentKeyRef.current !== props.contentKey;
+
+		if (viewerWasHidden || noteChanged) {
+			webviewRef.current?.send('pauseMediaPlayback');
+		}
+
+		previousContentKeyRef.current = props.contentKey;
+		wasViewerVisibleRef.current = viewerVisible;
+	}, [props.contentKey, props.visiblePanes]);
 
 	useEffect(() => {
 		let cancelled = false;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState, useEffect, useRef, forwardRef, useCallback, useImperativeHandle, ForwardedRef, useContext } from 'react';
+import { useState, useEffect, useRef, forwardRef, useCallback, useImperativeHandle, ForwardedRef, useContext, useLayoutEffect } from 'react';
 
 // eslint-disable-next-line no-unused-vars
 import { EditorCommand, NoteBodyEditorProps, NoteBodyEditorRef } from '../../../utils/types';
@@ -56,6 +56,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 	const webviewRef = useRef(null);
 	const previousContentKeyRef = useRef(props.contentKey);
 	const wasViewerVisibleRef = useRef(props.visiblePanes.includes('viewer'));
+	const viewerVisible = props.visiblePanes.includes('viewer');
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	const props_onChangeRef = useRef<Function>(null);
 	props_onChangeRef.current = props.onChange;
@@ -640,8 +641,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 		onMessage: props.onMessage,
 	});
 
-	useEffect(() => {
-		const viewerVisible = props.visiblePanes.includes('viewer');
+	useLayoutEffect(() => {
 		const viewerWasHidden = wasViewerVisibleRef.current && !viewerVisible;
 		const noteChanged = previousContentKeyRef.current !== props.contentKey;
 
@@ -651,7 +651,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 
 		previousContentKeyRef.current = props.contentKey;
 		wasViewerVisibleRef.current = viewerVisible;
-	}, [props.contentKey, props.visiblePanes]);
+	}, [props.contentKey, viewerVisible]);
 
 	useEffect(() => {
 		let cancelled = false;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
@@ -65,6 +65,8 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 	const editorRef = useRef<CodeMirrorControl>(null);
 	const rootRef = useRef(null);
 	const webviewRef = useRef(null);
+	const previousContentKeyRef = useRef(props.contentKey);
+	const wasViewerVisibleRef = useRef(props.visiblePanes.includes('viewer'));
 
 	type OnChangeCallback = (event: OnChangeEvent)=> void;
 	const props_onChangeRef = useRef<OnChangeCallback>(null);
@@ -192,6 +194,19 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 		content: props.content,
 		onMessage: props.onMessage,
 	});
+
+	useEffect(() => {
+		const viewerVisible = props.visiblePanes.includes('viewer');
+		const viewerWasHidden = wasViewerVisibleRef.current && !viewerVisible;
+		const noteChanged = previousContentKeyRef.current !== props.contentKey;
+
+		if (viewerWasHidden || noteChanged) {
+			webviewRef.current?.send('pauseMediaPlayback');
+		}
+
+		previousContentKeyRef.current = props.contentKey;
+		wasViewerVisibleRef.current = viewerVisible;
+	}, [props.contentKey, props.visiblePanes]);
 
 	useEffect(() => {
 		let cancelled = false;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState, useEffect, useRef, forwardRef, useCallback, useImperativeHandle, ForwardedRef, useContext } from 'react';
+import { useState, useEffect, useRef, forwardRef, useCallback, useImperativeHandle, ForwardedRef, useContext, useLayoutEffect } from 'react';
 
 import { EditorCommand, MarkupToHtmlOptions, NoteBodyEditorProps, NoteBodyEditorRef, OnChangeEvent } from '../../../utils/types';
 import { getResourcesFromPasteEvent } from '../../../utils/resourceHandling';
@@ -67,6 +67,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 	const webviewRef = useRef(null);
 	const previousContentKeyRef = useRef(props.contentKey);
 	const wasViewerVisibleRef = useRef(props.visiblePanes.includes('viewer'));
+	const viewerVisible = props.visiblePanes.includes('viewer');
 
 	type OnChangeCallback = (event: OnChangeEvent)=> void;
 	const props_onChangeRef = useRef<OnChangeCallback>(null);
@@ -195,8 +196,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 		onMessage: props.onMessage,
 	});
 
-	useEffect(() => {
-		const viewerVisible = props.visiblePanes.includes('viewer');
+	useLayoutEffect(() => {
 		const viewerWasHidden = wasViewerVisibleRef.current && !viewerVisible;
 		const noteChanged = previousContentKeyRef.current !== props.contentKey;
 
@@ -206,7 +206,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 
 		previousContentKeyRef.current = props.contentKey;
 		wasViewerVisibleRef.current = viewerVisible;
-	}, [props.contentKey, props.visiblePanes]);
+	}, [props.contentKey, viewerVisible]);
 
 	useEffect(() => {
 		let cancelled = false;

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -75,6 +75,7 @@ const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerCon
 	usePluginMessageResponder(webviewRef);
 
 	const domReadyRef = useRef(false);
+	const pauseMediaPlaybackWhenReadyRef = useRef(false);
 	type RemovePluginAssetsCallback = ()=> void;
 	const removePluginAssetsCallbackRef = useRef<RemovePluginAssetsCallback|null>(null);
 
@@ -111,6 +112,11 @@ const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerCon
 				});
 			},
 			send: (channel: string, arg0: unknown = null, arg1: unknown = null) => {
+				if (channel === 'pauseMediaPlayback' && !domReadyRef.current) {
+					pauseMediaPlaybackWhenReadyRef.current = true;
+					return;
+				}
+
 				const win = webviewRef.current?.contentWindow;
 
 				// Window may already be closed
@@ -139,6 +145,10 @@ const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerCon
 
 				if (channel === 'setMarkers') {
 					win.postMessage({ target: 'webview', name: 'setMarkers', data: { keywords: arg0, options: arg1 } }, '*');
+				}
+
+				if (channel === 'pauseMediaPlayback') {
+					win.postMessage({ target: 'webview', name: 'pauseMediaPlayback', data: {} }, '*');
 				}
 			},
 			focus: () => {
@@ -172,6 +182,10 @@ const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerCon
 	const webview_domReadyRef = useRef<EventListener>(null);
 	webview_domReadyRef.current = (event: Event) => {
 		domReadyRef.current = true;
+		if (pauseMediaPlaybackWhenReadyRef.current) {
+			pauseMediaPlaybackWhenReadyRef.current = false;
+			webviewRef.current?.contentWindow?.postMessage({ target: 'webview', name: 'pauseMediaPlayback', data: {} }, '*');
+		}
 		if (props.onDomReady) props.onDomReady(event);
 	};
 

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -430,14 +430,29 @@
 			}
 		};
 
-		const pauseMediaElements = (root = document) => {
+		const pauseMediaElements = (root = document, reloadEmbeds = false) => {
 			for (const element of root.querySelectorAll('audio, video')) {
 				element.pause();
 			}
 
+			for (const element of root.querySelectorAll('iframe')) {
+				const src = element.getAttribute('src') ?? '';
+				if (/^https:\/\/(?:www\.)?youtube(?:-nocookie)?\.com\/embed\//.test(src)) {
+					element.contentWindow?.postMessage(JSON.stringify({
+						event: 'command',
+						func: 'pauseVideo',
+						args: [],
+					}), '*');
+
+					if (reloadEmbeds) {
+						element.src = src;
+					}
+				}
+			}
+
 			for (const element of root.querySelectorAll('*')) {
 				if (element.shadowRoot) {
-					pauseMediaElements(element.shadowRoot);
+					pauseMediaElements(element.shadowRoot, reloadEmbeds);
 				}
 			}
 		};
@@ -452,7 +467,7 @@
 
 		ipc.pauseMediaPlayback = () => {
 			clearPauseMediaPlaybackTimeouts();
-			pauseMediaElements();
+			pauseMediaElements(document, true);
 
 			for (const delay of [100, 500]) {
 				const timeoutId = setTimeout(() => {

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -430,8 +430,43 @@
 			}
 		};
 
+		const pauseMediaElements = (root = document) => {
+			for (const element of root.querySelectorAll('audio, video')) {
+				element.pause();
+			}
+
+			for (const element of root.querySelectorAll('*')) {
+				if (element.shadowRoot) {
+					pauseMediaElements(element.shadowRoot);
+				}
+			}
+		};
+
+		let pauseMediaPlaybackTimeoutIds_ = [];
+		const clearPauseMediaPlaybackTimeouts = () => {
+			for (const timeoutId of pauseMediaPlaybackTimeoutIds_) {
+				clearTimeout(timeoutId);
+			}
+			pauseMediaPlaybackTimeoutIds_ = [];
+		};
+
+		ipc.pauseMediaPlayback = () => {
+			clearPauseMediaPlaybackTimeouts();
+			pauseMediaElements();
+
+			for (const delay of [100, 500]) {
+				const timeoutId = setTimeout(() => {
+					pauseMediaElements();
+					pauseMediaPlaybackTimeoutIds_ = pauseMediaPlaybackTimeoutIds_.filter(id => id !== timeoutId);
+				}, delay);
+				pauseMediaPlaybackTimeoutIds_.push(timeoutId);
+			}
+		}
+
 		ipc.setHtml = (event) => {
 			const html = event.html;
+
+			clearPauseMediaPlaybackTimeouts();
 
 			markJsHackMarkerInserted_ = false;
 

--- a/packages/renderer/MdToHtml/rules/externalEmbed.ts
+++ b/packages/renderer/MdToHtml/rules/externalEmbed.ts
@@ -63,7 +63,7 @@ const plugin = (markdownIt: MarkdownIt) => {
 			const originalUrl = activeEmbedVideo.originalUrl;
 			activeEmbedVideo = null; // Clear state
 
-			const embedUrl = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}`;
+			const embedUrl = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}?enablejsapi=1`;
 			const escapedUrl = markdownIt.utils.escapeHtml(originalUrl);
 
 			return `


### PR DESCRIPTION
# Reason 
When Joplin hides the viewer preview panel, it only sets the panel to display: none through CSS and does not stop the media playing inside the preview area. Therefore, ordinary videos and audios, especially YouTube embedded players, will continue to play sound even if they are not visible. To address this issue, we listen for note switches and viewer state changes from visible to hidden in CodeMirror v5/v6 and send the pauseMediaPlayback command. NoteTextViewer is responsible for forwarding this command to the preview iframe. When the preview page receives the command, it will pause all audio and video elements; for YouTube iframes, it stops playback using the pauseVideo message and a fallback of reloading the iframe. At the same time, enablejsapi=1 is added to the YouTube embed address to ensure external control commands are effective.

# Summary
- Stop media playback when the desktop note viewer is hidden or the note changes
- Pause regular audio/video elements in the note viewer
- Handle YouTube embeds by sending pauseVideo and reloading the iframe as a fallback
- Enable the YouTube JS API for generated external embeds

