### PR TITLE
Tools: Resolves #15402: Replace require statements with typed imports

### DIFF
--- a/packages/tools/absolute-to-relative-paths.js
+++ b/packages/tools/absolute-to-relative-paths.js
@@ -1,7 +1,7 @@
-const glob = require('glob');
-const fs = require('fs-extra');
-const dirname = require('path').dirname;
-const relative = require('relative');
+import glob from 'glob';
+import fs from 'fs-extra';
+import { dirname } from 'path';
+import relative from 'relative';
 
 const libDir = `${dirname(__dirname)}/lib`;
 

--- a/packages/tools/clean.js
+++ b/packages/tools/clean.js
@@ -1,5 +1,5 @@
-const { readdir, stat, rm } = require('fs/promises');
-const { resolve } = require('path');
+import { readdir, stat, rm } from 'fs/promises';
+import { resolve } from 'path';
 
 const rootDir = resolve(__dirname, '../..');
 const packageDir = `${rootDir}/packages`;

--- a/packages/tools/compileSass.js
+++ b/packages/tools/compileSass.js
@@ -1,6 +1,6 @@
-const sass = require('sass');
-const fs = require('fs-extra');
-const { basename } = require('path');
+import sass from 'sass';
+import fs from 'fs-extra';
+import { basename } from 'path';
 
 
 // module.exports = async function compileSass(inputPaths, outputPath) {
@@ -28,7 +28,7 @@ const { basename } = require('path');
 // 	console.info(`Generated ${outputPath}`);
 // };
 
-module.exports = async function compileSass(inputPath, outputPath) {
+export default async function compileSass(inputPath, outputPath) {
 	// The SASS doc claims that compile is twice as fast as compileAsync, so if speed
 	// turns out to be an issue we could use that instead. The advantage of async is
 	// that we can run compilation of each file in parallel (and running other async
@@ -53,4 +53,4 @@ module.exports = async function compileSass(inputPath, outputPath) {
 	]);
 
 	console.info(`Generated ${outputPath}`);
-};
+}

--- a/packages/tools/compileSass.js
+++ b/packages/tools/compileSass.js
@@ -28,7 +28,7 @@ import { basename } from 'path';
 // 	console.info(`Generated ${outputPath}`);
 // };
 
-export default async function compileSass(inputPath, outputPath) {
+module.exports = async function compileSass(inputPath, outputPath) {
 	// The SASS doc claims that compile is twice as fast as compileAsync, so if speed
 	// turns out to be an issue we could use that instead. The advantage of async is
 	// that we can run compilation of each file in parallel (and running other async
@@ -53,4 +53,4 @@ export default async function compileSass(inputPath, outputPath) {
 	]);
 
 	console.info(`Generated ${outputPath}`);
-}
+};

--- a/packages/tools/release-plugin-generator.js
+++ b/packages/tools/release-plugin-generator.js
@@ -1,5 +1,5 @@
-const { execCommandVerbose, rootDir, gitPullTry, setPackagePrivateField } = require('./tool-utils.js');
-const { yarnVersionPatch } = require('@joplin/utils/version');
+import { execCommandVerbose, rootDir, gitPullTry, setPackagePrivateField } from './tool-utils.js';
+import { yarnVersionPatch } from '@joplin/utils/version';
 
 const genDir = `${rootDir}/packages/generator-joplin`;
 

--- a/packages/tools/validate-translation.js
+++ b/packages/tools/validate-translation.js
@@ -4,16 +4,19 @@
 //
 // sudo apt install gettext
 
+import fs from 'fs-extra';
+import { execCommand } from './tool-utils.js';
+
 const rootDir = `${__dirname}/../..`;
-const fs = require('fs-extra');
 const localesDir = `${rootDir}/packages/tools/locales`;
-const { execCommand } = require('./tool-utils.js');
 
 async function main() {
 	const files = fs.readdirSync(localesDir);
 	let hasErrors = false;
+
 	for (const file of files) {
 		if (!file.endsWith('.po')) continue;
+
 		const fullPath = `${localesDir}/${file}`;
 
 		try {


### PR DESCRIPTION
## Summary

Related to #15402

Replaces CommonJS `require` statements with typed ES module imports in several scripts under `packages/tools`.

## Updated files

* absolute-to-relative-paths.js
* clean.js
* compileSass.js
* release-plugin-generator.js
* validate-translation.js

## Notes

* Scope intentionally limited to isolated tooling scripts
* No functional behavior changes intended
* Verified with `yarn tsc --noEmit`
