### PR TITLE
All: Resolves #15597: Add note lock backend path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1651,6 +1651,11 @@ packages/lib/services/noteList/renderTemplate.js
 packages/lib/services/noteList/renderViewProps.test.js
 packages/lib/services/noteList/renderViewProps.js
 packages/lib/services/noteList/renderers.js
+packages/lib/services/noteLock/NoteLockKey.js
+packages/lib/services/noteLock/NoteLockNote.js
+packages/lib/services/noteLock/NoteLockService.test.js
+packages/lib/services/noteLock/NoteLockService.js
+packages/lib/services/noteLock/isNoteLockEnabled.js
 packages/lib/services/ocr/OcrDriverBase.js
 packages/lib/services/ocr/OcrService.test.js
 packages/lib/services/ocr/OcrService.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1677,6 +1677,11 @@ packages/lib/services/noteList/renderTemplate.js
 packages/lib/services/noteList/renderViewProps.test.js
 packages/lib/services/noteList/renderViewProps.js
 packages/lib/services/noteList/renderers.js
+packages/lib/services/noteLock/NoteLockKey.js
+packages/lib/services/noteLock/NoteLockNote.js
+packages/lib/services/noteLock/NoteLockService.test.js
+packages/lib/services/noteLock/NoteLockService.js
+packages/lib/services/noteLock/isNoteLockEnabled.js
 packages/lib/services/ocr/OcrDriverBase.js
 packages/lib/services/ocr/OcrService.test.js
 packages/lib/services/ocr/OcrService.js

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -70,6 +70,8 @@ import NavService from './services/NavService';
 import getAppName from './getAppName';
 import PerformanceLogger from './PerformanceLogger';
 import Synchronizer from './Synchronizer';
+import NoteLockKey from './services/noteLock/NoteLockKey';
+import NoteLockService from './services/noteLock/NoteLockService';
 
 const appLogger: LoggerWrapper = Logger.create('App');
 const perfLogger = PerformanceLogger.create();
