### PR TITLE
Server: Allow configuring the default admin password with an environment variable

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -191,6 +191,7 @@ export async function initConfig(envType: Env, env: EnvVariables, overrides: any
 		joplinServerVersion: packageJson.version,
 		appName,
 		isJoplinCloud: apiBaseUrl.includes('.joplincloud.com') || apiBaseUrl.includes('.joplincloud.local'),
+		defaultAdminPassword: env.DEFAULT_ADMIN_PASSWORD,
 		env: envType,
 		rootDir: rootDir,
 		viewDir: viewDir,

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -191,7 +191,7 @@ export async function initConfig(envType: Env, env: EnvVariables, overrides: any
 		joplinServerVersion: packageJson.version,
 		appName,
 		isJoplinCloud: apiBaseUrl.includes('.joplincloud.com') || apiBaseUrl.includes('.joplincloud.local'),
-		defaultAdminPassword: env.DEFAULT_ADMIN_PASSWORD,
+		defaultAdminPassword: env.DEFAULT_ADMIN_PASSWORD || 'admin',
 		env: envType,
 		rootDir: rootDir,
 		viewDir: viewDir,

--- a/packages/server/src/db.initialState.test.ts
+++ b/packages/server/src/db.initialState.test.ts
@@ -1,0 +1,42 @@
+import { afterAllTests, beforeAllDb, models } from './utils/testing/testUtils';
+
+describe('db.initialState', () => {
+
+	afterEach(async () => {
+		await afterAllTests();
+	});
+
+	let testIndex = 0;
+	it.each([
+		{
+			label: 'should create a single admin user with a custom default password',
+			envValues: {
+				DEFAULT_ADMIN_PASSWORD: 'test-default',
+			},
+			test: async () => {
+				expect(await models().user().login('admin@localhost', 'admin')).toBeNull();
+				expect(await models().user().login('admin@localhost', 'test-default')).toBeTruthy();
+			},
+		},
+		{
+			label: 'should create a single admin user with a custom default password',
+			envValues: {
+				DEFAULT_ADMIN_PASSWORD: undefined,
+			},
+			test: async () => {
+				expect(await models().user().login('admin@localhost', 'admin')).toBeTruthy();
+				expect(await models().user().login('admin@localhost', 'test-default')).toBeNull();
+			},
+		},
+	])('$label', async ({ envValues, test }) => {
+		// Call beforeAllDb so that each case has its own database, initialized based on a different environment
+		// Use a different databaseKey to avoid locking issues on Windows.
+		const databaseKey = `db.initialState.${testIndex ++}`;
+		await beforeAllDb(databaseKey, {
+			envValues,
+		});
+
+		await test();
+	});
+
+});

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -36,7 +36,6 @@ const migrationDir = `${__dirname}/migrations`;
 export const sqliteDefaultDir = pathUtils.dirname(__dirname);
 
 export const defaultAdminEmail = 'admin@localhost';
-export const defaultAdminPassword = 'admin';
 
 export type DbConnection = Knex;
 

--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -32,6 +32,8 @@ const defaultEnvValues: EnvVariables = {
 	IS_ADMIN_INSTANCE: true,
 	INSTANCE_NAME: '',
 
+	DEFAULT_ADMIN_PASSWORD: 'admin',
+
 	// Maximum allowed drift between NTP time and server time. A few
 	// milliseconds is normally not an issue unless many clients are modifying
 	// the same note at the exact same time. But past a certain limit, it might
@@ -213,6 +215,8 @@ export interface EnvVariables {
 	JOPLINAPP_BASE_URL: string;
 	TERMS_URL: string;
 	PRIVACY_URL: string;
+
+	DEFAULT_ADMIN_PASSWORD: string;
 
 	DB_CLIENT: string;
 	DB_SLOW_QUERY_LOG_ENABLED: boolean;

--- a/packages/server/src/middleware/notificationHandler.test.ts
+++ b/packages/server/src/middleware/notificationHandler.test.ts
@@ -1,8 +1,9 @@
 import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models, koaAppContext, koaNext } from '../utils/testing/testUtils';
 import { Notification, UserFlagType } from '../services/database/types';
-import { defaultAdminEmail, defaultAdminPassword } from '../db';
+import { defaultAdminEmail } from '../db';
 import notificationHandler from './notificationHandler';
 import { AppContext } from '../utils/types';
+import config from '../config';
 
 const runNotificationHandler = async (sessionId: string): Promise<AppContext> => {
 	const context = await koaAppContext({ sessionId: sessionId });
@@ -37,7 +38,7 @@ describe('notificationHandler', () => {
 		admin = await models().user().save({
 			id: admin.id,
 			email: defaultAdminEmail,
-			password: defaultAdminPassword,
+			password: config().defaultAdminPassword,
 			is_admin: 1,
 			email_confirmed: 1,
 		}, { skipValidation: true });
@@ -75,7 +76,7 @@ describe('notificationHandler', () => {
 
 		await createUserAndSession(2, true, {
 			email: defaultAdminEmail,
-			password: defaultAdminPassword,
+			password: config().defaultAdminPassword,
 		});
 
 		await runNotificationHandler(session.id);

--- a/packages/server/src/middleware/notificationHandler.ts
+++ b/packages/server/src/middleware/notificationHandler.ts
@@ -1,20 +1,21 @@
 import { AppContext, KoaNext, NotificationView } from '../utils/types';
 import { isApiRequest } from '../utils/requestUtils';
 import { NotificationLevel } from '../services/database/types';
-import { defaultAdminEmail, defaultAdminPassword } from '../db';
+import { defaultAdminEmail } from '../db';
 import { _ } from '@joplin/lib/locale';
 import Logger from '@joplin/utils/Logger';
 import { NotificationKey } from '../models/NotificationModel';
 import { helpUrl, profileUrl } from '../utils/urlUtils';
 import { userFlagToString } from '../models/UserFlagModel';
 import renderMarkdown from '../utils/renderMarkdown';
+import config from '../config';
 
 const logger = Logger.create('notificationHandler');
 
 async function handleChangeAdminPasswordNotification(ctx: AppContext) {
 	if (!ctx.joplin.owner.is_admin) return;
 
-	const defaultAdmin = await ctx.joplin.models.user().login(defaultAdminEmail, defaultAdminPassword);
+	const defaultAdmin = await ctx.joplin.models.user().login(defaultAdminEmail, config().defaultAdminPassword);
 	const notificationModel = ctx.joplin.models.notification();
 
 	if (defaultAdmin) {

--- a/packages/server/src/middleware/notificationHandler.ts
+++ b/packages/server/src/middleware/notificationHandler.ts
@@ -19,11 +19,19 @@ async function handleChangeAdminPasswordNotification(ctx: AppContext) {
 	const notificationModel = ctx.joplin.models.notification();
 
 	if (defaultAdmin) {
+		const knownInsecurePassword = config().defaultAdminPassword === 'admin';
+		let message;
+		if (knownInsecurePassword) {
+			message = _('The default admin password is insecure and has not been changed! [Change it now](%s)', profileUrl());
+		} else {
+			message = _('The default admin password has not been changed! [Change it now](%s)', profileUrl());
+		}
+
 		await notificationModel.add(
 			ctx.joplin.owner.id,
 			NotificationKey.ChangeAdminPassword,
 			NotificationLevel.Important,
-			_('The default admin password is insecure and has not been changed! [Change it now](%s)', profileUrl()),
+			message,
 		);
 	} else {
 		await notificationModel.setRead(ctx.joplin.owner.id, NotificationKey.ChangeAdminPassword);

--- a/packages/server/src/migrations/20190913171451_create.ts
+++ b/packages/server/src/migrations/20190913171451_create.ts
@@ -1,7 +1,8 @@
 import { Knex } from 'knex';
-import { DbConnection, defaultAdminEmail, defaultAdminPassword } from '../db';
+import { DbConnection, defaultAdminEmail } from '../db';
 import { hashPassword } from '../utils/auth';
 import { uuidgen } from '@joplin/lib/uuid';
+import config from '../config';
 
 export const up = async (db: DbConnection) => {
 	await db.schema.createTable('users', (table: Knex.CreateTableBuilder) => {
@@ -98,7 +99,7 @@ export const up = async (db: DbConnection) => {
 	await db('users').insert({
 		id: adminId,
 		email: defaultAdminEmail,
-		password: await hashPassword(defaultAdminPassword),
+		password: await hashPassword(config().defaultAdminPassword),
 		full_name: 'Admin',
 		is_admin: 1,
 		updated_time: now,

--- a/packages/server/src/utils/types.ts
+++ b/packages/server/src/utils/types.ts
@@ -174,6 +174,7 @@ export interface Config extends EnvVariables {
 	joplinAppBaseUrl: string;
 	signupEnabled: boolean;
 	termsEnabled: boolean;
+	defaultAdminPassword: string;
 	accountTypesEnabled: boolean;
 	showErrorStackTraces: boolean;
 	database: DatabaseConfig;


### PR DESCRIPTION
# Problem

It's currently necessary to use the web UI to change the default admin credentials for Joplin Server.

# Solution

Allow customizing the default Joplin Server admin account password through the `DEFAULT_ADMIN_PASSWORD` environment variable. The new `DEFAULT_ADMIN_PASSWORD` applies to the first server startup (when the database is created/initialized) and is ignored for subsequent startups.

# Testing

This pull request includes a new automated test.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
