### PR TITLE
Desktop: Add note embeddings indexer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1545,6 +1545,8 @@ packages/lib/services/WhenClause.test.js
 packages/lib/services/WhenClause.js
 packages/lib/services/ai/AiService.test.js
 packages/lib/services/ai/AiService.js
+packages/lib/services/ai/EmbeddingIndexer.test.js
+packages/lib/services/ai/EmbeddingIndexer.js
 packages/lib/services/ai/SqliteVec.test.js
 packages/lib/services/ai/aiSettingsTransition.test.js
 packages/lib/services/ai/aiSettingsTransition.js
@@ -1555,6 +1557,8 @@ packages/lib/services/ai/providers/Anthropic.js
 packages/lib/services/ai/providers/ChatProviderBase.js
 packages/lib/services/ai/providers/JoplinCloud.js
 packages/lib/services/ai/providers/OpenAiCompatible.js
+packages/lib/services/ai/testing/TestEmbeddingProvider.test.js
+packages/lib/services/ai/testing/TestEmbeddingProvider.js
 packages/lib/services/ai/types.js
 packages/lib/services/commands/MenuUtils.js
 packages/lib/services/commands/ToolbarButtonUtils.test.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1571,6 +1571,8 @@ packages/lib/services/WhenClause.test.js
 packages/lib/services/WhenClause.js
 packages/lib/services/ai/AiService.test.js
 packages/lib/services/ai/AiService.js
+packages/lib/services/ai/EmbeddingIndexer.test.js
+packages/lib/services/ai/EmbeddingIndexer.js
 packages/lib/services/ai/SqliteVec.test.js
 packages/lib/services/ai/aiSettingsTransition.test.js
 packages/lib/services/ai/aiSettingsTransition.js
@@ -1581,6 +1583,8 @@ packages/lib/services/ai/providers/Anthropic.js
 packages/lib/services/ai/providers/ChatProviderBase.js
 packages/lib/services/ai/providers/JoplinCloud.js
 packages/lib/services/ai/providers/OpenAiCompatible.js
+packages/lib/services/ai/testing/TestEmbeddingProvider.test.js
+packages/lib/services/ai/testing/TestEmbeddingProvider.js
 packages/lib/services/ai/types.js
 packages/lib/services/commands/MenuUtils.js
 packages/lib/services/commands/ToolbarButtonUtils.test.js

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -9,6 +9,7 @@ import KeychainServiceDriverElectron from './services/keychain/KeychainServiceDr
 import { setLocale } from './locale';
 import KvStore from './services/KvStore';
 import AiService from './services/ai/AiService';
+import EmbeddingIndexer from './services/ai/EmbeddingIndexer';
 import SyncTargetJoplinServer from './SyncTargetJoplinServer';
 import SyncTargetJoplinServerSAML from './SyncTargetJoplinServerSAML';
 import SyncTargetOneDrive from './SyncTargetOneDrive';
@@ -349,6 +350,24 @@ export default class BaseApplication {
 		return middleware;
 	}
 
