### PR TITLE
Mobile: Fixes #15483: Disable external embeds on mobile and hide the setting

### DIFF
--- a/packages/app-mobile/contentScripts/rendererBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/useWebViewSetup.ts
@@ -1,6 +1,6 @@
 import { RefObject, useEffect, useMemo, useRef } from 'react';
 import shim from '@joplin/lib/shim';
-import Setting from '@joplin/lib/models/Setting';
+import Setting, { AppType } from '@joplin/lib/models/Setting';
 import { Platform } from 'react-native';
 import { SetUpResult } from '../types';
 import { themeStyle } from '../../components/global-style';
@@ -36,7 +36,9 @@ const useSource = (tempDirPath: string) => {
 		const subValues = Setting.subValues('markdown.plugin', Setting.toPlainObject());
 		const pluginOptions: PluginOptions = {};
 		for (const n in subValues) {
-			pluginOptions[n] = { enabled: !!subValues[n] };
+			const appTypes = Setting.settingMetadata(`markdown.plugin.${n}`).appTypes;
+			const enabled = !appTypes.includes(AppType.Mobile) ? false : !!subValues[n];
+			pluginOptions[n] = { enabled };
 		}
 
 		const rendererWebViewStaticOptions: RendererWebViewOptions = {

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1130,7 +1130,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		'markdown.plugin.emoji': { storage: SettingStorage.File, isGlobal: true, value: false, type: SettingItemType.Bool, section: 'markdownPlugins', public: true, appTypes: [AppType.Mobile, AppType.Desktop], label: () => `${_('Enable markdown emoji')}${wysiwygNo}` },
 		'markdown.plugin.insert': { storage: SettingStorage.File, isGlobal: true, value: false, type: SettingItemType.Bool, section: 'markdownPlugins', public: true, appTypes: [AppType.Mobile, AppType.Desktop], label: () => `${_('Enable ++insert++ syntax')}${wysiwygYes}` },
 		'markdown.plugin.multitable': { storage: SettingStorage.File, isGlobal: true, value: false, type: SettingItemType.Bool, section: 'markdownPlugins', public: true, appTypes: [AppType.Mobile, AppType.Desktop], label: () => `${_('Enable multimarkdown table extension')}${wysiwygNo}` },
-		'markdown.plugin.externalEmbed': { storage: SettingStorage.File, isGlobal: true, value: true, type: SettingItemType.Bool, section: 'markdownPlugins', public: true, appTypes: [AppType.Mobile, AppType.Desktop], label: () => `${_('Enable external embeds (e.g. YouTube Videos)')}${wysiwygYes}` },
+		'markdown.plugin.externalEmbed': { storage: SettingStorage.File, isGlobal: true, value: true, type: SettingItemType.Bool, section: 'markdownPlugins', public: true, appTypes: [AppType.Desktop], label: () => `${_('Enable external embeds (e.g. YouTube Videos)')}${wysiwygYes}` },
 
 		// For now, applies only to the Markdown viewer
 		'renderer.fileUrls': {


### PR DESCRIPTION
The new 'Enable external embeds' feature introduced in Joplin 3.6 does not work on mobile or web due to stricter security enforcement in React Native WebViews compared to Electron. As the feature is completely broken on these platforms, this PR forces the feature to be disabled on mobile and web and hides the setting on these platforms. Note that because the setting for the feature has already been released, it is not possible to rely on the default value anymore, as the values may have been overridden by the user. Therefore I have made a change to force any markdown.plugin settings which are not shown in the mobile app, to have the markdown plugin disabled. The only other existing markdown.plugin setting without AppType.Mobile is markdown.plugin.pdfViewer, which is not implemented on mobile anyway.

This fixes https://github.com/laurent22/joplin/issues/15483

### Testing

Testing includes verifying the feature works correctly and can be toggled on the desktop app, and verifying on mobile that the externalEmbed feature is disabled in all views and editors, the setting is hidden, and that another markdown.plugin setting which is included on mobile (mark) still works correctly and can be toggled.

As part of testing, when the code is built without the change to useWebViewSetup, the default value of true is utilised for the externalEmbed setting for a new mobile app installation, without any way to turn it off.

Desktop testing (MDE, RTE, Settings screen):
<img width="1514" height="809" alt="embed1" src="https://github.com/user-attachments/assets/b9eb08e4-e1bb-4b83-bdbf-381166d9b596" />
<img width="1511" height="808" alt="embed2" src="https://github.com/user-attachments/assets/96ceb6dc-8331-4574-884f-af5df92311fd" />
<img width="1512" height="809" alt="embed3" src="https://github.com/user-attachments/assets/62f6dec4-fa2a-4891-bd29-1df419e1aea6" />

Web testing (Viewer, MDE, RTE, Settings screen):
<img width="300" alt="embed4" src="https://github.com/user-attachments/assets/b634d3e9-1c64-47af-8bde-4bbe5f30cced" />
<img width="300" alt="embed5" src="https://github.com/user-attachments/assets/88dad78b-e466-4ade-aa4b-4927b3ba4753" />
<img width="300" alt="embed6" src="https://github.com/user-attachments/assets/6eba41bb-5d2a-4ced-82b9-5edc91737cfc" />
<img width="300" alt="embed7" src="https://github.com/user-attachments/assets/425adcd2-df34-4d5a-9b7e-7c489ae1daae" />

Mobile testing (Viewer, MDE, RTE, Settings screen):
<img width="300" alt="embed8" src="https://github.com/user-attachments/assets/0240df78-1e99-4323-934c-267215dcf2a5" />
<img width="300" alt="embed9" src="https://github.com/user-attachments/assets/b77bf211-2b2d-474b-b1d8-0abed09b4622" />
<img width="300" alt="embed10" src="https://github.com/user-attachments/assets/230f5970-00f5-42af-90ad-d12c6cc02d7c" />
<img width="300" alt="embed11" src="https://github.com/user-attachments/assets/2fa12bca-39ed-4d3d-bc45-e7e48ef30b99" />
