### PR TITLE
Plugins: Filter what values joplin.settings.globalValues can return

### DIFF
--- a/packages/lib/services/plugins/api/JoplinSettings.ts
+++ b/packages/lib/services/plugins/api/JoplinSettings.ts
@@ -184,9 +184,9 @@ export default class JoplinSettings {
 	 * https://github.com/laurent22/joplin/blob/dev/packages/lib/models/settings/builtInMetadata.ts
 	 */
 	public async globalValues(keys: string[]): Promise<unknown[]> {
-		const output: (string|number|boolean)[] = [];
+		const output: (string|number|boolean|undefined)[] = [];
 		for (const key of keys) {
-			output.push(Setting.value(key));
+			output.push(Setting.isSecureKey(key) ? undefined : Setting.value(key));
 		}
 		return output;
 	}

--- a/packages/lib/services/plugins/api/JoplinSettings.ts
+++ b/packages/lib/services/plugins/api/JoplinSettings.ts
@@ -195,6 +195,7 @@ export default class JoplinSettings {
 	 * @deprecated Use joplin.settings.globalValues()
 	 */
 	public async globalValue(key: string): Promise<unknown> {
+		if (Setting.isSecureKey(key)) return undefined;
 		return Setting.value(key);
 	}
 


### PR DESCRIPTION
I used `Setting.isSecureKey(key)` to verify if the value is secure.

`globalValues` now returns `undefined` for secure keys. I did not skip them to keep result order.

I also updated deprecated `globalValue`