### PR TITLE
Chore: Server: Test server Docker image using the sync fuzzer in CI

### DIFF
--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -221,4 +221,4 @@ jobs:
       
       - name: Check sync
         run: |
-          yarn syncFuzzer start --server-docker-image "joplin/server:$(dpkg --print-architecture)-0.0.0" --steps 3
+          yarn syncFuzzer start --use-running-server --steps 3

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -221,4 +221,4 @@ jobs:
       
       - name: Check sync
         run: |
-          yarn syncFuzzer start --server-docker-image "joplin/server:$(dpkg --print-architecture)-0.0.0" --max-steps 3
+          yarn syncFuzzer start --server-docker-image "joplin/server:$(dpkg --print-architecture)-0.0.0" --steps 3

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -218,3 +218,7 @@ jobs:
             echo 'Failed while checking the body response after request to /api/ping'
             exit 1;
           fi
+      
+      - name: Check sync
+        run: |
+          yarn syncFuzzer start --server-docker-image "joplin/server:$(dpkg --print-architecture)-0.0.0" --max-steps 3

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -221,4 +221,4 @@ jobs:
       
       - name: Check sync
         run: |
-          yarn syncFuzzer start --use-running-server --steps 3
+          yarn syncFuzzer start --use-running-server --steps 5

--- a/packages/tools/fuzzer/Fuzzer.ts
+++ b/packages/tools/fuzzer/Fuzzer.ts
@@ -60,7 +60,8 @@ export interface FuzzerConfig {
 	keepAccountsOnClose: boolean;
 	setupActions: ActionSpec[];
 
-	serverPath: string;
+	serverPath: string|null;
+	serverDockerImage: string|null;
 	isJoplinCloud: boolean;
 }
 
