### PR TITLE
Server: Improve `items/` route validation logic

### DIFF
--- a/packages/server/src/routes/index/items.test.ts
+++ b/packages/server/src/routes/index/items.test.ts
@@ -1,5 +1,7 @@
-import { beforeAllDb, afterAllTests, beforeEachDb, createItemTree, createUserAndSession, parseHtml } from '../../utils/testing/testUtils';
+import { beforeAllDb, afterAllTests, beforeEachDb, createItemTree, createUserAndSession, parseHtml, expectHttpError, expectNoHttpError, createItem } from '../../utils/testing/testUtils';
 import { execRequest } from '../../utils/testing/apiUtils';
+import { Uuid } from '../../services/database/types';
+import { makeNoteSerializedBody } from '../../utils/testing/serializedItems';
 
 describe('index_items', () => {
 
@@ -50,4 +52,28 @@ describe('index_items', () => {
 		}
 	});
 
+	test('should disallow accessing other users\' items from items/:id/content', async () => {
+		const { session: session1 } = await createUserAndSession(1);
+		const { session: session2 } = await createUserAndSession(2);
+
+		const itemJoplinId = '96765a68655f4446b3dbad7d41b6566e';
+		const item = await createItem(
+			session1.id,
+			`root:/${itemJoplinId}.md:`,
+			makeNoteSerializedBody({
+				id: itemJoplinId,
+			}),
+		);
+
+		const requestItem = (sessionId: Uuid) => {
+			return execRequest(sessionId, 'GET', `items/${item.id}/content`);
+		};
+
+		await expectNoHttpError(async () => {
+			await requestItem(session1.id);
+		});
+		await expectHttpError(async () => {
+			await requestItem(session2.id);
+		}, 404);
+	});
 });

--- a/packages/server/src/routes/index/items.ts
+++ b/packages/server/src/routes/index/items.ts
@@ -76,6 +76,9 @@ router.get('items', async (_path: SubPath, ctx: AppContext) => {
 
 router.get('items/:id/content', async (path: SubPath, ctx: AppContext) => {
 	const itemModel = ctx.joplin.models.item();
+	const canAccess = ctx.joplin.owner.is_admin || await itemModel.userHasItem(ctx.joplin.owner.id, path.id);
+	if (!canAccess) throw new ErrorNotFound();
+
 	const item = await itemModel.loadWithContent(path.id);
 	if (!item) throw new ErrorNotFound();
 	return respondWithItemContent(ctx.response, item, item.content);


### PR DESCRIPTION
# Summary

Improves checks in the `items/:id/content` route on Joplin Server.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
