### PR TITLE
Mobile: Fixes #15618: Make share to Joplin create the note in edit mode and support the RTE correctly

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -763,6 +763,10 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		});
 	}
 
+	public updateRefreshKey() {
+		this.refreshKey = Date.now();
+	}
+
 	private async reloadNoteAndUpdateRefreshKey() {
 		await shared.reloadNote(this);
 		this.refreshKey = this.props.editorNoteReloadTimeRequest;

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -76,6 +76,7 @@ export interface BaseNoteScreenComponent<State extends BaseState = BaseState> {
 	scheduleFocusUpdate(): void;
 	attachFile(asset: AttachFileAsset, fileType: string | null): void;
 	lastLoadedNoteId_?: string;
+	updateRefreshKey(): void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Forwarded to EventEmitter.on/off which receive heterogeneous event payloads; callers like Note.tsx pass concrete signatures
@@ -310,7 +311,7 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent) => {
 		mode = 'view';
 	}
 
-	if (isProvisionalNote && !comp.props.sharedData) {
+	if (isProvisionalNote) {
 		mode = 'edit';
 		comp.scheduleFocusUpdate();
 	}
@@ -371,6 +372,7 @@ shared.initState = async function(comp: BaseNoteScreenComponent) {
 		if (fieldsToSave.title !== undefined || fieldsToSave.body !== undefined) {
 			await Note.save(fieldsToSave);
 			comp.setState({ note: updatedNote, lastSavedNote: updatedNote });
+			comp.updateRefreshKey();
 		}
 		if (comp.props.sharedData.resources) {
 			for (let i = 0; i < comp.props.sharedData.resources.length; i++) {


### PR DESCRIPTION
Prior to Joplin 3.6 on mobile, using the 'Share To' function in an app to share to Joplin (eg. sharing a Chrome webpage) would always create the note in view mode. In Joplin 3.6, the introduction of the persisted view / edit state when opening notes, means that the share to function can now create a note directly in edit mode. While this works for the MDE, this does not work correctly for the RTE, because when the note contents are updated with the shared data after the editor has loaded, it does not currently trigger a reload of the RTE. This results in the note contents being blank, until the note is exited and reloaded, which will result in the data being lost if the user modifies the note contents before doing so.

This PR fixes this behaviour for sharing a note to Joplin with the RTE enabled, and additionally makes the share to note function always open the note in edit mode (like when creating a new empty note), as this is more logical behaviour, now that refreshing the note editor contents has been implemented correctly.

This fixes https://github.com/laurent22/joplin/issues/15618

### Testing

See video demonstrating share to Joplin opening it edit mode and correctly populating and persisting the contents of the share for both the MDE and RTE:

https://github.com/user-attachments/assets/559c50e6-b9db-41e2-b9c4-5f26e4138b25

I also verified that the behaviour of creating notes, opening notes, and opening deleted notes, is unaffected.