### PR TITLE
All: Fix alphabetical sorting by stripping whitespace from titles

### DIFF
--- a/packages/lib/components/shared/side-menu-shared.ts
+++ b/packages/lib/components/shared/side-menu-shared.ts
@@ -99,7 +99,7 @@ const sortTags = (tags: TagEntity[]) => {
 		// Note: while newly created tags are normalized and lowercase
 		// imported tags might be any case, so we need to do case-insensitive
 		// sort.
-		return collator.compare(a.title, b.title);
+		return collator.compare((a.title || '').trim(), (b.title || '').trim());
 	});
 	return tags;
 };

--- a/packages/lib/models/Folder.test.ts
+++ b/packages/lib/models/Folder.test.ts
@@ -519,4 +519,38 @@ describe('models/Folder', () => {
 		expect(validFolder).toBeNull();
 	});
 
+	it('should ignore leading and trailing whitespace when sorting folders', (async () => {
+		const f0 = await Folder.save({ title: ' a' });
+		const f1 = await Folder.save({ title: '\tb' });
+		const f2 = await Folder.save({ title: '\nc' });
+		const f3 = await Folder.save({ title: 'd ' });
+
+		// Test Folder.all() which uses handleTitleNaturalSorting
+		const sorted = await Folder.all({
+			order: [{ by: 'title', dir: 'ASC' }],
+		});
+
+		// Find the index of our test folders in the sorted output
+		const sortedFiltered = sorted.filter(f => [f0.id, f1.id, f2.id, f3.id].includes(f.id));
+		expect(sortedFiltered.length).toBe(4);
+		expect(sortedFiltered[0].id).toBe(f0.id);
+		expect(sortedFiltered[1].id).toBe(f1.id);
+		expect(sortedFiltered[2].id).toBe(f2.id);
+		expect(sortedFiltered[3].id).toBe(f3.id);
+
+		// Test Folder.sortFolderTree()
+		const tree = await Folder.sortFolderTree([
+			{ ...f3, children: [] },
+			{ ...f0, children: [] },
+			{ ...f2, children: [] },
+			{ ...f1, children: [] },
+		]);
+		expect(tree.length).toBe(4);
+		expect(tree[0].id).toBe(f0.id);
+		expect(tree[1].id).toBe(f1.id);
+		expect(tree[2].id).toBe(f2.id);
+		expect(tree[3].id).toBe(f3.id);
+	}));
+
 });
