### PR TITLE
Chore: Free more disk space before Android release build to prevent random CI failures

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -14,11 +14,28 @@ jobs:
           sudo apt-get update || true
           sudo apt-get install -y libsecret-1-dev
 
+      # Free disk space before anything else so the Gradle/NDK transforms
+      # (which can write 20GB+ during react-native-quick-crypto's OpenSSL
+      # build) don't exhaust the runner's ~14GB free space. Keep the Android
+      # SDK and Java toolchains; remove the large preinstalled packages this
+      # workflow doesn't use.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/share/swift || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          sudo rm -rf /usr/local/share/boost || true
+          sudo rm -rf /usr/local/share/powershell || true
+          sudo rm -rf /usr/local/lib/node_modules || true
+          docker system prune -af || true
+          df -h /
+
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '20'
-          
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v6
@@ -34,11 +51,6 @@ jobs:
         run:  yarn install
         env:
           SKIP_ONENOTE_CONVERTER_BUILD: 1
-      
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /opt/ghc || true
 
       - name: Assemble Android Release
         run: |

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -27,7 +27,6 @@ jobs:
           sudo rm -rf /opt/hostedtoolcache/CodeQL || true
           sudo rm -rf /usr/local/share/boost || true
           sudo rm -rf /usr/local/share/powershell || true
-          sudo rm -rf /usr/local/lib/node_modules || true
           docker system prune -af || true
           df -h /
 


### PR DESCRIPTION
The `AssembleRelease` job in `react-native-android-build-apk` has been failing randomly across PRs with `No space left on device` during Gradle/NDK transforms — the C/C++ build of `react-native-quick-crypto` against OpenSSL 3.x produces enough intermediates to exhaust the runner's ~14 GB of free space. This moves the `Free disk space` step to run before `setup-java`, `checkout`, `setup-node` and `yarn install` so the cleanup happens before anything writes to disk, and expands it to also remove Swift, CodeQL, Boost, PowerShell, the preinstalled global node_modules, and the Docker image cache — none of which this workflow uses. The Android SDK/NDK and Java toolchains are left untouched.