### PR TITLE
Desktop & CLI: Fixes #15217: fix onenote import target folder

### DIFF
--- a/packages/lib/services/interop/InteropService.test.ts
+++ b/packages/lib/services/interop/InteropService.test.ts
@@ -1,7 +1,7 @@
 import InteropService from '../../services/interop/InteropService';
 import { CustomExportContext, CustomImportContext, ExportModuleOutputFormat, ModuleType } from '../../services/interop/types';
 import shim from '../../shim';
-import { fileContentEqual, setupDatabaseAndSynchronizer, switchClient, checkThrowAsync, exportDir, supportDir } from '../../testing/test-utils';
+import { fileContentEqual, setupDatabaseAndSynchronizer, switchClient, checkThrowAsync, exportDir, supportDir, withWarningSilenced } from '../../testing/test-utils';
 import Folder from '../../models/Folder';
 import Note from '../../models/Note';
 import Tag from '../../models/Tag';
@@ -13,6 +13,7 @@ import * as ArrayUtils from '../../ArrayUtils';
 import InteropService_Importer_Custom from './InteropService_Importer_Custom';
 import InteropService_Exporter_Custom from './InteropService_Exporter_Custom';
 import Module, { makeExportModule, makeImportModule } from './Module';
+import { JSDOM } from 'jsdom';
 
 async function recreateExportDir() {
 	const dir = exportDir();
@@ -83,13 +84,57 @@ function memoryExportModule() {
 	return { result, module };
 }
 
+const oneNoteSimpleXpsPath = () => `${supportDir}/onenote/simple-xps.one`;
+
 describe('services_InteropService', () => {
+
+	const setupOneNoteDomParser = () => {
+		const jsdom = new JSDOM('<div></div>');
+		InteropService.instance().domParser = new jsdom.window.DOMParser();
+		InteropService.instance().xmlSerializer = new jsdom.window.XMLSerializer();
+	};
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);
 		await recreateExportDir();
 	});
+
+	it('should import OneNote files as a top-level folder when no destination folder is passed', (async () => {
+		setupOneNoteDomParser();
+		const service = InteropService.instance();
+		const oneNoteModule = service.findModuleByFormat(ModuleType.Importer, 'one');
+		expect(oneNoteModule.isNoteArchive).toBe(true);
+
+		await withWarningSilenced(/OneNoteConverter:/, async () => {
+			await service.import({
+				path: oneNoteSimpleXpsPath(),
+				format: 'one',
+			});
+		});
+
+		expect(await Folder.loadByTitleAndParent('simple-xps', '')).toBeTruthy();
+		expect((await Note.all()).some(note => note.title === 'Printout')).toBe(true);
+	}));
+
+	// Covers the command-import.ts behavior by passing destinationFolderId directly
+	it('should import OneNote files as a top-level folder when a destination folder is passed', (async () => {
+		setupOneNoteDomParser();
+		const service = InteropService.instance();
+		const destinationFolder = await Folder.save({ title: 'destination' });
+
+		await withWarningSilenced(/OneNoteConverter:/, async () => {
+			await service.import({
+				path: oneNoteSimpleXpsPath(),
+				format: 'one',
+				destinationFolderId: destinationFolder.id,
+			});
+		});
+
+		expect(await Folder.loadByTitleAndParent('simple-xps', '')).toBeTruthy();
+		expect(await Folder.loadByTitleAndParent('simple-xps', destinationFolder.id)).toBeFalsy();
+		expect((await Note.all()).some(note => note.title === 'Printout')).toBe(true);
+	}));
 
 	it('should export and import folders', (async () => {
 		const service = InteropService.instance();

--- a/packages/lib/services/interop/InteropService.ts
+++ b/packages/lib/services/interop/InteropService.ts
@@ -145,7 +145,7 @@ export default class InteropService {
 						'onepkg',
 					],
 					sources: [FileSystemItem.File],
-					isNoteArchive: false, // Tells whether the file can contain multiple notes (eg. Enex or Jex format)
+					isNoteArchive: true, // Tells whether the file can contain multiple notes (eg. Enex or Jex format)
 					description: _('OneNote Notebook'),
 				}, () => new InteropService_Importer_OneNote()),
 			];

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -174,8 +174,10 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 		logger.info('Importing HTML into Joplin');
 		const importer = new OneNoteHtmlImporter(fileToMetadata);
 		importer.setMetadata({ fileExtensions: ['html'] });
-		await importer.init(tempOutputDirectory, {
+		await importer.init(outputDirectory2, {
 			...this.options_,
+			destinationFolder: null,
+			destinationFolderId: null,
 			format: 'html',
 			outputFormat: ImportModuleOutputFormat.Html,
 		});


### PR DESCRIPTION

Fixes #15217 

OneNote import now creates top-level Joplin notebook. Not under selected notebook, CLI default notebook, or Trash.

Now:
- `isNoteArchive: true`
- clears `destinationFolder` and `destinationFolderId` before HTML import

Changing `isNoteArchive: true` without clearing destinationFolder. OneNote still uses HTML importer after conversion. If HTML importer gets temp root, new notebook can get temp folder name.

## Tests

Added `InteropService` coverage for desktop import and CLI `command-import`.