### PR TITLE
Server: Improve UUID generation logic

### DIFF
--- a/packages/server/src/models/SessionModel.ts
+++ b/packages/server/src/models/SessionModel.ts
@@ -1,6 +1,6 @@
 import BaseModel from './BaseModel';
 import { User, Session, Uuid } from '../services/database/types';
-import { uuidgen } from '@joplin/lib/uuid';
+import { uuidgen } from '../utils/uuid';
 import { ErrorForbidden } from '../utils/errors';
 import { Hour } from '../utils/time';
 import { isValidMFACode } from '../utils/crypto';

--- a/packages/server/src/models/SubscriptionModel.ts
+++ b/packages/server/src/models/SubscriptionModel.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { EmailSender, Subscription, User, UserFlagType, Uuid } from '../services/database/types';
 import { ErrorNotFound } from '../utils/errors';
 import { Day } from '../utils/time';
-import { uuidgen } from '@joplin/lib/uuid';
+import { uuidgen } from '../utils/uuid';
 import paymentFailedTemplate from '../views/emails/paymentFailedTemplate';
 import BaseModel from './BaseModel';
 import { AccountType } from './UserModel';

--- a/packages/server/src/models/TokenModel.ts
+++ b/packages/server/src/models/TokenModel.ts
@@ -1,6 +1,6 @@
 import { Token, User, Uuid } from '../services/database/types';
 import { ErrorForbidden, ErrorNotFound } from '../utils/errors';
-import { uuidgen } from '@joplin/lib/uuid';
+import { uuidgen } from '../utils/uuid';
 import BaseModel from './BaseModel';
 
 export default class TokenModel extends BaseModel<Token> {

--- a/packages/server/src/routes/admin/users.ts
+++ b/packages/server/src/routes/admin/users.ts
@@ -11,7 +11,7 @@ import { View } from '../../services/MustacheService';
 import defaultView from '../../utils/defaultView';
 import { AclAction } from '../../models/BaseModel';
 import { AccountType, accountTypeOptions, accountTypeToString } from '../../models/UserModel';
-import { uuidgen } from '@joplin/lib/uuid';
+import { uuidgen } from '../../utils/uuid';
 import { formatMaxItemSize, formatMaxTotalSize, formatTotalSize, formatTotalSizePercent, yesOrNo } from '../../utils/strings';
 import { getCanShareFolder, totalSizeClass } from '../../models/utils/user';
 import { yesNoDefaultOptions, yesNoOptions } from '../../utils/views/select';

--- a/packages/server/src/routes/api/users.ts
+++ b/packages/server/src/routes/api/users.ts
@@ -6,7 +6,7 @@ import { RouteType } from '../../utils/types';
 import { AppContext } from '../../utils/types';
 import { ErrorNotFound } from '../../utils/errors';
 import { AclAction } from '../../models/BaseModel';
-import { uuidgen } from '@joplin/lib/uuid';
+import { uuidgen } from '../../utils/uuid';
 
 const router = new Router(RouteType.Api);
 


### PR DESCRIPTION
# Summary

Updates `packages/server` to more consistently use `uuid` from `server/src/utils`, rather than `@joplin/lib/uuid`.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
