### PR TITLE
Server: Fixes #15507: Auto-unlock database after failed server migration

### DIFF
--- a/packages/server/src/db.migrations.test.ts
+++ b/packages/server/src/db.migrations.test.ts
@@ -82,4 +82,20 @@ describe('db.migrations', () => {
 		expect(await needsMigration(db())).toBe(false);
 	});
 
+	it('should recover from a stuck migration lock', async () => {
+		// Run one migration so that knex_migrations_lock exists.
+		await migrateUp(db());
+
+		// Simulate a server that crashed mid-migration: the lock row was set to
+		// is_locked=1 and never released. Without auto-unlock, the next migration
+		// call would hang forever waiting on the lock.
+		await db()('knex_migrations_lock').update({ is_locked: 1 });
+		expect((await db()('knex_migrations_lock').first()).is_locked).toBe(1);
+
+		await migrateLatest(db());
+
+		expect(await needsMigration(db())).toBe(false);
+		expect((await db()('knex_migrations_lock').first()).is_locked).toBe(0);
+	});
+
 });

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -316,8 +316,27 @@ const fixMigrationNames = async (db: DbConnection) => {
 	}
 };
 
-export async function migrateLatest(db: DbConnection, disableTransactions = false) {
+// Knex acquires a row in `knex_migrations_lock` before running migrations and releases it
+// after. Because the lock is committed outside the migration transaction, a server crash
+// mid-migration leaves the lock held, which then blocks every subsequent restart. Joplin
+// Server is single-instance per database, so it is always safe to clear the lock before
+// running migrations.
+const forceUnlockMigrations = async (db: DbConnection) => {
+	try {
+		await db.migrate.forceFreeMigrationsLock();
+	} catch (error) {
+		if (isNoSuchTableError(error)) return;
+		throw error;
+	}
+};
+
+const beforeMigrate = async (db: DbConnection) => {
 	await fixMigrationNames(db);
+	await forceUnlockMigrations(db);
+};
+
+export async function migrateLatest(db: DbConnection, disableTransactions = false) {
+	await beforeMigrate(db);
 
 	await db.migrate.latest({
 		directory: migrationDir,
@@ -326,7 +345,7 @@ export async function migrateLatest(db: DbConnection, disableTransactions = fals
 }
 
 export async function migrateUp(db: DbConnection, disableTransactions = false) {
-	await fixMigrationNames(db);
+	await beforeMigrate(db);
 
 	await db.migrate.up({
 		directory: migrationDir,
@@ -335,7 +354,7 @@ export async function migrateUp(db: DbConnection, disableTransactions = false) {
 }
 
 export async function migrateDown(db: DbConnection, disableTransactions = false) {
-	await fixMigrationNames(db);
+	await beforeMigrate(db);
 
 	await db.migrate.down({
 		directory: migrationDir,


### PR DESCRIPTION
Auto-release stuck migration lock to prevent server from being unable to start after a crashed database migration