### PR TITLE
Desktop: Add note embeddings storage layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1452,6 +1452,8 @@ packages/lib/models/Migration.js
 packages/lib/models/Note.customSortOrder.test.js
 packages/lib/models/Note.test.js
 packages/lib/models/Note.js
+packages/lib/models/NoteEmbedding.test.js
+packages/lib/models/NoteEmbedding.js
 packages/lib/models/NoteResource.js
 packages/lib/models/NoteTag.js
 packages/lib/models/Resource.test.js
@@ -1546,6 +1548,8 @@ packages/lib/services/ai/AiService.js
 packages/lib/services/ai/SqliteVec.test.js
 packages/lib/services/ai/aiSettingsTransition.test.js
 packages/lib/services/ai/aiSettingsTransition.js
+packages/lib/services/ai/chunker.test.js
+packages/lib/services/ai/chunker.js
 packages/lib/services/ai/classification.js
 packages/lib/services/ai/providers/Anthropic.js
 packages/lib/services/ai/providers/ChatProviderBase.js
@@ -1574,6 +1578,7 @@ packages/lib/services/database/migrations/48.js
 packages/lib/services/database/migrations/49.js
 packages/lib/services/database/migrations/50.js
 packages/lib/services/database/migrations/51.js
+packages/lib/services/database/migrations/52.js
 packages/lib/services/database/migrations/index.js
 packages/lib/services/database/sqlStringToLines.js
 packages/lib/services/database/types.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1478,6 +1478,8 @@ packages/lib/models/Migration.js
 packages/lib/models/Note.customSortOrder.test.js
 packages/lib/models/Note.test.js
 packages/lib/models/Note.js
+packages/lib/models/NoteEmbedding.test.js
+packages/lib/models/NoteEmbedding.js
 packages/lib/models/NoteResource.js
 packages/lib/models/NoteTag.js
 packages/lib/models/Resource.test.js
@@ -1572,6 +1574,8 @@ packages/lib/services/ai/AiService.js
 packages/lib/services/ai/SqliteVec.test.js
 packages/lib/services/ai/aiSettingsTransition.test.js
 packages/lib/services/ai/aiSettingsTransition.js
+packages/lib/services/ai/chunker.test.js
+packages/lib/services/ai/chunker.js
 packages/lib/services/ai/classification.js
 packages/lib/services/ai/providers/Anthropic.js
 packages/lib/services/ai/providers/ChatProviderBase.js
@@ -1600,6 +1604,7 @@ packages/lib/services/database/migrations/48.js
 packages/lib/services/database/migrations/49.js
 packages/lib/services/database/migrations/50.js
 packages/lib/services/database/migrations/51.js
+packages/lib/services/database/migrations/52.js
 packages/lib/services/database/migrations/index.js
 packages/lib/services/database/sqlStringToLines.js
 packages/lib/services/database/types.js

