### PR TITLE
Cli: Fix notebook title autocomplete

### DIFF
--- a/packages/app-cli/app/autocompletion.js
+++ b/packages/app-cli/app/autocompletion.js
@@ -91,7 +91,7 @@ async function handleAutocompletionPromise(line) {
 		if (argName === 'item') {
 			const notes = currentFolder ? await Note.previews(currentFolder.id, { titlePattern: `${next}*` }) : [];
 			const folders = await Folder.search({ titlePattern: `${next}*` });
-			l.push(...notes.map(n => n.title), folders.map(n => n.title));
+			l.push(...notes.map(n => n.title), ...folders.map(n => n.title));
 		}
 
 		if (argName === 'tag') {


### PR DESCRIPTION
# Problem

When a CLI command accepts either a note or notebook name, <kbd>tab</kbd> complete would complete to a comma-separated list of *all* possible notebook names.

This was caused by adding **all** of the possible notebook completion names as a single item to the completion list.

# Solution

Add each notebook name to the completion list, rather than all of them, as a single item.

# Screen recording

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/4d285f6c-519f-460b-9c45-5d425ac64ac9" alt="autocomplete has one option for all folders and one option for each note"/> | <video src="https://github.com/user-attachments/assets/726787d9-6066-4a54-bce5-31ae3cdee014" alt="autocomplete has one option per item" /> |



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
