### PR TITLE
Doc: Enable the Pro 100 GB plan

### DIFF
--- a/Assets/WebsiteAssets/templates/plans.mustache
+++ b/Assets/WebsiteAssets/templates/plans.mustache
@@ -118,10 +118,9 @@
 				{{> plan}}
 			{{/plans.pro}}
 
-			{{! TODO: Enable, when supported by Joplin Cloud
-			\{\{#plans.pro100Gb\}\}
-				\{\{> plan\}\}
-			\{\{/plans.pro100Gb\}\} }}
+			{{#plans.pro100Gb}}
+				{{> plan}}
+			{{/plans.pro100Gb}}
 
 			{{#plans.teams}}
 				{{> plan}}

--- a/packages/lib/utils/joplinCloud/index.ts
+++ b/packages/lib/utils/joplinCloud/index.ts
@@ -399,11 +399,10 @@ export const createFeatureTableMd = () => {
 			name: 'pro',
 			label: 'Pro',
 		},
-		// TODO: Enable, when supported by Joplin Cloud
-		// {
-		// 	name: 'pro100Gb',
-		// 	label: 'Pro 100 GB',
-		// },
+		{
+			name: 'pro100Gb',
+			label: 'Pro 100 GB',
+		},
 		{
 			name: 'teams',
 			label: 'Teams',
@@ -445,8 +444,7 @@ export const createFeatureTableMd = () => {
 			featureLabel: makeFeatureLabel(id, feature),
 			basic: getCellInfo(PlanName.Basic, id, feature),
 			pro: getCellInfo(PlanName.Pro, id, feature),
-			// TODO: Enable when supported by Joplin Cloud
-			// pro100Gb: getCellInfo(PlanName.Pro100Gb, id, feature),
+			pro100Gb: getCellInfo(PlanName.Pro100Gb, id, feature),
 			teams: getCellInfo(PlanName.Teams, id, feature),
 			joplinServerBusiness: getCellInfo(PlanName.JoplinServerBusiness, id, feature),
 		};


### PR DESCRIPTION
# Summary

Follow up to https://github.com/laurent22/joplin/pull/15528.

# Screen recording (dev-mode website)


https://github.com/user-attachments/assets/a581ad97-7356-4ed1-8bbd-1dac644b269c




<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
