### PR TITLE
Desktop: Fixes #15662: Reduce excessive bottom padding in Markdown editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
@@ -479,7 +479,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 			.CodeMirror-lines {
 				/* This is used to enable the scroll-past end behaviour. The same height should */
 				/* be applied to the viewer. */
-				padding-bottom: 400px !important;
+				padding-bottom: 150px !important;
 			}
 
 			/* Left padding is applied at the editor component level, so we should remove it from the lines */

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useEditorSettings.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useEditorSettings.ts
@@ -57,7 +57,7 @@ const useEditorSettings = (props: EditorSettingsProps) => {
 				marginLeft: 0,
 				marginRight: 0,
 				monospaceFont: settings.monospaceFont,
-				paddingBottom: 400,
+				paddingBottom: 150,
 			},
 			automatchBraces: settings.automatchBraces,
 			autocompleteMarkup: settings.autocompleteMarkup,

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -24,7 +24,7 @@
 		#rendered-md {
 			/* This is used to enable the scroll-past end behaviour. The same height should */
 			/* be applied to the editor. */
-			padding-bottom: 400px;
+			padding-bottom: 150px;
 		}
 
 		.mark-selected {


### PR DESCRIPTION
Fixes #15662

## Summary

Reduces the excessive bottom padding used by the Markdown editor and Markdown viewer.

The existing scroll-past-end padding was set to 400px, which created a large empty area at the bottom of notes. This change reduces the padding to 150px, matching the default effective spacing used by the Rich Text Editor (10em at the default 15px font size).

The editor and viewer padding values remain synchronized to preserve scroll synchronization and scroll-past-end behavior.

## Testing

* Tested Markdown editor with short notes
* Tested Markdown editor with long notes
* Tested Markdown viewer
* Tested split editor/viewer mode
* Verified editor/viewer scroll synchronization
* Verified scroll-past-end behavior remains functional
* Confirmed spacing is consistent with the Rich Text Editor

## Notes

* Updated CodeMirror 6 padding from 400px to 150px
* Updated CodeMirror 5 padding from 400px to 150px
* Updated Markdown viewer padding from 400px to 150px
* Mobile already uses a 150px scroll-past-end padding, improving consistency across platforms