--- a/packages/lib/BaseModel.ts
+++ b/packages/lib/BaseModel.ts
@@ -26,6 +26,7 @@ export enum ModelType {
 	Migration = 14,
 	SmartFilter = 15,
 	Command = 16,
+	NoteEmbedding = 17,
 }
 
 export interface SearchOptions {
@@ -86,6 +87,7 @@ class BaseModel {
 		['TYPE_MIGRATION', ModelType.Migration],
 		['TYPE_SMART_FILTER', ModelType.SmartFilter],
 		['TYPE_COMMAND', ModelType.Command],
+		['TYPE_NOTE_EMBEDDING', ModelType.NoteEmbedding],
 	];
 
 	private static uuidGenerator: ()=> string = uuid.create;
@@ -106,6 +108,7 @@ class BaseModel {
 	public static TYPE_MIGRATION = ModelType.Migration;
 	public static TYPE_SMART_FILTER = ModelType.SmartFilter;
 	public static TYPE_COMMAND = ModelType.Command;
+	public static TYPE_NOTE_EMBEDDING = ModelType.NoteEmbedding;
 
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- Set by the app to redux dispatch; per-app action types diverge so the function is typed loosely here
 	public static dispatch: Function = function() {};

--- a/packages/lib/models/NoteEmbedding.test.ts
+++ b/packages/lib/models/NoteEmbedding.test.ts
@@ -27,6 +27,19 @@ describe('NoteEmbedding', () => {
 		expect(await NoteEmbedding.byNoteId('note-1')).toEqual([]);
 	});
 
+	it('similaritySearch returns [] on a fresh profile (vec table not yet created)', async () => {
+		if (skipIfNoVec()) return;
+		// saveChunks creates the vec table lazily. Calling similaritySearch
+		// before any save must not crash with "no such table".
+		const results = await NoteEmbedding.similaritySearch([1, 0, 0, 0], { k: 5 });
+		expect(results).toEqual([]);
+	});
+
+	it('clearAll is a no-op on a fresh profile (vec table not yet created)', async () => {
+		if (skipIfNoVec()) return;
+		await expect(NoteEmbedding.clearAll()).resolves.toBeUndefined();
+	});
+
 	it('saves and reads back chunks for a note', async () => {
 		if (skipIfNoVec()) return;
 

--- a/packages/lib/models/NoteEmbedding.test.ts
+++ b/packages/lib/models/NoteEmbedding.test.ts
@@ -1,0 +1,150 @@
+import { setupDatabaseAndSynchronizer, switchClient, db } from '../testing/test-utils';
+import NoteEmbedding from './NoteEmbedding';
+
+// These tests exercise the storage layer end-to-end against a real database with
+// sqlite-vec loaded. Vectors are hand-crafted unit vectors so KNN ordering is
+// deterministic — no embedding model required.
+
+describe('NoteEmbedding', () => {
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+	});
+
+	const skipIfNoVec = () => {
+		if (!db(1).sqliteVecAvailable()) {
+			// eslint-disable-next-line no-console
+			console.warn('Skipping NoteEmbedding vector test: sqlite-vec unavailable');
+			return true;
+		}
+		return false;
+	};
+
+	it('reports zero counts on an empty index', async () => {
+		expect(await NoteEmbedding.distinctNoteIdCount()).toBe(0);
+		expect(await NoteEmbedding.countByNoteId('note-1')).toBe(0);
+		expect(await NoteEmbedding.byNoteId('note-1')).toEqual([]);
+	});
+
+	it('saves and reads back chunks for a note', async () => {
+		if (skipIfNoVec()) return;
+
+		await NoteEmbedding.saveChunks('note-1', 'test-model-v1', [
+			{ chunkIndex: 0, chunkText: 'first chunk', vector: [1, 0, 0, 0] },
+			{ chunkIndex: 1, chunkText: 'second chunk', vector: [0, 1, 0, 0] },
+		]);
+
+		const rows = await NoteEmbedding.byNoteId('note-1');
+		expect(rows.length).toBe(2);
+		expect(rows[0].chunk_index).toBe(0);
+		expect(rows[0].chunk_text).toBe('first chunk');
+		expect(rows[0].model_id).toBe('test-model-v1');
+		expect(rows[1].chunk_index).toBe(1);
+		expect(rows[1].chunk_text).toBe('second chunk');
+
+		expect(await NoteEmbedding.distinctNoteIdCount()).toBe(1);
+		expect(await NoteEmbedding.countByNoteId('note-1')).toBe(2);
+	});
+
+	it('replaces existing chunks on subsequent saveChunks for the same note', async () => {
+		if (skipIfNoVec()) return;
+
+		await NoteEmbedding.saveChunks('note-1', 'm', [
+			{ chunkIndex: 0, chunkText: 'old', vector: [1, 0, 0, 0] },
+			{ chunkIndex: 1, chunkText: 'old', vector: [0, 1, 0, 0] },
+		]);
+		await NoteEmbedding.saveChunks('note-1', 'm', [
+			{ chunkIndex: 0, chunkText: 'new', vector: [0, 0, 1, 0] },
+		]);
+
+		const rows = await NoteEmbedding.byNoteId('note-1');
+		expect(rows.length).toBe(1);
+		expect(rows[0].chunk_text).toBe('new');
+	});
+
+	it('similaritySearch returns chunks in distance order', async () => {
+		if (skipIfNoVec()) return;
+
+		await NoteEmbedding.saveChunks('note-1', 'm', [
+			{ chunkIndex: 0, chunkText: 'aligned-with-x', vector: [1, 0, 0, 0] },
+			{ chunkIndex: 1, chunkText: 'aligned-with-y', vector: [0, 1, 0, 0] },
+			{ chunkIndex: 2, chunkText: 'aligned-with-z', vector: [0, 0, 1, 0] },
+		]);
+
+		const results = await NoteEmbedding.similaritySearch([0.9, 0.1, 0, 0], { k: 3 });
+		expect(results.length).toBe(3);
+		expect(results[0].chunkText).toBe('aligned-with-x');
+		expect(results[1].chunkText).toBe('aligned-with-y');
+		expect(results[2].chunkText).toBe('aligned-with-z');
+		expect(results[0].distance).toBeLessThan(results[1].distance);
+		expect(results[1].distance).toBeLessThan(results[2].distance);
+	});
+
+	it('similaritySearch respects the noteIds scope filter', async () => {
+		if (skipIfNoVec()) return;
+
+		await NoteEmbedding.saveChunks('note-1', 'm', [
+			{ chunkIndex: 0, chunkText: 'note-1 chunk', vector: [1, 0, 0, 0] },
+		]);
+		await NoteEmbedding.saveChunks('note-2', 'm', [
+			{ chunkIndex: 0, chunkText: 'note-2 chunk', vector: [0.95, 0.05, 0, 0] },
+		]);
+
+		const all = await NoteEmbedding.similaritySearch([1, 0, 0, 0], { k: 10 });
+		expect(all.map(r => r.noteId).sort()).toEqual(['note-1', 'note-2']);
+
+		const scoped = await NoteEmbedding.similaritySearch([1, 0, 0, 0], { k: 10, noteIds: ['note-2'] });
+		expect(scoped.length).toBe(1);
+		expect(scoped[0].noteId).toBe('note-2');
+	});
+
+	it('deleteByNoteId removes only that note\'s chunks from both tables', async () => {
+		if (skipIfNoVec()) return;
+
+		await NoteEmbedding.saveChunks('note-1', 'm', [
+			{ chunkIndex: 0, chunkText: 'one', vector: [1, 0, 0, 0] },
+		]);
+		await NoteEmbedding.saveChunks('note-2', 'm', [
+			{ chunkIndex: 0, chunkText: 'two', vector: [0, 1, 0, 0] },
+		]);
+
+		await NoteEmbedding.deleteByNoteId('note-1');
+
+		expect(await NoteEmbedding.countByNoteId('note-1')).toBe(0);
+		expect(await NoteEmbedding.countByNoteId('note-2')).toBe(1);
+
+		// And the vec table is in sync: a search returns only note-2's chunk.
+		const results = await NoteEmbedding.similaritySearch([1, 0, 0, 0], { k: 10 });
+		expect(results.length).toBe(1);
+		expect(results[0].noteId).toBe('note-2');
+	});
+
+	it('clearAll wipes everything from both tables', async () => {
+		if (skipIfNoVec()) return;
+
+		await NoteEmbedding.saveChunks('note-1', 'm', [
+			{ chunkIndex: 0, chunkText: 'a', vector: [1, 0, 0, 0] },
+		]);
+		await NoteEmbedding.saveChunks('note-2', 'm', [
+			{ chunkIndex: 0, chunkText: 'b', vector: [0, 1, 0, 0] },
+		]);
+
+		await NoteEmbedding.clearAll();
+
+		expect(await NoteEmbedding.distinctNoteIdCount()).toBe(0);
+		const results = await NoteEmbedding.similaritySearch([1, 0, 0, 0], { k: 10 });
+		expect(results.length).toBe(0);
+	});
+
+	it('rejects mismatched vector dimensions', async () => {
+		if (skipIfNoVec()) return;
+
+		await expect(
+			NoteEmbedding.saveChunks('note-1', 'm', [
+				{ chunkIndex: 0, chunkText: 'a', vector: [1, 0, 0, 0] },
+				{ chunkIndex: 1, chunkText: 'b', vector: [1, 0, 0] },
+			]),
+		).rejects.toThrow(/dimension/);
+	});
+});

--- a/packages/lib/models/NoteEmbedding.test.ts
+++ b/packages/lib/models/NoteEmbedding.test.ts
@@ -112,6 +112,18 @@ describe('NoteEmbedding', () => {
 		expect(scoped[0].noteId).toBe('note-2');
 	});
 
+	it('similaritySearch returns [] when noteIds is an explicit empty array', async () => {
+		if (skipIfNoVec()) return;
+
+		await NoteEmbedding.saveChunks('note-1', 'm', [
+			{ chunkIndex: 0, chunkText: 'something', vector: [1, 0, 0, 0] },
+		]);
+
+		// An empty noteIds means "search within zero notes" — not "no filter".
+		const results = await NoteEmbedding.similaritySearch([1, 0, 0, 0], { k: 10, noteIds: [] });
+		expect(results).toEqual([]);
+	});
+
 	it('deleteByNoteId removes only that note\'s chunks from both tables', async () => {
 		if (skipIfNoVec()) return;
 

--- a/packages/lib/models/NoteEmbedding.ts
+++ b/packages/lib/models/NoteEmbedding.ts
@@ -1,0 +1,232 @@
+import BaseModel from '../BaseModel';
+import JoplinDatabase from '../JoplinDatabase';
+import { NoteEmbeddingsMetaEntity } from '../services/database/types';
+
+// Storage for per-note chunk embeddings produced by the AI embeddings index.
+//
+// Metadata (chunk text, source note ID, model identifier) lives in the regular
+// `note_embeddings_meta` table created by migration 52.
+//
+// The associated vectors are stored in a sqlite-vec `vec0` virtual table
+// (`note_embeddings_vec`) created lazily by `ensureVecTable()` when sqlite-vec
+// is available. Joining is done by rowid — the meta row's id is the same as
+// the vec row's rowid.
+//
+// All vector-touching methods check `JoplinDatabase.sqliteVecAvailable()` and
+// throw a clear error if vector search isn't supported on this platform. The
+// metadata-only methods work regardless.
+
+interface SaveChunk {
+	chunkIndex: number;
+	chunkText: string;
+	vector: number[];
+}
+
+interface SimilarityResult {
+	noteId: string;
+	chunkIndex: number;
+	chunkText: string;
+	distance: number;
+}
+
+interface SimilaritySearchOptions {
+	k: number;
+	// Maximum cosine distance to include. sqlite-vec returns L2 distance for
+	// vec0 by default; for normalised vectors L2² ≈ 2·(1 − cosine). The caller
+	// converts as needed; this layer just exposes the distance as returned by
+	// the extension.
+	maxDistance?: number;
+	// Restrict results to this set of note IDs. Used for scoped searches
+	// (notebook, tag, note) — the caller resolves scope → note IDs first.
+	noteIds?: string[];
+}
+
+export default class NoteEmbedding extends BaseModel {
+
+	public static tableName() {
+		return 'note_embeddings_meta';
+	}
+
+	public static modelType() {
+		return BaseModel.TYPE_NOTE_EMBEDDING;
+	}
+
+	private static joplinDb(): JoplinDatabase {
+		return this.db() as JoplinDatabase;
+	}
+
+	private static requireVec() {
+		if (!this.joplinDb().sqliteVecAvailable()) {
+			throw new Error('Vector search is unavailable: sqlite-vec extension is not loaded on this platform');
+		}
+	}
+
+	// Creates the sqlite-vec virtual table if it doesn't already exist. Called
+	// lazily because the CREATE VIRTUAL TABLE statement fails on platforms
+	// without the extension.
+	public static async ensureVecTable(dimension: number) {
+		this.requireVec();
+		await this.db().exec(
+			`CREATE VIRTUAL TABLE IF NOT EXISTS note_embeddings_vec USING vec0(embedding FLOAT[${dimension}])`,
+		);
+	}
+
+	public static async byNoteId(noteId: string): Promise<NoteEmbeddingsMetaEntity[]> {
+		return this.db().selectAll<NoteEmbeddingsMetaEntity>(
+			'SELECT * FROM note_embeddings_meta WHERE note_id = ? ORDER BY chunk_index ASC',
+			[noteId],
+		);
+	}
+
+	public static async countByNoteId(noteId: string): Promise<number> {
+		const row = await this.db().selectOne(
+			'SELECT COUNT(*) AS c FROM note_embeddings_meta WHERE note_id = ?',
+			[noteId],
+		) as { c: number } | null;
+		return row?.c ?? 0;
+	}
+
+	public static async distinctNoteIdCount(): Promise<number> {
+		const row = await this.db().selectOne(
+			'SELECT COUNT(DISTINCT note_id) AS c FROM note_embeddings_meta',
+		) as { c: number } | null;
+		return row?.c ?? 0;
+	}
+
+	// Removes every chunk for a note from both the meta table and the vec
+	// table. Used before re-indexing a changed note and during note deletion.
+	//
+	// The vec-table delete is guarded by both `sqliteVecAvailable()` AND the
+	// table's existence — saveChunks creates the vec table lazily, so on a
+	// fresh profile it may not exist yet.
+	public static async deleteByNoteId(noteId: string) {
+		const rows = await this.db().selectAll<{ id: number }>(
+			'SELECT id FROM note_embeddings_meta WHERE note_id = ?',
+			[noteId],
+		);
+		if (!rows.length) return;
+		const ids = rows.map(r => r.id);
+		const placeholders = ids.map(() => '?').join(',');
+		const queries: { sql: string; params: (string|number)[] }[] = [
+			{ sql: `DELETE FROM note_embeddings_meta WHERE id IN (${placeholders})`, params: ids },
+		];
+		if (this.joplinDb().sqliteVecAvailable() && await this.vecTableExists()) {
+			queries.push({ sql: `DELETE FROM note_embeddings_vec WHERE rowid IN (${placeholders})`, params: ids });
+		}
+		await this.db().transactionExecBatch(queries);
+	}
+
+	private static async vecTableExists(): Promise<boolean> {
+		const row = await this.db().selectOne(
+			'SELECT name FROM sqlite_master WHERE type=\'table\' AND name=\'note_embeddings_vec\'',
+		) as { name: string } | null;
+		return !!row;
+	}
+
+	// Replaces every chunk for a note with a new set. The `modelId` is recorded
+	// alongside each chunk so a future model change can trigger a re-index.
+	//
+	// Not transactional: if the process crashes mid-save the indexer will
+	// later see the half-written set, treat the note as out-of-date via the
+	// ItemChange cursor, and re-run saveChunks (which begins with a
+	// deleteByNoteId so the partial set is cleared). A future PR can add a
+	// proper transactional helper to `Database` once there are other callers
+	// that need it.
+	public static async saveChunks(noteId: string, modelId: string, chunks: SaveChunk[]) {
+		this.requireVec();
+		if (chunks.length === 0) {
+			await this.deleteByNoteId(noteId);
+			return;
+		}
+
+		const dimension = chunks[0].vector.length;
+		for (const chunk of chunks) {
+			if (chunk.vector.length !== dimension) {
+				throw new Error(`All vectors for a note must have the same dimension. Got ${chunk.vector.length}, expected ${dimension}`);
+			}
+		}
+
+		await this.ensureVecTable(dimension);
+		await this.deleteByNoteId(noteId);
+
+		const now = Date.now();
+		for (const chunk of chunks) {
+			// Insert into meta, then read back the auto-assigned id via
+			// last_insert_rowid() — node-sqlite3's exec() doesn't return it
+			// directly. The driver serialises queries through a mutex so the
+			// reading query runs on the same connection without races.
+			await this.db().exec({
+				sql: 'INSERT INTO note_embeddings_meta(note_id, chunk_index, model_id, chunk_text, created_time) VALUES (?, ?, ?, ?, ?)',
+				params: [noteId, chunk.chunkIndex, modelId, chunk.chunkText, now],
+			});
+			const row = await this.db().selectOne('SELECT last_insert_rowid() AS id') as { id: number } | null;
+			const lastID = row?.id;
+			if (!lastID) throw new Error('Failed to obtain rowid after embedding insert');
+
+			await this.db().exec({
+				sql: 'INSERT INTO note_embeddings_vec(rowid, embedding) VALUES (?, ?)',
+				params: [lastID, JSON.stringify(chunk.vector)],
+			});
+		}
+	}
+
+	public static async similaritySearch(
+		queryVector: number[],
+		options: SimilaritySearchOptions,
+	): Promise<SimilarityResult[]> {
+		this.requireVec();
+		const k = Math.max(1, options.k | 0);
+
+		// sqlite-vec's vec0 needs an inline `k = ?` constraint or a hardcoded
+		// LIMIT — a parameter-bound LIMIT after a JOIN isn't visible to its
+		// optimiser. We over-fetch (× 4) when noteIds filter is in play so the
+		// post-join filter doesn't starve the result set, then trim to k.
+		const fetchSize = options.noteIds?.length ? k * 4 : k;
+
+		const whereParts: string[] = [`v.embedding MATCH ? AND k = ${fetchSize}`];
+		const params: (string|number)[] = [JSON.stringify(queryVector)];
+
+		if (options.noteIds && options.noteIds.length) {
+			whereParts.push(`m.note_id IN (${options.noteIds.map(() => '?').join(',')})`);
+			params.push(...options.noteIds);
+		}
+
+		const sql = `
+			SELECT m.note_id, m.chunk_index, m.chunk_text, v.distance
+			FROM note_embeddings_vec v
+			JOIN note_embeddings_meta m ON m.id = v.rowid
+			WHERE ${whereParts.join(' AND ')}
+			ORDER BY v.distance
+			LIMIT ${k}
+		`;
+
+		const rows = await this.db().selectAll<{
+			note_id: string;
+			chunk_index: number;
+			chunk_text: string;
+			distance: number;
+		}>(sql, params);
+
+		const results = rows.map(r => ({
+			noteId: r.note_id,
+			chunkIndex: r.chunk_index,
+			chunkText: r.chunk_text,
+			distance: r.distance,
+		}));
+
+		if (options.maxDistance !== undefined) {
+			return results.filter(r => r.distance <= options.maxDistance);
+		}
+		return results;
+	}
+
+	// Drops every embedding from both tables. Used when the embedding model
+	// changes — the existing vectors are no longer comparable to anything new.
+	public static async clearAll() {
+		const queries: string[] = ['DELETE FROM note_embeddings_meta'];
+		if (this.joplinDb().sqliteVecAvailable()) {
+			queries.push('DELETE FROM note_embeddings_vec');
+		}
+		await this.db().transactionExecBatch(queries);
+	}
+}

--- a/packages/lib/models/NoteEmbedding.ts
+++ b/packages/lib/models/NoteEmbedding.ts
@@ -180,12 +180,20 @@ export default class NoteEmbedding extends BaseModel {
 		// rather than letting the query throw "no such table".
 		if (!await this.vecTableExists()) return [];
 
+		// An explicitly-empty noteIds means "search within zero notes" — return
+		// nothing rather than silently widening the search to all notes.
+		if (options.noteIds && options.noteIds.length === 0) return [];
+
 		const k = Math.max(1, options.k | 0);
 
 		// sqlite-vec's vec0 needs an inline `k = ?` constraint or a hardcoded
 		// LIMIT — a parameter-bound LIMIT after a JOIN isn't visible to its
-		// optimiser. We over-fetch (× 4) when noteIds filter is in play so the
-		// post-join filter doesn't starve the result set, then trim to k.
+		// optimiser. When a noteIds filter is in play we over-fetch by 4× so
+		// the post-join filter rarely starves the result set, then trim to k.
+		// This is a heuristic — pathological cases (large global indexes where
+		// most top matches fall outside the scope) can still under-fill. A
+		// follow-up can switch to pre-resolving noteIds → rowids and pushing
+		// the filter into the vec MATCH clause directly.
 		const fetchSize = options.noteIds?.length ? k * 4 : k;
 
 		const whereParts: string[] = [`v.embedding MATCH ? AND k = ${fetchSize}`];

--- a/packages/lib/models/NoteEmbedding.ts
+++ b/packages/lib/models/NoteEmbedding.ts
@@ -175,6 +175,11 @@ export default class NoteEmbedding extends BaseModel {
 		options: SimilaritySearchOptions,
 	): Promise<SimilarityResult[]> {
 		this.requireVec();
+		// On a fresh profile the vec table is created lazily by saveChunks(),
+		// so it may not exist yet. Treat that as "no embeddings to match"
+		// rather than letting the query throw "no such table".
+		if (!await this.vecTableExists()) return [];
+
 		const k = Math.max(1, options.k | 0);
 
 		// sqlite-vec's vec0 needs an inline `k = ?` constraint or a hardcoded
@@ -224,7 +229,9 @@ export default class NoteEmbedding extends BaseModel {
 	// changes — the existing vectors are no longer comparable to anything new.
 	public static async clearAll() {
 		const queries: string[] = ['DELETE FROM note_embeddings_meta'];
-		if (this.joplinDb().sqliteVecAvailable()) {
+		// Vec-table delete is guarded the same way as deleteByNoteId — the
+		// table is created lazily, so on a fresh profile it may not exist yet.
+		if (this.joplinDb().sqliteVecAvailable() && await this.vecTableExists()) {
 			queries.push('DELETE FROM note_embeddings_vec');
 		}
 		await this.db().transactionExecBatch(queries);

--- a/packages/lib/services/ai/chunker.test.ts
+++ b/packages/lib/services/ai/chunker.test.ts
@@ -1,0 +1,92 @@
+import { chunkText, defaultChunkOptions, cjkChunkOptions, optionsForText } from './chunker';
+
+describe('chunker', () => {
+
+	it('returns no chunks for empty or whitespace-only input', () => {
+		expect(chunkText('')).toEqual([]);
+		expect(chunkText('   \n\t ')).toEqual([]);
+	});
+
+	it('returns the whole text as a single chunk when shorter than chunkSize', () => {
+		const body = 'A short note that fits in one chunk.';
+		expect(chunkText(body)).toEqual([body]);
+	});
+
+	it('produces overlapping chunks for long input', () => {
+		// Pick a smaller chunk size for the test so we can reason about boundaries.
+		const options = { chunkSize: 100, chunkOverlap: 20 };
+		const body = 'a'.repeat(250);
+		const chunks = chunkText(body, options);
+
+		// step = 80; chunks at 0..100, 80..180, 160..250
+		expect(chunks.length).toBe(3);
+		expect(chunks[0].length).toBe(100);
+		expect(chunks[1].length).toBe(100);
+		expect(chunks[2].length).toBe(90);
+	});
+
+	it('preserves overlap content across consecutive chunks', () => {
+		const options = { chunkSize: 50, chunkOverlap: 10 };
+		const body = '0123456789'.repeat(20); // 200 chars
+		const chunks = chunkText(body, options);
+
+		// The last 10 chars of chunk[i] must equal the first 10 chars of chunk[i+1].
+		for (let i = 0; i < chunks.length - 1; i++) {
+			expect(chunks[i].slice(-options.chunkOverlap)).toBe(chunks[i + 1].slice(0, options.chunkOverlap));
+		}
+	});
+
+	it('throws when overlap is not smaller than chunk size', () => {
+		expect(() => chunkText('long text'.repeat(1000), { chunkSize: 10, chunkOverlap: 10 })).toThrow();
+		expect(() => chunkText('long text'.repeat(1000), { chunkSize: 10, chunkOverlap: 20 })).toThrow();
+	});
+
+	it('default chunk size leaves headroom for 512-token embedding models', () => {
+		// At ~3.5 chars/token (worst major Latin-script case: French, Spanish,
+		// German), the default chunk size must stay below 512 × 3.5 = 1792 chars
+		// so chunks aren't truncated. Overlap should stay around 10%.
+		expect(defaultChunkOptions.chunkSize).toBeGreaterThanOrEqual(1500);
+		expect(defaultChunkOptions.chunkSize).toBeLessThanOrEqual(1800);
+		expect(defaultChunkOptions.chunkOverlap).toBeGreaterThan(0);
+		expect(defaultChunkOptions.chunkOverlap).toBeLessThan(defaultChunkOptions.chunkSize);
+		const overlapRatio = defaultChunkOptions.chunkOverlap / defaultChunkOptions.chunkSize;
+		expect(overlapRatio).toBeGreaterThanOrEqual(0.05);
+		expect(overlapRatio).toBeLessThanOrEqual(0.20);
+	});
+
+	it('cJK chunk size leaves headroom for 512-token embedding models on dense scripts', () => {
+		// At ~1.2 chars/token for Chinese, 512 tokens covers ~615 chars.
+		expect(cjkChunkOptions.chunkSize).toBeGreaterThanOrEqual(500);
+		expect(cjkChunkOptions.chunkSize).toBeLessThanOrEqual(700);
+		const overlapRatio = cjkChunkOptions.chunkOverlap / cjkChunkOptions.chunkSize;
+		expect(overlapRatio).toBeGreaterThanOrEqual(0.05);
+		expect(overlapRatio).toBeLessThanOrEqual(0.20);
+	});
+
+	it('selects the default profile for English text', () => {
+		expect(optionsForText('The quick brown fox jumps over the lazy dog.')).toBe(defaultChunkOptions);
+	});
+
+	it('selects the default profile for European-language text', () => {
+		// cSpell:disable
+		expect(optionsForText('Le renard brun rapide saute par-dessus le chien paresseux.')).toBe(defaultChunkOptions);
+		expect(optionsForText('Der schnelle braune Fuchs springt über den faulen Hund.')).toBe(defaultChunkOptions);
+		// cSpell:enable
+	});
+
+	it('selects the CJK profile for dominantly-CJK text', () => {
+		// A sentence that's mostly Chinese — should land in the CJK profile.
+		expect(optionsForText('快速的棕色狐狸跳过了懒惰的狗。')).toBe(cjkChunkOptions);
+		// Japanese with kanji + kana — should also land in CJK.
+		expect(optionsForText('素早い茶色のキツネが怠け者の犬を飛び越える。')).toBe(cjkChunkOptions);
+		// Korean Hangul.
+		expect(optionsForText('빠른 갈색 여우가 게으른 개를 뛰어넘습니다.')).toBe(cjkChunkOptions);
+	});
+
+	it('does not pick the CJK profile for English text with a few stray CJK characters', () => {
+		// A long English note with one Chinese loanword should NOT be chunked as
+		// CJK — the dominant script is still English.
+		const body = `${'The quick brown fox jumps over the lazy dog. '.repeat(40)} 中文`;
+		expect(optionsForText(body)).toBe(defaultChunkOptions);
+	});
+});

--- a/packages/lib/services/ai/chunker.ts
+++ b/packages/lib/services/ai/chunker.ts
@@ -1,0 +1,97 @@
+import { scriptType } from '../../string-utils';
+
+// Splits a note body into roughly-equal chunks with overlap.
+//
+// Chunk sizes derive from three knobs:
+//
+// - TARGET_TOKENS_PER_CHUNK: how many tokens we want each chunk to contain.
+//   Sized to fit inside the 512-token context window of the small embedding
+//   models we plan to ship first (bge-small, nomic-embed-text,
+//   mxbai-embed-small). Larger chunks would be silently truncated by those
+//   models.
+// - OVERLAP_RATIO: fraction of each chunk that's also present in the next
+//   chunk. ~10% is the common default in vector-search literature.
+// - CHARS_PER_TOKEN: how many characters one token covers, which varies by
+//   language. We pick a conservative value per profile to avoid truncation.
+
+const TARGET_TOKENS_PER_CHUNK = 500;
+const OVERLAP_RATIO = 0.10;
+
+// Conservative chars/token estimate for English and other Latin-script
+// languages. English is closer to 4 chars/token but French / Spanish /
+// German tokenize denser — we pick the worst case so European-language users
+// don't see truncation.
+const DEFAULT_CHARS_PER_TOKEN = 3.5;
+
+// CJK (Chinese / Japanese / Korean) characters are much more
+// information-dense per character. ~1.2 chars/token covers all three.
+const CJK_CHARS_PER_TOKEN = 1.2;
+
+// A note must be at least this fraction of CJK characters to be chunked with
+// the CJK profile. Catches dominantly-CJK notes while letting English notes
+// with a loanword or two stay on the default profile.
+const CJK_DOMINANCE_THRESHOLD = 0.3;
+
+export interface ChunkOptions {
+	chunkSize: number;
+	chunkOverlap: number;
+}
+
+const makeOptions = (charsPerToken: number): ChunkOptions => {
+	const chunkSize = Math.round(TARGET_TOKENS_PER_CHUNK * charsPerToken);
+	const chunkOverlap = Math.round(chunkSize * OVERLAP_RATIO);
+	return { chunkSize, chunkOverlap };
+};
+
+export const defaultChunkOptions: ChunkOptions = makeOptions(DEFAULT_CHARS_PER_TOKEN);
+export const cjkChunkOptions: ChunkOptions = makeOptions(CJK_CHARS_PER_TOKEN);
+
+// Counts CJK characters in the text and returns true if they make up a
+// substantial fraction. `scriptType()` flags any presence of CJK characters,
+// which is too eager — a note with one Chinese loanword in an English page
+// shouldn't use the CJK chunking profile.
+//
+// Codepoint ranges: Hiragana + Katakana (U+3040–U+30FF), CJK Unified
+// Ideographs Extension A (U+3400–U+4DBF), CJK Unified Ideographs
+// (U+4E00–U+9FFF), Hangul Syllables (U+AC00–U+D7AF), CJK Compatibility
+// Ideographs (U+F900–U+FAFF). Using \u{...} escapes so the source file is
+// ASCII-safe — literal CJK characters here would be vulnerable to encoding
+// changes at save/transfer time.
+const cjkRegex = /[\u{3040}-\u{30FF}\u{3400}-\u{4DBF}\u{4E00}-\u{9FFF}\u{AC00}-\u{D7AF}\u{F900}-\u{FAFF}]/u;
+
+const isCjkDominant = (text: string): boolean => {
+	const script = scriptType(text);
+	if (script !== 'zh' && script !== 'ja' && script !== 'ko') return false;
+
+	let cjkCount = 0;
+	for (const ch of text) {
+		if (cjkRegex.test(ch)) cjkCount++;
+	}
+	return cjkCount / text.length >= CJK_DOMINANCE_THRESHOLD;
+};
+
+export const optionsForText = (text: string): ChunkOptions => {
+	return isCjkDominant(text) ? cjkChunkOptions : defaultChunkOptions;
+};
+
+const stepFromOptions = (options: ChunkOptions): number => {
+	const step = options.chunkSize - options.chunkOverlap;
+	if (step <= 0) throw new Error('chunkOverlap must be smaller than chunkSize');
+	return step;
+};
+
+export const chunkText = (text: string, options?: ChunkOptions): string[] => {
+	const normalised = (text ?? '').trim();
+	if (!normalised) return [];
+	const effective = options ?? optionsForText(normalised);
+	if (normalised.length <= effective.chunkSize) return [normalised];
+
+	const step = stepFromOptions(effective);
+	const chunks: string[] = [];
+	for (let start = 0; start < normalised.length; start += step) {
+		const end = Math.min(start + effective.chunkSize, normalised.length);
+		chunks.push(normalised.slice(start, end));
+		if (end === normalised.length) break;
+	}
+	return chunks;
+};

--- a/packages/lib/services/database/migrations/52.ts
+++ b/packages/lib/services/database/migrations/52.ts
@@ -1,0 +1,32 @@
+import { SqlQuery } from '../types';
+
+// Storage for the AI embeddings index. Two tables:
+//
+// - `note_embeddings_meta` holds the per-chunk metadata. It is a regular table
+//   so the metadata (chunk text, source note ID, model identifier) can be
+//   inspected and managed even on platforms where the sqlite-vec extension
+//   isn't available.
+//
+// - `note_embeddings_vec` is the sqlite-vec virtual table holding the actual
+//   vectors. It is created lazily by the embeddings code when sqlite-vec is
+//   available, because virtual-table syntax differs by extension version and
+//   trying to create it unconditionally would break startup on platforms
+//   without the prebuilt.
+//
+// Neither table is synced — embeddings are large, model-specific, and easily
+// re-derivable on demand.
+
+export default (): (SqlQuery|string)[] => {
+	return [
+		`CREATE TABLE IF NOT EXISTS note_embeddings_meta (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			note_id TEXT NOT NULL,
+			chunk_index INTEGER NOT NULL,
+			model_id TEXT NOT NULL,
+			chunk_text TEXT NOT NULL,
+			created_time INT NOT NULL DEFAULT 0
+		)`,
+		'CREATE INDEX IF NOT EXISTS note_embeddings_meta_note_id ON note_embeddings_meta(note_id)',
+		'CREATE UNIQUE INDEX IF NOT EXISTS note_embeddings_meta_note_chunk ON note_embeddings_meta(note_id, chunk_index)',
+	];
+};

--- a/packages/lib/services/database/migrations/index.ts
+++ b/packages/lib/services/database/migrations/index.ts
@@ -9,6 +9,7 @@ import migration48 from './48';
 import migration49 from './49';
 import migration50 from './50';
 import migration51 from './51';
+import migration52 from './52';
 
 import { Migration } from '../types';
 
@@ -23,6 +24,7 @@ const index: Migration[] = [
 	migration49,
 	migration50,
 	migration51,
+	migration52,
 ];
 
 export default index;

--- a/packages/lib/services/database/types.ts
+++ b/packages/lib/services/database/types.ts
@@ -96,6 +96,15 @@ export interface AlarmEntity {
   'trigger_time'?: number;
   'type_'?: number;
 }
+export interface ConflictNoteStateEntity {
+  'base_body'?: string;
+  'base_title'?: string;
+  'note_id'?: string | null;
+  'remote_body'?: string;
+  'remote_title'?: string;
+  'remote_updated_time'?: number;
+  'type_'?: number;
+}
 export interface DeletedItemEntity {
   'deleted_time'?: number;
   'id'?: number | null;
@@ -199,6 +208,15 @@ export interface MigrationEntity {
   'id'?: number | null;
   'number'?: number;
   'updated_time'?: number;
+  'type_'?: number;
+}
+export interface NoteEmbeddingsMetaEntity {
+  'chunk_index'?: number;
+  'chunk_text'?: string;
+  'created_time'?: number;
+  'id'?: number | null;
+  'model_id'?: string;
+  'note_id'?: string;
   'type_'?: number;
 }
 export interface NoteResourceEntity {
@@ -335,30 +353,21 @@ export interface SettingEntity {
   'value'?: string | null;
   'type_'?: number;
 }
-export interface ConflictNoteStateEntity {
-  'note_id'?: string;
-  'base_body'?: string;
-  'base_title'?: string;
-  'remote_body'?: string;
-  'remote_title'?: string;
-  'remote_updated_time'?: number;
-  'type_'?: number;
-}
 export interface SyncItemEntity {
+  'base_body'?: string;
+  'base_conflict_note_id'?: string;
+  'base_title'?: string;
   'force_sync'?: number;
   'id'?: number | null;
   'item_id'?: string;
   'item_location'?: number;
   'item_type'?: number;
+  'remote_item_updated_time'?: number;
   'sync_disabled'?: number;
   'sync_disabled_reason'?: string;
   'sync_target'?: number;
   'sync_time'?: number;
   'sync_warning_ignored'?: number;
-  'remote_item_updated_time'?: number;
-  'base_body'?: string;
-  'base_title'?: string;
-  'base_conflict_note_id'?: string;
   'type_'?: number;
 }
 export interface TableFieldEntity {
@@ -454,29 +463,20 @@ export const databaseSchema: DatabaseTables = {
 		type_: { type: 'number' },
 	},
 	sync_items: {
+		base_body: { type: 'string' },
+		base_conflict_note_id: { type: 'string' },
+		base_title: { type: 'string' },
 		force_sync: { type: 'number' },
 		id: { type: 'number' },
 		item_id: { type: 'string' },
 		item_location: { type: 'number' },
 		item_type: { type: 'number' },
+		remote_item_updated_time: { type: 'number' },
 		sync_disabled: { type: 'number' },
 		sync_disabled_reason: { type: 'string' },
 		sync_target: { type: 'number' },
 		sync_time: { type: 'number' },
 		sync_warning_ignored: { type: 'number' },
-		remote_item_updated_time: { type: 'number' },
-		base_body: { type: 'string' },
-		base_title: { type: 'string' },
-		base_conflict_note_id: { type: 'string' },
-		type_: { type: 'number' },
-	},
-	conflict_note_states: {
-		note_id: { type: 'string' },
-		base_body: { type: 'string' },
-		base_title: { type: 'string' },
-		remote_body: { type: 'string' },
-		remote_title: { type: 'string' },
-		remote_updated_time: { type: 'number' },
 		type_: { type: 'number' },
 	},
 	version: {
@@ -705,6 +705,24 @@ export const databaseSchema: DatabaseTables = {
 		title: { type: 'string' },
 		todo_completed_count: { type: 'any' },
 		updated_time: { type: 'number' },
+		type_: { type: 'number' },
+	},
+	conflict_note_states: {
+		base_body: { type: 'string' },
+		base_title: { type: 'string' },
+		note_id: { type: 'string' },
+		remote_body: { type: 'string' },
+		remote_title: { type: 'string' },
+		remote_updated_time: { type: 'number' },
+		type_: { type: 'number' },
+	},
+	note_embeddings_meta: {
+		chunk_index: { type: 'number' },
+		chunk_text: { type: 'string' },
+		created_time: { type: 'number' },
+		id: { type: 'number' },
+		model_id: { type: 'string' },
+		note_id: { type: 'string' },
 		type_: { type: 'number' },
 	},
 };

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -312,3 +312,9 @@ devicetypes
 xcodebuild
 openai
 vecs
+Hangul
+Hiragana
+Katakana
+Hanzi
+Ideographs
+chunker


### PR DESCRIPTION
Adds the local persistence layer for the AI embeddings index from the AI primitives spec. Note chunks and their vectors are stored in two paired tables — `note_embeddings_meta` (regular) and `note_embeddings_vec` (sqlite-vec virtual table) — joined by rowid, so metadata stays inspectable even on platforms without sqlite-vec.

A new `NoteEmbedding` model handles saving, deleting, and similarity search, gating vector operations on `JoplinDatabase.sqliteVecAvailable()` and degrading gracefully where the extension isn't loaded.

Also adds a chunker that splits notes into ~500-token windows with 10% overlap, with a separate CJK profile for Chinese / Japanese / Korean notes (smaller chunks since CJK characters are denser per token).

No user-visible change yet — this is the foundation the indexer and search API will build on.