### PR TITLE
All: add migration 50 for conflict resolution columns

### DIFF
--- a/packages/lib/models/BaseItem.test.ts
+++ b/packages/lib/models/BaseItem.test.ts
@@ -127,7 +127,10 @@ describe('BaseItem', () => {
 		const serialized = await Note.serialize(noteBefore);
 		const noteAfter = await Note.unserialize(serialized);
 
-		expect(noteAfter).toEqual(noteBefore);
+		const localOnlyFields = ['conflict_base_body', 'conflict_base_title', 'conflict_remote_body', 'conflict_remote_title', 'conflict_remote_updated_time'];
+		const noteBeforeComparable = { ...noteBefore } as Record<string, unknown>;
+		for (const f of localOnlyFields) delete noteBeforeComparable[f];
+		expect(noteAfter).toEqual(noteBeforeComparable);
 	});
 
 	it('should serialize and unserialize properties that contain new lines', async () => {
@@ -141,7 +144,10 @@ https://joplinapp.org/ \\n
 		const serialized = await Note.serialize(noteBefore);
 		const noteAfter = await Note.unserialize(serialized);
 
-		expect(noteAfter).toEqual(noteBefore);
+		const localOnlyFields = ['conflict_base_body', 'conflict_base_title', 'conflict_remote_body', 'conflict_remote_title', 'conflict_remote_updated_time'];
+		const noteBeforeComparable = { ...noteBefore } as Record<string, unknown>;
+		for (const f of localOnlyFields) delete noteBeforeComparable[f];
+		expect(noteAfter).toEqual(noteBeforeComparable);
 	});
 
 	it('should not serialize the note title and body', async () => {

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -450,11 +450,18 @@ export default class BaseItem extends BaseModel {
 			: propValue;
 	}
 
+	// Columns that exist only for local conflict resolution and must never be uploaded to the sync target.
+	private static readonly localOnlyFields_ = ['conflict_base_body', 'conflict_base_title', 'conflict_remote_body', 'conflict_remote_title', 'conflict_remote_updated_time'];
+
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- item is a BaseItemEntity subclass plus type_; shownKeys is a heterogeneous list of property names
 	public static async serialize(item: any, shownKeys: any[] = null) {
 		if (shownKeys === null) {
 			shownKeys = this.itemClass(item).fieldNames();
 			shownKeys.push('type_');
+			for (const f of BaseItem.localOnlyFields_) {
+				const idx = shownKeys.indexOf(f);
+				if (idx >= 0) shownKeys.splice(idx, 1);
+			}
 		}
 
 		item = this.filter(item);

--- a/packages/lib/services/database/migrations/50.ts
+++ b/packages/lib/services/database/migrations/50.ts
@@ -1,0 +1,14 @@
+import { SqlQuery } from '../types';
+
+export default (): (SqlQuery|string)[] => {
+	return [
+		'ALTER TABLE sync_items ADD COLUMN base_body TEXT NOT NULL DEFAULT ""',
+		'ALTER TABLE sync_items ADD COLUMN base_title TEXT NOT NULL DEFAULT ""',
+		'ALTER TABLE sync_items ADD COLUMN base_conflict_note_id TEXT NOT NULL DEFAULT ""',
+		'ALTER TABLE notes ADD COLUMN conflict_base_body TEXT NOT NULL DEFAULT ""',
+		'ALTER TABLE notes ADD COLUMN conflict_base_title TEXT NOT NULL DEFAULT ""',
+		'ALTER TABLE notes ADD COLUMN conflict_remote_body TEXT NOT NULL DEFAULT ""',
+		'ALTER TABLE notes ADD COLUMN conflict_remote_title TEXT NOT NULL DEFAULT ""',
+		'ALTER TABLE notes ADD COLUMN conflict_remote_updated_time INT NOT NULL DEFAULT 0',
+	];
+};

--- a/packages/lib/services/database/migrations/index.ts
+++ b/packages/lib/services/database/migrations/index.ts
@@ -7,6 +7,7 @@ import migration46 from './46';
 import migration47 from './47';
 import migration48 from './48';
 import migration49 from './49';
+import migration50 from './50';
 
 import { Migration } from '../types';
 
@@ -19,6 +20,7 @@ const index: Migration[] = [
 	migration47,
 	migration48,
 	migration49,
+	migration50,
 ];
 
 export default index;

--- a/packages/lib/services/database/types.ts
+++ b/packages/lib/services/database/types.ts
@@ -226,6 +226,11 @@ export interface NoteEntity {
   'author'?: string;
   'body'?: string;
   'conflict_original_id'?: string;
+  'conflict_base_body'?: string;
+  'conflict_base_title'?: string;
+  'conflict_remote_body'?: string;
+  'conflict_remote_title'?: string;
+  'conflict_remote_updated_time'?: number;
   'created_time'?: number;
   'deleted_time'?: number;
   'encryption_applied'?: number;
@@ -341,6 +346,9 @@ export interface SyncItemEntity {
   'sync_time'?: number;
   'sync_warning_ignored'?: number;
   'remote_item_updated_time'?: number;
+  'base_body'?: string;
+  'base_title'?: string;
+  'base_conflict_note_id'?: string;
   'type_'?: number;
 }
 export interface TableFieldEntity {
@@ -447,6 +455,9 @@ export const databaseSchema: DatabaseTables = {
 		sync_time: { type: 'number' },
 		sync_warning_ignored: { type: 'number' },
 		remote_item_updated_time: { type: 'number' },
+		base_body: { type: 'string' },
+		base_title: { type: 'string' },
+		base_conflict_note_id: { type: 'string' },
 		type_: { type: 'number' },
 	},
 	version: {
@@ -567,6 +578,11 @@ export const databaseSchema: DatabaseTables = {
 		author: { type: 'string' },
 		body: { type: 'string' },
 		conflict_original_id: { type: 'string' },
+		conflict_base_body: { type: 'string' },
+		conflict_base_title: { type: 'string' },
+		conflict_remote_body: { type: 'string' },
+		conflict_remote_title: { type: 'string' },
+		conflict_remote_updated_time: { type: 'number' },
 		created_time: { type: 'number' },
 		deleted_time: { type: 'number' },
 		encryption_applied: { type: 'number' },


### PR DESCRIPTION
### Summary
This PR adds the database foundation needed for Sync conflict resolution in Joplin. It is the first step in the conflict resolution feature.

Two sets of columns are added via migration 50.

The first set goes on the sync_items table. These three columns track the state of a note at the time of its last clean upload, which is needed to compute the base for a three-way merge later:

- base_body
- base_title
- base_conflict_note_id

The second set goes on the notes table. These columns are used to store resolution state on conflict notes and are strictly local, meaning they will never be uploaded to any sync target:

- conflict_base_body
- conflict_base_title
- conflict_remote_body
- conflict_remote_title
- conflict_remote_updated_time

To make sure the conflict note columns stay local, they are added to an exclusion list in BaseItem.serialize() so they get stripped before any note is serialized for sync.
The serialize/unserialize round trip tests were updated to exclude the new local-only conflict fields since they are intentionally stripped during serialization and will never be part of the synced output.
### Testing
Two fresh Joplin profiles were created using custom profile paths and both were started with the dev build. The database was inspected using sqlite3 after startup and both profiles showed version 50|50, confirming the migration ran cleanly on a fresh database. All 8 new columns were present on the correct tables with the right types and default values.

<img width="1160" height="282" alt="Screenshot 2026-05-26 at 5 11 17 PM" src="https://github.com/user-attachments/assets/d9f47a08-d899-4718-aa0b-ad8beb475241" />

Both profiles were pointed at the same OneDrive sync target and a full sync was performed. Notes synced correctly across both clients with no issues. The new columns in sync_items showed the expected empty defaults confirming nothing in the existing sync flow was broken.

https://github.com/user-attachments/assets/048f4254-bfb5-41b6-bfaf-f345ae24c385

A conflict was created by editing the same note on both profiles without syncing and then syncing them one after the other. The conflict note appeared correctly on the receiving client marked with is_conflict = 1 and no crashes occurred.

https://github.com/user-attachments/assets/648e4763-17ef-4f2b-8089-751a03a64b6e

All 11 existing conflict tests and all 20 BaseItem tests pass locally.

<img width="866" height="478" alt="Screenshot 2026-05-26 at 6 11 30 PM" src="https://github.com/user-attachments/assets/b0cd22d4-70bf-440b-ae08-1802c2c9b84d" />

### AI Assistance Disclosure:
AI was used in:
- For commands while testing
- Improving wording in PR description