### PR TITLE
All: Resolves #15549: add migration 51 for conflict resolution columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1562,6 +1562,7 @@ packages/lib/services/database/migrations/47.js
 packages/lib/services/database/migrations/48.js
 packages/lib/services/database/migrations/49.js
 packages/lib/services/database/migrations/50.js
+packages/lib/services/database/migrations/51.js
 packages/lib/services/database/migrations/index.js
 packages/lib/services/database/sqlStringToLines.js
 packages/lib/services/database/types.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1588,6 +1588,7 @@ packages/lib/services/database/migrations/47.js
 packages/lib/services/database/migrations/48.js
 packages/lib/services/database/migrations/49.js
 packages/lib/services/database/migrations/50.js
+packages/lib/services/database/migrations/51.js
 packages/lib/services/database/migrations/index.js
 packages/lib/services/database/sqlStringToLines.js
 packages/lib/services/database/types.js

--- a/packages/lib/services/database/migrations/51.ts
+++ b/packages/lib/services/database/migrations/51.ts
@@ -1,0 +1,17 @@
+import { SqlQuery } from '../types';
+
+export default (): (SqlQuery|string)[] => {
+	return [
+		'ALTER TABLE sync_items ADD COLUMN base_body TEXT NOT NULL DEFAULT ""',
+		'ALTER TABLE sync_items ADD COLUMN base_title TEXT NOT NULL DEFAULT ""',
+		'ALTER TABLE sync_items ADD COLUMN base_conflict_note_id TEXT NOT NULL DEFAULT ""',
+		`CREATE TABLE IF NOT EXISTS conflict_note_states (
+			note_id TEXT PRIMARY KEY,
+			base_body TEXT NOT NULL DEFAULT "",
+			base_title TEXT NOT NULL DEFAULT "",
+			remote_body TEXT NOT NULL DEFAULT "",
+			remote_title TEXT NOT NULL DEFAULT "",
+			remote_updated_time INT NOT NULL DEFAULT 0
+		)`,
+	];
+};

--- a/packages/lib/services/database/migrations/index.ts
+++ b/packages/lib/services/database/migrations/index.ts
@@ -8,6 +8,7 @@ import migration47 from './47';
 import migration48 from './48';
 import migration49 from './49';
 import migration50 from './50';
+import migration51 from './51';
 
 import { Migration } from '../types';
 
@@ -21,6 +22,7 @@ const index: Migration[] = [
 	migration48,
 	migration49,
 	migration50,
+	migration51,
 ];
 
 export default index;

--- a/packages/lib/services/database/types.ts
+++ b/packages/lib/services/database/types.ts
@@ -335,6 +335,15 @@ export interface SettingEntity {
   'value'?: string | null;
   'type_'?: number;
 }
+export interface ConflictNoteStateEntity {
+  'note_id'?: string;
+  'base_body'?: string;
+  'base_title'?: string;
+  'remote_body'?: string;
+  'remote_title'?: string;
+  'remote_updated_time'?: number;
+  'type_'?: number;
+}
 export interface SyncItemEntity {
   'force_sync'?: number;
   'id'?: number | null;
@@ -347,6 +356,9 @@ export interface SyncItemEntity {
   'sync_time'?: number;
   'sync_warning_ignored'?: number;
   'remote_item_updated_time'?: number;
+  'base_body'?: string;
+  'base_title'?: string;
+  'base_conflict_note_id'?: string;
   'type_'?: number;
 }
 export interface TableFieldEntity {
@@ -453,6 +465,18 @@ export const databaseSchema: DatabaseTables = {
 		sync_time: { type: 'number' },
 		sync_warning_ignored: { type: 'number' },
 		remote_item_updated_time: { type: 'number' },
+		base_body: { type: 'string' },
+		base_title: { type: 'string' },
+		base_conflict_note_id: { type: 'string' },
+		type_: { type: 'number' },
+	},
+	conflict_note_states: {
+		note_id: { type: 'string' },
+		base_body: { type: 'string' },
+		base_title: { type: 'string' },
+		remote_body: { type: 'string' },
+		remote_title: { type: 'string' },
+		remote_updated_time: { type: 'number' },
 		type_: { type: 'number' },
 	},
 	version: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10
 
 "7zip-bin@npm:5.2.0, 7zip-bin@npm:~5.2.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 10
+  version: 8
   cacheKey: 10
 
 "7zip-bin@npm:5.2.0, 7zip-bin@npm:~5.2.0":


### PR DESCRIPTION
### Summary:
Fixes #15549
The migration adds two things. First, three new columns on the sync_items table to track the state of a note at the time of its last clean upload, which is needed later to compute the base for a three-way merge:

- base_body
- base_title
- base_conflict_note_id

Second, a new separate table called conflict_note_states to store the resolution working state for a conflict note. This table is completely isolated from the notes table so plugins, import/export, and any external app that reads note data won't see it. The table uses note_id as the primary key since the relationship is one-to-one with the conflict note. This follows the same pattern as resource_local_states which keeps local-only resource fetch state out of the main resources table.

conflict_note_states columns:

- note_id (primary key, links to notes.id)
- base_body
- base_title
- remote_body
- remote_title
- remote_updated_time

One thing worth calling out is that since this is a separate table, the record won't be automatically deleted if someone deletes the conflict note directly rather than going through the conflict resolution UI. This will need to be handled either by hooking into the note deletion path or running a cleanup task. That's out of scope for this PR but will be addressed in a follow-up.

All new columns and the new table are empty for now. They will be populated in the next PR that implements the actual conflict resolution logic.

### Testing

- Two fresh Joplin profiles were created and both came up on version 50 with the correct schema. The conflict_note_states table was verified to exist with note_id as the primary key and all five columns with the right types and defaults. The three new sync_items columns were also confirmed present.

https://github.com/user-attachments/assets/cc4057f3-52b2-4aad-8a26-11c03dd770c3


- A conflict was created by editing the same note on both profiles while offline and then syncing them one after the other. The conflict note appeared correctly with no crashes, confirming the existing conflict behaviour is completely unaffected by the new schema.

https://github.com/user-attachments/assets/d5ef46b4-0dd5-4fcb-882a-734bc4b3d8ce


- Both profiles were pointed at the same OneDrive sync target and synced successfully. Note counts matched across both profiles confirming the migration did not touch or corrupt any existing data.


https://github.com/user-attachments/assets/7c7ffa34-ca99-4474-9714-b8c9d84bcbe6

AI Assistance Disclosure:
AI was used in:
- To get commands for testing
- Improving wording in PR description
