### PR TITLE
Chore: TypeScript: Migrate more `any` types

### DIFF
--- a/packages/app-cli/app/app.ts
+++ b/packages/app-cli/app/app.ts
@@ -22,15 +22,14 @@ import Cache from '@joplin/lib/Cache';
 
 type FolderOrNoteType = ModelType.Note | ModelType.Folder | 'folderOrNote';
 
+type CommandMetadata = ReturnType<BaseCommand['metadata']>;
+
 
 export class Application extends BaseApplication {
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Dynamic command loading system
-	private commands_: Record<string, any> = {};
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Dynamic command metadata
-	private commandMetadata_: any = null;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Dynamic command type
-	private activeCommand_: any = null;
+	private commands_: Record<string, BaseCommand> = {};
+	private commandMetadata_: Record<string, CommandMetadata> = null;
+	private activeCommand_: BaseCommand = null;
 	private allCommandsLoaded_ = false;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Dynamic GUI type with many optional methods
 	private gui_: any = null;
@@ -173,8 +172,7 @@ export class Application extends BaseApplication {
 		}
 
 		if (uiType !== null) {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Dynamic command type
-			const temp: Record<string, any> = {};
+			const temp: Record<string, BaseCommand> = {};
 			for (const n in this.commands_) {
 				if (!this.commands_.hasOwnProperty(n)) continue;
 				const c = this.commands_[n];
@@ -200,7 +198,7 @@ export class Application extends BaseApplication {
 	public async commandMetadata() {
 		if (this.commandMetadata_) return this.commandMetadata_;
 
-		let output = await this.cache_.getItem('metadata') as Record<string, unknown>;
+		let output = await this.cache_.getItem('metadata') as Record<string, CommandMetadata>;
 		if (output) {
 			this.commandMetadata_ = output;
 			return { ...this.commandMetadata_ };
@@ -445,8 +443,7 @@ export class Application extends BaseApplication {
 			this.gui_.setLogger(this.logger());
 			await this.gui_.start();
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Redux dispatch type requires AnyAction
-			await refreshFolders((action: any) => this.store().dispatch(action), '');
+			await refreshFolders(action => this.store().dispatch(action), '');
 
 			const tags = await Tag.allWithNotes();
 

--- a/packages/app-cli/app/autocompletion.ts
+++ b/packages/app-cli/app/autocompletion.ts
@@ -44,7 +44,7 @@ const handleAutocompletionPromise = async (line: string): Promise<CompletionResu
 	const l: string[] = [];
 	if (next[0] === '-') {
 		for (let i = 0; i < metadata.options.length; i++) {
-			const options = metadata.options[i][0].split(' ');
+			const options = (metadata.options[i] as string[])[0].split(' ');
 			// if there are multiple options then they will be separated by comma and
 			// space. The comma should be removed
 			if (options[0][options[0].length - 1] === ',') {

--- a/packages/app-cli/app/command-sync.ts
+++ b/packages/app-cli/app/command-sync.ts
@@ -3,7 +3,7 @@ import Setting from '@joplin/lib/models/Setting';
 import SyncTargetRegistry from '@joplin/lib/SyncTargetRegistry';
 import MigrationHandler from '@joplin/lib/services/synchronizer/MigrationHandler';
 import ResourceFetcher from '@joplin/lib/services/ResourceFetcher';
-import Synchronizer from '@joplin/lib/Synchronizer';
+import Synchronizer, { SyncStartOptions } from '@joplin/lib/Synchronizer';
 import { masterKeysWithoutPassword } from '@joplin/lib/services/e2ee/utils';
 import { appTypeToLockType } from '@joplin/lib/services/synchronizer/LockHandler';
 import BaseCommand from './base-command';
@@ -182,16 +182,10 @@ class Command extends BaseCommand {
 
 			const sync = await syncTarget.synchronizer();
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Synchronizer.start accepts `any` options; tightening here would diverge from lib
-			const options: any = {
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Synchronizer.reportToLines takes `any` (lib)
-				onProgress: (report: any) => {
+			const options: SyncStartOptions = {
+				onProgress: (report) => {
 					const lines = Synchronizer.reportToLines(report);
 					if (lines.length) cliUtils.redraw(lines.join(' '));
-				},
-				onMessage: (msg: string) => {
-					cliUtils.redrawDone();
-					this.stdout(msg);
 				},
 			};
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -949,7 +949,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 	// -----------------------------------------------------------------------------------------
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TinyMCE editor instance / event types are looser than the published @types/tinymce (we use APIs not in the published types: getDoc, getWin, formatter, ui.registry, undoManager extensions)
-	const loadDocumentAssets = (themeId: number, editor: any, pluginAssets: any[]) => {
+	const loadDocumentAssets = (themeId: number, editor: any, pluginAssets: RenderResultPluginAsset[]) => {
 		const theme = themeStyle(themeId);
 
 		let docHead_: HTMLHeadElement = null;
@@ -975,15 +975,13 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 			`gui/note-viewer/pluginAssets/highlight.js/${theme.codeThemeCss}`,
 		].concat(
 			pluginAssets
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TinyMCE editor instance / event types are looser than the published @types/tinymce (we use APIs not in the published types: getDoc, getWin, formatter, ui.registry, undoManager extensions)
-				.filter((a: any) => a.mime === 'text/css')
+				.filter(a => a.mime === 'text/css')
 				.map(assetToUrl),
 		);
 
 		const allJsFiles = [].concat(
 			pluginAssets
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TinyMCE editor instance / event types are looser than the published @types/tinymce (we use APIs not in the published types: getDoc, getWin, formatter, ui.registry, undoManager extensions)
-				.filter((a: any) => a.mime === 'application/javascript')
+				.filter(a => a.mime === 'application/javascript')
 				.map(assetToUrl),
 		);
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -948,8 +948,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 	// Set the initial content and load the plugin CSS and JS files
 	// -----------------------------------------------------------------------------------------
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TinyMCE editor instance / event types are looser than the published @types/tinymce (we use APIs not in the published types: getDoc, getWin, formatter, ui.registry, undoManager extensions)
-	const loadDocumentAssets = (themeId: number, editor: any, pluginAssets: RenderResultPluginAsset[]) => {
+	const loadDocumentAssets = (themeId: number, editor: Editor, pluginAssets: RenderResultPluginAsset[]) => {
 		const theme = themeStyle(themeId);
 
 		let docHead_: HTMLHeadElement = null;

--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StyledSyncReportText, StyledSyncReport, StyledSynchronizeButton, StyledRoot } from './styles';
 import { ButtonLevel } from '../Button/Button';
 import CommandService from '@joplin/lib/services/CommandService';
-import Synchronizer from '@joplin/lib/Synchronizer';
+import Synchronizer, { type ProgressReport } from '@joplin/lib/Synchronizer';
 import Setting from '@joplin/lib/models/Setting';
 import { _ } from '@joplin/lib/locale';
 import { AppState } from '../../app.reducer';
@@ -18,15 +18,13 @@ interface Props {
 	dispatch: Dispatch;
 	decryptionWorker: StateDecryptionWorker;
 	resourceFetcher: StateResourceFetcher;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- syncReport: any matches the lib reducer shape; tightening requires defining the synchronizer's report type there first
-	syncReport: any;
+	syncReport: ProgressReport;
 	syncStarted: boolean;
 	syncPending: boolean;
 	syncReportIsVisible: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- The generated report does not currently have a type
-const syncCompletedWithoutError = (syncReport: any) => {
+const syncCompletedWithoutError = (syncReport: ProgressReport) => {
 	return syncReport.completedTime && (!syncReport.errors || !syncReport.errors.length);
 };
 

--- a/packages/app-mobile/components/app-nav.tsx
+++ b/packages/app-mobile/components/app-nav.tsx
@@ -5,7 +5,7 @@ import { Dispatch } from 'redux';
 import NotesScreen from './screens/Notes/Notes';
 import SearchScreen from './screens/SearchScreen';
 import { Platform, View, StyleSheet } from 'react-native';
-import { AppState } from '../utils/types';
+import { AppState, Route } from '../utils/types';
 import { themeStyle } from './global-style';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import useKeyboardState from '../utils/hooks/useKeyboardState';
@@ -15,8 +15,7 @@ import { useMemo } from 'react';
 import KeyboardAvoidingView from './KeyboardAvoidingView';
 
 interface Props {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Route is a redux NAV action with heterogeneous payload (folderId, tagId, noteId, etc.); typing it would require restructuring action types across the mobile codebase
-	route: any;
+	route: Route;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Each screen has different props (themeId, dispatch, navigation, visible, ...); typing the union would force a refactor of every screen
 	screens: Record<string, { screen: ComponentType<any> }>;
 	dispatch: Dispatch;

--- a/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/utils/exportDebugReport.ts
+++ b/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/utils/exportDebugReport.ts
@@ -10,7 +10,7 @@ const exportDebugReport = async () => {
 	const logItemRows = [['Date', 'Level', 'Message']];
 	for (let i = 0; i < logItems.length; i++) {
 		const item = logItems[i];
-		logItemRows.push([time.formatMsToLocal(item.timestamp, 'MM-DDTHH:mm:ss'), item.level, item.message]);
+		logItemRows.push([time.formatMsToLocal(item.timestamp, 'MM-DDTHH:mm:ss'), item.level.toString(), item.message]);
 	}
 	const logItemCsv = service.csvCreate(logItemRows);
 

--- a/packages/app-mobile/components/screens/LogScreen.tsx
+++ b/packages/app-mobile/components/screens/LogScreen.tsx
@@ -6,7 +6,7 @@ import { reg } from '@joplin/lib/registry';
 import { ScreenHeader } from '../ScreenHeader';
 import time from '@joplin/lib/time';
 import { themeStyle } from '../global-style';
-import Logger from '@joplin/utils/Logger';
+import Logger, { LogEntry } from '@joplin/utils/Logger';
 import { BaseScreenComponent } from '../base-screen';
 import { _ } from '@joplin/lib/locale';
 import { MenuOptionType } from '../ScreenHeader';
@@ -17,13 +17,6 @@ import { TextInput } from 'react-native-paper';
 import shareFile from '../../utils/shareFile';
 
 const logger = Logger.create('LogScreen');
-
-interface LogEntry {
-	id: number;
-	timestamp: number;
-	level: number;
-	message: string;
-}
 
 interface Props {
 	themeId: number;
@@ -91,7 +84,7 @@ class LogScreenComponent extends BaseScreenComponent<Props, State> {
 
 	private async getLogEntries(showErrorsOnly: boolean, limit: number|null = null): Promise<LogEntry[]> {
 		const levels = this.getLogLevels(showErrorsOnly);
-		return await reg.logger().lastEntries(limit, { levels, filter: this.state.filter }) as LogEntry[];
+		return await reg.logger().lastEntries(limit, { levels, filter: this.state.filter });
 	}
 
 	private async onSharePress() {

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -6,6 +6,7 @@ import UndoRedoService from '@joplin/lib/services/UndoRedoService';
 import NoteBodyViewer from '../../NoteBodyViewer/NoteBodyViewer';
 import checkPermissions from '../../../utils/checkPermissions';
 import NoteEditor from '../../NoteEditor/NoteEditor';
+import { EditorControl } from '../../NoteEditor/types';
 import * as React from 'react';
 import { Keyboard, View, TextInput, StyleSheet, Linking, Share, NativeSyntheticEvent, useWindowDimensions } from 'react-native';
 import { Platform, PermissionsAndroid } from 'react-native';
@@ -174,8 +175,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	private saveActionQueues_: Record<string, AsyncActionQueue>;
 	private doFocusUpdate_: boolean;
 	private styles_: Record<string, ReturnType<typeof StyleSheet.create>>;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- editorRef can be a Markdown, RichText, or NoteBody viewer; each exposes a different command surface. Typing as the union would force narrowing at every call site.
-	private editorRef: any;
+	private editorRef: RefObject<EditorControl>;
 	private titleTextFieldRef: RefObject<TextInput>;
 	private navHandler: OnNavigateCallback;
 	private backHandler: ()=> Promise<boolean>;

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -183,8 +183,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	private noteTagDialog_closeRequested: ()=> void;
 	private refreshResource: (resource: ResourceEntity, noteBody?: string)=> Promise<void>;
 	private selection: SelectionRange;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Cached menu option entries are heterogeneous (different command types and option shapes)
-	private menuOptionsCache_: Record<string, any>;
+	private menuOptionsCache_: Record<string, MenuOptionType[]>;
 	private focusUpdateIID_: ReturnType<typeof setTimeout> | null;
 	private folderPickerOptions_: FolderPickerOptions;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- dialogbox is the react-native-dialogbox ref; the library ships no types

--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -5,7 +5,7 @@ import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 import Icon from './Icon';
 import Folder from '@joplin/lib/models/Folder';
-import Synchronizer from '@joplin/lib/Synchronizer';
+import Synchronizer, { type ProgressReport } from '@joplin/lib/Synchronizer';
 import NavService from '@joplin/lib/services/NavService';
 import { _ } from '@joplin/lib/locale';
 import { themeStyle } from './global-style';
@@ -34,8 +34,7 @@ interface Props {
 	themeId: number;
 	dispatch: Dispatch;
 	collapsedFolderIds: string[];
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- syncReport is typed as `any` in @joplin/lib/reducer and in `Synchronizer.reportToLines`; tightening here would require updating the lib type first
-	syncReport: any;
+	syncReport: ProgressReport;
 	decryptionWorker: StateDecryptionWorker;
 	resourceFetcher: StateResourceFetcher;
 	syncOnlyOverWifi: boolean;

--- a/packages/app-mobile/utils/appReducer.ts
+++ b/packages/app-mobile/utils/appReducer.ts
@@ -1,21 +1,10 @@
 import reducer from '@joplin/lib/reducer';
-import { AppState } from './types';
+import { AppState, Route } from './types';
 import appDefaultState, { DEFAULT_ROUTE } from './appDefaultState';
 import fastDeepEqual = require('fast-deep-equal');
 import Logger from '@joplin/utils/Logger';
 
 const logger = Logger.create('appReducer');
-
-// Narrow shape for entries this file reads from the redux NAV action payload.
-// The full action type is a wider, heterogeneous union — see the disable
-// comments below — so the fields outside this interface are accessed via `any`
-// elsewhere.
-interface Route {
-	routeName?: string;
-	folderId?: string;
-	noteId?: string;
-	isDeleted?: boolean;
-}
 
 const navHistory: Route[] = [];
 

--- a/packages/app-mobile/utils/appReducer.ts
+++ b/packages/app-mobile/utils/appReducer.ts
@@ -34,20 +34,15 @@ function historyCanGoBackTo(route: Route) {
 	return true;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Assigning types to these variables would be too big of a refactoring
-function removeAdjacentNoteDuplicates(items: any[]) {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Assigning types to these variables would be too big of a refactoring
-	return items.filter((item: any, idx: number) => (idx >= 1) ? !(item.routeName === 'Note' && items[idx - 1].routeName === 'Note' && items[idx - 1].noteId === item.noteId) : true);
+function removeAdjacentNoteDuplicates(items: Route[]) {
+	return items.filter((item, idx) => (idx >= 1) ? !(item.routeName === 'Note' && items[idx - 1].routeName === 'Note' && items[idx - 1].noteId === item.noteId) : true);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Assigning types to these variables would be too big of a refactoring
-function removeAdjacentFolderDuplicates(items: any[]) {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Assigning types to these variables would be too big of a refactoring
-	return items.filter((item: any, idx: number) => (idx >= 1) ? !(item.routeName === 'Notes' && items[idx - 1].routeName === 'Notes' && items[idx - 1].folderId === item.folderId) : true);
+function removeAdjacentFolderDuplicates(items: Route[]) {
+	return items.filter((item, idx) => (idx >= 1) ? !(item.routeName === 'Notes' && items[idx - 1].routeName === 'Notes' && items[idx - 1].folderId === item.folderId) : true);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Assigning types to these variables would be too big of a refactoring
-function removeLatestFolderIfSelected(items: any[], route: any) {
+function removeLatestFolderIfSelected(items: Route[], route: Route) {
 	if (items.length && route.routeName === 'Notes' && items[items.length - 1].folderId === route.folderId) {
 		items.splice(items.length - 1, 1);
 	}

--- a/packages/app-mobile/utils/types.ts
+++ b/packages/app-mobile/utils/types.ts
@@ -1,14 +1,23 @@
 import { State } from '@joplin/lib/reducer';
+import type { SideMenuContentOptions } from '../components/SideMenuContentNote';
+
+// Narrow shape of the redux NAV route that the mobile app stores in AppState
+// and the navigation history. The dispatched NAV action carries more
+// (heterogeneous) fields; only these are read back from state.
+export interface Route {
+	routeName?: string;
+	folderId?: string;
+	noteId?: string;
+	isDeleted?: boolean;
+}
 
 export interface AppState extends State {
 	showPanelsDialog: boolean;
 	isOnMobileData: boolean;
 	keyboardVisible: boolean;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- `route` is the redux NAV action payload (heterogeneous fields like folderId/tagId/noteId/etc.); typing it requires a coordinated refactor across the mobile codebase
-	route: any;
+	route: Route;
 	smartFilterId: string;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- `noteSideMenuOptions` is set per-screen with heterogeneous shapes; typing it requires a coordinated refactor across the mobile codebase
-	noteSideMenuOptions: any;
+	noteSideMenuOptions: SideMenuContentOptions;
 	disableSideMenuGestures: boolean;
 	noteEditorVisible: boolean;
 	syncWizardVisible: boolean;

--- a/packages/app-mobile/utils/types.ts
+++ b/packages/app-mobile/utils/types.ts
@@ -5,7 +5,7 @@ import type { SideMenuContentOptions } from '../components/SideMenuContentNote';
 // and the navigation history. The dispatched NAV action carries more
 // (heterogeneous) fields; only these are read back from state.
 export interface Route {
-	routeName?: string;
+	routeName: string;
 	folderId?: string;
 	noteId?: string;
 	isDeleted?: boolean;

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -40,12 +40,26 @@ const { Dirnames } = require('./services/synchronizer/utils/types');
 
 const logger = Logger.create('Synchronizer');
 
-interface ProgressReport {
+export interface ProgressReport {
 	errors: (Error | string)[];
 	state?: string;
 	startTime?: number;
 	completedTime?: number;
 	[counterKey: string]: unknown;
+}
+
+// The delta-sync cursor. Its shape is sync-target-specific, so it is treated
+// opaquely here and round-tripped through JSON by callers.
+export interface SyncContext {
+	delta?: unknown;
+}
+
+export interface SyncStartOptions {
+	onProgress?: (report: ProgressReport)=> void;
+	context?: SyncContext;
+	syncSteps?: string[];
+	throwOnError?: boolean;
+	saveContextHandler?: (newContext: SyncContext)=> void;
 }
 
 function isCannotSyncError(error: { code?: string; type?: string; message?: string } | null): boolean {
@@ -386,8 +400,7 @@ export default class Synchronizer {
 	// 1. UPLOAD: Send to the sync target the items that have changed since the last sync.
 	// 2. DELETE_REMOTE: Delete on the sync target, the items that have been deleted locally.
 	// 3. DELTA: Find on the sync target the items that have been modified or deleted and apply the changes locally.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Caller-provided sync options bag (onProgress, context, syncSteps, throwOnError, saveContextHandler); widening would require touching every Synchronizer.start call site
-	public async start(options: any = null) {
+	public async start(options: SyncStartOptions = null) {
 		if (!options) options = {};
 
 		if (this.state() !== 'idle') {

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -12,13 +12,13 @@ import { itemIsReadOnlySync, ItemSlice } from '../../models/utils/readOnly';
 import ItemChange from '../../models/ItemChange';
 import BaseItem from '../../models/BaseItem';
 
-interface SharedResource {
+export interface SharedResource {
 	uri: string;
 	mimeType: string;
 	name: string;
 }
 
-interface SharedData {
+export interface SharedData {
 	title: string;
 	text: string;
 	resources: SharedResource[];

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -8,6 +8,8 @@ import { _ } from '../locale';
 import Database from '../database';
 import ItemChange from './ItemChange';
 import ShareService from '../services/share/ShareService';
+import type EncryptionService from '../services/e2ee/EncryptionService';
+import type RevisionService from '../services/RevisionService';
 import itemCanBeEncrypted from './utils/itemCanBeEncrypted';
 import { getEncryptionEnabled } from '../services/synchronizer/syncInfoUtils';
 import JoplinError from '../JoplinError';
@@ -52,10 +54,8 @@ export interface EncryptedItemsStats {
 
 export default class BaseItem extends BaseModel {
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- EncryptionService is set at app startup; lib references it structurally to avoid a circular import (EncryptionService -> BaseItem)
-	public static encryptionService_: any = null;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- RevisionService is set at app startup; see encryptionService_ above
-	public static revisionService_: any = null;
+	public static encryptionService_: EncryptionService = null;
+	public static revisionService_: RevisionService = null;
 	public static shareService_: ShareService = null;
 	private static syncShareCache_: ShareState | null = null;
 

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -948,15 +948,14 @@ class Setting extends BaseModel {
 		return output;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- value is the per-setting raw value; formatValue branches by SettingItemType — narrowing forces casts in every branch
-	public static valueToString(key: string, value: any) {
+	public static valueToString(key: string, value: unknown) {
 		const md = this.settingMetadata(key);
-		value = this.formatValue(key, value);
-		if (md.type === SettingItemType.Int) return value.toFixed(0);
-		if (md.type === SettingItemType.Bool) return value ? '1' : '0';
-		if (md.type === SettingItemType.Array) return value ? JSON.stringify(value) : '[]';
-		if (md.type === SettingItemType.Object) return value ? JSON.stringify(value) : '{}';
-		if (md.type === SettingItemType.String) return value ? `${value}` : '';
+		const formatted = this.formatValue(key, value);
+		if (md.type === SettingItemType.Int) return formatted.toFixed(0);
+		if (md.type === SettingItemType.Bool) return formatted ? '1' : '0';
+		if (md.type === SettingItemType.Array) return formatted ? JSON.stringify(formatted) : '[]';
+		if (md.type === SettingItemType.Object) return formatted ? JSON.stringify(formatted) : '{}';
+		if (md.type === SettingItemType.String) return formatted ? `${formatted}` : '';
 
 		throw new Error(`Unhandled value type: ${md.type}`);
 	}
@@ -966,8 +965,7 @@ class Setting extends BaseModel {
 		return md.filter ? md.filter(value) : value;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See valueToString above
-	public static formatValue(key: string | SettingItemType, value: any) {
+	public static formatValue(key: string | SettingItemType, value: unknown) {
 		const type = typeof key === 'string' ? this.settingMetadata(key).type : key;
 
 		if (type === SettingItemType.Int) return !value ? 0 : Math.floor(Number(value));
@@ -1033,7 +1031,7 @@ class Setting extends BaseModel {
 		}
 
 		const md = this.settingMetadata(key);
-		return copyIfNeeded(md.value);
+		return copyIfNeeded(md.value) as SettingValueType<T>;
 	}
 
 	// This function returns the default value if the setting key does not exist.

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1015,8 +1015,7 @@ class Setting extends BaseModel {
 		}
 
 		if (key in this.constants_) {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Constants are heterogeneous (string, number, AppType, function); value() returns SettingValueType<T> which is parametric
-			const v = (this.constants_ as any)[key];
+			const v: unknown = this.constants_[key as keyof Constants];
 			const output = typeof v === 'function' ? v() : v;
 			if (output === 'SET_ME') throw new Error(`SET_ME constant has not been set: ${key}`);
 			return output;

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -8,6 +8,7 @@ import Logger from '@joplin/utils/Logger';
 import mergeGlobalAndLocalSettings from '../services/profileConfig/mergeGlobalAndLocalSettings';
 import splitGlobalAndLocalSettings from '../services/profileConfig/splitGlobalAndLocalSettings';
 import JoplinError from '../JoplinError';
+import type KeychainService from '../services/keychain/KeychainService';
 import builtInMetadata, { BuiltInMetadataKeys, BuiltInMetadataValues } from './settings/builtInMetadata';
 import { toSystemSlashes } from '@joplin/utils/path';
 import { AppType, Env, SettingItem, SettingItemType, SettingItems, SettingSection, SettingSectionSource, SettingStorage, SettingsRecord } from './settings/types';
@@ -315,8 +316,8 @@ class Setting extends BaseModel {
 	public static allowFileStorage = true;
 
 	private static metadata_: SettingItems = null;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- KeychainService concrete class lives in app-desktop/app-mobile; lib references it structurally to avoid cross-package imports
-	private static keychainService_: any = null;
+	// Type-only import: KeychainService imports Setting, so a value import would create a runtime cycle.
+	private static keychainService_: KeychainService = null;
 	private static keys_: string[] = null;
 	private static cache_: CacheItem<unknown>[] = [];
 	private static saveTimeoutId_: ReturnType<typeof shim.setTimeout> = null;
@@ -386,8 +387,7 @@ class Setting extends BaseModel {
 		return this.keychainService_;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See keychainService_ above
-	public static setKeychainService(s: any) {
+	public static setKeychainService(s: KeychainService) {
 		this.keychainService_ = s;
 	}
 
@@ -681,7 +681,7 @@ class Setting extends BaseModel {
 			return {
 				key,
 				value: await this.keychainService().password(`setting.${key}`),
-			};
+			} as unknown as CacheItem<T>;
 		}
 
 		return null;

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -681,6 +681,8 @@ class Setting extends BaseModel {
 			return {
 				key,
 				value: await this.keychainService().password(`setting.${key}`),
+				// TODO: KeychainService currently only supports string-valued settings
+				// For now, cast to preserve existing behavior:
 			} as CacheItem<unknown> as CacheItem<T>;
 		}
 

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -681,7 +681,7 @@ class Setting extends BaseModel {
 			return {
 				key,
 				value: await this.keychainService().password(`setting.${key}`),
-			} as unknown as CacheItem<T>;
+			} as CacheItem<unknown> as CacheItem<T>;
 		}
 
 		return null;

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -37,10 +37,9 @@ interface KeysOptions {
 
 // This is where the actual setting values are stored.
 // They are saved to database at regular intervals.
-interface CacheItem {
+interface CacheItem<T extends string|unknown> {
 	key: string;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Each setting has its own value type; tightening forces narrowing at every read/write site
-	value: any;
+	value: T extends string ? SettingValueType<T> : unknown;
 }
 
 export interface Constants {
@@ -319,7 +318,7 @@ class Setting extends BaseModel {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- KeychainService concrete class lives in app-desktop/app-mobile; lib references it structurally to avoid cross-package imports
 	private static keychainService_: any = null;
 	private static keys_: string[] = null;
-	private static cache_: CacheItem[] = [];
+	private static cache_: CacheItem<unknown>[] = [];
 	private static saveTimeoutId_: ReturnType<typeof shim.setTimeout> = null;
 	private static changeEventTimeoutId_: ReturnType<typeof shim.setTimeout> = null;
 	private static customMetadata_: SettingItems = {};
@@ -643,14 +642,14 @@ class Setting extends BaseModel {
 	// This allows loading a setting without doing any check on anything - this can be useful to
 	// retrieve a value for a setting that was previously registered, but no longer is. Also to
 	// retrieve setting values for plugins before the plugin is actually loaded.
-	private static async loadOneFromDb(key: string): Promise<CacheItem | null> {
+	private static async loadOneFromDb<T extends string>(key: T): Promise<CacheItem<T> | null> {
 		const row = await this.modelSelectOne('SELECT key, value FROM settings WHERE key = ?', [key]);
 		return row ? row : null;
 	}
 
 	// Low-level method to load a setting directly from the database. Should not be used in most cases.
 	// Does not apply setting default values.
-	public static async loadOne(key: string): Promise<CacheItem | null> {
+	public static async loadOne<T extends string>(key: T): Promise<CacheItem<T> | null> {
 		if (this.keyStorage(key) === SettingStorage.File) {
 			let fileSettings = await this.fileHandler.load();
 
@@ -664,7 +663,7 @@ class Setting extends BaseModel {
 				return {
 					key,
 					value: fileSettings[key],
-				};
+				} as CacheItem<T>;
 			} else {
 				return null;
 			}
@@ -693,7 +692,7 @@ class Setting extends BaseModel {
 		this.cancelScheduleChangeEvent();
 
 		this.cache_ = [];
-		const rows: CacheItem[] = await this.modelSelectAll('SELECT * FROM settings');
+		const rows: CacheItem<unknown>[] = await this.modelSelectAll('SELECT * FROM settings');
 
 
 		// Keys in the database takes precedence over keys in the keychain because
@@ -703,7 +702,7 @@ class Setting extends BaseModel {
 
 		const rowKeys = (rows as { key: string }[]).map(r => r.key);
 		const secureKeys = this.keys(false, null, { secureOnly: true });
-		const secureItems: CacheItem[] = [];
+		const secureItems: CacheItem<unknown>[] = [];
 		for (const key of secureKeys) {
 			if (rowKeys.includes(key)) continue;
 
@@ -716,7 +715,7 @@ class Setting extends BaseModel {
 			}
 		}
 
-		const itemsFromFile: CacheItem[] = [];
+		const itemsFromFile: CacheItem<unknown>[] = [];
 
 		if (this.canUseFileStorage()) {
 			let fileSettings = await this.fileHandler.load();
@@ -737,7 +736,7 @@ class Setting extends BaseModel {
 
 		this.cache_ = [];
 		const cachedKeys = new Set();
-		const pushItemsToCache = (items: CacheItem[]) => {
+		const pushItemsToCache = (items: CacheItem<unknown>[]) => {
 			for (let i = 0; i < items.length; i++) {
 				const c = items[i];
 
@@ -1029,7 +1028,7 @@ class Setting extends BaseModel {
 
 		for (let i = 0; i < this.cache_.length; i++) {
 			if (this.cache_[i].key === key) {
-				return copyIfNeeded(this.cache_[i].value);
+				return copyIfNeeded(this.cache_[i].value) as SettingValueType<T>;
 			}
 		}
 

--- a/packages/lib/models/settings/types.ts
+++ b/packages/lib/models/settings/types.ts
@@ -25,8 +25,7 @@ export enum SettingStorage {
 
 // This is the definition of a setting item
 export interface SettingItem {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Setting values are heterogeneous (string/number/bool/Record/Array); each consumer narrows from this base type
-	value: any;
+	value: unknown;
 	type: SettingItemType;
 	public: boolean;
 

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -10,6 +10,7 @@ import * as ArrayUtils from './ArrayUtils';
 import { FolderEntity, NoteEntity, NoteTagEntity } from './services/database/types';
 import { MasterKeyEntity } from './services/e2ee/types';
 import type { ProgressReport } from './Synchronizer';
+import type { SharedData } from './components/shared/note-screen-shared';
 
 interface SearchEntry {
 	id: string;
@@ -164,8 +165,7 @@ export interface State extends WindowState {
 	syncReport: ProgressReport;
 	searchResults: ProcessResultsRow[];
 	settings: Partial<SettingsRecord>;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- sharedData is mostly used in CLI for cross-screen scratch state; tightening forces touching the affected commands
-	sharedData: any;
+	sharedData: SharedData;
 	appState: string;
 	biometricsDone: boolean;
 	hasDisabledSyncItems: boolean;
@@ -503,7 +503,7 @@ function handleItemDelete(draft: Draft<State>, action: any) {
 		const selectedItemKeys = isSingular ? [windowDraft[selectedItemKey]] : windowDraft[selectedItemKey];
 		const isSelected = selectedItemKeys.includes(action.id);
 
-		const items = listKey in windowDraft ? windowDraft[listKey as keyof WindowState] : draft[listKey];
+		const items = (listKey in windowDraft ? windowDraft[listKey as keyof WindowState] : draft[listKey]) as { id: string }[];
 		const newItems = [];
 		let newSelectedIndexes: number[] = [];
 

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -9,6 +9,7 @@ import { ProfileConfig } from './services/profileConfig/types';
 import * as ArrayUtils from './ArrayUtils';
 import { FolderEntity, NoteEntity, NoteTagEntity } from './services/database/types';
 import { MasterKeyEntity } from './services/e2ee/types';
+import type { ProgressReport } from './Synchronizer';
 
 interface SearchEntry {
 	id: string;
@@ -160,7 +161,7 @@ export interface State extends WindowState {
 	syncStarted: boolean;
 	syncPending: boolean;
 	showQuitSyncDialog: boolean;
-	syncReport: Record<string, unknown>;
+	syncReport: ProgressReport;
 	searchResults: ProcessResultsRow[];
 	settings: Partial<SettingsRecord>;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- sharedData is mostly used in CLI for cross-screen scratch state; tightening forces touching the affected commands
@@ -214,7 +215,7 @@ export const defaultState: State = {
 	syncStarted: false,
 	syncPending: false,
 	showQuitSyncDialog: false,
-	syncReport: {},
+	syncReport: { errors: [] },
 	searchQuery: '',
 	searchResults: [],
 	settings: {},

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -503,7 +503,8 @@ function handleItemDelete(draft: Draft<State>, action: any) {
 		const selectedItemKeys = isSingular ? [windowDraft[selectedItemKey]] : windowDraft[selectedItemKey];
 		const isSelected = selectedItemKeys.includes(action.id);
 
-		const items = (listKey in windowDraft ? windowDraft[listKey as keyof WindowState] : draft[listKey]) as { id: string }[];
+		type ListItemSlice = { id: string };
+		const items = (listKey in windowDraft ? windowDraft[listKey as keyof WindowState] : draft[listKey]) as ListItemSlice[];
 		const newItems = [];
 		let newSelectedIndexes: number[] = [];
 

--- a/packages/lib/registry.ts
+++ b/packages/lib/registry.ts
@@ -4,7 +4,7 @@ import Setting from './models/Setting';
 import shim from './shim';
 import SyncTargetRegistry from './SyncTargetRegistry';
 import { AnyAction, Dispatch } from 'redux';
-import Synchronizer from './Synchronizer';
+import Synchronizer, { SyncStartOptions } from './Synchronizer';
 
 class Registry {
 
@@ -113,8 +113,7 @@ class Registry {
 		}
 	};
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- syncOptions passes through to Synchronizer.start(options: any); tightening would diverge from the underlying signature
-	public scheduleSync = async (delay: number = null, syncOptions: any = null, doWifiConnectionCheck = false) => {
+	public scheduleSync = async (delay: number = null, syncOptions: SyncStartOptions = null, doWifiConnectionCheck = false) => {
 		this.schedSyncCalls_.push(true);
 
 		try {

--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -55,7 +55,7 @@ import SyncTargetJoplinCloud from '../SyncTargetJoplinCloud';
 import KeychainService from '../services/keychain/KeychainService';
 import { loadKeychainServiceAndSettings } from '../services/SettingUtils';
 import { setActiveMasterKeyId, setEncryptionEnabled } from '../services/synchronizer/syncInfoUtils';
-import Synchronizer from '../Synchronizer';
+import Synchronizer, { SyncStartOptions } from '../Synchronizer';
 import SyncTargetNone from '../SyncTargetNone';
 import { setRSA } from '../services/e2ee/ppk/ppk';
 const md5 = require('md5');
@@ -528,8 +528,7 @@ function synchronizer(id: number = null) {
 // This is like calling synchronizer.start() but it handles the
 // complexity of passing around the sync context depending on
 // the client.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Synchronizer.start takes any options; tightening here would diverge from lib
-async function synchronizerStart(id: number = null, extraOptions: any = null) {
+async function synchronizerStart(id: number = null, extraOptions: SyncStartOptions = null) {
 	if (id === null) id = currentClient_;
 
 	const contextKey = `sync.${syncTargetId()}.context`;

--- a/packages/utils/Logger.ts
+++ b/packages/utils/Logger.ts
@@ -20,10 +20,25 @@ export enum LogLevel {
 
 type FormatFunction = (level: LogLevel, targetPrefix?: string)=> string;
 
+export interface LogEntry {
+	id: number;
+	source: string;
+	level: LogLevel;
+	message: string;
+	timestamp: number;
+}
+
+// Minimal structural view of the DB driver that Logger uses. The full Database
+// type lives in @joplin/lib, which depends on this package, so it cannot be
+// imported here.
+interface LoggerDatabase {
+	selectAll<T>(sql: string, params?: unknown[]): Promise<T[]>;
+	transactionExecBatch(queries: unknown[]): Promise<void>;
+}
+
 interface TargetOptions {
 	level?: LogLevel;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- DB driver: typing it tightly leaks through lastEntries() to all callers reading row fields via `any`-driven access. Refactoring those callers is out of scope.
-	database?: any;
+	database?: LoggerDatabase;
 	console?: Console;
 	prefix?: string;
 	path?: string;
@@ -224,14 +239,14 @@ class Logger {
 	}
 
 	// Only for database at the moment
-	public async lastEntries(limit = 100, options: LastEntriesOptions|null = null) {
+	public async lastEntries(limit = 100, options: LastEntriesOptions|null = null): Promise<LogEntry[]> {
 		if (options === null) options = {};
 		if (!options.levels) options.levels = [LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error];
 		if (!options.levels.length) return [];
 
 		for (let i = 0; i < this.targets_.length; i++) {
 			const target = this.targets_[i];
-			if (target.type === 'database') {
+			if (target.type === 'database' && target.database) {
 				const sql = [`SELECT * FROM logs WHERE level IN (${options.levels.join(',')})`];
 				const sqlParams = [];
 
@@ -246,7 +261,7 @@ class Logger {
 					sqlParams.push(limit);
 				}
 
-				return await target.database.selectAll(sql.join(' '), sqlParams);
+				return await target.database.selectAll<LogEntry>(sql.join(' '), sqlParams);
 			}
 		}
 		return [];
@@ -326,7 +341,7 @@ class Logger {
 				}).finally(() => {
 					if (release) release();
 				});
-			} else if (target.type === 'database') {
+			} else if (target.type === 'database' && target.database) {
 				const msg = [];
 				if (targetPrefix) msg.push(targetPrefix);
 				msg.push(this.objectsToString(...object));
@@ -348,7 +363,7 @@ class Logger {
 					});
 				}
 
-				target.database.transactionExecBatch(queries);
+				void target.database.transactionExecBatch(queries);
 			}
 		}
 	}

--- a/readme/dev/any_cleanup_progress.md
+++ b/readme/dev/any_cleanup_progress.md
@@ -78,6 +78,8 @@ Counts captured 2026-05-11 before any work. Note: the original `app-cli` row cou
 
 Total in-scope comments at start: **2,952** across **633 files**.
 
+A later follow-up pass (June 2026, branch `chore/claude/better-types`) revisited `any` that the per-package effort deliberately deferred — cases where the type had to be tightened at its **source** so caller skips cascade away, or that spanned multiple packages. See the "Multiple packages - June 2026" section in [any_cleanup_progress_details.md](./any_cleanup_progress_details.md) for the per-change detail.
+
 ## Recommended order
 
 Smallest packages first to validate the workflow and surface common patterns before tackling the large ones:

--- a/readme/dev/any_cleanup_progress_details.md
+++ b/readme/dev/any_cleanup_progress_details.md
@@ -960,3 +960,6 @@ The remaining `any` annotations cluster into a handful of structural reasons tha
 
 All `yarn tsc --noEmit` and `yarn linter-ci packages/lib/` runs pass for every batch commit.
 
+## Multiple packages - June 2026
+
+Migrated several `any` types that weren't migrated before. Some of these required changes spanning multiple packages and were previously left aside for this reason. Others were missed during the previous migrations.

--- a/readme/dev/any_cleanup_progress_details.md
+++ b/readme/dev/any_cleanup_progress_details.md
@@ -963,3 +963,30 @@ All `yarn tsc --noEmit` and `yarn linter-ci packages/lib/` runs pass for every b
 ## Multiple packages - June 2026
 
 Migrated several `any` types that weren't migrated before. Some of these required changes spanning multiple packages and were previously left aside for this reason. Others were missed during the previous migrations.
+
+The common technique was to tighten the type at its **definition** (the source) so that callers' documented skips cascade away too. The changes, by package:
+
+`packages/lib`
+- `Synchronizer.ts` — added exported `SyncStartOptions`, `SyncContext` and `ProgressReport`; typed `start(options)`. Cascaded to `registry.ts` (`scheduleSync`), `app-cli/command-sync.ts` and `testing/test-utils.ts`.
+- `models/BaseItem.ts` — `encryptionService_` / `revisionService_` typed via `import type` of `EncryptionService` / `RevisionService` (a value import would re-create the runtime cycle those services have with `BaseItem`).
+- `models/Setting.ts` — `CacheItem` made generic (`CacheItem<T>`) with `loadOne<T>` returning the precise per-key value; `formatValue` / `valueToString` params → `unknown`; `SettingItem.value` → `unknown`; `keychainService_` → `import type KeychainService`.
+- `reducer.ts` — `State.syncReport` → `ProgressReport` (cascaded to `app-desktop/gui/Sidebar` and `app-mobile/side-menu-content`); `State.sharedData` → `SharedData` (exported from `note-screen-shared.ts`). Removing `sharedData: any` un-poisoned `State[keyof State]` and surfaced a previously-masked dynamic-key access in `handleItemDelete`, fixed with a localized cast.
+
+`packages/utils`
+- `Logger.ts` — `TargetOptions.database` → a minimal structural `LoggerDatabase` interface (the concrete `Database` lives in `@joplin/lib`, which depends on this package, so it cannot be imported); added exported `LogEntry` and typed `lastEntries()`. Cascaded to `app-mobile/LogScreen.tsx` (removed a duplicate `LogEntry` and a cast) and `exportDebugReport.ts`.
+
+`packages/app-cli`
+- `app/app.ts` — `commands_` / `activeCommand_` → `BaseCommand`; `commandMetadata_` → `Record<string, ReturnType<BaseCommand['metadata']>>`; the redux dispatch callback now infers from `Dispatch`. `gui_` left `any` (the GUI is the untyped `app-gui.js`). `autocompletion.ts` gained one localized cast for `base-command`'s loose `options` element.
+
+`packages/app-mobile`
+- `utils/types.ts` — `AppState.route` → `Route` (the `Route` interface was moved here from `appReducer.ts` and shared); `noteSideMenuOptions` → `SideMenuContentOptions`.
+- `utils/appReducer.ts` — the nav-history helpers (`removeAdjacent*`, `removeLatestFolderIfSelected`) → `Route[]` / `Route`.
+- `components/app-nav.tsx` — `Props.route` → the shared `Route`.
+- `components/screens/Note/Note.tsx` — `menuOptionsCache_` → `Record<string, MenuOptionType[]>`; `editorRef` → `RefObject<EditorControl>` (it only ever attaches to `NoteEditor`, whose handle is `EditorControl`).
+
+`packages/app-desktop`
+- `gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx` — `pluginAssets` → `RenderResultPluginAsset[]`.
+
+Genuinely-untyped boundaries were left as `any` with accurate reasons: the `app-gui.js` GUI handle, the `react-native-dialogbox` ref, mixed React-Native style records, the heterogeneous reducer `action` union, the per-screen `ComponentType<any>`, and the TinyMCE editor / event types that are looser than the published `@types/tinymce`.
+
+One pre-existing inconsistency was uncovered and left for separate follow-up: `app-mobile`'s `ShareExtension.SharedData` declares `resources: string[]`, but the lib consumer reads each resource as a `SharedResource` object — the two same-named types should be reconciled after verifying the native share payload.


### PR DESCRIPTION
# Problem

Many of the `any` types in Joplin's codebase can be safely replaced with other types. Doing so improves type safety and allows removing `eslint-disable-next-line` comments.

# Solution

Migrate more `any` types to proper TypeScript types.

Follow-up to #15339.

# Process

Like https://github.com/laurent22/joplin/pull/15339, the bulk of the changes in this pull request were done by Claude Code.

