### PR TITLE
Desktop: Add sqlite-vec extension loading for vector search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1543,6 +1543,7 @@ packages/lib/services/WhenClause.test.js
 packages/lib/services/WhenClause.js
 packages/lib/services/ai/AiService.test.js
 packages/lib/services/ai/AiService.js
+packages/lib/services/ai/SqliteVec.test.js
 packages/lib/services/ai/aiSettingsTransition.test.js
 packages/lib/services/ai/aiSettingsTransition.js
 packages/lib/services/ai/classification.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1569,6 +1569,7 @@ packages/lib/services/WhenClause.test.js
 packages/lib/services/WhenClause.js
 packages/lib/services/ai/AiService.test.js
 packages/lib/services/ai/AiService.js
+packages/lib/services/ai/SqliteVec.test.js
 packages/lib/services/ai/aiSettingsTransition.test.js
 packages/lib/services/ai/aiSettingsTransition.js
 packages/lib/services/ai/classification.js

--- a/packages/app-desktop/main-html.ts
+++ b/packages/app-desktop/main-html.ts
@@ -31,6 +31,7 @@ import EncryptionService from '@joplin/lib/services/e2ee/EncryptionService';
 import FileApiDriverLocal from '@joplin/lib/file-api-driver-local';
 import * as React from 'react';
 import nodeSqlite = require('sqlite3');
+import sqliteVec = require('sqlite-vec');
 import initLib from '@joplin/lib/initLib';
 import PerformanceLogger from '@joplin/lib/PerformanceLogger';
 import * as pdfJs from 'pdfjs-dist';
@@ -93,6 +94,7 @@ const main = async () => {
 		appVersion,
 		electronBridge: bridge(),
 		nodeSqlite,
+		sqliteVec,
 		pdfJs: pdfJs as PdfJs,
 		isAppleSilicon,
 	});

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -224,6 +224,7 @@
     "fs-extra": "11.3.4",
     "keytar": "7.9.0",
     "node-fetch": "2.6.7",
+    "sqlite-vec": "0.1.9",
     "sqlite3": "5.1.6"
   }
 }