@@ -134,6 +136,8 @@ export default class BaseApplication {
 		ResourceService.isRunningInBackground_ = false;
 		// ResourceService.isRunningInBackground_ = false;
 		ResourceFetcher.instance_ = null;
+		NoteLockKey.destroyInstance();
+		NoteLockService.destroyInstance();
 		EncryptionService.instance_ = null;
 		DecryptionWorker.instance_ = null;
 

--- a/packages/lib/models/Note.test.ts
+++ b/packages/lib/models/Note.test.ts
@@ -1,8 +1,8 @@
-import Setting from './Setting';
+import Setting, { Env } from './Setting';
 import BaseModel from '../BaseModel';
 import shim from '../shim';
 import markdownUtils from '../markdownUtils';
-import { sortedIds, createNTestNotes, expectThrow, setupDatabaseAndSynchronizer, switchClient, checkThrowAsync, supportDir, expectNotThrow, simulateReadOnlyShareEnv, msleep, db } from '../testing/test-utils';
+import { sortedIds, createNTestNotes, expectThrow, setupDatabaseAndSynchronizer, switchClient, checkThrowAsync, supportDir, expectNotThrow, simulateReadOnlyShareEnv, msleep, db, encryptionService, revisionService } from '../testing/test-utils';
 import Folder from './Folder';
 import Note from './Note';
 import Tag from './Tag';
@@ -21,6 +21,9 @@ import { getTrashFolderId } from '../services/trash';
 import getConflictFolderId from './utils/getConflictFolderId';
 import Revision from './Revision';
 import RevisionService from '../services/RevisionService';
+import NoteLockKey from '../services/noteLock/NoteLockKey';
+import NoteLockService from '../services/noteLock/NoteLockService';
+import EncryptionService from '../services/e2ee/EncryptionService';
 
 async function allItems() {
 	const folders = await Folder.all();
@@ -32,6 +35,9 @@ describe('models/Note', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);
+		NoteLockKey.destroyInstance();
+		NoteLockService.destroyInstance();
+		EncryptionService.instance_ = encryptionService();
 	});
 
 	it('should find resource and note IDs', (async () => {
@@ -241,6 +247,117 @@ describe('models/Note', () => {
 	it('should include lock state in preview fields', () => {
 		expect(Note.previewFields()).toContain('is_locked');
 		expect(Note.previewFields()).not.toContain('extracted_resource_ids');
+	});
+
+	it('should store note lock ciphertext while decrypting only gated loads', async () => {
+		await NoteLockKey.instance().create('123456');
+		const resourceId1 = '06894e83b8f84d3d8cbe0f1587f9e226';
+		const resourceId2 = '06894e83b8f84d3d8cbe0f1587f9e227';
+		const plainTextBody = `secret [](:/${resourceId1}) [](:/${resourceId2})`;
+
+		const note = await Note.save({
+			body: plainTextBody,
+			is_locked: 1,
+		}, { useNoteLock: true });
+		const storedNote = await Note.load(note.id);
+
+		expect(storedNote.body).not.toBe(plainTextBody);
+		expect(storedNote.extracted_resource_ids).toBe(`${resourceId1},${resourceId2}`);
+		expect((await Note.load(note.id, { useNoteLock: true })).body).toBe(plainTextBody);
+
+		await expect(Note.load(note.id, { fields: ['id', 'is_locked'], useNoteLock: true })).rejects.toThrow();
+		await expect(Note.load(note.id, { fields: ['id', 'body'], useNoteLock: true })).rejects.toThrow('Gated note lock load with body is missing lock state');
+
+		await Note.save(await Note.load(note.id, { useNoteLock: true }), { useNoteLock: true });
+		expect((await Note.load(note.id)).body).not.toBe(plainTextBody);
+		expect((await Note.load(note.id, { useNoteLock: true })).body).toBe(plainTextBody);
+
+		await expect(Note.save({
+			id: note.id,
+			body: 'must not be stored',
+		}, { useNoteLock: true })).rejects.toThrow('Gated note lock save is missing lock state');
+		expect((await Note.load(note.id, { useNoteLock: true })).body).toBe(plainTextBody);
+
+		await Note.save({
+			...await Note.load(note.id, { useNoteLock: true }),
+			body: `${plainTextBody} edited`,
+		}, { useNoteLock: true });
+		expect((await Note.load(note.id, { useNoteLock: true })).body).toBe(`${plainTextBody} edited`);
+
+		await Note.save({
+			...await Note.load(note.id, { useNoteLock: true }),
+			body: 'unlocked',
+			is_locked: 0,
+		}, { useNoteLock: true });
+		const unlockedNote = await Note.load(note.id);
+		expect(unlockedNote.body).toBe('unlocked');
+		expect(unlockedNote.extracted_resource_ids).toBe('');
+	});
+
+	it('should not decrypt locked notes while the feature is disabled', async () => {
+		await NoteLockKey.instance().create('123456');
+		const note = await Note.save({
+			body: 'secret',
+			is_locked: 1,
+		}, { useNoteLock: true });
+
+		Setting.setConstant('env', Env.Prod);
+		try {
+			expect((await Note.load(note.id, { useNoteLock: true })).body).toBe(note.body);
+		} finally {
+			Setting.setConstant('env', Env.Dev);
+		}
+	});
+
+	it('should fail closed when note lock encryption cannot decrypt or encrypt', async () => {
+		const noteLockKey = NoteLockKey.instance();
+		await noteLockKey.create('123456');
+		const note = await Note.save({
+			body: 'secret',
+			is_locked: 1,
+		}, { useNoteLock: true });
+
+		noteLockKey.lock();
+		await expect(Note.save({
+			body: 'must not be stored',
+			is_locked: 1,
+		}, { useNoteLock: true })).rejects.toThrow('Note lock key is not unlocked');
+		expect(await Note.all()).toHaveLength(1);
+
+		await noteLockKey.unlock('123456');
+		const corruptedBody = `${note.body}invalid`;
+		await db().exec('UPDATE notes SET body = ? WHERE id = ?', [corruptedBody, note.id]);
+		await expect(Note.load(note.id, { useNoteLock: true })).rejects.toThrow();
+		expect((await Note.load(note.id)).body).toBe(corruptedBody);
+
+		const incompleteBody = note.body.slice(0, -1);
+		await db().exec('UPDATE notes SET body = ? WHERE id = ?', [incompleteBody, note.id]);
+		await expect(Note.load(note.id, { useNoteLock: true })).rejects.toThrow();
+		expect((await Note.load(note.id)).body).toBe(incompleteBody);
+	});
+
+	it('should clear plaintext revision data when locking a note', async () => {
+		const note = await Note.save({ body: 'plain text' });
+		await Note.save({ id: note.id, body: 'updated plain text' });
+		await revisionService().collectRevisions();
+		expect(await Revision.countRevisions(Note.modelType(), note.id)).toBe(1);
+		const encryptedRevision = await Revision.save({
+			item_type: Note.modelType(),
+			item_id: note.id,
+			item_updated_time: Date.now(),
+			is_locked: 1,
+		});
+
+		await NoteLockKey.instance().create('123456');
+		await Note.save({
+			...await Note.load(note.id),
+			is_locked: 1,
+		}, { useNoteLock: true });
+
+		expect(await Revision.countRevisions(Note.modelType(), note.id)).toBe(1);
+		expect(await Revision.load(encryptedRevision.id)).toBeTruthy();
+		await ItemChange.waitForAllSaved();
+		expect(await ItemChange.oldNoteContent(note.id)).toBe(null);
 	});
 
 	it('should reset fields for a duplicate', (async () => {

--- a/packages/lib/models/Note.test.ts
+++ b/packages/lib/models/Note.test.ts
@@ -266,7 +266,7 @@ describe('models/Note', () => {
 		expect((await Note.load(note.id, { useNoteLock: true })).body).toBe(plainTextBody);
 
 		await expect(Note.load(note.id, { fields: ['id', 'is_locked'], useNoteLock: true })).rejects.toThrow();
-		await expect(Note.load(note.id, { fields: ['id', 'body'], useNoteLock: true })).rejects.toThrow('Gated note lock load with body is missing lock state');
+		await expect(Note.load(note.id, { fields: ['id', 'body'], useNoteLock: true })).rejects.toThrow('Gated note lock load is missing lock state');
 
 		await Note.save(await Note.load(note.id, { useNoteLock: true }), { useNoteLock: true });
 		expect((await Note.load(note.id)).body).not.toBe(plainTextBody);

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -783,7 +783,7 @@ export default class Note extends BaseItem {
 
 	public static async load(id: string, options: LoadOptions = null): Promise<NoteEntity> {
 		const note = await super.load(id, options);
-		if (isNoteLockEnabled() && !!options?.useNoteLock) await NoteLockNote.decryptBody(note);
+		if (isNoteLockEnabled() && !!options?.useNoteLock) return NoteLockNote.decryptBody(note);
 		return note;
 	}
 

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -26,6 +26,8 @@ import { resolveFileRef, RefKind } from '../services/whiteboard/resolveRef';
 const { isImageMimeType } = require('../resourceUtils');
 import { MarkupToHtml } from '@joplin/renderer';
 import { ALL_NOTES_FILTER_ID } from '../reserved-ids';
+import NoteLockNote from '../services/noteLock/NoteLockNote';
+import isNoteLockEnabled from '../services/noteLock/isNoteLockEnabled';
 
 export interface PreviewsOrder {
 	by: string;
@@ -779,8 +781,10 @@ export default class Note extends BaseItem {
 		return n.updated_time < date;
 	}
 
-	public static load(id: string, options: LoadOptions = null): Promise<NoteEntity> {
-		return super.load(id, options);
+	public static async load(id: string, options: LoadOptions = null): Promise<NoteEntity> {
+		const note = await super.load(id, options);
+		if (isNoteLockEnabled() && !!options?.useNoteLock) await NoteLockNote.decryptBody(note, options?.fields);
+		return note;
 	}
 
 	public static async save(o: NoteEntity, options: SaveOptions = null): Promise<NoteEntity> {
@@ -824,6 +828,9 @@ export default class Note extends BaseItem {
 		// we should set beforeNoteJson to the current contents in the database, or the last value which was stored
 		// in the item_changes table
 		const oldNote = !isNew && o.id ? await Note.load(o.id) : null;
+		if (isNoteLockEnabled() && !!options?.useNoteLock) {
+			await NoteLockNote.prepareForSave(o, this.linkedItemIds, isNew);
+		}
 
 		syncDebugLog.info('Save Note: P:', oldNote);
 
@@ -832,7 +839,9 @@ export default class Note extends BaseItem {
 		// has just been downloaded from the sync target and save is invoked when the note has not yet been decrypted
 		if (oldNote && !oldNote.encryption_applied) {
 			const changedSinceCollection = this.revisionService().changedSinceCollection(o.id);
-			if (changedSinceCollection) {
+			if (isNoteLockEnabled() && NoteLockNote.isLocked(o)) {
+				beforeNoteJson = null;
+			} else if (changedSinceCollection) {
 				beforeNoteJson = await ItemChange.oldNoteContent(o.id);
 			} else {
 				beforeNoteJson = JSON.stringify(oldNote);
@@ -853,6 +862,11 @@ export default class Note extends BaseItem {
 		syncDebugLog.info('Save Note: N:', o);
 
 		let savedNote = await super.save(o, options);
+
+		if (isNoteLockEnabled() && !!options?.useNoteLock && NoteLockNote.isLocking(o, oldNote)) {
+			await ItemChange.waitForAllSaved();
+			await this.revisionService().deleteUnencryptedHistoryForNote(savedNote.id, { sourceDescription: 'Note.save: note lock' });
+		}
 
 		void ItemChange.add(BaseModel.TYPE_NOTE, savedNote.id, isNew ? ItemChange.TYPE_CREATE : ItemChange.TYPE_UPDATE, {
 			changeSource, changeId: options?.changeId, beforeChangeItemJson: beforeNoteJson,

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -783,7 +783,7 @@ export default class Note extends BaseItem {
 
 	public static async load(id: string, options: LoadOptions = null): Promise<NoteEntity> {
 		const note = await super.load(id, options);
-		if (isNoteLockEnabled() && !!options?.useNoteLock) await NoteLockNote.decryptBody(note, options?.fields);
+		if (isNoteLockEnabled() && !!options?.useNoteLock) await NoteLockNote.decryptBody(note);
 		return note;
 	}
 

--- a/packages/lib/models/Revision.ts
+++ b/packages/lib/models/Revision.ts
@@ -407,6 +407,18 @@ export default class Revision extends BaseItem {
 		await this.batchDelete(revisions.map(item => item.id), options);
 	}
 
+	// Same as deleteHistoryForNote, but keeps locked revisions when clearing plaintext history during note locking.
+	public static async deleteUnencryptedHistoryForNote(noteIds: string | string[], options: DeleteOptions) {
+		const ids = Array.isArray(noteIds) ? noteIds : [noteIds];
+
+		const revisions: RevisionEntity[] = await this.modelSelectAll(
+			`SELECT id FROM revisions WHERE item_type = ? AND item_id in (${this.escapeIdsForSql(ids)}) AND is_locked = 0 ORDER BY item_updated_time DESC`,
+			[ModelType.Note],
+		);
+
+		await this.batchDelete(revisions.map(item => item.id), options);
+	}
+
 	public static async revisionExists(itemType: ModelType, itemId: string, updatedTime: number) {
 		const existingRev = await Revision.latestRevision(itemType, itemId);
 		return existingRev && existingRev.item_updated_time === updatedTime;

--- a/packages/lib/models/utils/types.ts
+++ b/packages/lib/models/utils/types.ts
@@ -31,6 +31,7 @@ export interface LoadOptions {
 	limit?: number;
 	includeConflicts?: boolean;
 	includeDeleted?: boolean;
+	useNoteLock?: boolean;
 }
 
 export interface FolderLoadOptions extends LoadOptions {
@@ -50,6 +51,7 @@ export interface SaveOptions {
 	dispatchUpdateAction?: boolean;
 	dispatchOptions?: { preserveSelection: boolean };
 	disableReadOnlyCheck?: boolean;
+	useNoteLock?: boolean;
 
 	changeSource?: number;
 

--- a/packages/lib/services/RevisionService.ts
+++ b/packages/lib/services/RevisionService.ts
@@ -372,10 +372,19 @@ export default class RevisionService extends BaseService {
 	public async deleteHistoryForNote(noteIds: string | string[], options: DeleteOptions) {
 		const ids = Array.isArray(noteIds) ? noteIds : [noteIds];
 		await Revision.deleteHistoryForNote(ids, options);
+		await this.resetHistoryState_(ids);
+	}
 
+	public async deleteUnencryptedHistoryForNote(noteIds: string | string[], options: DeleteOptions) {
+		const ids = Array.isArray(noteIds) ? noteIds : [noteIds];
+		await Revision.deleteUnencryptedHistoryForNote(ids, options);
+		await this.resetHistoryState_(ids);
+	}
+
+	private async resetHistoryState_(noteIds: string[]) {
 		// Clear any cached content in the item_changes table and reset the state of the note in the revision service, to ensure that any new revisions created
 		// upon revision collection do not include contents which were present prior to triggering the deletion
-		for (const noteId of ids) {
+		for (const noteId of noteIds) {
 			await ItemChange.resetOldNoteContent(noteId);
 			RevisionService.instance().removeChangedSinceCollection(noteId);
 		}

--- a/packages/lib/services/e2ee/EncryptionService.test.ts
+++ b/packages/lib/services/e2ee/EncryptionService.test.ts
@@ -162,6 +162,27 @@ describe('services_EncryptionService', () => {
 		expect(plainText2 === veryLongSecret).toBe(true);
 	}));
 
+	it('should encrypt and decrypt with a supplied decrypted master key', (async () => {
+		let masterKey = await service.generateMasterKey('123456');
+		masterKey = await MasterKey.save(masterKey);
+		const decryptedMasterKey = await service.decryptMasterKeyContent(masterKey, '123456');
+		const options = {
+			masterKeyId: masterKey.id,
+			decryptedMasterKey,
+		};
+
+		expect(service.loadedMasterKeysCount()).toBe(0);
+
+		const cipherText = await service.encryptString('some secret', options);
+		expect(await service.decryptString(cipherText, options)).toBe('some secret');
+		expect(service.loadedMasterKeysCount()).toBe(0);
+
+		await expect(service.decryptString(cipherText, {
+			...options,
+			masterKeyId: '01234568abcdefgh01234568abcdefgh',
+		})).rejects.toThrow('Supplied master key ID does not match encrypted content');
+	}));
+
 	it('should decrypt various encryption methods', (async () => {
 		let masterKey = await service.generateMasterKey('123456');
 		masterKey = await MasterKey.save(masterKey);

--- a/packages/lib/services/e2ee/EncryptionService.ts
+++ b/packages/lib/services/e2ee/EncryptionService.ts
@@ -53,6 +53,7 @@ export interface EncryptOptions {
 	onProgress?: (event: { doneSize: number })=> void;
 	encryptionHandler?: EncryptionCustomHandler;
 	masterKeyId?: string;
+	decryptedMasterKey?: string;
 }
 
 type GetPasswordCallback = ()=> string|Promise<string>;
@@ -581,7 +582,7 @@ export default class EncryptionService {
 
 		const method = options.encryptionMethod;
 		const masterKeyId = options.masterKeyId ? options.masterKeyId : this.activeMasterKeyId();
-		const masterKeyPlainText = (await this.loadedMasterKey(masterKeyId)).plainText;
+		const masterKeyPlainText = await this.masterKeyPlainText_(masterKeyId, options);
 		const chunkSize = this.chunkSize(method);
 		const crypto = shim.crypto;
 
@@ -618,7 +619,7 @@ export default class EncryptionService {
 		if (!options) options = {};
 
 		const header = await this.decodeHeaderSource_(source) as { encryptionMethod: number; masterKeyId: string };
-		const masterKeyPlainText = (await this.loadedMasterKey(header.masterKeyId)).plainText;
+		const masterKeyPlainText = await this.masterKeyPlainText_(header.masterKeyId, options);
 
 		let doneSize = 0;
 
@@ -639,6 +640,14 @@ export default class EncryptionService {
 			const plainText = await this.decrypt(header.encryptionMethod, masterKeyPlainText, block);
 			await destination.append(plainText);
 		}
+	}
+
+	private async masterKeyPlainText_(masterKeyId: string, options: EncryptOptions) {
+		if (options.decryptedMasterKey !== undefined) {
+			if (options.masterKeyId !== masterKeyId) throw new Error(`Supplied master key ID does not match encrypted content: ${masterKeyId}`);
+			return options.decryptedMasterKey;
+		}
+		return (await this.loadedMasterKey(masterKeyId)).plainText;
 	}
 
 	private stringReader_(string: string, sync = false) {

--- a/packages/lib/services/noteLock/NoteLockKey.ts
+++ b/packages/lib/services/noteLock/NoteLockKey.ts
@@ -1,0 +1,103 @@
+import uuid from '../../uuid';
+import EncryptionService from '../e2ee/EncryptionService';
+import { MasterKeyEntity } from '../e2ee/types';
+import { localSyncInfo, saveLocalSyncInfo } from '../synchronizer/syncInfoUtils';
+
+interface DecryptedNoteLockKey {
+	id: string;
+	plainText: string;
+}
+
+export default class NoteLockKey {
+
+	public static instance_: NoteLockKey = null;
+
+	private decryptedKey_: string = null;
+	private keyId_: string = null;
+	private unlockExpiryTimestamp_: number = null;
+
+	private constructor(private encryptionService_: EncryptionService = EncryptionService.instance()) {}
+
+	public static instance() {
+		if (!this.instance_) {
+			this.instance_ = new NoteLockKey();
+		}
+		return this.instance_;
+	}
+
+	public static destroyInstance() {
+		this.instance_?.lock();
+		this.instance_ = null;
+	}
+
+	public load(): MasterKeyEntity {
+		return localSyncInfo().noteLockKey;
+	}
+
+	public save(o: MasterKeyEntity): MasterKeyEntity {
+		const key = { ...o };
+		if (!key.id) {
+			key.id = uuid.create();
+			key.created_time = Date.now();
+		}
+		key.updated_time = Date.now();
+
+		const syncInfo = localSyncInfo();
+		syncInfo.noteLockKey = key;
+		saveLocalSyncInfo(syncInfo);
+
+		if (this.keyId_ && this.keyId_ !== key.id) this.lock();
+
+		return key;
+	}
+
+	public async create(password: string, unlockExpiryTimestamp: number = null) {
+		if (this.load()) throw new Error('Note lock key already exists');
+		return this.createNewKey_(password, unlockExpiryTimestamp);
+	}
+
+	public async reset(password: string, unlockExpiryTimestamp: number = null) {
+		return this.createNewKey_(password, unlockExpiryTimestamp);
+	}
+
+	public async unlock(password: string, unlockExpiryTimestamp: number = null) {
+		const key = this.load();
+		if (!key) throw new Error('Note lock key has not been created');
+		if (!key.id) throw new Error('Note lock key does not have an ID');
+
+		const decryptedKey = await this.encryptionService_.decryptMasterKeyContent(key, password);
+		this.keyId_ = key.id;
+		this.decryptedKey_ = decryptedKey;
+		this.unlockExpiryTimestamp_ = unlockExpiryTimestamp;
+	}
+
+	public lock() {
+		this.keyId_ = null;
+		this.decryptedKey_ = null;
+		this.unlockExpiryTimestamp_ = null;
+	}
+
+	public isUnlocked() {
+		this.invalidateExpiredKey_();
+		if (this.keyId_ && this.keyId_ !== this.load()?.id) this.lock();
+		return !!this.decryptedKey_;
+	}
+
+	public decryptedKey(): DecryptedNoteLockKey {
+		if (!this.isUnlocked()) throw new Error('Note lock key is not unlocked');
+		return {
+			id: this.keyId_,
+			plainText: this.decryptedKey_,
+		};
+	}
+
+	private async createNewKey_(password: string, unlockExpiryTimestamp: number = null) {
+		const key = this.save(await this.encryptionService_.generateMasterKey(password));
+		await this.unlock(password, unlockExpiryTimestamp);
+		return key;
+	}
+
+	private invalidateExpiredKey_() {
+		if (this.unlockExpiryTimestamp_ !== null && this.unlockExpiryTimestamp_ <= Date.now()) this.lock();
+	}
+}

--- a/packages/lib/services/noteLock/NoteLockNote.ts
+++ b/packages/lib/services/noteLock/NoteLockNote.ts
@@ -1,0 +1,46 @@
+import { NoteEntity } from '../database/types';
+import NoteLockService from './NoteLockService';
+
+const linkedItemIdPattern = /^[a-f0-9]{32}$/;
+
+export default class NoteLockNote {
+
+	public static isLocked(note: NoteEntity): boolean {
+		if (!note) return false;
+		return !!note.is_locked;
+	}
+
+	public static isLocking(note: NoteEntity, oldNote: NoteEntity): boolean {
+		if (!oldNote) return false;
+		return this.isLocked(note) && !oldNote.is_locked;
+	}
+
+	public static async decryptBody(note: NoteEntity, fields?: string | string[]) {
+		if (this.hasField_(fields, 'body') && !this.hasField_(fields, 'is_locked')) throw new Error('Gated note lock load with body is missing lock state');
+		if (this.isLocked(note)) {
+			// A missing body here means the gated load did not request enough fields, so pass an empty string and let decryption fail explicitly.
+			note.body = await NoteLockService.instance().decryptString(note.body ?? '');
+		}
+	}
+
+	public static async prepareForSave(note: NoteEntity, linkedItemIds: (body: string)=> string[], isNew: boolean) {
+		if (!note) return;
+		// Gated saves for existing notes should be based on a loaded note, so missing lock state is a logic error.
+		if (note.is_locked === undefined && !isNew) throw new Error('Gated note lock save is missing lock state');
+		const isLocked = this.isLocked(note);
+		if (!isLocked) note.extracted_resource_ids = '';
+		if (note.body === undefined) return;
+
+		const plainTextBody = note.body ?? '';
+		if (isLocked) {
+			note.extracted_resource_ids = linkedItemIds(plainTextBody).filter(id => linkedItemIdPattern.test(id)).join(',');
+			note.body = await NoteLockService.instance().encryptString(plainTextBody);
+		}
+	}
+
+	private static hasField_(fields: string | string[], fieldName: string) {
+		if (!fields) return false;
+		if (typeof fields === 'string') return fields === fieldName;
+		return fields.includes(fieldName);
+	}
+}

--- a/packages/lib/services/noteLock/NoteLockNote.ts
+++ b/packages/lib/services/noteLock/NoteLockNote.ts
@@ -1,7 +1,6 @@
 import { NoteEntity } from '../database/types';
+import isItemId from '../../models/utils/isItemId';
 import NoteLockService from './NoteLockService';
-
-const linkedItemIdPattern = /^[a-f0-9]{32}$/;
 
 export default class NoteLockNote {
 
@@ -33,7 +32,7 @@ export default class NoteLockNote {
 
 		const plainTextBody = note.body ?? '';
 		if (isLocked) {
-			note.extracted_resource_ids = linkedItemIds(plainTextBody).filter(id => linkedItemIdPattern.test(id)).join(',');
+			note.extracted_resource_ids = linkedItemIds(plainTextBody).filter(id => !!isItemId(id)).join(',');
 			note.body = await NoteLockService.instance().encryptString(plainTextBody);
 		}
 	}

--- a/packages/lib/services/noteLock/NoteLockNote.ts
+++ b/packages/lib/services/noteLock/NoteLockNote.ts
@@ -15,8 +15,9 @@ export default class NoteLockNote {
 		return this.isLocked(note) && !oldNote.is_locked;
 	}
 
-	public static async decryptBody(note: NoteEntity, fields?: string | string[]) {
-		if (this.hasField_(fields, 'body') && !this.hasField_(fields, 'is_locked')) throw new Error('Gated note lock load with body is missing lock state');
+	public static async decryptBody(note: NoteEntity) {
+		if (!note) throw new Error('Gated note lock load is missing note');
+		if (note.is_locked === undefined) throw new Error('Gated note lock load is missing lock state');
 		if (this.isLocked(note)) {
 			// A missing body here means the gated load did not request enough fields, so pass an empty string and let decryption fail explicitly.
 			note.body = await NoteLockService.instance().decryptString(note.body ?? '');
@@ -24,23 +25,16 @@ export default class NoteLockNote {
 	}
 
 	public static async prepareForSave(note: NoteEntity, linkedItemIds: (body: string)=> string[], isNew: boolean) {
-		if (!note) return;
+		if (!note) throw new Error('Gated note lock save is missing note');
 		// Gated saves for existing notes should be based on a loaded note, so missing lock state is a logic error.
 		if (note.is_locked === undefined && !isNew) throw new Error('Gated note lock save is missing lock state');
 		const isLocked = this.isLocked(note);
 		if (!isLocked) note.extracted_resource_ids = '';
-		if (note.body === undefined) return;
 
 		const plainTextBody = note.body ?? '';
 		if (isLocked) {
 			note.extracted_resource_ids = linkedItemIds(plainTextBody).filter(id => linkedItemIdPattern.test(id)).join(',');
 			note.body = await NoteLockService.instance().encryptString(plainTextBody);
 		}
-	}
-
-	private static hasField_(fields: string | string[], fieldName: string) {
-		if (!fields) return false;
-		if (typeof fields === 'string') return fields === fieldName;
-		return fields.includes(fieldName);
 	}
 }

--- a/packages/lib/services/noteLock/NoteLockNote.ts
+++ b/packages/lib/services/noteLock/NoteLockNote.ts
@@ -14,13 +14,17 @@ export default class NoteLockNote {
 		return this.isLocked(note) && !oldNote.is_locked;
 	}
 
-	public static async decryptBody(note: NoteEntity) {
+	public static async decryptBody(note: NoteEntity): Promise<NoteEntity> {
 		if (!note) throw new Error('Gated note lock load is missing note');
 		if (note.is_locked === undefined) throw new Error('Gated note lock load is missing lock state');
 		if (this.isLocked(note)) {
 			// A missing body here means the gated load did not request enough fields, so pass an empty string and let decryption fail explicitly.
-			note.body = await NoteLockService.instance().decryptString(note.body ?? '');
+			return {
+				...note,
+				body: await NoteLockService.instance().decryptString(note.body ?? ''),
+			};
 		}
+		return note;
 	}
 
 	public static async prepareForSave(note: NoteEntity, linkedItemIds: (body: string)=> string[], isNew: boolean) {

--- a/packages/lib/services/noteLock/NoteLockService.test.ts
+++ b/packages/lib/services/noteLock/NoteLockService.test.ts
@@ -1,0 +1,74 @@
+import Setting from '../../models/Setting';
+import { afterAllCleanUp, encryptionService, fileContentEqual, setupDatabaseAndSynchronizer, supportDir, switchClient, synchronizerStart } from '../../testing/test-utils';
+import EncryptionService from '../e2ee/EncryptionService';
+import NoteLockKey from './NoteLockKey';
+import NoteLockService from './NoteLockService';
+
+describe('NoteLockService', () => {
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await setupDatabaseAndSynchronizer(2);
+		await switchClient(1);
+		NoteLockKey.destroyInstance();
+		NoteLockService.destroyInstance();
+		EncryptionService.instance_ = encryptionService();
+	});
+
+	afterAll(async () => {
+		await afterAllCleanUp();
+	});
+
+	it('should encrypt and decrypt strings and files without loading an E2EE master key', async () => {
+		const encryptionServiceInstance = EncryptionService.instance();
+		const noteLockKey = NoteLockKey.instance();
+		const service = NoteLockService.instance();
+		await noteLockKey.create('123456');
+
+		const cipherText = await service.encryptString('some secret');
+		expect(await service.decryptString(cipherText)).toBe('some secret');
+
+		const sourcePath = `${supportDir}/photo.jpg`;
+		const encryptedPath = `${Setting.value('tempDir')}/note-lock-photo.crypted`;
+		const decryptedPath = `${Setting.value('tempDir')}/note-lock-photo.jpg`;
+		await service.encryptFile(sourcePath, encryptedPath);
+		await service.decryptFile(encryptedPath, decryptedPath);
+
+		expect(fileContentEqual(sourcePath, encryptedPath)).toBe(false);
+		expect(fileContentEqual(sourcePath, decryptedPath)).toBe(true);
+		expect(encryptionServiceInstance.loadedMasterKeysCount()).toBe(0);
+	});
+
+	it('should clear cached key data and only rotate on reset', async () => {
+		const noteLockKey = NoteLockKey.instance();
+		const firstKey = await noteLockKey.create('123456');
+		await expect(noteLockKey.create('123456')).rejects.toThrow('Note lock key already exists');
+
+		noteLockKey.lock();
+		expect(noteLockKey.isUnlocked()).toBe(false);
+		await expect(noteLockKey.unlock('wrong password')).rejects.toThrow();
+
+		await noteLockKey.unlock('123456', Date.now() - 1);
+		expect(noteLockKey.isUnlocked()).toBe(false);
+
+		const secondKey = await noteLockKey.reset('654321');
+		expect(secondKey.id).not.toBe(firstKey.id);
+		expect(noteLockKey.isUnlocked()).toBe(true);
+	});
+
+	it('should sync the encrypted note lock key without loading it into the E2EE registry', async () => {
+		const createdKey = await NoteLockKey.instance().create('123456');
+		NoteLockKey.destroyInstance();
+		NoteLockService.destroyInstance();
+		await synchronizerStart();
+
+		await switchClient(2);
+		EncryptionService.instance_ = encryptionService();
+		await synchronizerStart();
+
+		const syncedKey = NoteLockKey.instance();
+		expect(syncedKey.load()).toEqual(createdKey);
+		expect(syncedKey.isUnlocked()).toBe(false);
+		expect(EncryptionService.instance().loadedMasterKeysCount()).toBe(0);
+	});
+});

--- a/packages/lib/services/noteLock/NoteLockService.ts
+++ b/packages/lib/services/noteLock/NoteLockService.ts
@@ -1,0 +1,49 @@
+import EncryptionService, { EncryptOptions } from '../e2ee/EncryptionService';
+import NoteLockKey from './NoteLockKey';
+
+export default class NoteLockService {
+
+	public static instance_: NoteLockService = null;
+
+	private constructor(
+		private encryptionService_: EncryptionService,
+		private noteLockKey_: NoteLockKey,
+	) {}
+
+	public static instance() {
+		if (!this.instance_) {
+			const encryptionService = EncryptionService.instance();
+			const noteLockKey = NoteLockKey.instance();
+			this.instance_ = new NoteLockService(encryptionService, noteLockKey);
+		}
+		return this.instance_;
+	}
+
+	public static destroyInstance() {
+		this.instance_ = null;
+	}
+
+	public async encryptString(plainText: string) {
+		return this.encryptionService_.encryptString(plainText, this.encryptionOptions_());
+	}
+
+	public async decryptString(cipherText: string) {
+		return this.encryptionService_.decryptString(cipherText, this.encryptionOptions_());
+	}
+
+	public async encryptFile(srcPath: string, destPath: string) {
+		return this.encryptionService_.encryptFile(srcPath, destPath, this.encryptionOptions_());
+	}
+
+	public async decryptFile(srcPath: string, destPath: string) {
+		return this.encryptionService_.decryptFile(srcPath, destPath, this.encryptionOptions_());
+	}
+
+	private encryptionOptions_(): EncryptOptions {
+		const key = this.noteLockKey_.decryptedKey();
+		return {
+			masterKeyId: key.id,
+			decryptedMasterKey: key.plainText,
+		};
+	}
+}

--- a/packages/lib/services/noteLock/isNoteLockEnabled.ts
+++ b/packages/lib/services/noteLock/isNoteLockEnabled.ts
@@ -1,0 +1,7 @@
+import Setting, { Env } from '../../models/Setting';
+
+const isNoteLockEnabled = () => {
+	return Setting.value('env') === Env.Dev;
+};
+
+export default isNoteLockEnabled;

--- a/packages/lib/services/synchronizer/syncInfoUtils.test.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.test.ts
@@ -121,6 +121,25 @@ describe('syncInfoUtils', () => {
 		expect(mergeSyncInfos(syncInfo1, syncInfo2).appMinVersion).toBe('0.0.0');
 	});
 
+	it('should merge sync target info and keep the latest note lock key', () => {
+		const syncInfo1 = new SyncInfo();
+		syncInfo1.noteLockKey = {
+			id: '1',
+			content: 'content1',
+			updated_time: 100,
+		};
+
+		const syncInfo2 = new SyncInfo();
+		syncInfo2.noteLockKey = {
+			id: '2',
+			content: 'content2',
+			updated_time: 200,
+		};
+
+		expect(mergeSyncInfos(syncInfo1, syncInfo2).noteLockKey).toEqual(syncInfo2.noteLockKey);
+		expect(mergeSyncInfos(new SyncInfo(), syncInfo1).noteLockKey).toEqual(syncInfo1.noteLockKey);
+	});
+
 	it('should merge sync target info and takes into account usage of master key - 1', async () => {
 		const syncInfo1 = new SyncInfo();
 		syncInfo1.masterKeys = [{
@@ -229,6 +248,15 @@ describe('syncInfoUtils', () => {
 					'hasBeenUsed': true,
 				},
 			],
+			'noteLockKey': {
+				'id': '400227d8a77c4d3bb7346514861c643c',
+				'created_time': 1515008161362,
+				'updated_time': 1708103706234,
+				'source_application': 'net.cozic.joplin-desktop',
+				'encryption_method': 4,
+				'checksum': '',
+				'content': '{"iv":"M1uezlW1Pu1g3dwrCTqcHg=="}',
+			},
 			'ppk': {
 				'value': {
 					'id': 'SNQ5ZCs61KDVUW2qqqqHd3',
@@ -270,6 +298,13 @@ describe('syncInfoUtils', () => {
 					'updated_time': 1708103706234,
 				},
 			],
+			'noteLockKey': {
+				'created_time': 1515008161362,
+				'encryption_method': 4,
+				'id': '400227d8a77c4d3bb7346514861c643c',
+				'source_application': 'net.cozic.joplin-desktop',
+				'updated_time': 1708103706234,
+			},
 			'ppk': {
 				'updatedTime': 1633274368892,
 				'value': {
@@ -334,6 +369,7 @@ describe('syncInfoUtils', () => {
 		expect(result.e2ee).toEqual(false);
 		expect(result.appMinVersion).toEqual('3.7.0');
 		expect(result.masterKeys).toEqual([]);
+		expect(result.noteLockKey).toEqual(null);
 
 		Logger.globalLogger.enabled = true;
 	});

--- a/packages/lib/services/synchronizer/syncInfoUtils.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.ts
@@ -261,6 +261,16 @@ export function mergeSyncInfos(s1: SyncInfo, s2: SyncInfo): SyncInfo {
 		}
 	}
 
+	const noteLockKey1 = s1.noteLockKey;
+	const noteLockKey2 = s2.noteLockKey;
+	if (!noteLockKey1) {
+		output.noteLockKey = noteLockKey2;
+	} else if (!noteLockKey2) {
+		output.noteLockKey = noteLockKey1;
+	} else {
+		output.noteLockKey = (noteLockKey1.updated_time || 0) >= (noteLockKey2.updated_time || 0) ? noteLockKey1 : noteLockKey2;
+	}
+
 	// We use >= so that the version from s1 (local) is preferred to the version in s2 (remote).
 	// For example, if s2 has appMinVersion 0.00 and s1 has appMinVersion 0.0.0, we choose the
 	// local version, 0.0.0.
@@ -279,6 +289,7 @@ export class SyncInfo {
 	private e2ee_: SyncInfoValueBoolean;
 	private activeMasterKeyId_: SyncInfoValueString;
 	private masterKeys_: MasterKeyEntity[] = [];
+	private noteLockKey_: MasterKeyEntity = null;
 	private ppk_: SyncInfoValuePublicPrivateKeyPair;
 	private appMinVersion_: string = appMinVersion_;
 	private revisionServiceEnabled_: SyncInfoValueBoolean;
@@ -300,6 +311,7 @@ export class SyncInfo {
 			e2ee: this.e2ee_,
 			activeMasterKeyId: this.activeMasterKeyId_,
 			masterKeys: this.masterKeys,
+			noteLockKey: this.noteLockKey,
 			ppk: this.ppk_,
 			appMinVersion: this.appMinVersion,
 			revisionServiceEnabled: this.revisionServiceEnabled_,
@@ -317,6 +329,11 @@ export class SyncInfo {
 				delete mk.checksum;
 				return mk;
 			});
+		}
+
+		if (filtered.noteLockKey) {
+			delete filtered.noteLockKey.content;
+			delete filtered.noteLockKey.checksum;
 		}
 
 		// Truncate the private key and public key
@@ -344,6 +361,7 @@ export class SyncInfo {
 		this.e2ee_ = 'e2ee' in s ? s.e2ee : { value: false, updatedTime: 0 };
 		this.activeMasterKeyId_ = 'activeMasterKeyId' in s ? s.activeMasterKeyId : { value: '', updatedTime: 0 };
 		this.masterKeys_ = 'masterKeys' in s ? s.masterKeys : [];
+		this.noteLockKey_ = 'noteLockKey' in s ? s.noteLockKey : null;
 		this.ppk_ = 'ppk' in s ? s.ppk : { value: null, updatedTime: 0 };
 		this.appMinVersion_ = s.appMinVersion ? s.appMinVersion : '0.0.0';
 		this.revisionServiceEnabled_ = 'revisionServiceEnabled' in s ? s.revisionServiceEnabled : { value: true, updatedTime: 0 };
@@ -441,6 +459,16 @@ export class SyncInfo {
 		if (JSON.stringify(v) === JSON.stringify(this.masterKeys_)) return;
 
 		this.masterKeys_ = v;
+	}
+
+	public get noteLockKey(): MasterKeyEntity {
+		return this.noteLockKey_;
+	}
+
+	public set noteLockKey(v: MasterKeyEntity) {
+		if (JSON.stringify(v) === JSON.stringify(this.noteLockKey_)) return;
+
+		this.noteLockKey_ = v;
 	}
 
 	public keyTimestamp(name: string): number {


### PR DESCRIPTION
## Summary

Resolves #15597.

Adds the backend key path and gated note load/save path for note locking.

This does not make note locking user-facing yet.

Revision creation/marking for locked notes is handled in a later PR. This PR only clears plaintext revision history when a note first becomes locked.

## Changes

- adds a supplied-key path in `EncryptionService`
- stores the encrypted note lock key in sync info
- adds `NoteLockKey` and `NoteLockService`
- adds explicit `useNoteLock` handling for gated `Note.load` and `Note.save`
- extracts linked IDs before encrypting note bodies
- clears `extracted_resource_ids` when saving through the note lock path unlocked
- cleans up plaintext history when a note first becomes locked

## Earlier review

This backend slice was first opened as a draft on my fork so it could get early feedback while it was stacked on the schema PR: https://github.com/keshav0479/joplin/pull/1

The review rounds there already shaped this version: the feature code was moved out of `Note.save`/`Note.load` into helpers behind `isNoteLockEnabled()`, the gated save was simplified to fail loudly when lock state is missing instead of trying to recover, revision cleanup got its own explicit query, and the naming moved to `noteLock` / `NoteLock...` / `useNoteLock` after the `is_locked` rename in the schema PR. The last set of review comments from that draft is applied here too.

## Testing

- `node .yarn/releases/yarn-4.16.0.cjs workspace @joplin/lib tsc`
- `node .yarn/releases/yarn-4.16.0.cjs workspace @joplin/lib test --runInBand models/Note.test.js services/noteLock/NoteLockService.test.js services/e2ee/EncryptionService.test.js services/synchronizer/syncInfoUtils.test.js models/Revision.test.js services/RevisionService.test.js`

## Manual testing

Did a manual desktop pass with two clean profiles syncing through a filesystem target.

First I checked normal sync: profile A created a notebook, a note, and an attachment, then synced. Profile B synced from the same target and received everything correctly. I edited the note on profile B, synced again, then synced profile A and confirmed the edit came back.

Then I checked E2EE sync in both directions. Profile A enabled E2EE, created a note with an attachment, and synced it. Profile B synced from the same target, unlocked E2EE, and the incoming note body and attachment were readable. I edited the note on profile B, synced it, then synced profile A and confirmed the edit was readable there too.

I also checked the filesystem sync target during the E2EE run. The note, resource, and revision items were encrypted, and the plaintext note body was not present there.

https://github.com/user-attachments/assets/162b8592-e062-460b-b279-2e8facf99a88

## AI Assistance Disclosure

I used AI tools while working on this PR, mainly for code review, checking the diff for scope issues, and sanity-checking the test plan. I went through the changes myself, kept the PR limited to the backend/key-path groundwork, and understand the code being submitted.
