### PR TITLE
Chore: Doc: Add (currently disabled) website/checkout logic for a self-hosted plan

### DIFF
--- a/Assets/WebsiteAssets/templates/partials/plan.mustache
+++ b/Assets/WebsiteAssets/templates/partials/plan.mustache
@@ -38,7 +38,7 @@
 		{{/featureLabelsOff}}
 
 		{{#pricingTable}}
-			<strong>Pricing</strong>
+			<strong translate>Pricing</strong>
 			<table class="table">
 				<tbody>
 					{{#rows}}

--- a/Assets/WebsiteAssets/templates/partials/plan.mustache
+++ b/Assets/WebsiteAssets/templates/partials/plan.mustache
@@ -36,7 +36,18 @@
 		{{#featureLabelsOff}}
 			<p class="unchecked-text"><i class="fas fa-times feature feature-off"></i>{{label}}</p>
 		{{/featureLabelsOff}}
-		
+
+		{{#pricingTable}}
+			<strong>Pricing</strong>
+			<table class="table">
+				<tbody>
+					{{#rows}}
+						<tr><td>{{condition}}</td><td>{{priceYearly}}</td></tr>
+					{{/rows}}
+				</tbody>
+			</table>
+		{{/pricingTable}}
+
 		<p class="text-center subscribe-wrapper">
 			<a id="subscribeButton-{{name}}" href="{{cfaUrl}}" class="button-link btn-white subscribeButton cfa-button">{{cfaLabel}}</a>
 
@@ -58,29 +69,27 @@
 			const buttonId = 'subscribeButton-' + planName;
 			const buttonElement = document.getElementById(buttonId);
 
-			if (stripePricesIds.monthly) {
-				function handleResult() {
-					console.info('Redirected to checkout');
+			function handleResult() {
+				console.info('Redirected to checkout');
+			}
+
+			buttonElement.addEventListener("click", function(evt) {
+				const priceId = stripePricesIds[subscriptionPeriod];
+
+				if (!priceId) {
+					console.error('Invalid period: ' + subscriptionPeriod);
+					return;
 				}
 
-				buttonElement.addEventListener("click", function(evt) {
-					evt.preventDefault();
+				evt.preventDefault();
 
-					const priceId = stripePricesIds[subscriptionPeriod];
-
-					if (!priceId) {
-						console.error('Invalid period: ' + subscriptionPeriod);
-						return;
-					}
-
-					createCheckoutSession(priceId).then(function(data) {
-						stripe.redirectToCheckout({
-							sessionId: data.sessionId
-						})
-						.then(handleResult);
-					});
+				createCheckoutSession(priceId).then(function(data) {
+					stripe.redirectToCheckout({
+						sessionId: data.sessionId
+					})
+					.then(handleResult);
 				});
-			}
+			});
 
 			for (const button of document.querySelectorAll('button.action-toggleIncreaseStorage')) {
 				button.onclick = () => {

--- a/Assets/WebsiteAssets/templates/plans.mustache
+++ b/Assets/WebsiteAssets/templates/plans.mustache
@@ -250,6 +250,8 @@
 
 		$('.toggle-button-self').click((event) => {
 			event.preventDefault();
+			// Self-hosting is currently yearly-only
+			applyPeriod('yearly');
 			setHostingType('self');
 		});
 

--- a/packages/lib/utils/joplinCloud/index.ts
+++ b/packages/lib/utils/joplinCloud/index.ts
@@ -38,11 +38,17 @@ enum PlanHostingType {
 	Self = 'self',
 }
 
+export interface PlanTieredPricingTableRow {
+	condition: string;
+	priceYearly: string;
+}
+
 export interface Plan {
 	name: string;
 	title: string;
 	priceMonthly?: StripePublicConfigPrice;
 	priceYearly?: StripePublicConfigPrice;
+	pricingTable?: { rows: PlanTieredPricingTableRow[] };
 	featured: boolean;
 	iconName: string;
 	featuresOn: FeatureId[];
@@ -67,15 +73,38 @@ export enum PriceCurrency {
 	USD = 'USD',
 }
 
-export interface StripePublicConfigPrice {
+export interface StripePublicConfigTieredAmount {
+	amount: string;
+	formattedAmount: string;
+	users: [number, number|'infinity'];
+	userRange: { min: number; max: number };
+}
+
+export interface StripePublicConfigBasePrice {
 	accountType: number; // AccountType
 	id: string;
 	period: PricePeriod;
+	currency: PriceCurrency;
+}
+
+export interface StripePublicConfigFixedPrice extends StripePublicConfigBasePrice {
 	amount: string;
 	formattedAmount: string;
 	formattedMonthlyAmount: string;
-	currency: PriceCurrency;
+
+	amounts: undefined;
 }
+
+export interface StripePublicConfigTieredPrice extends StripePublicConfigBasePrice {
+	amounts: StripePublicConfigTieredAmount[];
+
+	quantityMinimum: number;
+	amount: undefined;
+	formattedAmount: undefined;
+	formattedMonthlyAmount: undefined;
+}
+
+export type StripePublicConfigPrice = StripePublicConfigFixedPrice | StripePublicConfigTieredPrice;
 
 export interface StripePublicConfig {
 	publishableKey: string;
@@ -92,17 +121,28 @@ function formatPrice(amount: string | number, currency: PriceCurrency): string {
 	throw new Error(`Unsupported currency: ${currency}`);
 }
 
-interface FindPriceQuery {
-	accountType?: number;
-	period?: PricePeriod;
-	priceId?: string;
-}
+export const isTieredPrice = (p: StripePublicConfigPrice): p is StripePublicConfigTieredPrice => {
+	return 'amounts' in p;
+};
 
 export function loadStripeConfig(env: string, filePath: string): StripePublicConfig {
 	const config: StripePublicConfig = JSON.parse(fs.readFileSync(filePath, 'utf8'))[env];
 	if (!config) throw new Error(`Invalid env: ${env}`);
 
-	const decoratePrices = (p: StripePublicConfigPrice) => {
+	const decoratePrices = (p: StripePublicConfigPrice): StripePublicConfigPrice => {
+		if (isTieredPrice(p)) {
+			return {
+				...p,
+				amounts: p.amounts.map(amount => ({
+					...amount,
+					formattedAmount: formatPrice(amount.amount, p.currency),
+					userRange: {
+						min: amount.users[0],
+						max: amount.users[1] === 'infinity' ? Number.POSITIVE_INFINITY : amount.users[1],
+					},
+				})),
+			};
+		}
 		return {
 			...p,
 			formattedAmount: formatPrice(p.amount, p.currency),
@@ -114,6 +154,12 @@ export function loadStripeConfig(env: string, filePath: string): StripePublicCon
 	config.archivedPrices = config.archivedPrices.map(decoratePrices);
 
 	return config;
+}
+
+interface FindPriceQuery {
+	accountType?: number;
+	period?: PricePeriod;
+	priceId?: string;
 }
 
 export function findPrice(config: StripePublicConfig, query: FindPriceQuery): StripePublicConfigPrice {
@@ -455,7 +501,32 @@ export const createFeatureTableMd = () => {
 	return markdownUtils.createMarkdownTable(headers, rows);
 };
 
+const getTieredPricingTable = (price: StripePublicConfigPrice) => {
+	if (!isTieredPrice(price)) throw new Error(`Not a tiered price: ${price.id}`);
+
+	const rows: PlanTieredPricingTableRow[] = [];
+	for (const amount of price.amounts) {
+		const formatUserCount = (count: number) => {
+			if (count === Number.POSITIVE_INFINITY) {
+				return '∞';
+			}
+			return String(count);
+		};
+		rows.push({
+			condition: `${
+				formatUserCount(amount.userRange.min)
+			}—${
+				formatUserCount(amount.userRange.max)
+			} users`,
+			priceYearly: `${amount.formattedAmount} / user / year`,
+		});
+	}
+	return rows;
+};
+
 export function getPlans(stripeConfig: StripePublicConfig): Record<PlanName, Plan> {
+	// TODO: Set to true to enable self-hosting self-service.
+	const selfServiceSelfHostingEnabled = false;
 	return {
 		basic: {
 			name: 'basic',
@@ -560,8 +631,23 @@ export function getPlans(stripeConfig: StripePublicConfig): Record<PlanName, Pla
 			featuresOff: [],
 			featureLabelsOn: getFeatureLabelsByPlan(PlanName.JoplinServerBusiness, true),
 			featureLabelsOff: [],
-			cfaLabel: _('Get a quote'),
-			cfaUrl: 'https://tally.so/r/D4BlOE',
+			...(selfServiceSelfHostingEnabled ? {
+				pricingTable: {
+					rows: getTieredPricingTable(findPrice(stripeConfig, {
+						accountType: 5,
+						period: PricePeriod.Yearly,
+					})),
+				},
+				cfaLabel: _('Try it out'),
+				cfaUrl: '',
+				priceYearly: findPrice(stripeConfig, {
+					accountType: 5,
+					period: PricePeriod.Yearly,
+				}),
+			} : {
+				cfaLabel: _('Get a quote'),
+				cfaUrl: 'https://tally.so/r/D4BlOE',
+			}),
 			footnote: '',
 			learnMoreUrl: 'https://joplinapp.org/help/apps/joplin_server_business',
 			hostingType: PlanHostingType.Self,

--- a/packages/lib/utils/joplinCloud/index.ts
+++ b/packages/lib/utils/joplinCloud/index.ts
@@ -638,7 +638,7 @@ export function getPlans(stripeConfig: StripePublicConfig): Record<PlanName, Pla
 						period: PricePeriod.Yearly,
 					})),
 				},
-				cfaLabel: _('Try it out'),
+				cfaLabel: _('Try it now'),
 				cfaUrl: '',
 				priceYearly: findPrice(stripeConfig, {
 					accountType: 5,

--- a/packages/server/stripeConfig.json
+++ b/packages/server/stripeConfig.json
@@ -58,6 +58,27 @@
 				"period": "yearly",
 				"amount": "95.88",
 				"currency": "EUR"
+			},
+			{
+				"accountType": 5,
+				"id": "price_1ThCwVL9ZkKzC9sXU9AVyDB1",
+				"period": "yearly",
+				"quantityMinimum": 2,
+				"amounts": [
+					{
+						"amount": "40.00",
+						"users": [2, 10]
+					},
+					{
+						"amount": "30.00",
+						"users": [11, 50]
+					},
+					{
+						"amount": "20.00",
+						"users": [51, "infinity"]
+					}
+				],
+				"currency": "EUR"
 			}
 		],
 		"archivedPrices": []
@@ -120,6 +141,27 @@
 				"id": "price_1TZbplLx4fybOTqJ3VmzuqmZ",
 				"period": "yearly",
 				"amount": "95.88",
+				"currency": "EUR"
+			},
+			{
+				"accountType": 5,
+				"id": "price_1TgZ0zLx4fybOTqJl0xF4kHr",
+				"period": "yearly",
+				"quantityMinimum": 2,
+				"amounts": [
+					{
+						"amount": "40.00",
+						"users": [2, 10]
+					},
+					{
+						"amount": "30.00",
+						"users": [11, 50]
+					},
+					{
+						"amount": "20.00",
+						"users": [51, "infinity"]
+					}
+				],
 				"currency": "EUR"
 			}
 		],


### PR DESCRIPTION
# Summary

This pull request adds (currently disabled) logic to support purchasing a self-hosted subscription type from the Joplin website.

# To enable

After the backend changes are released, the new checkout session logic can be enabled by changing the `selfServiceSelfHostingEnabled` constant to `true`.

# Testing

With a server instance with the backend changes applied:
| Current PR | With `selfServiceSelfHostingEnabled` |
|-------|--------|
| <video src="https://github.com/user-attachments/assets/97db684a-6da3-4245-9ede-12b82804d817" alt="screen recording: shows clicking the 'try it out' links on the plans page; shows that the joplin server business plan still has 'get a quote'"/> | <video src="https://github.com/user-attachments/assets/6ab6db2d-fd5c-4786-9109-12f9edc04507" alt="joplin server business plan now reads 'try it now' instead of 'get a quote'"/> |




<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
