### PR TITLE
Android: Fixes #15496: Fix file system sync

### DIFF
--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -128,9 +128,9 @@ export default class FsDriverRN extends FsDriverBase {
 		}
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		let output: any[] = [];
-		for (let i = 0; i < stats.length; i++) {
-			const stat = stats[i];
+		type RawStat = any;
+
+		const toRelativePath = (stat: RawStat) => {
 			let relativePath = isScoped ? stat.uri : stat.path;
 
 			// Workaround: Paths returned by RNFS.readDir can include a leading /private/, when this isn't included
@@ -144,6 +144,14 @@ export default class FsDriverRN extends FsDriverBase {
 			}
 
 			relativePath = relativePath.substring(path.length + 1);
+			return relativePath;
+		};
+
+		let output: RawStat[] = [];
+		for (let i = 0; i < stats.length; i++) {
+			const stat = stats[i];
+
+			const relativePath = toRelativePath(stat);
 			const standardStat = this.rnfsStatToStd_(stat, relativePath);
 			output.push(standardStat);
 

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -131,24 +131,19 @@ export default class FsDriverRN extends FsDriverBase {
 		let output: any[] = [];
 		for (let i = 0; i < stats.length; i++) {
 			const stat = stats[i];
-			let relativePath;
-			if (isScoped) {
-				relativePath = stat.uri;
-			} else {
-				relativePath = stat.path;
+			let relativePath = isScoped ? stat.uri : stat.path;
 
-				// Workaround: Paths returned by RNFS.readDir can include a leading /private/, when this isn't included
-				// in the original path variable:
-				if (stat.path.startsWith('/private/') && !path.startsWith('/private/')) {
-					relativePath = relativePath.replace(/^\/private/, '');
-				}
-
-				if (!relativePath.startsWith(path)) {
-					logger.warn('readDirStats: Relative path does not start with original:', { relativePath, path });
-				}
-
-				relativePath = relativePath.substring(path.length + 1);
+			// Workaround: Paths returned by RNFS.readDir can include a leading /private/, when this isn't included
+			// in the original path variable:
+			if (relativePath.startsWith('/private/') && !path.startsWith('/private/')) {
+				relativePath = relativePath.replace(/^\/private/, '');
 			}
+
+			if (!relativePath.startsWith(path)) {
+				logger.warn('readDirStats: Relative path does not start with original:', { relativePath, path });
+			}
+
+			relativePath = relativePath.substring(path.length + 1);
 			const standardStat = this.rnfsStatToStd_(stat, relativePath);
 			output.push(standardStat);
 


### PR DESCRIPTION
# Problem

https://github.com/laurent22/joplin/pull/15362 broke `readDirStats` for Android scoped paths, breaking file system sync.

#15362 adjusted `FsDriverRN.readDirStats` to fix an issue that broke plugin loading on iOS. However, if the path was scoped, the output `stat`'s `path` was set to the **full scoped path**, rather than a relative path. Callers of `readDirStats` expect relative paths.

# Solution

Return relative paths from `readDirStats` even if `isScoped` is true.

Fixes #15496.

# Testing

## Automated testing

The `!isScoped` path is covered by [startup fsDriver tests](https://github.com/laurent22/joplin/blob/134064c8296880d63b64ddc6e3743fc6dc926cf7/packages/app-mobile/utils/fs-driver/runOnDeviceTests.ts#L256).

I've started the app in dev mode on both iOS and Android and verified that the "On device testing failed" alert isn't shown.

## Manual testing

### Android: File system sync

https://github.com/user-attachments/assets/cd125950-c7bd-4812-ba05-367842cfe397

### iOS: Plugin startup

https://github.com/user-attachments/assets/4d4d120f-8bf6-4e5d-8978-64d615d5950c


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
