### PR TITLE
Chore: iOS: Simplify UI test build output and retry tests on failure

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -58,5 +58,4 @@ jobs:
         shell: bash
         run: |
           cd ${GITHUB_WORKSPACE}/packages/app-mobile/
-          cd ios && pod install
-          cd .. && yarn test-ui-ios
+          yarn test-ui-ios

--- a/packages/app-mobile/ios/testing.xcconfig
+++ b/packages/app-mobile/ios/testing.xcconfig
@@ -8,3 +8,20 @@
 //      https://github.com/swiftlang/swift-evolution/blob/main/proposals/0443-warning-control-flags.md
 OTHER_SWIFT_FLAGS = $(inherited) -suppress-warnings
 WARNING_CFLAGS = $(inherited) -w
+
+//
+// Options to improve build time
+// Ref: https://gist.github.com/gorhom/2d7caaeb64c21694dc691cedbe18e134
+//      https://developer.apple.com/documentation/xcode/build-settings-reference
+//
+
+// Optimize for fast builds
+ASSETCATALOG_COMPILER_OPTIMIZATION=time
+GCC_OPTIMIZATION_LEVEL=0
+GCC_PRECOMPILE_PREFIX_HEADER=YES
+
+// Don't generate dsym debug information
+DEBUG_INFORMATION_FORMAT=dwarf
+
+// Run neighboring build tasks in parallel, when supported
+FUSE_BUILD_SCRIPT_PHASES = YES

--- a/packages/app-mobile/ios/testing.xcconfig
+++ b/packages/app-mobile/ios/testing.xcconfig
@@ -20,8 +20,5 @@ ASSETCATALOG_COMPILER_OPTIMIZATION=time
 GCC_OPTIMIZATION_LEVEL=0
 GCC_PRECOMPILE_PREFIX_HEADER=YES
 
-// Don't generate dsym debug information
-DEBUG_INFORMATION_FORMAT=dwarf
-
 // Run neighboring build tasks in parallel, when supported
 FUSE_BUILD_SCRIPT_PHASES = YES

--- a/packages/app-mobile/ios/testing.xcconfig
+++ b/packages/app-mobile/ios/testing.xcconfig
@@ -1,0 +1,10 @@
+
+// Disable most warnings: Many of Joplin's dependencies (e.g. Expo) emit thousands of lines of
+// Objective C and Swift warnings when doing a full build. This makes it difficult to inspect
+// logs when tests fail in CI. For now, disable **all** warnings when doing CI testing. This is
+// done in a separate .xcconfig file to avoid silencing warnings when developing in XCode.
+//
+// Ref: https://stackoverflow.com/a/60091097
+//      https://github.com/swiftlang/swift-evolution/blob/main/proposals/0443-warning-control-flags.md
+OTHER_SWIFT_FLAGS = $(inherited) -suppress-warnings
+WARNING_CFLAGS = $(inherited) -w

--- a/packages/app-mobile/tools/uiTests.ts
+++ b/packages/app-mobile/tools/uiTests.ts
@@ -15,32 +15,47 @@ const getSimulator = async () => {
 		.name;
 };
 
+
+// Based roughly on the approach taken by react-native-esbuild
+// (https://github.com/oblador/react-native-esbuild/blob/e5897955357e3fe6a48e1dd90ccb909426d24566/package.json#L9)
 const uiTests = async () => {
 	if (process.platform !== 'darwin') throw new Error('UI tests currently must run on MacOS');
 
 	const iosDir = join(dirname(__dirname), 'ios');
+	const workspaceFile = join(iosDir, 'Joplin.xcworkspace');
 
-	// Based on the approach taken by react-native-esbuild
-	// (https://github.com/oblador/react-native-esbuild/blob/e5897955357e3fe6a48e1dd90ccb909426d24566/package.json#L9)
-	await execCommand([
-		'xcrun',
-		'xcodebuild',
-		'test',
-		// Only log errors and warnings.
-		'-quiet',
+	const env = {
+		RUNNING_UI_TESTS: '1',
+		XCODE_XCCONFIG_FILE: join(iosDir, 'testing.xcconfig'),
+	};
+
+	const sharedOptions = [
 		'-workspace',
-		join(iosDir, 'Joplin.xcworkspace'),
+		workspaceFile,
 		'-scheme', 'Joplin',
 		// Create a release build: Without this, the React Native dev server needs to be running
 		// in the background:
 		'-configuration', 'Release',
 		'-destination', `platform=iOS Simulator,name=${await getSimulator()}`,
-	], {
-		env: {
-			RUNNING_UI_TESTS: '1',
-			XCODE_XCCONFIG_FILE: join(iosDir, 'testing.xcconfig'),
-		},
-	});
+	];
+
+	// Build first, in quiet mode, to avoid hundreds of thousands of lines of build output.
+	await execCommand([
+		'xcrun',
+		'xcodebuild',
+		'build-for-testing',
+		// Only log errors and warnings.
+		'-quiet',
+		...sharedOptions,
+	], { env });
+
+	// Run, with normal output. This makes it easier to debug test failures
+	await execCommand([
+		'xcrun',
+		'xcodebuild',
+		'test-without-building',
+		...sharedOptions,
+	], { env });
 };
 
 export default uiTests;

--- a/packages/app-mobile/tools/uiTests.ts
+++ b/packages/app-mobile/tools/uiTests.ts
@@ -1,4 +1,5 @@
 import { execCommand } from '@joplin/utils';
