### PR TITLE
Server: Reject items with a null byte in any field

### DIFF
--- a/packages/server/src/models/ItemModel.test.ts
+++ b/packages/server/src/models/ItemModel.test.ts
@@ -6,7 +6,8 @@ import { StorageDriverType } from '../utils/types';
 import config from '../config';
 import { msleep } from '../utils/time';
 import loadStorageDriver from './items/storage/loadStorageDriver';
-import { ErrorPayloadTooLarge } from '../utils/errors';
+import { ErrorBadRequest, ErrorPayloadTooLarge } from '../utils/errors';
+import { makeNoteSerializedBody } from '../utils/testing/serializedItems';
 import { isSqlite } from '../db';
 
 describe('ItemModel', () => {
@@ -290,6 +291,42 @@ describe('ItemModel', () => {
 		models = newModelFactory(db(), dbSlave(), config());
 
 		await expectNotThrow(async () => models.item().loadWithContent(item.id));
+	});
+
+	test('should reject Joplin items whose fields contain a null byte', async () => {
+		const { user: user1 } = await createUserAndSession(1);
+		const factory = newModelFactory(db(), dbSlave(), config());
+
+		const nul = String.fromCharCode(0);
+		const noteId = '00000000000000000000000000000001';
+		const body = makeNoteSerializedBody({
+			id: noteId,
+			title: 'topology',
+			body: `Just a body with a null byte${nul} in the middle`,
+		});
+
+		const result = await factory.item().saveFromRawContent(user1, {
+			name: `${noteId}.md`,
+			body: Buffer.from(body),
+		});
+
+		expect(result[`${noteId}.md`].error).toBeTruthy();
+		expect(result[`${noteId}.md`].error.httpCode).toBe(ErrorBadRequest.httpCode);
+		expect(result[`${noteId}.md`].error.message).toMatch(/null byte/);
+	});
+
+	test('should accept non-Joplin binary uploads containing a null byte', async () => {
+		const { user: user1 } = await createUserAndSession(1);
+		const factory = newModelFactory(db(), dbSlave(), config());
+
+		const nul = String.fromCharCode(0);
+		const result = await factory.item().saveFromRawContent(user1, {
+			name: 'binary.bin',
+			body: Buffer.from(`some${nul}bytes`),
+		});
+
+		expect(result['binary.bin'].error).toBeNull();
+		expect(result['binary.bin'].item).toBeTruthy();
 	});
 
 	const setupImportContentTest = async () => {

--- a/packages/server/src/models/ItemModel.test.ts
+++ b/packages/server/src/models/ItemModel.test.ts
@@ -6,7 +6,7 @@ import { StorageDriverType } from '../utils/types';
 import config from '../config';
 import { msleep } from '../utils/time';
 import loadStorageDriver from './items/storage/loadStorageDriver';
-import { ErrorBadRequest, ErrorPayloadTooLarge } from '../utils/errors';
+import { ErrorPayloadTooLarge, ErrorUnprocessableEntity } from '../utils/errors';
 import { makeNoteSerializedBody } from '../utils/testing/serializedItems';
 import { isSqlite } from '../db';
 
@@ -311,7 +311,7 @@ describe('ItemModel', () => {
 		});
 
 		expect(result[`${noteId}.md`].error).toBeTruthy();
-		expect(result[`${noteId}.md`].error.httpCode).toBe(ErrorBadRequest.httpCode);
+		expect(result[`${noteId}.md`].error.httpCode).toBe(ErrorUnprocessableEntity.httpCode);
 		expect(result[`${noteId}.md`].error.message).toMatch(/null byte/);
 	});
 

--- a/packages/server/src/models/ItemModel.ts
+++ b/packages/server/src/models/ItemModel.ts
@@ -648,7 +648,7 @@ export default class ItemModel extends BaseModel<Item> {
 						const nul = String.fromCharCode(0);
 						for (const k of Object.keys(joplinItem)) {
 							if (typeof joplinItem[k] === 'string' && joplinItem[k].includes(nul)) {
-								throw new ErrorBadRequest(`Item ${rawItem.name} cannot be saved because its ${k} contains a null byte`);
+								throw new ErrorUnprocessableEntity(`Item ${rawItem.name} cannot be saved because its ${k} contains a null byte`);
 							}
 						}
 

--- a/packages/server/src/models/ItemModel.ts
+++ b/packages/server/src/models/ItemModel.ts
@@ -641,6 +641,17 @@ export default class ItemModel extends BaseModel<Item> {
 
 					if (isJoplinItem) {
 						joplinItem = await unserializeJoplinItem(rawItem.body.toString());
+
+						// Null bytes break Joplin's serialised item format and can cause
+						// silent truncation in some HTTP clients (notably React Native on
+						// iOS), making the item unreadable on those devices.
+						const nul = String.fromCharCode(0);
+						for (const k of Object.keys(joplinItem)) {
+							if (typeof joplinItem[k] === 'string' && joplinItem[k].includes(nul)) {
+								throw new ErrorBadRequest(`Item ${rawItem.name} cannot be saved because its ${k} contains a null byte`);
+							}
+						}
+
 						isNote = joplinItem.type_ === ModelType.Note;
 						resourceIds = isNote ? linkedResourceIds(joplinItem.body) : [];
 


### PR DESCRIPTION
Items uploaded with a null byte (`\x00`) in their content can become unreadable on some clients — most notably mobile builds based on React Native on iOS, where the HTTP layer truncates the response at the null byte and the note fails to parse. Once such an item exists on the server, every affected device fails to sync past it.

This change rejects any Joplin item upload whose serialised content contains a null byte in any string field, returning a clear 400 error rather than silently storing data that some clients cannot read. Resource and binary file uploads are unaffected — only Joplin items (notes, folders, tags, etc.) are checked. Combined with the matching client-side validation, this prevents the issue from reappearing through either entry point.