### PR TITLE
All: Fixes #15610: Trying to fix duplicate tags when tagging notes with existing Cyrillic titles

### DIFF
--- a/packages/lib/models/Tag.test.ts
+++ b/packages/lib/models/Tag.test.ts
@@ -220,6 +220,25 @@ describe('models/Tag', () => {
 		expect(tag1).toStrictEqual(tag2);
 	});
 
+	it('should not create duplicate tags when tagging notes with existing Cyrillic titles', async () => {
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
+		const note2 = await Note.save({ title: 'ma 2nd note', parent_id: folder1.id });
+		const tag = await Tag.save({ title: 'Посмотреть' });
+
+		await Tag.setNoteTagsByTitles(note1.id, ['Посмотреть']);
+		await Tag.setNoteTagsByTitles(note2.id, ['Посмотреть']);
+
+		const allTags = await Tag.all();
+		const note1Tags = await Tag.tagsByNoteId(note1.id);
+		const note2Tags = await Tag.tagsByNoteId(note2.id);
+
+		expect(allTags.length).toBe(1);
+		expect(allTags[0].id).toBe(tag.id);
+		expect(note1Tags.map(tag => tag.id)).toEqual([tag.id]);
+		expect(note2Tags.map(tag => tag.id)).toEqual([tag.id]);
+	});
+
 	it('should not create duplicate tags when tagging with existing titles (issue #14540)', async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });

--- a/packages/lib/models/Tag.ts
+++ b/packages/lib/models/Tag.ts
@@ -172,19 +172,35 @@ export default class Tag extends BaseItem {
 
 	public static async loadByTitle(title: string): Promise<TagEntity | null> {
 		const trimmedTitle = title.trim();
+		const normalizedTitle = trimmedTitle.normalize('NFC');
 		const lowercaseTitle = trimmedTitle.toLowerCase();
-		const normalizedLowercaseTitle = trimmedTitle.normalize('NFC').toLowerCase();
+		const normalizedLowercaseTitle = normalizedTitle.toLowerCase();
 		// We use a manual query here instead of loadByField to ensure deterministic ordering (ORDER BY created_time ASC)
-		// when visually similar tags exist in the database.
-		// We use created_time instead of id because IDs are UUIDs and cannot be meaningfully ordered.
-		const tag = await this.modelSelectOne(`SELECT * FROM ${this.tableName()} WHERE title = ? COLLATE NOCASE ORDER BY created_time ASC`, [lowercaseTitle]);
+        // when visually similar tags exist in the database.
+        // We use created_time instead of id because IDs are UUIDs and cannot be meaningfully ordered.
+		const titleLookupSql = `SELECT * FROM ${this.tableName()} WHERE title = ? ORDER BY created_time ASC`;
+		const nocaseTitleLookupSql = `SELECT * FROM ${this.tableName()} WHERE title = ? COLLATE NOCASE ORDER BY created_time ASC`;
+
+		let tag = await this.modelSelectOne(titleLookupSql, [trimmedTitle]);
+		if (tag) return tag;
+
+		if (normalizedTitle !== trimmedTitle) {
+			tag = await this.modelSelectOne(titleLookupSql, [normalizedTitle]);
+			if (tag) return tag;
+		}
+
+		tag = await this.modelSelectOne(nocaseTitleLookupSql, [lowercaseTitle]);
 		if (tag) return tag;
 
 		if (normalizedLowercaseTitle !== lowercaseTitle) {
-			return await this.modelSelectOne(`SELECT * FROM ${this.tableName()} WHERE title = ? COLLATE NOCASE ORDER BY created_time ASC`, [normalizedLowercaseTitle]);
+			tag = await this.modelSelectOne(nocaseTitleLookupSql, [normalizedLowercaseTitle]);
+			if (tag) return tag;
 		}
 
-		return null;
+		const tags = await this.modelSelectAll(`SELECT * FROM ${this.tableName()} ORDER BY created_time ASC`);
+		return tags.find((tag: TagEntity) => {
+			return (tag.title || '').trim().normalize('NFC').toLowerCase() === normalizedLowercaseTitle;
+		}) || null;
 	}
 
 	public static async addNoteTagByTitle(noteId: string, tagTitle: string) {


### PR DESCRIPTION
Trying to fix duplicate tags when tagging notes with existing Cyrillic titles