### PR TITLE
Chore: Fix "yarn generatePluginTypes" command

### DIFF
--- a/packages/lib/services/e2ee/ppk/webCrypto/WebCryptoRsa.ts
+++ b/packages/lib/services/e2ee/ppk/webCrypto/WebCryptoRsa.ts
@@ -9,7 +9,7 @@ export type WebCryptoSlice = {
 	>;
 };
 
-interface KeyPair {
+export interface KeyPair {
 	publicKey: CryptoKey;
 	privateKey: CryptoKey|null;
 }


### PR DESCRIPTION
# Problem

The `yarn generatePluginTypes` command failed with
```
services/e2ee/ppk/webCrypto/buildRsaCryptoProvider.ts:7:7 - error TS4023: Exported variable 'buildRsaCryptoProvider' has or is using name 'KeyPair' from external module "/home/self/Documents/joplin/packages/lib/services/e2ee/ppk/webCrypto/WebCryptoRsa" but cannot be named.

7 const buildRsaCryptoProvider = (rsaMode: PublicKeyAlgorithm, crypto: WebCryptoSlice|typeof webcrypto) => {
        ~~~~~~~~~~~~~~~~~~~~~~

```

# Solution

Export the `KeyPair` type from `WebCryptoRsa.ts`.

# Testing

`yarn generatePluginTypes` now runs successfully.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
