### PR TITLE
Doc: Add a Joplin Cloud plan with more available storage to the website

### DIFF
--- a/Assets/WebsiteAssets/css/site.css
+++ b/Assets/WebsiteAssets/css/site.css
@@ -205,6 +205,25 @@ h3 {
 	font-size: 1.3em;
 }
 
+.action-link {
+	/* Override default styles so that the class can apply to <button>s */
+	background: none;
+	border: none;
+	padding: 0;
+	color: inherit;
+	font-weight: bold;
+	font-size: 1em;
+	text-decoration: none;
+	display: block;
+	margin: 2px 0 0 1.7em;
+	text-align: left;
+	cursor: pointer;
+}
+
+.action-link:hover .action-label {
+	text-decoration: underline;
+}
+
 p,
 .button-link {
 	line-height: 30.8px;
@@ -759,6 +778,12 @@ footer .bottom-links-row p {
     font-weight: bold;
     font-size: 0.8em;
     opacity: 0.5;
+}
+
+/* Prevents parts of the feature comparison table from being offscreen
+   on mobile */
+.joplin-cloud-feature-list {
+	overflow-x: auto;
 }
 
 /*****************************************************************

--- a/Assets/WebsiteAssets/templates/partials/plan.mustache
+++ b/Assets/WebsiteAssets/templates/partials/plan.mustache
@@ -25,11 +25,16 @@
 			{{/priceYearly.formattedMonthlyAmount}}
 
 		{{#featureLabelsOn}}
-			<p><i class="fas fa-check feature feature-on"></i>{{.}}</p>
+			<p>
+				<i class="fas fa-check feature feature-on"></i>{{label}}
+				{{#actions}}
+					<button type="button" class="action-link action-{{actionId}}">→ <span class="action-label">{{label}}</span></button>
+				{{/actions}}
+			</p>
 		{{/featureLabelsOn}}
 
 		{{#featureLabelsOff}}
-			<p class="unchecked-text"><i class="fas fa-times feature feature-off"></i>{{.}}</p>
+			<p class="unchecked-text"><i class="fas fa-times feature feature-off"></i>{{label}}</p>
 		{{/featureLabelsOff}}
 		
 		<p class="text-center subscribe-wrapper">
@@ -75,6 +80,12 @@
 						.then(handleResult);
 					});
 				});
+			}
+
+			for (const button of document.querySelectorAll('button.action-toggleIncreaseStorage')) {
+				button.onclick = () => {
+					document.body.classList.toggle('-increased-storage');
+				};
 			}
 		})();
 	</script>

--- a/Assets/WebsiteAssets/templates/plans.mustache
+++ b/Assets/WebsiteAssets/templates/plans.mustache
@@ -31,6 +31,14 @@
 			color: black;
 		}
 
+		/* Replace the Pro plan with the Pro+ plan when requesting increased storage */
+		body.-increased-storage .plan-group .account-type-2 {
+			display: none !important;
+		}
+		body:not(.-increased-storage) .plan-group .account-type-4 {
+			display: none !important;
+		}
+
 		@media (max-width: 480px) {
 			.toggle-container {
 				flex-direction: column;
@@ -101,7 +109,7 @@
 			</div>	
 		</div>
 		
-		<div class="row plan-group plan-prices-monthly">
+		<div class="row plan-group plan-prices-monthly default-storage">
 			{{#plans.basic}}
 				{{> plan}}
 			{{/plans.basic}}
@@ -109,6 +117,10 @@
 			{{#plans.pro}}
 				{{> plan}}
 			{{/plans.pro}}
+
+			{{#plans.pro100Gb}}
+				{{> plan}}
+			{{/plans.pro100Gb}}
 
 			{{#plans.teams}}
 				{{> plan}}

--- a/packages/lib/utils/joplinCloud/index.ts
+++ b/packages/lib/utils/joplinCloud/index.ts
@@ -8,6 +8,7 @@ type FeatureId = string;
 export enum PlanName {
 	Basic = 'basic',
 	Pro = 'pro',
+	Pro100Gb = 'pro100Gb',
 	Teams = 'teams',
 	JoplinServerBusiness = 'joplinServerBusiness',
 }
@@ -17,14 +18,17 @@ interface PlanFeature {
 	description?: string;
 	basic: boolean;
 	pro: boolean;
+	pro100Gb: boolean;
 	teams: boolean;
 	joplinServerBusiness?: boolean;
 	basicInfo?: string;
 	proInfo?: string;
+	pro100GbInfo?: string;
 	teamsInfo?: string;
 	joplinServerBusinessInfo?: string;
 	basicInfoShort?: string;
 	proInfoShort?: string;
+	pro100GbInfoShort?: string;
 	teamsInfoShort?: string;
 	joplinServerBusinessInfoShort?: string;
 }
@@ -43,8 +47,8 @@ export interface Plan {
 	iconName: string;
 	featuresOn: FeatureId[];
 	featuresOff: FeatureId[];
-	featureLabelsOn: string[];
-	featureLabelsOff: string[];
+	featureLabelsOn: FeatureRow[];
+	featureLabelsOff: FeatureRow[];
 	cfaLabel: string;
 	cfaUrl: string;
 	footnote: string;
@@ -140,24 +144,30 @@ const features = (): Record<FeatureId, PlanFeature> => {
 			title: _('Max note or attachment size'),
 			basic: true,
 			pro: true,
+			pro100Gb: true,
 			teams: true,
 			basicInfo: _('%d MB per note or attachment', 10),
 			proInfo: _('%d MB per note or attachment', 200),
+			pro100GbInfo: _('%d MB per note or attachment', 200),
 			teamsInfo: _('%d MB per note or attachment', 200),
 			basicInfoShort: _('%d MB', 10),
 			proInfoShort: _('%d MB', 200),
+			pro100GbInfoShort: _('%d MB', 200),
 			teamsInfoShort: _('%d MB', 200),
 		},
 		maxStorage: {
 			title: _('Storage space'),
 			basic: true,
 			pro: true,
+			pro100Gb: true,
 			teams: true,
 			basicInfo: _('%d GB storage space', 2),
 			proInfo: _('%d GB storage space', 30),
+			pro100GbInfo: _('%d GB storage space', 100),
 			teamsInfo: _('%d GB storage space', 50),
 			basicInfoShort: _('%d GB', 2),
 			proInfoShort: _('%d GB', 30),
+			pro100GbInfoShort: _('%d GB', 100),
 			teamsInfoShort: _('%d GB', 50),
 		},
 		publishNote: {
@@ -165,6 +175,7 @@ const features = (): Record<FeatureId, PlanFeature> => {
 			description: 'You can [publish a note](https://joplinapp.org/help/apps/publish_note) from the Joplin app. You will get a link that you can share with other users, who can then view the note in their browser.',
 			basic: true,
 			pro: true,
+			pro100Gb: true,
 			teams: true,
 			joplinServerBusiness: true,
 		},
@@ -172,6 +183,7 @@ const features = (): Record<FeatureId, PlanFeature> => {
 			title: _('Sync as many devices as you want'),
 			basic: true,
 			pro: true,
+			pro100Gb: true,
 			teams: true,
 			joplinServerBusiness: true,
 		},
@@ -187,6 +199,7 @@ const features = (): Record<FeatureId, PlanFeature> => {
 			description: _('This allows another user to share a notebook with you, and you can then both collaborate on it. It does not however allow you to share a notebook with someone else, unless you have the feature "%s".', shareNotebookTitle),
 			basic: true,
 			pro: true,
+			pro100Gb: true,
 			teams: true,
 			joplinServerBusiness: true,
 		},
@@ -195,6 +208,7 @@ const features = (): Record<FeatureId, PlanFeature> => {
 			description: 'You can [share a notebook](https://joplinapp.org/help/apps/share_notebook/) with other Joplin Cloud users, who can then view the notes and edit them.',
 			basic: false,
 			pro: true,
+			pro100Gb: true,
 			teams: true,
 			joplinServerBusiness: true,
 		},
@@ -203,6 +217,7 @@ const features = (): Record<FeatureId, PlanFeature> => {
 			description: '[Email to Note](https://joplinapp.org/help/apps/email_to_note/) allows you to save your emails in Joplin Cloud by forwarding your emails to a special email address. The subject of the email will become the note title, and the email body will become the note content.',
 			basic: false,
 			pro: true,
+			pro100Gb: true,
 			teams: true,
 			joplinServerBusiness: true,
 		},
@@ -211,6 +226,7 @@ const features = (): Record<FeatureId, PlanFeature> => {
 			description: 'You can [customise the banner](https://joplinapp.org/help/apps/publish_note#customising-the-publishing-banner) that appears on top of your published notes, for example by adding a custom logo and text, and changing the banner colour.',
 			basic: false,
 			pro: true,
+			pro100Gb: true,
 			teams: true,
 			joplinServerBusiness: true,
 		},
@@ -219,6 +235,7 @@ const features = (): Record<FeatureId, PlanFeature> => {
 			description: 'The [Teams functionality](https://joplinapp.org/help/apps/teams/) enables the efficient administration of multiple users within a team. Serving as a centralized hub, it provides an overview of all users within your organisations, facilitating easy addition or removal of members, as well as centralised billing.',
 			basic: false,
 			pro: false,
+			pro100Gb: false,
 			teams: true,
 			joplinServerBusiness: true,
 		},
@@ -227,6 +244,7 @@ const features = (): Record<FeatureId, PlanFeature> => {
 			description: 'Billing is consolidated, ensuring a single monthly or yearly invoice, based on your chosen plan. The billing is automatically adjusted in accordance with the number of team members',
 			basic: false,
 			pro: false,
+			pro100Gb: false,
 			teams: true,
 		},
 		sharePermissions: {
@@ -234,6 +252,7 @@ const features = (): Record<FeatureId, PlanFeature> => {
 			description: '[Share permissions](https://joplinapp.org/help/apps/share_permissions/) allow you to define whether a notebook you share with someone can be edited or is read-only. It can be useful for example to share documentation that you do not want to be modified.',
 			basic: false,
 			pro: false,
+			pro100Gb: false,
 			teams: true,
 			joplinServerBusiness: true,
 		},
@@ -241,6 +260,7 @@ const features = (): Record<FeatureId, PlanFeature> => {
 			title: _('Priority support'),
 			basic: false,
 			pro: false,
+			pro100Gb: false,
 			teams: true,
 			joplinServerBusiness: true,
 		},
@@ -248,6 +268,7 @@ const features = (): Record<FeatureId, PlanFeature> => {
 			title: _('Self-hosted'),
 			basic: false,
 			pro: false,
+			pro100Gb: false,
 			teams: false,
 			joplinServerBusiness: true,
 		},
@@ -255,6 +276,7 @@ const features = (): Record<FeatureId, PlanFeature> => {
 			title: _('Source code available'),
 			basic: false,
 			pro: false,
+			pro100Gb: false,
 			teams: false,
 			joplinServerBusiness: true,
 		},
@@ -273,12 +295,47 @@ export const getFeatureIdsByPlan = (planName: PlanName, featureOn: boolean): Fea
 	return output;
 };
 
-export const getFeatureLabelsByPlan = (planName: PlanName, featureOn: boolean): string[] => {
-	const output: FeatureId[] = [];
+interface FeatureAction {
+	label: string;
+	actionId: string;
+}
+
+interface FeatureRow {
+	label: string;
+	actions: FeatureAction[];
+}
+
+const getFeatureActions = (planName: PlanName, featureId: FeatureId, featureEnabled: boolean) => {
+	const result: FeatureAction[] = [];
+
+	if (featureId === 'maxStorage' && featureEnabled) {
+		if (planName === PlanName.Pro) {
+			result.push({
+				label: _('Upgrade to 100 GB'),
+				actionId: 'toggleIncreaseStorage',
+			});
+		} else if (planName === PlanName.Pro100Gb) {
+			const defaultPlan = features().maxStorage.proInfoShort;
+			result.push({
+				label: _('Back to %s', defaultPlan),
+				actionId: 'toggleIncreaseStorage',
+			});
+		}
+	}
+
+	return result;
+};
+
+export const getFeatureLabelsByPlan = (planName: PlanName, featureOn: boolean): FeatureRow[] => {
+	const output: FeatureRow[] = [];
 
 	for (const [featureId, v] of Object.entries(features())) {
 		if (v[planName] === featureOn) {
-			output.push(getFeatureLabel(planName, featureId));
+			const actions = getFeatureActions(planName, featureId, featureOn);
+			output.push({
+				label: getFeatureLabel(planName, featureId),
+				actions,
+			});
 		}
 	}
 
@@ -334,6 +391,10 @@ export const createFeatureTableMd = () => {
 			label: 'Pro',
 		},
 		{
+			name: 'pro100Gb',
+			label: 'Pro 100 GB',
+		},
+		{
 			name: 'teams',
 			label: 'Teams',
 		},
@@ -370,6 +431,7 @@ export const createFeatureTableMd = () => {
 			featureLabel: makeFeatureLabel(id, feature),
 			basic: getCellInfo(PlanName.Basic, feature),
 			pro: getCellInfo(PlanName.Pro, feature),
+			pro100Gb: getCellInfo(PlanName.Pro100Gb, feature),
 			teams: getCellInfo(PlanName.Teams, feature),
 			joplinServerBusiness: getCellInfo(PlanName.JoplinServerBusiness, feature),
 		};
@@ -422,6 +484,29 @@ export function getPlans(stripeConfig: StripePublicConfig): Record<PlanName, Pla
 			featuresOff: getFeatureIdsByPlan(PlanName.Pro, false),
 			featureLabelsOn: getFeatureLabelsByPlan(PlanName.Pro, true),
 			featureLabelsOff: getFeatureLabelsByPlan(PlanName.Pro, false),
+			cfaLabel: _('Try it now'),
+			cfaUrl: '',
+			footnote: '',
+			hostingType: PlanHostingType.Managed,
+		},
+
+		pro100Gb: {
+			name: 'pro100Gb',
+			title: _('Pro 100 GB'),
+			priceMonthly: findPrice(stripeConfig, {
+				accountType: 4,
+				period: PricePeriod.Monthly,
+			}),
+			priceYearly: findPrice(stripeConfig, {
+				accountType: 4,
+				period: PricePeriod.Yearly,
+			}),
+			featured: true,
+			iconName: 'pro-icon',
+			featuresOn: getFeatureIdsByPlan(PlanName.Pro100Gb, true),
+			featuresOff: getFeatureIdsByPlan(PlanName.Pro100Gb, false),
+			featureLabelsOn: getFeatureLabelsByPlan(PlanName.Pro100Gb, true),
+			featureLabelsOff: getFeatureLabelsByPlan(PlanName.Pro100Gb, false),
 			cfaLabel: _('Try it now'),
 			cfaUrl: '',
 			footnote: '',

--- a/packages/server/stripeConfig.json
+++ b/packages/server/stripeConfig.json
@@ -1,48 +1,62 @@
 {
 	"dev": {
-		"publishableKey": "pk_test_51IvkOPLx4fybOTqJetV23Y5S9YHU9KoOtE6Ftur0waWoWahkHdENjDKSVcl7v3y8Y0Euv7Uwd7O7W4UFasRwd0wE00MPcprz9Q",
+		"publishableKey": "pk_test_51ScYvKL9ZkKzC9sXicNUSd3MAq6fIYAdGbRD1qlroJBpIXeO2VKIoCh8nLLRpTU9vf034VO1LmgfLgFMA7Gdavu4001GVysL65",
 		"webhookBaseUrl": "http://joplincloud.local:22300",
 		"prices": [
 			{
 				"accountType": 1,
-				"id": "price_1JAx31Lx4fybOTqJRcGdsSfg",
+				"id": "price_1TTPQHL9ZkKzC9sXEOq6yJhm",
 				"period": "monthly",
 				"amount": "1.99",
 				"currency": "EUR"
 			},
 			{
 				"accountType": 1,
-				"id": "price_1JIb4fLx4fybOTqJHnOUPVdf",
+				"id": "price_1TTPQpL9ZkKzC9sXROvbq8QN",
 				"period": "yearly",
 				"amount": "17.88",
 				"currency": "EUR"
 			},
 			{
 				"accountType": 2,
-				"id": "price_1JAx1eLx4fybOTqJ5VhkxaKC",
+				"id": "price_1TTPSFL9ZkKzC9sXndzVwgP6",
 				"period": "monthly",
 				"amount": "5.99",
 				"currency": "EUR"
 			},
 			{
 				"accountType": 2,
-				"id": "price_1JJFp7Lx4fybOTqJ0f4w2UvY",
+				"id": "price_1TTPSsL9ZkKzC9sXMbctbZar",
 				"period": "yearly",
 				"amount": "57.48",
 				"currency": "EUR"
 			},
 			{
 				"accountType": 3,
-				"id": "price_1Kl9uBLx4fybOTqJhx7q4zzj",
+				"id": "price_1TTPTnL9ZkKzC9sXKHF7ksrj",
 				"period": "monthly",
 				"amount": "7.99",
 				"currency": "EUR"
 			},
 			{
 				"accountType": 3,
-				"id": "price_1Kl9uNLx4fybOTqJpsB2l3Kg",
+				"id": "price_1TTPU7L9ZkKzC9sX1kpvGHt1",
 				"period": "yearly",
 				"amount": "80.28",
+				"currency": "EUR"
+			},
+			{
+				"accountType": 4,
+				"id": "price_1TTPZyL9ZkKzC9sXy6j5bAJf",
+				"period": "monthly",
+				"amount": "9.99",
+				"currency": "EUR"
+			},
+			{
+				"accountType": 4,
+				"id": "price_1TTPb1L9ZkKzC9sXtboasvjt",
+				"period": "yearly",
+				"amount": "95.88",
 				"currency": "EUR"
 			}
 		],
@@ -92,6 +106,20 @@
 				"id": "price_1Kl9nLLx4fybOTqJYTtts35z",
 				"period": "yearly",
 				"amount": "80.28",
+				"currency": "EUR"
+			},
+			{
+				"accountType": 4,
+				"id": "price_1TZboILx4fybOTqJH1JDHDSI",
+				"period": "monthly",
+				"amount": "9.99",
+				"currency": "EUR"
+			},
+			{
+				"accountType": 4,
+				"id": "price_1TZbplLx4fybOTqJ3VmzuqmZ",
+				"period": "yearly",
+				"amount": "95.88",
 				"currency": "EUR"
 			}
 		],


### PR DESCRIPTION
# Summary

This pull request updates the website with a "Pro 100 GB" Joplin Cloud plan.

This pull request is currently a draft: There are supporting backend changes that still need to be merged and/or enabled.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
