### PR TITLE
Web: Fixes #15530: Fix plugin support

### DIFF
--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -407,12 +407,13 @@ export default class PluginService extends BaseService {
 			// On mobile, plugin scripts are loaded directly by the WebView
 			// from the filesystem, so we don't need to read them here.
 			const indexPath = `${distPath}/index.js`;
-			if (shim.mobilePlatform()) {
+			const loadMainScript = !shim.mobilePlatform() || shim.mobilePlatform() === 'web';
+			if (loadMainScript) {
 				if (!(await fsDriver.exists(indexPath))) {
 					throw new Error(`Plugin bundle not found at: ${indexPath}`);
 				}
 			}
-			const scriptText = (manifestOnly || shim.mobilePlatform()) ? '' : await fsDriver.readFile(indexPath);
+			const scriptText = (manifestOnly || !loadMainScript) ? '' : await fsDriver.readFile(indexPath);
 			const pluginId = makePluginId(filename(path));
 
 			return this.loadPlugin(distPath, manifestText, scriptText, pluginId);


### PR DESCRIPTION
# Problem

Since https://github.com/laurent22/joplin/commit/8e8a6dd65672e8f600f1f61f5749bc71ab6aa2be, plugins fail to load in the web app. 8e8a6dd65672e8f600f1f61f5749bc71ab6aa2be loads plugins through `XMLHttpRequest` to a `file://` URL. This fails on web, since plugins are stored using a virtual file system, which cannot be accessed through `file://` URIs.

# Solution

On web, send the plugin main script to the background webview.

Fixes #15530.

# Testing

Web (Chromium 148):
1. Start the web app (with a profile with a plugin installed).
2. Verify that the plugin loads successfully.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
