### PR TITLE
Desktop: Set Windows publisher name for installer verification

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -47,6 +47,9 @@
     "asar": true,
     "asarUnpack": "./node_modules/node-notifier/vendor/**",
     "win": {
+      "publisherName": [
+        "Joplin"
+      ],
       "sign": "./sign.js",
       "rfc3161TimeStampServer": "http://timestamp.digicert.com",
       "icon": "../../Assets/ImageSources/Joplin.ico",


### PR DESCRIPTION
Adds the `publisherName` field to the electron-builder Windows config so that the auto-updater verifies the Authenticode signature of downloaded installers against the expected `CN=Joplin` certificate subject. The installer was already signed correctly; this enables the runtime verification step on the client side.