### PR TITLE
All: Prevent notes with null bytes in title or body from being saved

### DIFF
--- a/packages/lib/BaseModel.test.ts
+++ b/packages/lib/BaseModel.test.ts
@@ -43,4 +43,20 @@ describe('BaseModel', () => {
 			expect(run).not.toThrow();
 		}
 	});
+
+	const nul = String.fromCharCode(0);
+	test.each([
+		[{ title: 'fine', body: 'fine' }, false],
+		[{ title: `bad${nul}title`, body: 'fine' }, true],
+		[{ title: 'fine', body: `bad${nul}body` }, true],
+		[{ title: 'fine' }, false],
+		[{ body: 'fine' }, false],
+	])('userSideValidation should reject titles or bodies containing a null byte (input: %j)', (input, shouldThrow) => {
+		const run = () => BaseModel.userSideValidation(input);
+		if (shouldThrow) {
+			expect(run).toThrow(/null byte/);
+		} else {
+			expect(run).not.toThrow();
+		}
+	});
 });

--- a/packages/lib/BaseModel.test.ts
+++ b/packages/lib/BaseModel.test.ts
@@ -49,9 +49,10 @@ describe('BaseModel', () => {
 		[{ title: 'fine', body: 'fine' }, false],
 		[{ title: `bad${nul}title`, body: 'fine' }, true],
 		[{ title: 'fine', body: `bad${nul}body` }, true],
+		[{ source_url: `https://example.com/${nul}` }, true],
 		[{ title: 'fine' }, false],
 		[{ body: 'fine' }, false],
-	])('userSideValidation should reject titles or bodies containing a null byte (input: %j)', (input, shouldThrow) => {
+	])('userSideValidation should reject any string field containing a null byte (input: %j)', (input, shouldThrow) => {
 		const run = () => BaseModel.userSideValidation(input);
 		if (shouldThrow) {
 			expect(run).toThrow(/null byte/);

--- a/packages/lib/BaseModel.ts
+++ b/packages/lib/BaseModel.ts
@@ -601,7 +601,7 @@ class BaseModel {
 		return query;
 	}
 
-	public static userSideValidation(o: { id?: string; title?: string; user_updated_time?: number; user_created_time?: number }) {
+	public static userSideValidation(o: { id?: string; title?: string; body?: string; user_updated_time?: number; user_created_time?: number }) {
 		if (o.id && !o.id.match(/^[a-f0-9]{32}$/)) {
 			throw new Error('Validation error: ID must a 32-characters lowercase hexadecimal string');
 		}
@@ -614,6 +614,13 @@ class BaseModel {
 		const maxTitleLength = 4096;
 		if (typeof o.title === 'string' && o.title.length > maxTitleLength) {
 			throw new Error(`Validation error: title must be ${maxTitleLength} characters or less`);
+		}
+
+		// Null bytes break Joplin's serialised note format and can cause silent
+		// truncation in some HTTP clients (notably React Native on iOS).
+		const nul = String.fromCharCode(0);
+		if ((typeof o.title === 'string' && o.title.includes(nul)) || (typeof o.body === 'string' && o.body.includes(nul))) {
+			throw new Error('Validation error: title and body cannot contain a null byte');
 		}
 	}
 

--- a/packages/lib/BaseModel.ts
+++ b/packages/lib/BaseModel.ts
@@ -601,14 +601,14 @@ class BaseModel {
 		return query;
 	}
 
-	public static userSideValidation(o: { id?: string; title?: string; body?: string; user_updated_time?: number; user_created_time?: number }) {
-		if (o.id && !o.id.match(/^[a-f0-9]{32}$/)) {
+	public static userSideValidation(o: Record<string, unknown>) {
+		if (typeof o.id === 'string' && !o.id.match(/^[a-f0-9]{32}$/)) {
 			throw new Error('Validation error: ID must a 32-characters lowercase hexadecimal string');
 		}
 
 		const timestamps = ['user_updated_time', 'user_created_time'] as const;
 		for (const k of timestamps) {
-			if ((k in o) && (typeof o[k] !== 'number' || isNaN(o[k]) || o[k] < 0)) throw new Error('Validation error: user_updated_time and user_created_time must be numbers greater than 0');
+			if ((k in o) && (typeof o[k] !== 'number' || isNaN(o[k] as number) || (o[k] as number) < 0)) throw new Error('Validation error: user_updated_time and user_created_time must be numbers greater than 0');
 		}
 
 		const maxTitleLength = 4096;
@@ -619,8 +619,11 @@ class BaseModel {
 		// Null bytes break Joplin's serialised note format and can cause silent
 		// truncation in some HTTP clients (notably React Native on iOS).
 		const nul = String.fromCharCode(0);
-		if ((typeof o.title === 'string' && o.title.includes(nul)) || (typeof o.body === 'string' && o.body.includes(nul))) {
-			throw new Error('Validation error: title and body cannot contain a null byte');
+		for (const k of Object.keys(o)) {
+			const v = o[k];
+			if (typeof v === 'string' && v.includes(nul)) {
+				throw new Error(`Validation error: ${k} cannot contain a null byte`);
+			}
 		}
 	}
 


### PR DESCRIPTION
A note containing a null byte (`\x00`) in its title or body cannot be reliably synced. The null byte can cause some clients (notably mobile builds based on React Native on iOS) to truncate the downloaded note at the null byte when downloading the item, leaving the note unreadable and breaking sync of subsequent items on that device.

Joplin's normal editors never produce null bytes, but they can slip in via the local data API or third-party plugins.

This change rejects any user-initiated save (data API, plugin, clipper, etc.) whose title or body contains a null byte, with a clear validation error. Sync, decryption, and other internal save paths are unaffected, so existing notes received from other devices are still stored locally as before.