### PR TITLE
Desktop: Fixes #15575: Crash on deleting ca. 4000 notes

### DIFF
--- a/packages/app-desktop/gui/NoteList/utils/useActiveDescendantId.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useActiveDescendantId.ts
@@ -5,34 +5,27 @@ const useActiveDescendantId = (selectedFolderId: string, selectedNoteIds: string
 	const selectedNoteIdsRef = useRef(selectedNoteIds);
 	selectedNoteIdsRef.current = selectedNoteIds;
 
-	const [activeNoteId, setActiveNoteId] = useState('');
+	const [focusedNoteId, setFocusedNoteId] = useState('');
+
 	useEffect(() => {
-		setActiveNoteId(selectedNoteIdsRef.current?.[0] ?? '');
+		setFocusedNoteId(selectedNoteIdsRef.current?.[0] ?? '');
 	}, [selectedFolderId]);
 
-	const previousNoteIdsRef = useRef<string[]>(null);
-	previousNoteIdsRef.current = usePrevious(selectedNoteIds);
+	const previousSelectedNoteIds = usePrevious(selectedNoteIds, []);
+	let activeNoteId = focusedNoteId;
+
+	if (!selectedNoteIds.includes(activeNoteId)) {
+		// Prefer added items
+		activeNoteId = selectedNoteIds.find(id => !previousSelectedNoteIds.includes(id)) ?? selectedNoteIds[0] ?? '';
+	}
 
 	useEffect(() => {
-		const previousNoteIds = previousNoteIdsRef.current ?? [];
+		if (focusedNoteId !== activeNoteId) {
+			setFocusedNoteId(activeNoteId);
+		}
+	}, [focusedNoteId, activeNoteId]);
 
-		setActiveNoteId(current => {
-			if (selectedNoteIds.includes(current)) {
-				return current;
-			} else {
-				// Prefer added items
-				for (const id of selectedNoteIds) {
-					if (!previousNoteIds.includes(id)) {
-						return id;
-					}
-				}
-
-				return selectedNoteIds[0] ?? '';
-			}
-		});
-	}, [selectedNoteIds]);
-
-	return { activeNoteId, setActiveNoteId };
+	return { activeNoteId, setActiveNoteId: setFocusedNoteId };
 };
 
 export default useActiveDescendantId;


### PR DESCRIPTION
Fixes #15575 

The problem comes from `useActiveDescendantId`.

The hook updated `activeNoteId` every time `selectedNoteIds` changed. Each deletion changes `selectedNoteIds`. The hook keeps calling `setActiveNoteId` which caused the crash

So the fix is to refactor the hook, keep the same behavior, and avoid heavy re-rendering
I also verified that this hook was created once and was not really changed later to fix another issue. So I had to confirm just the default behavior with no risk of causing regression 