### PR TITLE
All: Fixes #15608: Fix duplicate tag creation for special unicode characters

### DIFF
--- a/packages/lib/models/Tag.test.ts
+++ b/packages/lib/models/Tag.test.ts
@@ -263,4 +263,15 @@ describe('models/Tag', () => {
 		expect(loadedTag.id).toBe(legacyTagId);
 		expect(loadedTag.id).not.toBe(normalizedTag.id);
 	});
+
+	it.each([
+		// cSpell:disable
+		'Посмотреть 1',
+		'Öp',
+		// cSpell:enable
+	])('should find match for tags which have been saved, when they contain special unicode characters', async (title) => {
+		await Tag.save({ title });
+		const loadedTag = await Tag.loadByTitle(title);
+		expect(loadedTag.id).not.toBeNull();
+	});
 });

--- a/packages/lib/models/Tag.ts
+++ b/packages/lib/models/Tag.ts
@@ -172,17 +172,18 @@ export default class Tag extends BaseItem {
 	}
 
 	public static async loadByTitle(title: string): Promise<TagEntity | null> {
+		// Case insensitive matching via NOCASE does not work for certain characters, such as Ö or Cyrillic characters, but this is an accepted limitation
+		// now that mixed case tags are supported
 		const trimmedTitle = title.trim();
-		const lowercaseTitle = trimmedTitle.toLowerCase();
-		const normalizedLowercaseTitle = trimmedTitle.normalize('NFC').toLowerCase();
+		const normalizedTitle = trimmedTitle.normalize('NFC');
 		// We use a manual query here instead of loadByField to ensure deterministic ordering (ORDER BY created_time ASC)
 		// when visually similar tags exist in the database.
 		// We use created_time instead of id because IDs are UUIDs and cannot be meaningfully ordered.
-		const tag = await this.modelSelectOne(`SELECT * FROM ${this.tableName()} WHERE title = ? COLLATE NOCASE ORDER BY created_time ASC`, [lowercaseTitle]);
+		const tag = await this.modelSelectOne(`SELECT * FROM ${this.tableName()} WHERE title = ? COLLATE NOCASE ORDER BY created_time ASC`, [trimmedTitle]);
 		if (tag) return tag;
 
-		if (normalizedLowercaseTitle !== lowercaseTitle) {
-			return await this.modelSelectOne(`SELECT * FROM ${this.tableName()} WHERE title = ? COLLATE NOCASE ORDER BY created_time ASC`, [normalizedLowercaseTitle]);
+		if (normalizedTitle !== trimmedTitle) {
+			return await this.modelSelectOne(`SELECT * FROM ${this.tableName()} WHERE title = ? COLLATE NOCASE ORDER BY created_time ASC`, [normalizedTitle]);
 		}
 
 		return null;


### PR DESCRIPTION
PR https://github.com/laurent22/joplin/pull/14599 introduced a regression whereby when tags are added which contain special unicode characters such as Ö or Cyrillic characters, tagging additional notes with the same tag would result in a new tag being created every time. This is because the PR incorrectly reintroduced lowercasing the input of the Tag.loadByTitle function, before passing it to the sql. This was removed as part of PR https://github.com/laurent22/joplin/pull/12931 which added support for mixed case tags. This PR remedies this and adds a comment about the relevant mixed case tags limitation.

This targets release-3.6 because it is a regression introduced in Joplin 3.6.

This fixes https://github.com/laurent22/joplin/issues/15608

### Testing

- Verified that the following tags no longer create duplicate tags:
Öp
Посмотреть 1
- Verified that both Apples and apples match in the tag search, when searched in either case

See video:

https://github.com/user-attachments/assets/9fa0b801-a283-4426-b7ad-4fcedfd7163d