+

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -350,7 +350,7 @@ export default class Folder extends BaseItem {
 	public static handleTitleNaturalSorting(items: FolderEntity[], options: { order?: { by: string; dir: string }[] }) {
 		if (options.order?.length > 0 && options.order[0].by === 'title') {
 			const collator = getCollator();
-			items.sort((a, b) => ((options.order[0].dir === 'ASC') ? 1 : -1) * collator.compare(a.title, b.title));
+			items.sort((a, b) => ((options.order[0].dir === 'ASC') ? 1 : -1) * collator.compare((a.title || '').trim(), (b.title || '').trim()));
 		}
 	}
 
@@ -935,7 +935,7 @@ export default class Folder extends BaseItem {
 
 			folders.sort((a: FolderEntityWithChildren, b: FolderEntityWithChildren) => {
 				if (a.parent_id === b.parent_id) {
-					return collator.compare(a.title, b.title);
+					return collator.compare((a.title || '').trim(), (b.title || '').trim());
 				}
 				return 0;
 			});

--- a/packages/lib/models/Note.test.ts
+++ b/packages/lib/models/Note.test.ts
@@ -470,6 +470,36 @@ describe('models/Note', () => {
 		expect(sortedNotes3[4].id).toBe(note2.id);
 	}));
 
+	it('should ignore leading and trailing whitespace when sorting', (async () => {
+		const folder1 = await Folder.save({});
+
+		// Create notes with leading and trailing whitespaces in titles
+		const note0 = await Note.save({ title: ' a', parent_id: folder1.id });
+		const note1 = await Note.save({ title: '\tb', parent_id: folder1.id });
+		const note2 = await Note.save({ title: '\nc', parent_id: folder1.id });
+		const note3 = await Note.save({ title: 'd ', parent_id: folder1.id });
+
+		// Test Note.previews() (natural sorting on load)
+		const sortedNotes = await Note.previews(folder1.id, {
+			fields: ['id', 'title'],
+			order: [{ by: 'title', dir: 'ASC' }],
+		});
+
+		expect(sortedNotes.length).toBe(4);
+		expect(sortedNotes[0].id).toBe(note0.id);
+		expect(sortedNotes[1].id).toBe(note1.id);
+		expect(sortedNotes[2].id).toBe(note2.id);
+		expect(sortedNotes[3].id).toBe(note3.id);
+
+		// Test Note.sortNotes() (in-memory sorting of loaded list)
+		const customSorted = Note.sortNotes([note3, note0, note2, note1], [{ by: 'title', dir: 'ASC' }], false);
+		expect(customSorted.length).toBe(4);
+		expect(customSorted[0].id).toBe(note0.id);
+		expect(customSorted[1].id).toBe(note1.id);
+		expect(customSorted[2].id).toBe(note2.id);
+		expect(customSorted[3].id).toBe(note3.id);
+	}));
+
 	it('should create a conflict note', async () => {
 		const folder = await Folder.save({ title: 'Source Folder' });
 		const origNote = await Note.save({ title: 'note', parent_id: folder.id, share_id: 'SHARE', is_shared: 1 });

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -321,8 +321,8 @@ export default class Note extends BaseItem {
 			r = noteFieldComp(a.user_created_time, b.user_created_time);
 			if (r) return r;
 
-			const titleA = a.title ? a.title.toLowerCase() : '';
-			const titleB = b.title ? b.title.toLowerCase() : '';
+			const titleA = a.title ? a.title.toLowerCase().trim() : '';
+			const titleB = b.title ? b.title.toLowerCase().trim() : '';
 			r = noteFieldComp(titleA, titleB);
 			if (r) return r;
 
@@ -344,7 +344,7 @@ export default class Note extends BaseItem {
 				if (typeof bProp === 'string') bProp = bProp.toLowerCase();
 
 				if (order.by === 'title') {
-					r = -1 * collator.compare(aProp as string, bProp as string);
+					r = -1 * collator.compare((aProp as string || '').trim(), (bProp as string || '').trim());
 				} else {
 					if (aProp < bProp) r = +1;
 					if (aProp > bProp) r = -1;
@@ -1192,7 +1192,7 @@ export default class Note extends BaseItem {
 	public static handleTitleNaturalSorting(items: NoteEntity[], options: { order?: { by: string; dir: string }[] }) {
 		if (options.order.length > 0 && options.order[0].by === 'title') {
 			const collator = getCollator();
-			items.sort((a, b) => ((options.order[0].dir === 'ASC') ? 1 : -1) * collator.compare(a.title, b.title));
+			items.sort((a, b) => ((options.order[0].dir === 'ASC') ? 1 : -1) * collator.compare((a.title || '').trim(), (b.title || '').trim()));
 		}
 	}
 


### PR DESCRIPTION
Currently, if a note, folder, or tag title starts with a whitespace, it breaks the alphabetical sorting. Since these characters have lower Unicode values, titles like `" a"` incorrectly bubble up to the very top of the list instead of sorting under "a" or "b".

This PR fixes that by trimming leading and trailing whitespaces in the sorting logic when comparing titles.

### Changes
* **Notes (`Note.ts`)**: Trim note titles in `sortNotes()` and `handleTitleNaturalSorting()`.
* **Folders (`Folder.ts`)**: Trim folder titles in `handleTitleNaturalSorting()` and `sortFolderTree()`.
* **Tags (`side-menu-shared.ts`)**: Trim tag titles in `sortTags()`.

### Testing
Added Jest unit tests in `Note.test.ts` and `Folder.test.ts` to verify the fix with various whitespaces (spaces, tabs, newlines). All tests, linter, and spellcheck pass cleanly.