### PR TITLE
Chore: Retry `yarn install` when it randomly fails on CI

### DIFF
--- a/.github/scripts/build_windows.ps1
+++ b/.github/scripts/build_windows.ps1
@@ -1,0 +1,21 @@
+# Install dependencies and run `yarn dist` for the Windows desktop app.
+# Extra args are forwarded to `yarn dist` (e.g. --publish=never).
+#
+# `yarn install` can fail randomly on CI when node-pre-gyp downloads prebuilt
+# sqlite3 binaries from GitHub Releases, so we retry it a few times.
+function Build-WindowsApp {
+	param([string[]]$DistArgs = @())
+
+	$attempts = 3
+	for ($i = 1; $i -le $attempts; $i++) {
+		yarn install
+		if ($LASTEXITCODE -eq 0) { break }
+		if ($i -eq $attempts) { exit $LASTEXITCODE }
+		Write-Host "yarn install failed (attempt $i/$attempts) - retrying..."
+		Start-Sleep -Seconds 10
+	}
+
+	cd packages/app-desktop
+	yarn dist @DistArgs
+	if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}

--- a/.github/scripts/run_ci.sh
+++ b/.github/scripts/run_ci.sh
@@ -112,7 +112,29 @@ echo "Rust $( rustc --version )"
 # =============================================================================
 
 cd "$ROOT_DIR"
-yarn install
+
+# Retry a command up to a few times. Used to absorb random CI flakes, e.g.
+# `yarn install` failing when node-pre-gyp downloads prebuilt sqlite3 binaries
+# from GitHub Releases.
+retry() {
+	local attempts=3
+	local i=1
+	while true; do
+		"$@"
+		local result=$?
+		if [ $result -eq 0 ]; then
+			return 0
+		fi
+		if [ $i -ge $attempts ]; then
+			return $result
+		fi
+		echo "\`$*\` failed (attempt $i/$attempts) - retrying..."
+		i=$((i + 1))
+		sleep 10
+	done
+}
+
+retry yarn install
 testResult=$?
 if [ $testResult -ne 0 ]; then
 	echo "Yarn installation failed. Search for 'exit code 1' in the log for more information."

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -96,10 +96,11 @@ jobs:
           SSL_ESIGNER_CREDENTIAL_ID: ${{ secrets.SSL_ESIGNER_CREDENTIAL_ID }}
           SSL_ESIGNER_USER_TOTP: ${{ secrets.SSL_ESIGNER_USER_TOTP }}
           SIGN_APPLICATION: 1
-        # To ensure that the operations stop on failure, all commands
-        # should be on one line with "&&" in between.
+        # `yarn install` can fail randomly on CI when node-pre-gyp downloads
+        # prebuilt sqlite3 binaries from GitHub Releases - retry a few times.
         run: |
-          yarn install && cd packages/app-desktop && yarn dist
+          . "${env:GITHUB_WORKSPACE}/.github/scripts/build_windows.ps1"
+          Build-WindowsApp
 
       # Build and package the Windows app, without publishing it, just to
       # verify that the build process hasn't been broken.
@@ -111,7 +112,8 @@ jobs:
           SERVER_REPOSITORY: joplin/server
           SERVER_TAG_PREFIX: server
         run: |
-          yarn install && cd packages/app-desktop && yarn dist --publish=never
+          . "${env:GITHUB_WORKSPACE}/.github/scripts/build_windows.ps1"
+          Build-WindowsApp -DistArgs "--publish=never"
 
       - name: Publish Docker manifest
         if: runner.os == 'Linux'

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -298,3 +298,4 @@ keybinds
 unobserve
 querystring
 msgbox
+LASTEXITCODE


### PR DESCRIPTION
The error came from `node-pre-gyp` trying to download a prebuilt `sqlite3` binary from GitHub Releases:

```
node-pre-gyp http GET https://github.com/TryGhost/node-sqlite3/releases/download/v5.1.6/napi-v6-win32-unknown-x64.tar.gz
...
sqlite3@npm:5.1.6 [ea905] couldn't be built successfully (exit code 3221226505)
```

Two things make this flaky:

1.  **GitHub Releases CDN hiccups** — node-pre-gyp's HTTP GET to `github.com/TryGhost/node-sqlite3/releases/download/...` is a plain download with no built-in retry. Any transient TLS/connection reset, 5xx, or rate-limit blip aborts the install. Six packages install sqlite3 in parallel during `yarn install`, so the chance at least one fetch fails is much higher than for a single download.
2.  **Exit code 3221226505** = `0xC0000139` (STATUS_ENTRYPOINT_NOT_FOUND) on Windows — what node-pre-gyp returns when the prebuilt it downloaded is corrupt or incomplete (partial tarball, truncated `.node` file), so Node can't resolve a symbol when it tries to load the binary. It's the symptom of a half-finished download rather than a real linker problem.

So the binary itself exists and is correct — the network fetch just occasionally fails or truncates. Retrying `yarn install` re-runs node-pre-gyp, which re-downloads and almost always succeeds the second time.