### PR TITLE
All: Improve how resource filenames are determined

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1433,6 +1433,7 @@ packages/lib/models/utils/paginatedFeed.js
 packages/lib/models/utils/paginationToSql.js
 packages/lib/models/utils/readOnly.test.js
 packages/lib/models/utils/readOnly.js
+packages/lib/models/utils/resourceUtils.test.js
 packages/lib/models/utils/resourceUtils.js
 packages/lib/models/utils/types.js
 packages/lib/models/utils/userData.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -1406,6 +1406,7 @@ packages/lib/models/utils/paginatedFeed.js
 packages/lib/models/utils/paginationToSql.js
 packages/lib/models/utils/readOnly.test.js
 packages/lib/models/utils/readOnly.js
+packages/lib/models/utils/resourceUtils.test.js
 packages/lib/models/utils/resourceUtils.js
 packages/lib/models/utils/types.js
 packages/lib/models/utils/userData.test.js

--- a/packages/lib/models/utils/resourceUtils.test.ts
+++ b/packages/lib/models/utils/resourceUtils.test.ts
@@ -1,0 +1,18 @@
+import { resourceFilename } from './resourceUtils';
+
+describe('resourceUtils', () => {
+	it.each([
+		{
+			id: 'this/is a test',
+			mime: 'text/plain',
+			expected: 'this_is_a_test.txt',
+		},
+		{
+			id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+			mime: 'application/json',
+			expected: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json',
+		},
+	])('should correctly determine resource filenames (case %#)', ({ id, mime, expected }) => {
+		expect(resourceFilename({ id, mime })).toBe(expected);
+	});
+});

--- a/packages/lib/models/utils/resourceUtils.ts
+++ b/packages/lib/models/utils/resourceUtils.ts
@@ -1,6 +1,6 @@
 import type { ResourceEntity } from '../../services/database/types';
 import * as mime from '../../mime-utils';
-import { filename } from '@joplin/utils/path';
+import { filename, safeFileExtension } from '@joplin/utils/path';
 
 // This file contains resource-related utilities that do not
 // depend on the database, settings, etc.
@@ -8,7 +8,7 @@ import { filename } from '@joplin/utils/path';
 export const resourceFilename = (resource: ResourceEntity, encryptedBlob = false) => {
 	let extension = encryptedBlob ? 'crypted' : resource.file_extension;
 	if (!extension) extension = resource.mime ? mime.toFileExtension(resource.mime) : '';
-	extension = extension ? `.${extension}` : '';
+	extension = extension ? `.${safeFileExtension(extension)}` : '';
 	// Resource IDs should contain only alphanumeric characters
 	const idComponent = resource.id.replace(/[^a-zA-Z0-9]/g, '_');
 	return idComponent + extension;

--- a/packages/lib/models/utils/resourceUtils.ts
+++ b/packages/lib/models/utils/resourceUtils.ts
@@ -9,7 +9,9 @@ export const resourceFilename = (resource: ResourceEntity, encryptedBlob = false
 	let extension = encryptedBlob ? 'crypted' : resource.file_extension;
 	if (!extension) extension = resource.mime ? mime.toFileExtension(resource.mime) : '';
 	extension = extension ? `.${extension}` : '';
-	return resource.id + extension;
+	// Resource IDs should contain only alphanumeric characters
+	const idComponent = resource.id.replace(/[^a-zA-Z0-9]/g, '_');
+	return idComponent + extension;
 };
 
 export const resourceRelativePath = (resource: ResourceEntity, relativeResourceDirPath: string, encryptedBlob = false) => {


### PR DESCRIPTION
# Summary

Removes invalid characters from resource filenames (which are computed from resource IDs).

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
