### PR TITLE
Desktop: Fixes #15482: Fix external embeds originating from Youtube on mobile not working

### DIFF
--- a/packages/renderer/MdToHtml/rules/externalEmbed.ts
+++ b/packages/renderer/MdToHtml/rules/externalEmbed.ts
@@ -1,7 +1,7 @@
 import type * as MarkdownIt from 'markdown-it';
 
 const extractVideoId = (url: string) => {
-	const pattern = /^https?:\/\/(?:www\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/;
+	const pattern = /^https?:\/\/(?:www\.|m\.)?(?:youtube\.com\/watch\?(?:.*&)?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/;
 	const match = url.match(pattern);
 	return match ? match[1] : null;
 };


### PR DESCRIPTION
Youtube links originating from the mobile version of Youtube currently do not create embedded videos due to those formats not matching the regex for detecting urls eligible for external embeds. This PR extends the regex to include the mobile link formats as well.

This fixes https://github.com/laurent22/joplin/issues/15482

### Testing

Verified all 3 formats of youtube link create a working external embed on the desktop app in the MDE and RTE:
<img width="495" height="669" alt="mobilelinks" src="https://github.com/user-attachments/assets/d4c5b479-69ef-4ec6-bea7-316a5cf8e2c4" />
