### PR TITLE
Mobile: Fixes #15479: Fixed mobile "new notebook" instructions

### DIFF
--- a/readme/welcome/1_welcome_to_joplin.md
+++ b/readme/welcome/1_welcome_to_joplin.md
@@ -53,7 +53,7 @@ A lot more is possible including adding code samples, math formulae or checkbox 
 Joplin notes are organised into a tree of notebooks and sub-notebooks.
 
 - On **desktop**, you can create a notebook by clicking on New Notebook, then you can organise them as you wish by dragging and dropping them into other notebooks or right-clicking and selecting "Move to notebook". You can also drag a sub-notebook to the "Notebooks" header to move it to the root. 
-- On **mobile**, press the "+" icon and select "New notebook".
+- On **mobile**, press the "☰" icon and select "New notebook".
 - On **terminal**, press `:mn`
 
 ![](./SubNotebooks.png)


### PR DESCRIPTION
Fixes #15479 
Documentation fix to change the "+" icon to the "☰" for more accurate instruction.
"On mobile, press the "☰" icon and select "New notebook".
