### PR TITLE
Desktop,Mobile,Server: Fix Fountain rendering issue

### DIFF
--- a/packages/app-cli/tests/md_to_html/sanitize_24.html
+++ b/packages/app-cli/tests/md_to_html/sanitize_24.html
@@ -1,0 +1,11 @@
+
+		<!-- joplin-metadata-print-title = false -->
+		<div class="fountain joplin-editable">
+			<pre class="joplin-source" hidden data-joplin-language="fountain" data-joplin-source-open="```fountain&#10;" data-joplin-source-close="&#10;```&#10;">&lt;img src=x onerror=&quot;something()&quot;/&gt;... 
+</pre>
+			
+			<div class="page">
+				<p><img src="x"/>...</p>
+			</div>
+		</div>
+	

--- a/packages/app-cli/tests/md_to_html/sanitize_24.md
+++ b/packages/app-cli/tests/md_to_html/sanitize_24.md
@@ -1,0 +1,3 @@
+```fountain
+<img src=x onerror="something()"/>... 
+```

--- a/packages/renderer/MdToHtml/rules/fountain.ts
+++ b/packages/renderer/MdToHtml/rules/fountain.ts
@@ -1,4 +1,5 @@
 const fountain = require('../../vendor/fountain.min.js');
+import htmlUtils from '../../htmlUtils';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Theme is defined in @joplin/lib and we don't import it here
 const pluginAssets = function(theme: any) {
@@ -140,13 +141,14 @@ function renderFountainScript(markdownIt: any, content: string) {
 		`;
 	}
 
+	const contentHtml = result.html.script;
 	return `
 		<!-- joplin-metadata-print-title = false -->
 		<div class="fountain joplin-editable">
 			<pre class="joplin-source" hidden data-joplin-language="fountain" data-joplin-source-open="\`\`\`fountain&#10;" data-joplin-source-close="&#10;\`\`\`&#10;">${markdownIt.utils.escapeHtml(content)}</pre>
-			${titlePageHtml}
+			${htmlUtils.sanitizeHtml(titlePageHtml)}
 			<div class="page">
-				${result.html.script}
+				${htmlUtils.sanitizeHtml(contentHtml)}
 			</div>
 		</div>
 	`;


### PR DESCRIPTION
# Summary

Improves output sanitization when rendering `fountain` blocks.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