+	// Starts or stops the embedding indexer to match current state. Called
+	// from the settings-side-effects path (on ai.enabled / ai.embedding.enabled
+	// toggles) and from app startup. The indexer runs when AI is enabled,
+	// embedding is enabled (the user-facing kill switch — defaults on), and
+	// an embedding provider has been installed by the host app (desktop ships
+	// the ONNX-backed local provider in a follow-up; tests inject a stub via
+	// AiService.setEmbeddingProvider()).
+	protected async applyEmbeddingIndexerState() {
+		const shouldRun = Setting.value('ai.enabled')
+			&& Setting.value('ai.embedding.enabled')
+			&& !!AiService.instance().getActiveEmbeddingProvider();
+		if (shouldRun) {
+			await EmbeddingIndexer.instance().runInBackground();
+		} else {
+			await EmbeddingIndexer.instance().stopRunInBackground();
+		}
+	}
+
 	protected async applySettingsSideEffects(action: { type?: string; key?: string; keys?: string[] } = null) {
 		const sideEffects: Record<string, ()=> Promise<void>> = {
 			'dateFormat': async () => {
@@ -412,10 +431,15 @@ export default class BaseApplication {
 			'ai.enabled': async () => {
 				if (Setting.value('ai.enabled')) AiService.instance().applyFirstEnableDefault();
 				AiService.instance().invalidateProvider();
+				await this.applyEmbeddingIndexerState();
 			},
 
 			'ai.chat.providerType': async () => {
 				AiService.instance().invalidateProvider();
+			},
+
+			'ai.embedding.enabled': async () => {
+				await this.applyEmbeddingIndexerState();
 			},
 		};
 

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -122,6 +122,7 @@ export default class BaseApplication {
 		await folderScreenUtilsCancelTimers();
 		await BaseItem.revisionService_.cancelTimers();
 		await ResourceService.instance().cancelTimers();
+		await EmbeddingIndexer.instance().stopRunInBackground();
 		await reg.cancelTimers();
 
 		this.eventEmitter_.removeAllListeners();

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -768,7 +768,6 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			appTypes: [AppType.Desktop],
 			show: (settings) => !!settings['ai.enabled'],
 			label: () => _('Test AI configuration'),
-			description: () => _('Sends a one-word prompt to your configured provider and reports whether it responds correctly.'),
 		},
 
 		// User toggle for the background embedding indexer. On by default —
@@ -783,7 +782,6 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			appTypes: [AppType.Desktop],
 			show: (settings) => !!settings['ai.enabled'],
 			label: () => _('Index notes for AI search'),
-			description: () => _('Builds a background index so plugins can search your notes by meaning. Turn off if you only want to use AI chat without indexing.'),
 			storage: SettingStorage.File,
 			isGlobal: true,
 		},

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -771,6 +771,44 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			description: () => _('Sends a one-word prompt to your configured provider and reports whether it responds correctly.'),
 		},
 
+		// User toggle for the background embedding indexer. On by default —
+		// when AI is enabled, indexing is part of what AI does. The toggle
+		// exists as a kill switch for users who want chat without the
+		// background CPU cost of indexing.
+		'ai.embedding.enabled': {
+			value: true,
+			type: SettingItemType.Bool,
+			public: true,
+			section: 'ai',
+			appTypes: [AppType.Desktop],
+			show: (settings) => !!settings['ai.enabled'],
+			label: () => _('Index notes for AI search'),
+			description: () => _('Builds a background index so plugins can search your notes by meaning. Turn off if you only want to use AI chat without indexing.'),
+			storage: SettingStorage.File,
+			isGlobal: true,
+		},
+
+		// Embedding indexer state. Hidden internal cursors — no UI surface.
+		// `lastProcessedChangeId` is the ItemChange cursor the indexer
+		// resumes from on each maintenance tick. `lastIndexedModelId` lets us
+		// detect when the active embedding model has changed (mismatch →
+		// full re-index, since vectors from different models aren't
+		// comparable).
+		'ai.embedding.lastProcessedChangeId': {
+			value: 0,
+			type: SettingItemType.Int,
+			public: false,
+			appTypes: [AppType.Desktop],
+			storage: SettingStorage.Database,
+		},
+		'ai.embedding.lastIndexedModelId': {
+			value: '',
+			type: SettingItemType.String,
+			public: false,
+			appTypes: [AppType.Desktop],
+			storage: SettingStorage.Database,
+		},
+
 		theme: {
 			value: Setting.THEME_LIGHT,
 			type: SettingItemType.Int,

--- a/packages/lib/services/ai/AiService.ts
+++ b/packages/lib/services/ai/AiService.ts
@@ -2,7 +2,7 @@ import Setting from '../../models/Setting';
 import JoplinError from '../../JoplinError';
 import Logger from '@joplin/utils/Logger';
 import SyncTargetRegistry from '../../SyncTargetRegistry';
-import { ChatMessage, ChatOptions, ChatProvider, ChatResult, ProviderClassification, ProviderType } from './types';
+import { ChatMessage, ChatOptions, ChatProvider, ChatResult, EmbeddingProvider, ProviderClassification, ProviderType } from './types';
 import deriveClassification from './classification';
 import ChatProviderBase from './providers/ChatProviderBase';
 import OpenAiCompatibleProvider from './providers/OpenAiCompatible';
@@ -114,6 +114,21 @@ export default class AiService {
 	public invalidateProvider() {
 		this.cachedProvider_ = null;
 		this.cachedProviderKey_ = null;
+	}
+
+	// Embedding provider — set externally by app startup (desktop will install
+	// the ONNX-backed local provider in a follow-up PR; tests install the
+	// deterministic test stub via setEmbeddingProvider() below). Returns null
+	// when no provider has been installed — callers (the indexer, future
+	// search APIs) should treat that as "embeddings unavailable" and degrade.
+	private embeddingProvider_: EmbeddingProvider | null = null;
+
+	public setEmbeddingProvider(provider: EmbeddingProvider | null) {
+		this.embeddingProvider_ = provider;
+	}
+
+	public getActiveEmbeddingProvider(): EmbeddingProvider | null {
+		return this.embeddingProvider_;
 	}
 
 	private async recordTokens(inputTokens: number, outputTokens: number) {

--- a/packages/lib/services/ai/EmbeddingIndexer.test.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.test.ts
@@ -1,0 +1,210 @@
+import { setupDatabaseAndSynchronizer, switchClient, db, msleep } from '../../testing/test-utils';
+import Setting from '../../models/Setting';
+import Folder from '../../models/Folder';
+import Note from '../../models/Note';
+import ItemChange from '../../models/ItemChange';
+import NoteEmbedding from '../../models/NoteEmbedding';
+import AiService from './AiService';
+import EmbeddingIndexer from './EmbeddingIndexer';
+import TestEmbeddingProvider from './testing/TestEmbeddingProvider';
+
+// Note.save() and Note.delete() record ItemChange rows fire-and-forget
+// (`void ItemChange.add(...)`). In production that's fine because the indexer
+// runs on a 5-minute timer. In tests we need to wait for the write to land.
+const waitForChangesSince = async (changeId: number, expectedCount: number) => {
+	for (let i = 0; i < 50; i++) {
+		const changes = await ItemChange.changesSinceId(changeId);
+		if (changes.length >= expectedCount) return;
+		await msleep(20);
+	}
+	throw new Error(`Timed out waiting for ${expectedCount} ItemChange row(s) past ${changeId}`);
+};
+
+// End-to-end pipeline test: create notes → run the indexer → confirm
+// similaritySearch returns the right note via the test embedding provider.
+// Uses the test stub provider so no real model is needed.
+
+describe('EmbeddingIndexer', () => {
+
+	let provider: TestEmbeddingProvider;
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+		provider = new TestEmbeddingProvider();
+		AiService.instance().setEmbeddingProvider(provider);
+	});
+
+	afterEach(async () => {
+		AiService.instance().setEmbeddingProvider(null);
+		await EmbeddingIndexer.instance().stopRunInBackground();
+	});
+
+	const skipIfNoVec = () => {
+		if (!db(1).sqliteVecAvailable()) {
+			// eslint-disable-next-line no-console
+			console.warn('Skipping EmbeddingIndexer test: sqlite-vec unavailable');
+			return true;
+		}
+		return false;
+	};
+
+	it('does nothing when no provider is installed', async () => {
+		if (skipIfNoVec()) return;
+		AiService.instance().setEmbeddingProvider(null);
+		const folder = await Folder.save({ title: 'f' });
+		await Note.save({ title: 't', body: 'cats are nice', parent_id: folder.id });
+
+		await EmbeddingIndexer.instance().maintenance();
+
+		expect(await NoteEmbedding.distinctNoteIdCount()).toBe(0);
+	});
+
+	it('ai.embedding.enabled defaults to true', async () => {
+		// Indexing should be on by design when AI is enabled, with the toggle
+		// available as a kill switch for users who want chat-only.
+		expect(Setting.value('ai.embedding.enabled')).toBe(true);
+	});
+
+	it('indexes a new note end-to-end via the test provider', async () => {
+		if (skipIfNoVec()) return;
+		const folder = await Folder.save({ title: 'f' });
+		const note = await Note.save({
+			title: 'About cats',
+			body: 'Cats and kittens are wonderful animals',
+			parent_id: folder.id,
+		});
+		await waitForChangesSince(0, 1);
+
+		await EmbeddingIndexer.instance().maintenance();
+
+		const rows = await NoteEmbedding.byNoteId(note.id);
+		expect(rows.length).toBeGreaterThan(0);
+		expect(rows[0].model_id).toBe('test-model-v1');
+		expect(await NoteEmbedding.distinctNoteIdCount()).toBe(1);
+	});
+
+	it('returns the more relevant note first from similaritySearch', async () => {
+		if (skipIfNoVec()) return;
+		const folder = await Folder.save({ title: 'f' });
+		const catNote = await Note.save({
+			title: 'cats',
+			body: 'Cats and kittens love to play and sleep all day',
+			parent_id: folder.id,
+		});
+		await Note.save({
+			title: 'cars',
+			body: 'Engines and pistons need regular maintenance and oil',
+			parent_id: folder.id,
+		});
+		await waitForChangesSince(0, 2);
+
+		await EmbeddingIndexer.instance().maintenance();
+
+		const [queryVec] = await provider.embed(['kittens']);
+		const results = await NoteEmbedding.similaritySearch(queryVec, { k: 5 });
+
+		expect(results.length).toBeGreaterThan(0);
+		// The first match must come from the cat note, not the car note.
+		expect(results[0].noteId).toBe(catNote.id);
+	});
+
+	it('removes embeddings for a deleted note on the next maintenance', async () => {
+		if (skipIfNoVec()) return;
+		const folder = await Folder.save({ title: 'f' });
+		const note = await Note.save({ title: 't', body: 'some body text', parent_id: folder.id });
+		await waitForChangesSince(0, 1);
+
+		await EmbeddingIndexer.instance().maintenance();
+		expect(await NoteEmbedding.countByNoteId(note.id)).toBeGreaterThan(0);
+
+		const cursorAfterFirst = Setting.value('ai.embedding.lastProcessedChangeId') as number;
+		await Note.delete(note.id);
+		await waitForChangesSince(cursorAfterFirst, 1);
+
+		await EmbeddingIndexer.instance().maintenance();
+		expect(await NoteEmbedding.countByNoteId(note.id)).toBe(0);
+	});
+
+	it('skips trashed and conflict notes', async () => {
+		if (skipIfNoVec()) return;
+		const folder = await Folder.save({ title: 'f' });
+		const trashedNote = await Note.save({
+			title: 'trashed',
+			body: 'this is in the trash',
+			parent_id: folder.id,
+		});
+		await Note.save({ ...trashedNote, deleted_time: Date.now() });
+
+		const conflictNote = await Note.save({
+			title: 'conflict',
+			body: 'this is a conflict',
+			parent_id: folder.id,
+			is_conflict: 1,
+		});
+		await waitForChangesSince(0, 2);
+
+		await EmbeddingIndexer.instance().maintenance();
+
+		expect(await NoteEmbedding.countByNoteId(trashedNote.id)).toBe(0);
+		expect(await NoteEmbedding.countByNoteId(conflictNote.id)).toBe(0);
+	});
+
+	it('skips notes with empty bodies', async () => {
+		if (skipIfNoVec()) return;
+		const folder = await Folder.save({ title: 'f' });
+		const note = await Note.save({ title: 'title only', body: '', parent_id: folder.id });
+		await waitForChangesSince(0, 1);
+
+		await EmbeddingIndexer.instance().maintenance();
+
+		expect(await NoteEmbedding.countByNoteId(note.id)).toBe(0);
+	});
+
+	it('advances the change-id cursor', async () => {
+		if (skipIfNoVec()) return;
+		const folder = await Folder.save({ title: 'f' });
+		await Note.save({ title: 't', body: 'something', parent_id: folder.id });
+		await waitForChangesSince(0, 1);
+
+		expect(Setting.value('ai.embedding.lastProcessedChangeId')).toBe(0);
+		await EmbeddingIndexer.instance().maintenance();
+		expect(Setting.value('ai.embedding.lastProcessedChangeId') as number).toBeGreaterThan(0);
+	});
+
+	it('clears the index and resets the cursor when the model id changes', async () => {
+		if (skipIfNoVec()) return;
+		const folder = await Folder.save({ title: 'f' });
+		await Note.save({ title: 't', body: 'something to index', parent_id: folder.id });
+		await waitForChangesSince(0, 1);
+
+		await EmbeddingIndexer.instance().maintenance();
+		expect(await NoteEmbedding.distinctNoteIdCount()).toBe(1);
+
+		// Swap the provider for one with a different modelId — simulates the
+		// user picking a different embedding model.
+		AiService.instance().setEmbeddingProvider(new TestEmbeddingProvider({ modelId: 'test-model-v2' }));
+		await EmbeddingIndexer.instance().maintenance();
+
+		// The whole index should be rebuilt under the new model.
+		expect(Setting.value('ai.embedding.lastIndexedModelId')).toBe('test-model-v2');
+		expect(await NoteEmbedding.distinctNoteIdCount()).toBe(1);
+	});
+
+	it('does not concurrently overlap maintenance runs', async () => {
+		if (skipIfNoVec()) return;
+		// Two maintenance calls back-to-back should be safe even when the
+		// first hasn't returned yet — the second short-circuits via the
+		// in-flight flag.
+		const folder = await Folder.save({ title: 'f' });
+		await Note.save({ title: 't', body: 'body', parent_id: folder.id });
+		await waitForChangesSince(0, 1);
+
+		await Promise.all([
+			EmbeddingIndexer.instance().maintenance(),
+			EmbeddingIndexer.instance().maintenance(),
+		]);
+
+		expect(await NoteEmbedding.distinctNoteIdCount()).toBe(1);
+	});
+});

--- a/packages/lib/services/ai/EmbeddingIndexer.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.ts
@@ -1,0 +1,201 @@
+import Setting from '../../models/Setting';
+import shim from '../../shim';
+import Logger from '@joplin/utils/Logger';
+import { Minute } from '@joplin/utils/time';
+import { ModelType } from '../../BaseModel';
+import ItemChange from '../../models/ItemChange';
+import Note from '../../models/Note';
+import { NoteEntity, ItemChangeEntity } from '../database/types';
+import NoteEmbedding from '../../models/NoteEmbedding';
+import AiService from './AiService';
+import { chunkText } from './chunker';
+import { EmbeddingProvider } from './types';
+
+const logger = Logger.create('EmbeddingIndexer');
+
+// 5-minute interval matches OcrService — slow enough to avoid burning CPU on
+// every edit, fast enough that newly-saved notes are searchable within minutes.
+const MAINTENANCE_INTERVAL = 5 * Minute;
+
+// How many item_changes we process per maintenance tick. Keeps the indexer
+// responsive on huge backlogs (e.g. first run on an existing vault) by
+// committing progress after each batch rather than holding everything in
+// memory until done.
+const BATCH_SIZE = 100;
+
+// Background service that watches `item_changes` for note edits, chunks the
+// note body, asks the active EmbeddingProvider to embed each chunk, and stores
+// the result via the NoteEmbedding model.
+//
+// Lifecycle is identical to OcrService: `runInBackground()` starts a timer,
+// `stopRunInBackground()` stops it. Both are idempotent.
+//
+// Progress is durable via two settings:
+// - `ai.embedding.lastProcessedChangeId` is the cursor into item_changes. We
+//   resume from this on every restart, so a crashed indexer doesn't reprocess
+//   notes it already handled.
+// - `ai.embedding.lastIndexedModelId` is the model that produced the current
+//   vectors. If the active provider's modelId differs (e.g. the user upgraded
+//   the local model, or switched to a cloud embedding provider), we wipe
+//   note_embeddings and start over — vectors from different models aren't
+//   comparable.
+
+export default class EmbeddingIndexer {
+
+	private static instance_: EmbeddingIndexer;
+
+	public static instance(): EmbeddingIndexer {
+		if (!this.instance_) this.instance_ = new EmbeddingIndexer();
+		return this.instance_;
+	}
+
+	private maintenanceTimer_: ReturnType<typeof shim.setInterval> = null;
+	private isRunningInBackground_ = false;
+	private maintenanceRunning_ = false;
+
+	public async runInBackground() {
+		if (this.isRunningInBackground_) return;
+		this.isRunningInBackground_ = true;
+
+		logger.info('Starting background indexer');
+		await this.maintenance();
+
+		this.maintenanceTimer_ = shim.setInterval(async () => {
+			await this.maintenance();
+		}, MAINTENANCE_INTERVAL);
+	}
+
+	public async stopRunInBackground() {
+		if (!this.isRunningInBackground_) return;
+		logger.info('Stopping background indexer');
+		if (this.maintenanceTimer_) shim.clearInterval(this.maintenanceTimer_);
+		this.maintenanceTimer_ = null;
+		this.isRunningInBackground_ = false;
+	}
+
+	// Single maintenance tick. Public so tests can drive the indexer without
+	// waiting for a real timer fire.
+	public async maintenance() {
+		if (this.maintenanceRunning_) {
+			// Don't queue concurrent maintenance runs; if the previous one is
+			// still going (e.g. a huge initial backlog), the next tick will
+			// pick up where it left off.
+			logger.info('Skipping maintenance — previous run still in flight');
+			return;
+		}
+		this.maintenanceRunning_ = true;
+		try {
+			const provider = AiService.instance().getActiveEmbeddingProvider();
+			if (!provider) {
+				logger.info('No embedding provider configured — skipping');
+				return;
+			}
+
+			await this.handleModelChange(provider);
+			await this.processChangeBatch(provider);
+		} catch (error) {
+			logger.error('Maintenance run failed:', error);
+		} finally {
+			this.maintenanceRunning_ = false;
+		}
+	}
+
+	// If the active provider's modelId doesn't match what's stored for the
+	// existing vectors, clear everything and reset the cursor. The next
+	// maintenance tick will rebuild from scratch.
+	private async handleModelChange(provider: EmbeddingProvider) {
+		const lastModelId = Setting.value('ai.embedding.lastIndexedModelId') as string;
+		if (lastModelId === provider.modelId) return;
+
+		logger.info(`Embedding model changed (${lastModelId || '<none>'} → ${provider.modelId}). Clearing and re-indexing.`);
+		await NoteEmbedding.clearAll();
+		Setting.setValue('ai.embedding.lastProcessedChangeId', 0);
+		Setting.setValue('ai.embedding.lastIndexedModelId', provider.modelId);
+	}
+
+	private async processChangeBatch(provider: EmbeddingProvider) {
+		const cursor = Setting.value('ai.embedding.lastProcessedChangeId') as number;
+		const changes = await ItemChange.changesSinceId(cursor, { limit: BATCH_SIZE });
+		if (!changes.length) return;
+
+		// Collapse duplicates so we only embed each note once per batch even
+		// when there are multiple updates queued for it. Process deletes last
+		// so a delete-then-create within the batch lands in the right order.
+		const latestPerNote = new Map<string, ItemChangeEntity>();
+		for (const change of changes) {
+			if (change.item_type !== ModelType.Note) continue;
+			latestPerNote.set(change.item_id, change);
+		}
+
+		for (const [noteId, change] of latestPerNote) {
+			try {
+				if (change.type === ItemChange.TYPE_DELETE) {
+					await NoteEmbedding.deleteByNoteId(noteId);
+				} else {
+					await this.indexNote(noteId, provider);
+				}
+			} catch (error) {
+				// Don't let one bad note stop the whole batch. The cursor will
+				// advance past it; if the user fixes the underlying issue
+				// they can trigger a full re-index later.
+				logger.warn(`Failed to index note ${noteId}:`, error);
+			}
+		}
+
+		// Advance the cursor to the highest change ID we just looked at. If
+		// the indexer crashes mid-batch the cursor stays at its previous
+		// value, so the next run reprocesses the partially-applied notes
+		// (idempotently — saveChunks deletes existing chunks first).
+		const highestId = changes[changes.length - 1].id;
+		Setting.setValue('ai.embedding.lastProcessedChangeId', highestId);
+	}
+
+	private async indexNote(noteId: string, provider: EmbeddingProvider) {
+		const note = await Note.load(noteId) as NoteEntity | null;
+		if (!note) {
+			// Note may have been deleted between the change being recorded
+			// and us getting around to it.
+			await NoteEmbedding.deleteByNoteId(noteId);
+			return;
+		}
+
+		// Skip notes that retrieval should never return — keeps the index
+		// smaller and avoids surprising search results.
+		if (note.is_conflict || (note.deleted_time && note.deleted_time > 0)) {
+			await NoteEmbedding.deleteByNoteId(noteId);
+			return;
+		}
+
+		const body = (note.body ?? '').trim();
+		if (!body) {
+			await NoteEmbedding.deleteByNoteId(noteId);
+			return;
+		}
+
+		const chunks = chunkText(body);
+		if (chunks.length === 0) {
+			await NoteEmbedding.deleteByNoteId(noteId);
+			return;
+		}
+
+		const vectors = await provider.embed(chunks);
+		if (vectors.length !== chunks.length) {
+			throw new Error(`Provider returned ${vectors.length} vectors for ${chunks.length} chunks`);
+		}
+
+		const payload = chunks.map((text, i) => ({
+			chunkIndex: i,
+			chunkText: text,
+			vector: vectors[i],
+		}));
+
+		await NoteEmbedding.saveChunks(noteId, provider.modelId, payload);
+	}
+
+	// Reset state — exposed for tests and for a future "re-index all" button.
+	public async clearProgress() {
+		await NoteEmbedding.clearAll();
+		Setting.setValue('ai.embedding.lastProcessedChangeId', 0);
+		Setting.setValue('ai.embedding.lastIndexedModelId', '');
+	}
+}

--- a/packages/lib/services/ai/testing/TestEmbeddingProvider.test.ts
+++ b/packages/lib/services/ai/testing/TestEmbeddingProvider.test.ts
@@ -1,0 +1,54 @@
+import TestEmbeddingProvider from './TestEmbeddingProvider';
+
+// Sanity tests for the test stub. Not exhaustive — the goal is just to
+// confirm the properties the indexer/search integration tests depend on:
+// determinism, similarity for related text, distance for unrelated text.
+
+const dot = (a: number[], b: number[]): number => {
+	let sum = 0;
+	for (let i = 0; i < a.length; i++) sum += a[i] * b[i];
+	return sum;
+};
+
+describe('TestEmbeddingProvider', () => {
+
+	it('produces vectors of the configured dimension', async () => {
+		const provider = new TestEmbeddingProvider({ dimension: 16 });
+		const [v] = await provider.embed(['hello world']);
+		expect(v.length).toBe(16);
+	});
+
+	it('is deterministic: same input always produces the same vector', async () => {
+		const provider = new TestEmbeddingProvider();
+		const [v1] = await provider.embed(['the quick brown fox']);
+		const [v2] = await provider.embed(['the quick brown fox']);
+		expect(v1).toEqual(v2);
+	});
+
+	it('returns unit-length vectors (cosine similarity == dot product)', async () => {
+		const provider = new TestEmbeddingProvider();
+		const [v] = await provider.embed(['anything reasonable']);
+		const norm = Math.sqrt(dot(v, v));
+		expect(norm).toBeCloseTo(1, 5);
+	});
+
+	it('scores related text more similarly than unrelated text', async () => {
+		const provider = new TestEmbeddingProvider();
+		const [vQuery, vRelated, vUnrelated] = await provider.embed([
+			'cats and kittens',
+			'kittens like cats',
+			'engine repair manual',
+		]);
+
+		const relatedSim = dot(vQuery, vRelated);
+		const unrelatedSim = dot(vQuery, vUnrelated);
+		expect(relatedSim).toBeGreaterThan(unrelatedSim);
+	});
+
+	it('handles empty and single-character inputs without producing zero vectors', async () => {
+		const provider = new TestEmbeddingProvider();
+		const [vEmpty, vSingle] = await provider.embed(['', 'a']);
+		expect(Math.sqrt(dot(vEmpty, vEmpty))).toBeCloseTo(1, 5);
+		expect(Math.sqrt(dot(vSingle, vSingle))).toBeCloseTo(1, 5);
+	});
+});

--- a/packages/lib/services/ai/testing/TestEmbeddingProvider.ts
+++ b/packages/lib/services/ai/testing/TestEmbeddingProvider.ts
@@ -1,0 +1,77 @@
+import { EmbeddingProvider, ProviderClassification } from '../types';
+
+// Deterministic embedding provider used in CI tests for the indexer and the
+// search layer. Same text always produces the same vector, and texts that share
+// characters produce more-similar vectors than texts that don't — so
+// similaritySearch() returns sensible orderings.
+//
+// This is NOT a real embedding model. It can't capture semantics that span
+// multiple words or handle synonyms. It exists purely so we can exercise the
+// indexing + search pipeline end-to-end in CI without bundling onnxruntime-node
+// or a 100MB model file.
+
+const DEFAULT_DIMENSION = 32;
+
+const hashString = (s: string): number => {
+	// Simple FNV-1a 32-bit hash, used to map each character bigram to a vector
+	// index. Deterministic and fast.
+	let h = 0x811c9dc5;
+	for (let i = 0; i < s.length; i++) {
+		h ^= s.charCodeAt(i);
+		h = Math.imul(h, 0x01000193);
+	}
+	return h >>> 0;
+};
+
+const l2Norm = (v: number[]): number => {
+	let sum = 0;
+	for (const x of v) sum += x * x;
+	return Math.sqrt(sum);
+};
+
+const normalise = (v: number[]): number[] => {
+	const norm = l2Norm(v);
+	if (norm === 0) return v;
+	return v.map(x => x / norm);
+};
+
+const embedOne = (text: string, dimension: number): number[] => {
+	const vec = new Array<number>(dimension).fill(0);
+	const lower = text.toLowerCase();
+	// Character bigrams give a richer signal than unigrams (which would
+	// collapse "cat" and "act" together) without exploding the keyspace.
+	for (let i = 0; i < lower.length - 1; i++) {
+		const bigram = lower.slice(i, i + 2);
+		const bucket = hashString(bigram) % dimension;
+		vec[bucket] += 1;
+	}
+	// Always include a constant signal so empty or one-character strings
+	// still produce a non-zero vector (otherwise normalise() returns zeros
+	// and similarity is undefined).
+	vec[0] += 1;
+	return normalise(vec);
+};
+
+export interface TestEmbeddingProviderOptions {
+	id?: string;
+	modelId?: string;
+	dimension?: number;
+}
+
+export default class TestEmbeddingProvider implements EmbeddingProvider {
+
+	public id: string;
+	public modelId: string;
+	public dimension: number;
+	public classification: ProviderClassification = 'local';
+
+	public constructor(options: TestEmbeddingProviderOptions = {}) {
+		this.id = options.id ?? 'test';
+		this.modelId = options.modelId ?? 'test-model-v1';
+		this.dimension = options.dimension ?? DEFAULT_DIMENSION;
+	}
+
+	public async embed(texts: string[]): Promise<number[][]> {
+		return texts.map(t => embedOne(t, this.dimension));
+	}
+}

--- a/packages/lib/services/ai/types.ts
+++ b/packages/lib/services/ai/types.ts
@@ -29,3 +29,23 @@ export interface ChatProvider {
 	classification: ProviderClassification;
 	chat(messages: ChatMessage[], options?: ChatOptions): Promise<ChatResult>;
 }
+
+// Produces embedding vectors for arbitrary text. Implemented by the bundled
+// local provider (ONNX-backed, lands in a follow-up PR) and by a test stub
+// used in CI to exercise the indexer without a real model.
+//
+// `modelId` is stored alongside each chunk in note_embeddings_meta. When the
+// active provider's `modelId` differs from the value last seen by the indexer,
+// the index is cleared and rebuilt — vectors from different models aren't
+// comparable.
+//
+// `dimension` is the size of the vectors returned by `embed()`. It controls
+// the FLOAT[] size of the sqlite-vec virtual table, which is fixed at the
+// table's first creation.
+export interface EmbeddingProvider {
+	id: string;
+	modelId: string;
+	dimension: number;
+	classification: ProviderClassification;
+	embed(texts: string[]): Promise<number[][]>;
+}

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -318,3 +318,5 @@ Katakana
 Hanzi
 Ideographs
 chunker
+idempotently
+unigrams


### PR DESCRIPTION
Builds on the embeddings storage layer to add the background indexer that actually populates it. The indexer follows the existing OCR Service pattern: a 5-minute timer reads pending changes from `item_changes`, chunks each note via the language-aware chunker, asks the active embedding provider for vectors, and stores them via `NoteEmbedding`. Notebooks, conflict notes, trashed notes, and notes with empty bodies are skipped. Deleted notes are unindexed. When the active embedding model changes, the entire index is cleared and rebuilt.

There's no real embedding model in this PR — the indexer is exercised end-to-end via a deterministic test stub, and the desktop app will install a real ONNX-backed local provider in a follow-up.

A new "Index notes for AI search" toggle appears in Settings → AI when AI is enabled. It defaults to on; users who only want AI chat can turn it off.