### PR TITLE
Server: Prevent SAML login from accessing existing local password accounts

### DIFF
--- a/packages/server/src/models/UserModel.test.ts
+++ b/packages/server/src/models/UserModel.test.ts
@@ -593,6 +593,22 @@ describe('UserModel', () => {
 		}
 	});
 
+	test('should not log in as a local account via SSO based on email match alone', async () => {
+		const localUser = await createUser(1);
+
+		config().SAML_ENABLED = true;
+
+		try {
+			const result = await models().user().ssoLogin(localUser.email, 'Attacker Controlled Name');
+			expect(result).toBeNull();
+
+			const reloaded = await models().user().load(localUser.id);
+			expect(reloaded.is_external).toBe(0);
+		} finally {
+			config().SAML_ENABLED = false;
+		}
+	});
+
 	test('should generate a unique SSO code', async () => {
 		const createExternalUser = async (index: number) => {
 			const user = await createUser(index);

--- a/packages/server/src/models/UserModel.ts
+++ b/packages/server/src/models/UserModel.ts
@@ -230,6 +230,11 @@ export default class UserModel extends BaseModel<User> {
 
 		let user = await this.loadByEmail(email);
 
+		// A local, password-based account already owns this email address. Do
+		// not allow a SAML assertion to log in as it - this would bypass the
+		// local account's password.
+		if (user && !user.is_external) return null;
+
 		if (!user) { // User does not exist
 			user = {
 				email: email,


### PR DESCRIPTION
When both SAML SSO and local password authentication are enabled, a SAML login whose asserted email matched an existing local (password-based) account would log in as that account, without a password check.

After this change, SAML logins only succeed for accounts that were created via SSO. If the asserted email belongs to a local password account, the SAML login is rejected.

Linking a local account to an SSO identity is not supported by this change and would need to be a separate, explicitly-authenticated flow.