--- a/packages/lib/JoplinDatabase.ts
+++ b/packages/lib/JoplinDatabase.ts
@@ -140,6 +140,7 @@ export default class JoplinDatabase extends Database {
 	private version_: number = null;
 	private tableFieldNames_: Record<string, string[]> = {};
 	private tableDescriptions_: Record<string, Record<string, string>>;
+	private sqliteVecAvailable_ = false;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Base Database class uses `any` for driver — different drivers (sqlite, better-sqlite3, web) have different shapes
 	public constructor(driver: any) {
@@ -150,9 +151,36 @@ export default class JoplinDatabase extends Database {
 		return this.initialized_;
 	}
 
+	// Returns true if the sqlite-vec extension loaded successfully when the
+	// database was opened. False on platforms where the prebuilt is missing or
+	// extension loading is otherwise blocked. Callers that need vector search
+	// (the AI embeddings index) should gate on this and degrade gracefully
+	// rather than throwing.
+	public sqliteVecAvailable() {
+		return this.sqliteVecAvailable_;
+	}
+
 	public async open(options: Record<string, unknown>) {
 		await super.open(options);
+		await this.tryLoadSqliteVec();
 		return this.initialize();
+	}
+
+	private async tryLoadSqliteVec() {
+		const sqliteVec = shim.sqliteVec();
+		if (!sqliteVec) {
+			this.sqliteVecAvailable_ = false;
+			this.logger().info('sqlite-vec not provided by the host app; vector search disabled');
+			return;
+		}
+		try {
+			await this.loadExtension(sqliteVec.getLoadablePath());
+			this.sqliteVecAvailable_ = true;
+			this.logger().info('sqlite-vec extension loaded');
+		} catch (error) {
+			this.sqliteVecAvailable_ = false;
+			this.logger().warn('sqlite-vec extension failed to load; vector search disabled:', error.message ?? error);
+		}
 	}
 
 	public tableFieldNames(tableName: string) {

--- a/packages/lib/JoplinDatabase.ts
+++ b/packages/lib/JoplinDatabase.ts
@@ -179,7 +179,7 @@ export default class JoplinDatabase extends Database {
 			this.logger().info('sqlite-vec extension loaded');
 		} catch (error) {
 			this.sqliteVecAvailable_ = false;
-			this.logger().warn('sqlite-vec extension failed to load; vector search disabled:', error.message ?? error);
+			this.logger().warn('sqlite-vec extension failed to load; vector search disabled:', error);
 		}
 	}
 

--- a/packages/lib/database.ts
+++ b/packages/lib/database.ts
@@ -178,16 +178,13 @@ export default class Database {
 		return this.tryCall('selectOne', sql, params);
 	}
 
-	public async loadExtension(/* path */) {
-		return; // Disabled for now as fuzzy search extension is not in use
-
-		// let result =  null;
-		// try {
-		// 	result = await this.driver().loadExtension(path);
-		// 	return result;
-		// } catch (e) {
-		// 	throw new Error(`Could not load extension ${path}`);
-		// }
+	public async loadExtension(path: string) {
+		try {
+			return await this.driver().loadExtension(path);
+		} catch (error) {
+			error.message = `Could not load extension ${path}: ${error.message}`;
+			throw error;
+		}
 	}
 
 	public async selectAll<T = Row>(sql: string, params: SqlParams = null): Promise<T[]> {

--- a/packages/lib/jest.setup.js
+++ b/packages/lib/jest.setup.js
@@ -5,12 +5,23 @@ const nodeSqlite = require('sqlite3');
 const pdfJs = require('pdfjs-dist');
 const packageInfo = require('./package.json');
 
+// sqlite-vec is only bundled with the desktop app in production. We pull it in
+// here so tests covering the embeddings index have a working extension to load.
+// Wrapped in try/catch so platforms without a prebuilt (e.g. Linux ARM CI runners)
+// don't crash the whole suite — they just skip the vector-specific tests.
+let sqliteVec = null;
+try {
+	sqliteVec = require('sqlite-vec');
+} catch (error) {
+	console.warn('sqlite-vec unavailable in tests on this platform:', error.message);
+}
+
 // Used for testing some shared components
 const React = require('react');
 
 require('../../jest.base-setup.js')();
 
-shimInit({ pdfJs, sharp, nodeSqlite, React, appVersion: () => packageInfo.version });
+shimInit({ pdfJs, sharp, nodeSqlite, sqliteVec, React, appVersion: () => packageInfo.version });
 
 global.afterEach(async () => {
 	await afterEachCleanUp();

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -38,6 +38,7 @@
     "react": "19.1.5",
     "react-dom": "19.1.5",
     "sharp": "0.34.5",
+    "sqlite-vec": "0.1.9",
     "tesseract.js": "6.0.1",
     "typescript": "5.9.3"
   },

--- a/packages/lib/services/ai/SqliteVec.test.ts
+++ b/packages/lib/services/ai/SqliteVec.test.ts
@@ -1,0 +1,60 @@
+import { setupDatabaseAndSynchronizer, switchClient, db } from '../../testing/test-utils';
+
+// Verifies the sqlite-vec extension is loaded and behaves correctly. Uses
+// hand-crafted unit vectors so we can assert exact KNN ordering without depending
+// on a real embedding model.
+
+describe('SqliteVec', () => {
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+	});
+
+	it('loads the extension and reports availability', () => {
+		// If this fails the rest of the suite is meaningless — sqlite-vec wasn't
+		// loaded by jest.setup.js for this platform.
+		expect(db(1).sqliteVecAvailable()).toBe(true);
+	});
+
+	it('exposes the vec_version() function', async () => {
+		const row = await db(1).selectOne('SELECT vec_version() AS v');
+		expect(typeof row.v).toBe('string');
+		expect(row.v.length).toBeGreaterThan(0);
+	});
+
+	it('supports KNN queries against a vec0 virtual table', async () => {
+		// Three 4D unit vectors pointing along distinct axes. The query vector is
+		// nearly aligned with the first one, so KNN should return them in this
+		// exact order. We pass vectors as JSON strings — sqlite-vec accepts that
+		// form alongside raw bytes, and it sidesteps node-sqlite3's blob handling.
+		const dim = 4;
+		await db(1).exec(`CREATE VIRTUAL TABLE test_vecs USING vec0(embedding FLOAT[${dim}])`);
+
+		const vectors: [number, number[]][] = [
+			[1, [1, 0, 0, 0]],
+			[2, [0, 1, 0, 0]],
+			[3, [0, 0, 1, 0]],
+		];
+		for (const [id, vec] of vectors) {
+			await db(1).exec({
+				sql: 'INSERT INTO test_vecs(rowid, embedding) VALUES (?, ?)',
+				params: [id, JSON.stringify(vec)],
+			});
+		}
+
+		const queryVector = JSON.stringify([0.9, 0.1, 0, 0]);
+		const rows = await db(1).selectAll<{ rowid: number; distance: number }>(
+			'SELECT rowid, distance FROM test_vecs WHERE embedding MATCH ? ORDER BY distance LIMIT 3',
+			[queryVector],
+		);
+
+		expect(rows.length).toBe(3);
+		expect(rows[0].rowid).toBe(1);
+		expect(rows[1].rowid).toBe(2);
+		expect(rows[2].rowid).toBe(3);
+		// First result must be strictly closer than the others.
+		expect(rows[0].distance).toBeLessThan(rows[1].distance);
+		expect(rows[1].distance).toBeLessThan(rows[2].distance);
+	});
+});

--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -118,6 +118,8 @@ export interface ShimInitOptions {
 	electronBridge?: any;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- node sqlite driver shape is per-platform; see shim.nodeSqlite_
 	nodeSqlite?: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- sqlite-vec is only bundled with desktop; see shim.sqliteVec_
+	sqliteVec?: any;
 	pdfJs?: PdfJs;
 	isAppleSilicon?: ()=> boolean;
 }
@@ -130,6 +132,7 @@ function shimInit(options: ShimInitOptions = null) {
 		appVersion: null,
 		electronBridge: null,
 		nodeSqlite: null,
+		sqliteVec: null,
 		pdfJs: null,
 		isAppleSilicon: () => false,
 		...options,
@@ -141,6 +144,7 @@ function shimInit(options: ShimInitOptions = null) {
 	const pdfJs = options.pdfJs;
 
 	shim.setNodeSqlite(options.nodeSqlite);
+	shim.setSqliteVec(options.sqliteVec);
 
 	shim.fsDriver = () => {
 		throw new Error('Not implemented');

--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -101,6 +101,8 @@ let react_: typeof React = null;
 let reactDom_: typeof ReactDom = null;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- node sqlite driver is set per-platform (better-sqlite3, react-native sqlite, etc.); accessed structurally
 let nodeSqlite_: any = null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- sqlite-vec is only bundled with desktop; null on platforms that don't ship it
+let sqliteVec_: any = null;
 
 const shim = {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Geolocation API differs across platforms (browser Geolocation, RN Geolocation module); accessed structurally
@@ -533,6 +535,18 @@ const shim = {
 	nodeSqlite: () => {
 		if (!nodeSqlite_) throw new Error('Trying to access nodeSqlite before it has been set!!!');
 		return nodeSqlite_;
+	},
+
+	// sqlite-vec is only bundled with the desktop app. Other platforms (CLI,
+	// mobile, web) leave it unset and the embeddings index gracefully reports
+	// itself as unavailable rather than crashing.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See sqliteVec_
+	setSqliteVec: (sqliteVec: any) => {
+		sqliteVec_ = sqliteVec;
+	},
+
+	sqliteVec: () => {
+		return sqliteVec_;
 	},
 
 	setReact: (react: typeof React) => {

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -311,3 +311,4 @@ simctl
 devicetypes
 xcodebuild
 openai
+vecs

--- a/yarn.lock
+++ b/yarn.lock
@@ -12441,6 +12441,7 @@ __metadata:
     roboto-fontface: "npm:0.10.0"
     smalltalk: "npm:2.5.1"
     source-map-support: "npm:0.5.21"
+    sqlite-vec: "npm:0.1.9"
     sqlite3: "npm:5.1.6"
     styled-components: "npm:5.3.11"
     styled-system: "npm:5.1.5"
@@ -12807,6 +12808,7 @@ __metadata:
     server-destroy: "npm:1.0.1"
     sharp: "npm:0.34.5"
     sprintf-js: "npm:1.1.3"
+    sqlite-vec: "npm:0.1.9"
     sqlite3: "npm:5.1.6"
     string-padding: "npm:1.0.2"
     string-to-stream: "npm:3.0.1"
@@ -53924,6 +53926,65 @@ __metadata:
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
   checksum: 10/c34828732ab8509c2741e5fd1af6b767c3daf2c642f267788f933a65b1614943c282e74c4284f4fa749c264b18ee016a0d37a3e5b73aee446da46277d3a85daa
+  languageName: node
+  linkType: hard
+
+"sqlite-vec-darwin-arm64@npm:0.1.9":
+  version: 0.1.9
+  resolution: "sqlite-vec-darwin-arm64@npm:0.1.9"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"sqlite-vec-darwin-x64@npm:0.1.9":
+  version: 0.1.9
+  resolution: "sqlite-vec-darwin-x64@npm:0.1.9"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"sqlite-vec-linux-arm64@npm:0.1.9":
+  version: 0.1.9
+  resolution: "sqlite-vec-linux-arm64@npm:0.1.9"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"sqlite-vec-linux-x64@npm:0.1.9":
+  version: 0.1.9
+  resolution: "sqlite-vec-linux-x64@npm:0.1.9"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"sqlite-vec-windows-x64@npm:0.1.9":
+  version: 0.1.9
+  resolution: "sqlite-vec-windows-x64@npm:0.1.9"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"sqlite-vec@npm:0.1.9":
+  version: 0.1.9
+  resolution: "sqlite-vec@npm:0.1.9"
+  dependencies:
+    sqlite-vec-darwin-arm64: "npm:0.1.9"
+    sqlite-vec-darwin-x64: "npm:0.1.9"
+    sqlite-vec-linux-arm64: "npm:0.1.9"
+    sqlite-vec-linux-x64: "npm:0.1.9"
+    sqlite-vec-windows-x64: "npm:0.1.9"
+  dependenciesMeta:
+    sqlite-vec-darwin-arm64:
+      optional: true
+    sqlite-vec-darwin-x64:
+      optional: true
+    sqlite-vec-linux-arm64:
+      optional: true
+    sqlite-vec-linux-x64:
+      optional: true
+    sqlite-vec-windows-x64:
+      optional: true
+  checksum: 10/05a8bbc54ea5a7cc883f54772b57228c7f2288a7abad267d964e023725049b53f2652b2704ed20e36ac0d5a7038b5c1d544dfc29e5a6b9a464db95fbded02c79
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Wires the [sqlite-vec](https://github.com/asg017/sqlite-vec) SQLite extension into the desktop app's database driver. This is the foundation for the local embeddings index from the AI primitives spec — note chunks will be stored and queried via sqlite-vec once the indexing layer lands.

The extension loads automatically when the database opens on desktop and is exposed via `JoplinDatabase.sqliteVecAvailable()` so downstream code can degrade gracefully on platforms without a prebuilt. CLI, mobile, and tests without the package just see vector search reported as unavailable — nothing crashes.

No user-visible change yet.