### PR TITLE
iOS: Fixes #15490: Fix scroll jumps while editing long paragraphs

### DIFF
--- a/packages/editor/CodeMirror/extensions/searchExtension.ts
+++ b/packages/editor/CodeMirror/extensions/searchExtension.ts
@@ -174,19 +174,6 @@ const searchExtension = (onEvent: OnEventCallback, settings: EditorSettings): Ex
 			},
 		} : undefined),
 
-		// On mobile, scrolling is handled externally (page-level native scroll), so
-		// .cm-scroller has no internal scroll. A @codemirror/view upgrade (6.35→6.41)
-		// added rect-clipping after each failed scroll attempt, which prevents the
-		// fallback window.scrollBy from firing. Use native element.scrollIntoView to
-		// fix findNext/findPrevious and GoDocEnd.
-		settings.useExternalSearch ? EditorView.scrollHandler.of((view, range) => {
-			const { node } = view.domAtPos(range.head);
-			const el = node.nodeType === Node.ELEMENT_NODE ? node as Element : node.parentElement;
-			if (!el) return false;
-			el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
-			return true;
-		}) : [],
-
 		autoScrollToMatchPlugin,
 
 		EditorState.transactionExtender.of((tr) => {


### PR DESCRIPTION
# Problem

400dc70f328aeddb9500a36a8f2573a222853b5f replaced the default CodeMirror scrolling logic to fix #15116 after a CodeMirror upgrade. This CodeMirror upgrade was later [reverted](https://github.com/laurent22/joplin/pull/15155) in the `release-3.6` branch.

At the time of this writing, `@codemirror/view` is still v6.35.0 in `packages/editor/package.json`, which does not need the scrolling logic workaround:
https://github.com/laurent22/joplin/blob/134064c8296880d63b64ddc6e3743fc6dc926cf7/packages/editor/package.json#L41

# Solution

Revert commit 400dc70f328aeddb9500a36a8f2573a222853b5f for the `release-3.6` branch.

Fixes #15490.

# Screen recordings

| Before | After   |
|--------|---------|
| <video src="https://github.com/user-attachments/assets/36992c47-872c-4c0b-acf7-b8d4517512ea" alt="scroll jumps to the top of the paragraph on each keystroke"/> | <video src="https://github.com/user-attachments/assets/0076fe82-0585-42ea-a0aa-8651784f7ba6" alt="scroll remains stable while typing"/> |


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