@@ -204,6 +205,7 @@ export default class Fuzzer {
 		return {
 			baseUrl: 'http://localhost:22300/',
 			baseDirectory: config.serverPath,
+			dockerImage: config.serverDockerImage,
 			adminAuth: {
 				email: 'admin@localhost',
 				password: process.env['FUZZER_SERVER_ADMIN_PASSWORD'] ?? 'admin',

--- a/packages/tools/fuzzer/Fuzzer.ts
+++ b/packages/tools/fuzzer/Fuzzer.ts
@@ -60,7 +60,7 @@ export interface FuzzerConfig {
 	keepAccountsOnClose: boolean;
 	setupActions: ActionSpec[];
 
-	serverPath: string|null;
+	serverPath: string;
 	serverDockerImage: string|null;
 	isJoplinCloud: boolean;
 }

--- a/packages/tools/fuzzer/Fuzzer.ts
+++ b/packages/tools/fuzzer/Fuzzer.ts
@@ -61,7 +61,7 @@ export interface FuzzerConfig {
 	setupActions: ActionSpec[];
 
 	serverPath: string;
-	serverDockerImage: string|null;
+	useRunningServer: boolean;
 	isJoplinCloud: boolean;
 }
 
@@ -205,7 +205,7 @@ export default class Fuzzer {
 		return {
 			baseUrl: 'http://localhost:22300/',
 			baseDirectory: config.serverPath,
-			dockerImage: config.serverDockerImage,
+			useRunningServer: config.useRunningServer,
 			adminAuth: {
 				email: 'admin@localhost',
 				password: process.env['FUZZER_SERVER_ADMIN_PASSWORD'] ?? 'admin',

--- a/packages/tools/fuzzer/cli.ts
+++ b/packages/tools/fuzzer/cli.ts
@@ -182,6 +182,13 @@ void yargs
 						'This also enables testing for some Joplin Cloud-specific features (e.g. read-only shares).',
 					].join(''),
 				},
+				'server-docker-image': {
+					type: 'string',
+					default: '',
+					description: [
+						'A Docker image name: If provided, the fuzzer will start Joplin Server using the provided Docker image.',
+					].join(''),
+				},
 				'setup': {
 					type: 'string',
 					default: '',
@@ -223,6 +230,7 @@ void yargs
 				},
 				clientCount,
 				serverPath: serverPath,
+				serverDockerImage: argv.serverDockerImage || null,
 				isJoplinCloud: !!argv.joplinCloud,
 				keepAccountsOnClose: argv.keepAccounts,
 				enableE2ee: argv.enableE2ee,

--- a/packages/tools/fuzzer/cli.ts
+++ b/packages/tools/fuzzer/cli.ts
@@ -185,7 +185,10 @@ void yargs
 				'use-running-server': {
 					type: 'boolean',
 					default: false,
-					description: 'When set, the fuzzer will connect to the server running on the default host/port (localhost:22300), rather than starting its own server instance.',
+					description: [
+						'When set to true, the fuzzer will connect to the server running on the default host/port (localhost:22300). ',
+						'When not set, the fuzzer starts an instance of Joplin Server.',
+					].join(''),
 				},
 				'setup': {
 					type: 'string',

--- a/packages/tools/fuzzer/cli.ts
+++ b/packages/tools/fuzzer/cli.ts
@@ -182,12 +182,10 @@ void yargs
 						'This also enables testing for some Joplin Cloud-specific features (e.g. read-only shares).',
 					].join(''),
 				},
-				'server-docker-image': {
-					type: 'string',
-					default: '',
-					description: [
-						'A Docker image name: If provided, the fuzzer will start Joplin Server using the provided Docker image.',
-					].join(''),
+				'use-running-server': {
+					type: 'boolean',
+					default: false,
+					description: 'When set, the fuzzer will connect to the server running on the default host/port (localhost:22300), rather than starting its own server instance.',
 				},
 				'setup': {
 					type: 'string',
@@ -230,7 +228,7 @@ void yargs
 				},
 				clientCount,
 				serverPath: serverPath,
-				serverDockerImage: argv.serverDockerImage || null,
+				useRunningServer: argv.useRunningServer,
 				isJoplinCloud: !!argv.joplinCloud,
 				keepAccountsOnClose: argv.keepAccounts,
 				enableE2ee: argv.enableE2ee,

--- a/packages/tools/fuzzer/cli.ts
+++ b/packages/tools/fuzzer/cli.ts
@@ -7,6 +7,7 @@ import { packagesDir } from './constants';
 import { ActionSpec } from './ActionRunner';
 import { readFile } from 'fs/promises';
 import Fuzzer, { FuzzerConfig } from './Fuzzer';
+import { isTTY } from '@joplin/utils/cli';
 const { shimInit } = require('@joplin/lib/shim-init-node');
 
 const globalLogger = new Logger();
@@ -59,7 +60,11 @@ const main = async (config: FuzzerConfig, restoreFromSnapshot: boolean) => {
 	} catch (error) {
 		logger.error('ERROR', error);
 		if (fuzzer) {
-			await fuzzer.openDebugSession();
+			if (isTTY()) {
+				await fuzzer.openDebugSession();
+			} else {
+				logger.info('(Not opening a debug session -- not running interactively)');
+			}
 		}
 		process.exitCode = 1;
 	} finally {

--- a/packages/tools/fuzzer/ipc/Client.ts
+++ b/packages/tools/fuzzer/ipc/Client.ts
@@ -386,17 +386,18 @@ class Client implements ActionableClient {
 
 		await this.account_.onClientDisconnected();
 
+		for (const listener of this.onCloseListeners_) {
+			listener();
+		}
+
+		this.childProcess_.close();
+
 		// Before removing the profile directory, verify that the profile directory is in the
 		// expected location:
 		const profileDirectory = resolvePathWithinDir(this.context_.baseDir, this.profileDirectory);
 		assert.ok(profileDirectory, 'profile directory for client should be contained within the main temporary profiles directory (should be safe to delete)');
 		await remove(profileDirectory);
 
-		for (const listener of this.onCloseListeners_) {
-			listener();
-		}
-
-		this.childProcess_.close();
 		this.closed_ = true;
 		logger.info('Closed client ', this.email);
 	}

--- a/packages/tools/fuzzer/ipc/Client.ts
+++ b/packages/tools/fuzzer/ipc/Client.ts
@@ -42,6 +42,9 @@ type AccountData = Readonly<{
 	onClientDisconnected: ()=> Promise<void>;
 }>;
 
+// Don't generate passwords starting with '-'. Such passwords can
+// be interpreted as command arguments if sent to the CLI app via
+// the command line.
 const createPassword = () => createSecureRandom().replace(/^-/, '_');
 
 const emailPrefix = 'fuzzer-user-';

--- a/packages/tools/fuzzer/ipc/Client.ts
+++ b/packages/tools/fuzzer/ipc/Client.ts
@@ -42,6 +42,8 @@ type AccountData = Readonly<{
 	onClientDisconnected: ()=> Promise<void>;
 }>;
 
+const createPassword = () => createSecureRandom().replace(/^-/, '_');
+
 const emailPrefix = 'fuzzer-user-';
 
 const loadAccountAndResetPassword = async (
@@ -64,7 +66,7 @@ const loadAccountAndResetPassword = async (
 	const email = response.email;
 
 	// The password needs to be set *after* creating the user.
-	const password = createSecureRandom();
+	const password = createPassword();
 	await context.execApi('PATCH', userRoute, {
 		email,
 		password,
@@ -104,7 +106,7 @@ const createNewAccount = async (email: string, context: FuzzContext): Promise<Ac
 	});
 	const userId = getStringProperty(apiOutput, 'id');
 
-	const e2eePassword = context.enableE2ee ? createSecureRandom().replace(/^-/, '_') : null;
+	const e2eePassword = context.enableE2ee ? createPassword() : null;
 	return loadAccountAndResetPassword(userId, e2eePassword, context);
 };
 

--- a/packages/tools/fuzzer/ipc/Client.ts
+++ b/packages/tools/fuzzer/ipc/Client.ts
@@ -120,6 +120,7 @@ type ChildProcessWrapper = {
 	stderr: Stream.Readable;
 	writeStdin: (data: Buffer|string)=> void;
 	close: ()=> void;
+	onClosed: (eventHandler: OnCloseListener)=> void;
 };
 
 // Should match the prompt used by the CLI "batch" command.
@@ -320,6 +321,9 @@ class Client implements ActionableClient {
 				},
 				stderr: rawChildProcess.stderr,
 				stdout: rawChildProcess.stdout,
+				onClosed: (eventHandler) => {
+					rawChildProcess.once('close', eventHandler);
+				},
 				close: () => {
 					rawChildProcess.stdin.destroy();
 					rawChildProcess.kill();
@@ -390,13 +394,20 @@ class Client implements ActionableClient {
 			listener();
 		}
 
-		this.childProcess_.close();
-
 		// Before removing the profile directory, verify that the profile directory is in the
 		// expected location:
 		const profileDirectory = resolvePathWithinDir(this.context_.baseDir, this.profileDirectory);
 		assert.ok(profileDirectory, 'profile directory for client should be contained within the main temporary profiles directory (should be safe to delete)');
-		await remove(profileDirectory);
+		this.childProcess_.onClosed(async () => {
+			try {
+				await remove(profileDirectory);
+				logger.info('Removed profile directory', profileDirectory);
+			} catch (error) {
+				logger.error('Failed to remove profile directory', profileDirectory);
+			}
+		});
+
+		this.childProcess_.close();
 
 		this.closed_ = true;
 		logger.info('Closed client ', this.email);

--- a/packages/tools/fuzzer/ipc/Server.ts
+++ b/packages/tools/fuzzer/ipc/Server.ts
@@ -28,6 +28,7 @@ const createApi = async (serverUrl: string, adminAuth: UserData) => {
 interface ServerConfig {
 	baseUrl: string;
 	baseDirectory: string;
+	dockerImage: string|null;
 	adminAuth: UserData;
 }
 
@@ -39,6 +40,7 @@ export default class Server {
 	private api_: JoplinServerApi|null = null;
 	private serverUrl_: string;
 	private adminAuth_: UserData;
+	private usingDocker_: boolean;
 	private server_: execa.ExecaChildProcess<string>;
 	private baseDirectory_: string;
 
@@ -55,19 +57,8 @@ export default class Server {
 			this.serverUrl_ = `${this.serverUrl_}/`;
 		}
 
-		const mainEntrypoint = join(serverDir, 'dist', 'app.js');
-		this.server_ = execa.node(mainEntrypoint, [
-			'--env', 'dev',
-		], {
-			env: {
-				JOPLIN_IS_TESTING: '1',
-			},
-			cwd: serverDir,
-			stdin: 'ignore', // No stdin
-			// For debugging:
-			stderr: process.stderr,
-			// stdout: process.stdout,
-		});
+		this.usingDocker_ = !!config.dockerImage;
+		this.server_ = startServerProcess(config, this.usingDocker_);
 	}
 
 	private static assertCanUseSnapshots_() {
@@ -80,9 +71,11 @@ export default class Server {
 	}
 
 	public assertCanUseSnapshots() {
-		// For now, alias the static method. In the future, more checks that require
-		// a server instance may be added:
 		Server.assertCanUseSnapshots_();
+
+		if (this.usingDocker_) {
+			throw new Error('Not supported: Creating snapshots while using a server instance in Docker.');
+		}
 	}
 
 	public static async fromSnapshot({
@@ -148,4 +141,42 @@ export default class Server {
 	}
 }
 
+const startServerProcess = (config: ServerConfig, useDocker: boolean) => {
+	const baseDirectory = resolve(config.baseDirectory);
+	if (useDocker) {
+		if (!config.dockerImage) {
+			throw new Error('Attempting to run in Docker without a Docker image specified');
+		}
 
+		return execa('docker', [
+			'docker', 'run',
+			config.dockerImage,
+			// The MAX_TIME_DRIFT check isn't necessary: All clients will be running
+			// with the same system clock.
+			'--env', 'MAX_TIME_DRIFT=0',
+			'--env', 'JOPLIN_IS_TESTING=1',
+			'node', 'dist/app.js',
+			'--env', 'dev',
+		], {
+			cwd: baseDirectory,
+			stdin: 'ignore', // No stdin
+			// For debugging:
+			stderr: process.stderr,
+			// stdout: process.stdout,
+		});
+	} else {
+		const mainEntrypoint = join(baseDirectory, 'dist', 'app.js');
+		return execa.node(mainEntrypoint, [
+			'--env', 'dev',
+		], {
+			env: {
+				JOPLIN_IS_TESTING: '1',
+			},
+			cwd: baseDirectory,
+			stdin: 'ignore', // No stdin
+			// For debugging:
+			stderr: process.stderr,
+			// stdout: process.stdout,
+		});
+	}
+};

--- a/packages/tools/fuzzer/ipc/Server.ts
+++ b/packages/tools/fuzzer/ipc/Server.ts
@@ -154,6 +154,8 @@ const startServerProcess = (config: ServerConfig, useDocker: boolean) => {
 			// with the same system clock.
 			'--env', 'MAX_TIME_DRIFT=0',
 			'--env', 'JOPLIN_IS_TESTING=1',
+			'-p', '22300:22300',
+			'--rm',
 			config.dockerImage,
 			'node', 'dist/app.js',
 			'--env', 'dev',

--- a/packages/tools/fuzzer/ipc/Server.ts
+++ b/packages/tools/fuzzer/ipc/Server.ts
@@ -28,7 +28,7 @@ const createApi = async (serverUrl: string, adminAuth: UserData) => {
 interface ServerConfig {
 	baseUrl: string;
 	baseDirectory: string;
-	dockerImage: string|null;
+	useRunningServer: boolean;
 	adminAuth: UserData;
 }
 
@@ -40,8 +40,7 @@ export default class Server {
 	private api_: JoplinServerApi|null = null;
 	private serverUrl_: string;
 	private adminAuth_: UserData;
-	private usingDocker_: boolean;
-	private server_: execa.ExecaChildProcess<string>;
+	private server_: execa.ExecaChildProcess<string>|null;
 	private baseDirectory_: string;
 
 	public constructor(config: ServerConfig) {
@@ -57,8 +56,23 @@ export default class Server {
 			this.serverUrl_ = `${this.serverUrl_}/`;
 		}
 
-		this.usingDocker_ = !!config.dockerImage;
-		this.server_ = startServerProcess(config, this.usingDocker_);
+		const mainEntrypoint = join(serverDir, 'dist', 'app.js');
+		if (!config.useRunningServer) {
+			this.server_ = execa.node(mainEntrypoint, [
+				'--env', 'dev',
+			], {
+				env: {
+					JOPLIN_IS_TESTING: '1',
+				},
+				cwd: serverDir,
+				stdin: 'ignore', // No stdin
+				// For debugging:
+				stderr: process.stderr,
+				// stdout: process.stdout,
+			});
+		} else {
+			this.server_ = null;
+		}
 	}
 
 	private static assertCanUseSnapshots_() {
@@ -73,8 +87,8 @@ export default class Server {
 	public assertCanUseSnapshots() {
 		Server.assertCanUseSnapshots_();
 
-		if (this.usingDocker_) {
-			throw new Error('Not supported: Creating snapshots while using a server instance in Docker.');
+		if (!this.server_) {
+			throw new Error('Not supported: Creating snapshots using an external server instance.');
 		}
 	}
 
@@ -136,46 +150,13 @@ export default class Server {
 	}
 
 	public async close() {
-		this.server_.cancel();
-		logger.info('Closed the server.');
+		if (this.server_) {
+			this.server_.cancel();
+			logger.info('Closed the server.');
+		} else {
+			logger.info('Server not closed: Running using an external server.');
+		}
 	}
 }
 
-const startServerProcess = (config: ServerConfig, useDocker: boolean) => {
-	const baseDirectory = resolve(config.baseDirectory);
-	const options: execa.Options = {
-		env: {
-			JOPLIN_IS_TESTING: '1',
-		},
 
-		cwd: baseDirectory,
-		stdin: 'ignore', // No stdin
-		// For debugging:
-		stderr: process.stderr,
-		// stdout: process.stdout,
-	};
-
-	if (useDocker) {
-		if (!config.dockerImage) {
-			throw new Error('Attempting to run in Docker without a Docker image specified');
-		}
-
-		return execa('docker', [
-			'run',
-			// The MAX_TIME_DRIFT check isn't necessary: All clients will be running
-			// with the same system clock.
-			'--env', 'MAX_TIME_DRIFT=0',
-			'--env', 'JOPLIN_IS_TESTING=1',
-			'-p', '22300:22300',
-			'--rm',
-			config.dockerImage,
-			'node', 'dist/app.js',
-			'--env', 'dev',
-		], options);
-	} else {
-		const mainEntrypoint = join(baseDirectory, 'dist', 'app.js');
-		return execa.node(mainEntrypoint, [
-			'--env', 'dev',
-		], options);
-	}
-};

--- a/packages/tools/fuzzer/ipc/Server.ts
+++ b/packages/tools/fuzzer/ipc/Server.ts
@@ -149,12 +149,12 @@ const startServerProcess = (config: ServerConfig, useDocker: boolean) => {
 		}
 
 		return execa('docker', [
-			'docker', 'run',
-			config.dockerImage,
+			'run',
 			// The MAX_TIME_DRIFT check isn't necessary: All clients will be running
 			// with the same system clock.
 			'--env', 'MAX_TIME_DRIFT=0',
 			'--env', 'JOPLIN_IS_TESTING=1',
+			config.dockerImage,
 			'node', 'dist/app.js',
 			'--env', 'dev',
 		], {

--- a/packages/tools/fuzzer/ipc/Server.ts
+++ b/packages/tools/fuzzer/ipc/Server.ts
@@ -143,6 +143,18 @@ export default class Server {
 
 const startServerProcess = (config: ServerConfig, useDocker: boolean) => {
 	const baseDirectory = resolve(config.baseDirectory);
+	const options: execa.Options = {
+		env: {
+			JOPLIN_IS_TESTING: '1',
+		},
+
+		cwd: baseDirectory,
+		stdin: 'ignore', // No stdin
+		// For debugging:
+		stderr: process.stderr,
+		// stdout: process.stdout,
+	};
+
 	if (useDocker) {
 		if (!config.dockerImage) {
 			throw new Error('Attempting to run in Docker without a Docker image specified');
@@ -159,26 +171,11 @@ const startServerProcess = (config: ServerConfig, useDocker: boolean) => {
 			config.dockerImage,
 			'node', 'dist/app.js',
 			'--env', 'dev',
-		], {
-			cwd: baseDirectory,
-			stdin: 'ignore', // No stdin
-			// For debugging:
-			stderr: process.stderr,
-			// stdout: process.stdout,
-		});
+		], options);
 	} else {
 		const mainEntrypoint = join(baseDirectory, 'dist', 'app.js');
 		return execa.node(mainEntrypoint, [
 			'--env', 'dev',
-		], {
-			env: {
-				JOPLIN_IS_TESTING: '1',
-			},
-			cwd: baseDirectory,
-			stdin: 'ignore', // No stdin
-			// For debugging:
-			stderr: process.stderr,
-			// stdout: process.stdout,
-		});
+		], options);
 	}
 };


### PR DESCRIPTION
# Problem

The CI logic responsible for building the Joplin Server docker image currently does limited testing. With https://github.com/laurent22/joplin/pull/15472, dev dependencies aren't included in the Docker image. As a result, it's easier to break the Docker image without breaking other tests.

# Solution

- Run the sync fuzzer in CI using the built Docker image.
- Fix several issues with the sync fuzzer that could cause issues while running in CI.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