+import { Second } from '@joplin/utils/time';
 import { dirname, join } from 'path';
 
 const getSimulator = async () => {
@@ -53,6 +54,7 @@ const uiTests = async () => {
 	];
 
 	// Build first, in quiet mode, to avoid hundreds of thousands of lines of build output.
+	const buildStart = performance.now();
 	await execCommand([
 		'xcrun',
 		'xcodebuild',
@@ -61,6 +63,9 @@ const uiTests = async () => {
 		'-quiet',
 		...sharedOptions,
 	], { env });
+	const buildEnd = performance.now();
+
+	console.log('Finished build in', (buildEnd - buildStart) / Second, 'seconds');
 
 	// Run, with normal output. This makes it easier to debug test failures
 	const runUiTests = () => {

--- a/packages/app-mobile/tools/uiTests.ts
+++ b/packages/app-mobile/tools/uiTests.ts
@@ -15,6 +15,19 @@ const getSimulator = async () => {
 		.name;
 };
 
+const retry = async <T> (fn: ()=> Promise<T>, maxRetries: number) => {
+	let lastError;
+	for (let retry = 1; retry <= maxRetries; retry++) {
+		try {
+			return await fn();
+		} catch (error) {
+			console.error('Failed to run UI tests (attempt ', retry, ' / ', maxRetries, '): ', error);
+			lastError = error;
+		}
+	}
+	throw lastError;
+};
+
 
 // Based roughly on the approach taken by react-native-esbuild
 // (https://github.com/oblador/react-native-esbuild/blob/e5897955357e3fe6a48e1dd90ccb909426d24566/package.json#L9)
@@ -50,12 +63,16 @@ const uiTests = async () => {
 	], { env });
 
 	// Run, with normal output. This makes it easier to debug test failures
-	await execCommand([
-		'xcrun',
-		'xcodebuild',
-		'test-without-building',
-		...sharedOptions,
-	], { env });
+	const runUiTests = () => {
+		return execCommand([
+			'xcrun',
+			'xcodebuild',
+			'test-without-building',
+			...sharedOptions,
+		], { env });
+	};
+
+	await retry(runUiTests, 2);
 };
 
 export default uiTests;

--- a/packages/app-mobile/tools/uiTests.ts
+++ b/packages/app-mobile/tools/uiTests.ts
@@ -18,6 +18,8 @@ const getSimulator = async () => {
 const uiTests = async () => {
 	if (process.platform !== 'darwin') throw new Error('UI tests currently must run on MacOS');
 
+	const iosDir = join(dirname(__dirname), 'ios');
+
 	// Based on the approach taken by react-native-esbuild
 	// (https://github.com/oblador/react-native-esbuild/blob/e5897955357e3fe6a48e1dd90ccb909426d24566/package.json#L9)
 	await execCommand([
@@ -27,7 +29,7 @@ const uiTests = async () => {
 		// Only log errors and warnings.
 		'-quiet',
 		'-workspace',
-		join(dirname(__dirname), 'ios', 'Joplin.xcworkspace'),
+		join(iosDir, 'Joplin.xcworkspace'),
 		'-scheme', 'Joplin',
 		// Create a release build: Without this, the React Native dev server needs to be running
 		// in the background:
@@ -36,6 +38,7 @@ const uiTests = async () => {
 	], {
 		env: {
 			RUNNING_UI_TESTS: '1',
+			XCODE_XCCONFIG_FILE: join(iosDir, 'testing.xcconfig'),
 		},
 	});
 };

--- a/packages/app-mobile/tools/uiTests.ts
+++ b/packages/app-mobile/tools/uiTests.ts
@@ -16,19 +16,6 @@ const getSimulator = async () => {
 		.name;
 };
 
-const retry = async <T> (fn: ()=> Promise<T>, maxRetries: number) => {
-	let lastError;
-	for (let retry = 1; retry <= maxRetries; retry++) {
-		try {
-			return await fn();
-		} catch (error) {
-			console.error('Failed to run UI tests (attempt ', retry, ' / ', maxRetries, '): ', error);
-			lastError = error;
-		}
-	}
-	throw lastError;
-};
-
 
 // Based roughly on the approach taken by react-native-esbuild
 // (https://github.com/oblador/react-native-esbuild/blob/e5897955357e3fe6a48e1dd90ccb909426d24566/package.json#L9)
@@ -74,10 +61,13 @@ const uiTests = async () => {
 			'xcodebuild',
 			'test-without-building',
 			...sharedOptions,
+
+			'-retry-tests-on-failure',
+			'-test-iterations', '3',
 		], { env });
 	};
 
-	await retry(runUiTests, 2);
+	await runUiTests();
 };
 
 export default uiTests;


### PR DESCRIPTION
# Problem

- When the new iOS UI tests fail in CI, the output is difficult to inspect.
  - There are a huge number of warnings from dependencies (e.g. Expo).
- The tests have failed in CI on at least one unrelated pull request.
- The iOS build step is slow.

# Solution

- Improve test logs:
  - Hide warnings when building for CI testing.
  - Run tests without `-quiet`, but keep `-quiet` enabled for the build step.
    - With this change, test runs output a log that includes test progress and timestamps for the stages of the test.
- Retry tests on failure.
- Improve CI build performance: Optimize for fast builds, rather than fast execution.



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
