### PR TITLE
Mobile: Fix startup failure

### DIFF
--- a/packages/lib/eventManager.ts
+++ b/packages/lib/eventManager.ts
@@ -1,4 +1,4 @@
-import * as fastDeepEqual from 'fast-deep-equal';
+import fastDeepEqual = require('fast-deep-equal');
 import { EventEmitter } from 'events';
 import type { State as AppState } from './reducer';
 import { ModelType } from './BaseModel';

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -17,7 +17,7 @@ import { checkIfItemCanBeAddedToFolder, checkIfItemCanBeChanged, checkIfItemsCan
 import { checkObjectHasProperties } from '@joplin/utils/object';
 
 const { sprintf } = require('sprintf-js');
-import * as moment from 'moment';
+import moment from 'moment';
 
 export interface ItemsThatNeedDecryptionResult {
 	hasMore: boolean;

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -17,7 +17,7 @@ import { checkIfItemCanBeAddedToFolder, checkIfItemCanBeChanged, checkIfItemsCan
 import { checkObjectHasProperties } from '@joplin/utils/object';
 
 const { sprintf } = require('sprintf-js');
-import moment from 'moment';
+import moment = require('moment');
 
 export interface ItemsThatNeedDecryptionResult {
 	hasMore: boolean;

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -25,7 +25,7 @@ import Logger from '@joplin/utils/Logger';
 import { SettingsRecord } from './models/settings/types';
 import { Toast, ToastType } from './services/plugins/api/types';
 import { unique } from './array';
-import * as fastDeepEqual from 'fast-deep-equal';
+import fastDeepEqual = require('fast-deep-equal');
 const { ALL_NOTES_FILTER_ID } = require('./reserved-ids');
 const { createSelectorCreator, defaultMemoize } = require('reselect');
 const { createCachedSelector } = require('re-reselect');

--- a/packages/lib/services/DecryptionWorker.ts
+++ b/packages/lib/services/DecryptionWorker.ts
@@ -10,7 +10,7 @@ import EncryptionService from './e2ee/EncryptionService';
 import PerformanceLogger from '../PerformanceLogger';
 import AsyncActionQueue from '../AsyncActionQueue';
 
-import * as EventEmitter from 'events';
+import EventEmitter from 'events';
 const perfLogger = PerformanceLogger.create();
 
 interface DecryptionResult {

--- a/packages/lib/services/DecryptionWorker.ts
+++ b/packages/lib/services/DecryptionWorker.ts
@@ -10,7 +10,7 @@ import EncryptionService from './e2ee/EncryptionService';
 import PerformanceLogger from '../PerformanceLogger';
 import AsyncActionQueue from '../AsyncActionQueue';
 
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 const perfLogger = PerformanceLogger.create();
 
 interface DecryptionResult {

--- a/packages/lib/services/synchronizer/syncInfoUtils.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.ts
@@ -10,7 +10,7 @@ import { compareVersions } from 'compare-versions';
 import { _ } from '../../locale';
 import JoplinError from '../../JoplinError';
 import { ErrorCode } from '../../errors';
-import * as fastDeepEqual from 'fast-deep-equal';
+import fastDeepEqual = require('fast-deep-equal');
 
 const logger = Logger.create('syncInfoUtils');
 

--- a/packages/lib/time.ts
+++ b/packages/lib/time.ts
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------------------------------
 
 import shim from './shim';
-import * as moment from 'moment';
+import moment from 'moment';
 
 type ConditionHandler = ()=> boolean;
 

--- a/packages/lib/time.ts
+++ b/packages/lib/time.ts
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------------------------------
 
 import shim from './shim';
-import moment from 'moment';
+import moment = require('moment');
 
 type ConditionHandler = ()=> boolean;
 

--- a/packages/lib/utils/frontMatter.ts
+++ b/packages/lib/utils/frontMatter.ts
@@ -3,7 +3,7 @@ import { NoteEntity } from '../services/database/types';
 import { MdFrontMatterExport } from '../services/interop/types';
 import time from '../time';
 import * as yaml from 'js-yaml';
-import * as moment from 'moment';
+import moment from 'moment';
 
 export interface ParsedMeta {
 	metadata: NoteEntity;

--- a/packages/lib/utils/frontMatter.ts
+++ b/packages/lib/utils/frontMatter.ts
@@ -3,7 +3,7 @@ import { NoteEntity } from '../services/database/types';
 import { MdFrontMatterExport } from '../services/interop/types';
 import time from '../time';
 import * as yaml from 'js-yaml';
-import moment from 'moment';
+import moment = require('moment');
 
 export interface ParsedMeta {
 	metadata: NoteEntity;

--- a/packages/utils/Logger.ts
+++ b/packages/utils/Logger.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment';
+import moment from 'moment';
 import { Mutex } from 'async-mutex';
 const { sprintf } = require('sprintf-js');
 

--- a/packages/utils/Logger.ts
+++ b/packages/utils/Logger.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment = require('moment');
 import { Mutex } from 'async-mutex';
 const { sprintf } = require('sprintf-js');
 


### PR DESCRIPTION
# Problem

With #15533, the mobile app fails to start.

https://github.com/laurent22/joplin/pull/15533 converted several `require`s to `import * as ... from ...`s, which seem to be incompatible with the mobile app.

Related: https://github.com/laurent22/joplin/pull/10652.

# Solution

Replace the new `import * as ... from ...`s with `import ... = require(...)`s.

# Testing

1. Create a dev build of the iOS app
2. Verify that the iOS app starts successfully
3. Create a new note
4. Sync (target: OneDrive)
5. Verify that sync completes successfully

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
