### PR TITLE
Desktop: Resolves #15334: Importing from OneNote: Note order should be preserved  

### DIFF
--- a/packages/lib/services/interop/InteropService_Importer_OneNote.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.test.ts
@@ -146,15 +146,19 @@ describe('InteropService_Importer_OneNote', () => {
 
 		const pageTwo = notes.find(n => n.title === 'Page 2');
 		expectWithInstructions(menuLines[3].trim()).toBe(`<li class="l1"><a href=":/${pageTwo.id}" target="content" title="Page 2">${pageTwo.title}</a>`);
+		expectWithInstructions(pageTwo.order).toBe(-3);
 
 		const pageTwoA = notes.find(n => n.title === 'Page 2-a');
 		expectWithInstructions(menuLines[4].trim()).toBe(`<li class="l2"><a href=":/${pageTwoA.id}" target="content" title="Page 2-a">${pageTwoA.title}</a>`);
+		expectWithInstructions(pageTwoA.order).toBe(-4);
 
 		const pageTwoAA = notes.find(n => n.title === 'Page 2-a-a');
 		expectWithInstructions(menuLines[5].trim()).toBe(`<li class="l3"><a href=":/${pageTwoAA.id}" target="content" title="Page 2-a-a">${pageTwoAA.title}</a>`);
+		expectWithInstructions(pageTwoAA.order).toBe(-5);
 
 		const pageTwoB = notes.find(n => n.title === 'Page 2-b');
 		expectWithInstructions(menuLines[7].trim()).toBe(`<li class="l2"><a href=":/${pageTwoB.id}" target="content" title="Page 2-b">${pageTwoB.title}</a>`);
+		expectWithInstructions(pageTwoB.order).toBe(-7);
 	});
 
 	it('should created subsections', async () => {

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -57,6 +57,7 @@ const setEnableUnresponsiveCheck = (enabled: boolean) => {
 
 interface NoteMetadata {
 	created: Date;
+	order?: number;
 	updated: Date;
 	// Saving the title in the metadata allows using special characters not supported by the file
 	// system in imported note titles (e.g. "/")
@@ -274,9 +275,19 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 
 				return new Date(timeSeconds * 1000);
 			};
+			const parseOrderMeta = (selector: string) => {
+				const element = dom.querySelector<HTMLMetaElement>(selector);
+				if (!element) return undefined;
+
+				const orderIndex = Number(element.content);
+				if (!Number.isInteger(orderIndex) || orderIndex < 0) return undefined;
+
+				return -orderIndex;
+			};
 
 			return {
 				created: parseTimestampMeta('meta[name="X-Created-Time"]'),
+				order: parseOrderMeta('meta[name="X-OneNote-Order"]'),
 				updated: parseTimestampMeta('meta[name="X-Updated-Time"]'),
 				title: dom.title,
 			};
@@ -348,6 +359,7 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			// ID mappings and other metadata (unused at this stage of the import process)
 			// Remove leading space to avoid unnecessary blank lines in test snapshots
 			{ selector: 'meta[name="X-Original-Page-Id"]', preprocess: removeLeadingSpace },
+			{ selector: 'meta[name="X-OneNote-Order"]', preprocess: removeLeadingSpace },
 			{ selector: 'meta[name="X-Created-Time"]', preprocess: removeLeadingSpace },
 			{ selector: 'meta[name="X-Updated-Time"]', preprocess: removeLeadingSpace },
 
@@ -625,6 +637,7 @@ class OneNoteHtmlImporter extends InteropService_Importer_Md {
 
 					user_updated_time: metadata.updated.getTime(),
 					user_created_time: metadata.created.getTime(),
+					order: metadata.order ?? note.order,
 					title: metadata.title || note.title,
 				};
 

--- a/packages/onenote-converter/renderer/src/page/mod.rs
+++ b/packages/onenote-converter/renderer/src/page/mod.rs
@@ -36,7 +36,7 @@ impl<'a> Renderer<'a> {
         }
     }
 
-    pub(crate) fn render_page(&mut self, page: &Page) -> Result<String> {
+    pub(crate) fn render_page(&mut self, page: &Page, page_order_index: u32) -> Result<String> {
         let title_text = page.title_text().unwrap_or("Untitled Page".to_string());
 
         let mut content = String::new();
@@ -69,6 +69,7 @@ impl<'a> Renderer<'a> {
 
         crate::templates::page::render(
             &page.link_target_id(),
+            page_order_index,
             &PageTimestamps {
                 created_time: page.created_time().unix_timestamp(),
                 updated_time: page.updated_time().unix_timestamp(),

--- a/packages/onenote-converter/renderer/src/section.rs
+++ b/packages/onenote-converter/renderer/src/section.rs
@@ -53,11 +53,16 @@ impl Renderer {
             }
 
             for page in page_series.pages() {
-                let render_result =
-                    self.render_page_to_file(page, &section_dir, &output_dir, || {
+                let render_result = self.render_page_to_file(
+                    page,
+                    toc.len() as u32,
+                    &section_dir,
+                    &output_dir,
+                    || {
                         fallback_title_index += 1;
                         fallback_title_index
-                    });
+                    },
+                );
                 match render_result {
                     Ok(toc_entry) => {
                         toc.push(toc_entry);
@@ -100,6 +105,7 @@ impl Renderer {
     fn render_page_to_file<F>(
         &mut self,
         page: &Page,
+        page_order_index: u32,
         section_dir: &str,
         output_dir: &str,
         fallback_title_idx: F,
@@ -113,7 +119,7 @@ impl Renderer {
             .unwrap_or_else(|| format!("Untitled Page {}", fallback_title_idx()));
 
         let mut renderer = page::Renderer::new(section_dir.into(), self);
-        let page_html = renderer.render_page(page)?;
+        let page_html = renderer.render_page(page, page_order_index)?;
 
         let page_path = self.write_html_file(section_dir, &title, &page_html)?;
         log!("Created page file: {:?}", page_path);

--- a/packages/onenote-converter/renderer/src/templates/page.html
+++ b/packages/onenote-converter/renderer/src/templates/page.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>{{ name }}</title>
     <meta name="X-Original-Page-Id" content="{{ page_id_attr }}"/>
+    <meta name="X-OneNote-Order" content="{{ page_order_index_attr }}"/>
     <meta name="X-Created-Time" content="{{ created_date_attr }}"/>
     <meta name="X-Updated-Time" content="{{ updated_date_attr }}"/>
     <style>

--- a/packages/onenote-converter/renderer/src/templates/page.rs
+++ b/packages/onenote-converter/renderer/src/templates/page.rs
@@ -14,6 +14,7 @@ pub(crate) struct PageTimestamps {
 #[template(path = "page.html", escape = "none")]
 struct PageTemplate<'a> {
     page_id_attr: &'a str,
+    page_order_index_attr: &'a str,
     created_date_attr: &'a str,
     updated_date_attr: &'a str,
     name: &'a str,
@@ -23,6 +24,7 @@ struct PageTemplate<'a> {
 
 pub(crate) fn render(
     page_id: &str,
+    page_order_index: u32,
     timestamps: &PageTimestamps,
     name: &str,
     content: &str,
@@ -32,6 +34,7 @@ pub(crate) fn render(
         content,
         name: &html_entities(name),
         page_id_attr: &html_entities(page_id),
+        page_order_index_attr: &page_order_index.to_string(),
         created_date_attr: &timestamps.created_time.to_string(),
         updated_date_attr: &timestamps.updated_time.to_string(),
         global_styles: global_styles


### PR DESCRIPTION
Resolves #15334 

The issue was caused by Rust not saving the OneNote page order in the generated HTML files and the TypeScript importer did not have a way to figure out the order.

I found two ways to fix this. The first was to get the order from generated table-of-contents HTML. The second was to pass the OneNote page order as metadata. I chose this to avoid depending on the table-of-contents, because its HTML structure could change later and break the order logic.

I did not create a new test. I just updated `should preserve indentation of subpages in Section page` because it already imports a real OneNote and checks the generated table of contents.