### PR TITLE
All: Fixes #15482: Support YouTube embeds for mobile YouTube URLs

### DIFF
--- a/packages/renderer/MdToHtml/rules/externalEmbed.ts
+++ b/packages/renderer/MdToHtml/rules/externalEmbed.ts
@@ -1,9 +1,29 @@
 import type * as MarkdownIt from 'markdown-it';
 
-const extractVideoId = (url: string) => {
-	const pattern = /^https?:\/\/(?:www\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/;
-	const match = url.match(pattern);
-	return match ? match[1] : null;
+const extractVideoId = (url: string): string | null => {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return null;
+	}
+
+	const host = parsed.hostname.toLowerCase();
+
+	if (host === 'youtu.be') {
+		const id = parsed.pathname.slice(1).split('/')[0];
+		return /^[a-zA-Z0-9_-]{11}$/.test(id) ? id : null;
+	}
+
+	if (host === 'youtube.com' || host.endsWith('.youtube.com')) {
+		const pathMatch = parsed.pathname.match(/^\/(embed|v)\/([a-zA-Z0-9_-]{11})/);
+		if (pathMatch) return pathMatch[2];
+
+		const v = parsed.searchParams.get('v');
+		return v && /^[a-zA-Z0-9_-]{11}$/.test(v) ? v : null;
+	}
+
+	return null;
 };
 
 const plugin = (markdownIt: MarkdownIt) => {


### PR DESCRIPTION
Fixes #15482

## Summary

YouTube external embeds only worked when the URL matched a narrow regex (`www.youtube.com/watch?v=`, `youtu.be/`, etc.). Links copied from YouTube on mobile often use hosts like `m.youtube.com` or extra query parameters (`&pp=`, `&app=desktop`, …), so `extractVideoId` failed and the note showed a plain link instead of an embedded player.

This change parses URLs with the `URL` API and extracts the video ID from:

- `youtu.be` short links
- Any `youtube.com` / `*.youtube.com` host (including `m.youtube.com`, `www.youtube.com`, bare `youtube.com`)
- `/watch?v=`, `/embed/`, and `/v/` paths, including when extra query params are present

## Screenshot

| Before | After |
|--------|-------|
|<img width="1408" height="613" alt="594661626-ce514fb8-7ef8-4800-8731-6bf2bcb1cfa4" src="https://github.com/user-attachments/assets/b37a790b-1d5e-4af6-bf2f-64c83392a7fe" /> |  <img width="1920" height="1080" alt="Screenshot (294)" src="https://github.com/user-attachments/assets/3c64a729-0b01-4f48-9be2-28a4ad744f61" />|


