### PR TITLE
Mobile: Fixes #10144: Fix Joplin Server resource uploads when ignoring TLS errors

### DIFF
--- a/packages/lib/JoplinServerApi.test.js
+++ b/packages/lib/JoplinServerApi.test.js
@@ -6,7 +6,7 @@ describe('JoplinServerApi', () => {
     afterEach(() => {
         jest.restoreAllMocks();
     });
-    test('should pass ignoreTlsErrors to uploadBlob requests', async (_url, options) => {
+    test('should pass ignoreTlsErrors to uploadBlob requests', async () => {
         const uploadBlobSpy = jest.spyOn(shim_1.default, 'uploadBlob').mockImplementation(async (_url, options) => {
             return {
                 ok: true,

--- a/packages/lib/JoplinServerApi.test.js
+++ b/packages/lib/JoplinServerApi.test.js
@@ -1,0 +1,47 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const JoplinServerApi_1 = require("./JoplinServerApi");
+const shim_1 = require("./shim");
+describe('JoplinServerApi', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+    test('should pass ignoreTlsErrors to uploadBlob requests', async (_url, options) => {
+        const uploadBlobSpy = jest.spyOn(shim_1.default, 'uploadBlob').mockImplementation(async (_url, options) => {
+            return {
+                ok: true,
+                status: 200,
+                headers: options.headers,
+                text: async () => 'ok',
+            };
+        });
+        jest.spyOn(shim_1.default, 'fsDriver').mockImplementation(() => {
+            return {
+                stat: async () => ({ size: 7 }),
+            };
+        });
+        const api = new JoplinServerApi_1.default({
+            baseUrl: () => 'https://joplin.lan',
+            userContentBaseUrl: () => 'https://joplinusercontent.lan',
+            username: () => '',
+            password: () => '',
+            apiKey: () => '',
+            session: () => ({ id: 'session-id', user_id: 'user-id' }),
+            ignoreTlsErrors: () => true,
+        });
+        await api.exec('PUT', 'api/items/root:/.resource/test:/content', null, null, { 'Content-Type': 'application/octet-stream' }, { source: 'file', path: '/tmp/test-resource', responseFormat: 'text' });
+        expect(uploadBlobSpy).toHaveBeenCalledTimes(1);
+        expect(uploadBlobSpy).toHaveBeenCalledWith('https://joplin.lan/api/items/root:/.resource/test:/content', expect.objectContaining({
+            method: 'PUT',
+            path: '/tmp/test-resource',
+            ignoreTlsErrors: true,
+            headers: expect.objectContaining({
+                'Content-Type': 'application/octet-stream',
+                'Content-Length': '7',
+                'X-API-AUTH': 'session-id',
+                'X-API-MIN-VERSION': '2.6.0',
+            }),
+        }));
+    });
+});
+//# sourceMappingURL=JoplinServerApi.test.js.map

--- a/packages/lib/JoplinServerApi.test.ts
+++ b/packages/lib/JoplinServerApi.test.ts
@@ -1,0 +1,61 @@
+import JoplinServerApi from './JoplinServerApi';
+import shim from './shim';
+
+describe('JoplinServerApi', () => {
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	test('should pass ignoreTlsErrors to uploadBlob requests', async () => {
+		const uploadBlobSpy = jest.spyOn(shim, 'uploadBlob').mockImplementation(async (_url, options) => {
+			return {
+				ok: true,
+				status: 200,
+				headers: options.headers,
+				text: async () => 'ok',
+			};
+		});
+
+		jest.spyOn(shim, 'fsDriver').mockImplementation(() => {
+			return {
+				stat: async () => ({ size: 7 }),
+			} as any;
+		});
+
+		const api = new JoplinServerApi({
+			baseUrl: () => 'https://joplin.lan',
+			userContentBaseUrl: () => 'https://joplinusercontent.lan',
+			username: () => '',
+			password: () => '',
+			apiKey: () => '',
+			session: () => ({ id: 'session-id', user_id: 'user-id' }),
+			ignoreTlsErrors: () => true,
+		});
+
+		await api.exec(
+			'PUT',
+			'api/items/root:/.resource/test:/content',
+			null,
+			null,
+			{ 'Content-Type': 'application/octet-stream' },
+			{ source: 'file', path: '/tmp/test-resource', responseFormat: 'text' as any },
+		);
+
+		expect(uploadBlobSpy).toHaveBeenCalledTimes(1);
+		expect(uploadBlobSpy).toHaveBeenCalledWith(
+			'https://joplin.lan/api/items/root:/.resource/test:/content',
+			expect.objectContaining({
+				method: 'PUT',
+				path: '/tmp/test-resource',
+				ignoreTlsErrors: true,
+				headers: expect.objectContaining({
+					'Content-Type': 'application/octet-stream',
+					'Content-Length': '7',
+					'X-API-AUTH': 'session-id',
+					'X-API-MIN-VERSION': '2.6.0',
+				}),
+			}),
+		);
+	});
+});

--- a/packages/lib/JoplinServerApi.ts
+++ b/packages/lib/JoplinServerApi.ts
@@ -18,6 +18,7 @@ interface Options {
 	password(): string;
 	apiKey(): string;
 	session(): Session | null;
+	ignoreTlsErrors?(): boolean;
 	env?: Env;
 }
 
@@ -178,8 +179,9 @@ export default class JoplinServerApi {
 		headers['X-API-MIN-VERSION'] = '2.6.0'; // Need server 2.6 for new lock support
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See exec_.body above
-		const fetchOptions: { headers: Record<string, string>; method: string; path?: string; body?: any } = { headers, method };
+		const fetchOptions: { headers: Record<string, string>; method: string; path?: string; body?: any; ignoreTlsErrors?: boolean } = { headers, method };
 		if (options.path) fetchOptions.path = options.path;
+		fetchOptions.ignoreTlsErrors = this.options_.ignoreTlsErrors ? this.options_.ignoreTlsErrors() : false;
 
 		if (body) {
 			if (typeof body === 'object') {

--- a/packages/lib/SyncTargetJoplinCloud.ts
+++ b/packages/lib/SyncTargetJoplinCloud.ts
@@ -11,6 +11,7 @@ interface FileApiOptions {
 	username(): string;
 	password(): string;
 	apiKey(): string;
+	ignoreTlsErrors(): boolean;
 }
 
 export default class SyncTargetJoplinCloud extends BaseSyncTarget {
@@ -91,6 +92,7 @@ export default class SyncTargetJoplinCloud extends BaseSyncTarget {
 			username: () => Setting.value('sync.10.username'),
 			password: () => Setting.value('sync.10.password'),
 			apiKey: () => Setting.value('sync.10.apiKey'),
+			ignoreTlsErrors: () => Setting.value('net.ignoreTlsErrors'),
 		});
 	}
 

--- a/packages/lib/SyncTargetJoplinServer.ts
+++ b/packages/lib/SyncTargetJoplinServer.ts
@@ -15,6 +15,7 @@ export interface FileApiOptions {
 	username(): string;
 	password(): string;
 	apiKey(): string;
+	ignoreTlsErrors(): boolean;
 }
 
 export async function newFileApi(id: number, options: FileApiOptions) {
@@ -25,6 +26,7 @@ export async function newFileApi(id: number, options: FileApiOptions) {
 		password: () => options.password(),
 		apiKey: () => options.apiKey(),
 		session: (): Session => null,
+		ignoreTlsErrors: () => options.ignoreTlsErrors(),
 		env: Setting.value('env'),
 	};
 
@@ -151,6 +153,7 @@ export default class SyncTargetJoplinServer extends BaseSyncTarget {
 			username: () => Setting.value('sync.9.username'),
 			password: () => Setting.value('sync.9.password'),
 			apiKey: () => Setting.value('sync.9.apiKey'),
+			ignoreTlsErrors: () => Setting.value('net.ignoreTlsErrors'),
 		});
 	}
 

--- a/packages/lib/SyncTargetJoplinServerSAML.ts
+++ b/packages/lib/SyncTargetJoplinServerSAML.ts
@@ -14,6 +14,7 @@ export async function newFileApi(id: number, options: FileApiOptions) {
 		password: () => '',
 		apiKey: () => Setting.value('sync.11.apiKey'),
 		session: () => ({ id: Setting.value('sync.11.id'), user_id: Setting.value('sync.11.userId') }),
+		ignoreTlsErrors: () => options.ignoreTlsErrors(),
 		env: Setting.value('env'),
 	};
 
@@ -130,6 +131,7 @@ export default class SyncTargetJoplinServerSAML extends SyncTargetJoplinServer {
 			username: () => '',
 			password: () => '',
 			apiKey: () => Setting.value('sync.11.apiKey'),
+			ignoreTlsErrors: () => Setting.value('net.ignoreTlsErrors'),
 		};
 		return initFileApi(SyncTargetJoplinServerSAML.id(), this.logger(), this.lastFileApiOptions_);
 	}

--- a/packages/lib/services/share/ShareService.ts
+++ b/packages/lib/services/share/ShareService.ts
@@ -89,6 +89,7 @@ export default class ShareService {
 			username: () => Setting.value(`sync.${syncTargetId}.username`),
 			password: () => Setting.value(`sync.${syncTargetId}.password`),
 			apiKey: () => Setting.value(`sync.${syncTargetId}.apiKey`),
+			ignoreTlsErrors: () => Setting.value('net.ignoreTlsErrors'),
 			session: () => {
 				if (syncTargetId === 11) {
 					return {


### PR DESCRIPTION
## Summary

This pull request fixes a mobile synchronisation bug where Joplin Server resource uploads fail when the server uses a self-signed TLS certificate and the client is configured to ignore TLS certificate errors.

Fixes #10144.

## Problem

On Android, note synchronisation against Joplin Server could succeed while resource uploads still failed with an error similar to:

- `java.security.cert.CertPathValidatorException: Trust anchor for certification path not found`

In practice this meant that synchronising an image or other attachment could fail even when `Ignore TLS certificate errors` was enabled.

The root cause was that the Joplin Server sync stack did not propagate `net.ignoreTlsErrors` to the request options used by `shim.uploadBlob(...)`. The mobile React Native upload path reads this flag and maps it to RNFetchBlob's `trusty` option, but Joplin Server requests never passed it through.

## Solution

This change propagates `ignoreTlsErrors` through the Joplin Server sync clients so that file uploads use the same TLS override behaviour as other sync targets already do.

Changes included:

- `packages/lib/JoplinServerApi.ts`
  Pass `ignoreTlsErrors` into the fetch options used by `fetch`, `fetchBlob`, and `uploadBlob`.
- `packages/lib/SyncTargetJoplinServer.ts`
  Add `ignoreTlsErrors` to the sync target file API options and pass `net.ignoreTlsErrors` when initialising the server file API.
- `packages/lib/SyncTargetJoplinCloud.ts`
  Keep Joplin Cloud initialisation consistent with the same option propagation.
- `packages/lib/SyncTargetJoplinServerSAML.ts`
  Keep the SAML-backed Joplin Server target consistent with the same option propagation.
- `packages/lib/services/share/ShareService.ts`
  Ensure the share API client is also initialised with the same TLS option.

## Automated tests

Added a focused unit test in:

- `packages/lib/JoplinServerApi.test.ts`

The test verifies that a file upload request made through `JoplinServerApi` passes `ignoreTlsErrors: true` to `shim.uploadBlob(...)`.

## Validation

### Automated

Ran:

- `yarn workspace @joplin/lib tsc --noEmit`
- `yarn workspace @joplin/lib test JoplinServerApi.test.js --runInBand`

### Manual

Tested on Android against Joplin Server behind HTTPS with a self-signed certificate.

1. Enable `Ignore TLS certificate errors` in the mobile sync configuration.
2. Configure Joplin Server with a self-signed certificate.
3. Synchronise notes successfully.
4. Attach an image to a note and run sync.
5. Confirm that the resource upload completes successfully instead of failing with `Trust anchor for certification path not found`.

Also reviewed the affected call sites to confirm the change remains scoped to Joplin Server / Joplin Cloud / Joplin Server (SAML) clients and does not alter unrelated sync targets.
