### PR TITLE
Desktop: Add embedding model downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1547,6 +1547,9 @@ packages/lib/services/ai/AiService.test.js
 packages/lib/services/ai/AiService.js
 packages/lib/services/ai/EmbeddingIndexer.test.js
 packages/lib/services/ai/EmbeddingIndexer.js
+packages/lib/services/ai/EmbeddingModelDownloader.test.js
+packages/lib/services/ai/EmbeddingModelDownloader.js
+packages/lib/services/ai/OnnxRuntime.test.js
 packages/lib/services/ai/SqliteVec.test.js
 packages/lib/services/ai/aiSettingsTransition.test.js
 packages/lib/services/ai/aiSettingsTransition.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1573,6 +1573,9 @@ packages/lib/services/ai/AiService.test.js
 packages/lib/services/ai/AiService.js
 packages/lib/services/ai/EmbeddingIndexer.test.js
 packages/lib/services/ai/EmbeddingIndexer.js
+packages/lib/services/ai/EmbeddingModelDownloader.test.js
+packages/lib/services/ai/EmbeddingModelDownloader.js
+packages/lib/services/ai/OnnxRuntime.test.js
 packages/lib/services/ai/SqliteVec.test.js
 packages/lib/services/ai/aiSettingsTransition.test.js
 packages/lib/services/ai/aiSettingsTransition.js

--- a/packages/app-desktop/main-html.ts
+++ b/packages/app-desktop/main-html.ts
@@ -32,6 +32,7 @@ import FileApiDriverLocal from '@joplin/lib/file-api-driver-local';
 import * as React from 'react';
 import nodeSqlite = require('sqlite3');
 import sqliteVec = require('sqlite-vec');
+import onnxRuntime = require('onnxruntime-node');
 import initLib from '@joplin/lib/initLib';
 import PerformanceLogger from '@joplin/lib/PerformanceLogger';
 import * as pdfJs from 'pdfjs-dist';
@@ -95,6 +96,7 @@ const main = async () => {
 		electronBridge: bridge(),
 		nodeSqlite,
 		sqliteVec,
+		onnxRuntime,
 		pdfJs: pdfJs as PdfJs,
 		isAppleSilicon,
 	});

--- a/packages/app-desktop/main-html.ts
+++ b/packages/app-desktop/main-html.ts
@@ -32,7 +32,6 @@ import FileApiDriverLocal from '@joplin/lib/file-api-driver-local';
 import * as React from 'react';
 import nodeSqlite = require('sqlite3');
 import sqliteVec = require('sqlite-vec');
-import onnxRuntime = require('onnxruntime-node');
 import initLib from '@joplin/lib/initLib';
 import PerformanceLogger from '@joplin/lib/PerformanceLogger';
 import * as pdfJs from 'pdfjs-dist';
@@ -88,6 +87,19 @@ const main = async () => {
 	}
 
 	pdfJs.GlobalWorkerOptions.workerSrc = `${bridge().electronApp().buildDir()}/pdf.worker.min.js`;
+
+	// onnxruntime-node loads a native binding at require time. Wrap it so a missing or broken
+	// prebuilt degrades to "embeddings unavailable" rather than crashing the whole app at startup.
+	//
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- onnxruntime-node has its own typings; we only need to forward the loaded module to the shim
+	let onnxRuntime: any = null;
+	try {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports -- guarded require avoids a top-level import that would crash on a missing native binding
+		onnxRuntime = require('onnxruntime-node');
+	} catch (error) {
+		// eslint-disable-next-line no-console -- main-html runs before the logger is initialised below
+		console.warn('onnxruntime-node failed to load; AI embeddings will be unavailable:', (error as Error).message);
+	}
 
 	shimInit({
 		keytar,

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -224,6 +224,7 @@
     "fs-extra": "11.3.4",
     "keytar": "7.9.0",
     "node-fetch": "2.6.7",
+    "onnxruntime-node": "1.26.0",
     "sqlite-vec": "0.1.9",
     "sqlite3": "5.1.6"
   }

--- a/packages/app-desktop/tools/bundleJs.ts
+++ b/packages/app-desktop/tools/bundleJs.ts
@@ -30,7 +30,7 @@ const makeBuildContext = (entryPoint: string, renderer: boolean, addDebugStats: 
 				// in the final bundle.
 				name: 'joplin--relative-imports-for-externals',
 				setup: build => {
-					const externalRegex = /^(.*\.node|sqlite3|node-fetch|electron|@electron\/remote\/.*|electron\/.*|@mapbox\/node-pre-gyp|jsdom)$/;
+					const externalRegex = /^(.*\.node|sqlite3|node-fetch|electron|@electron\/remote\/.*|electron\/.*|@mapbox\/node-pre-gyp|jsdom|onnxruntime-node)$/;
 					build.onResolve({ filter: externalRegex }, args => {
 						// Electron packages don't need relative requires
 						if (args.path === 'electron' || args.path.startsWith('electron/')) {

--- a/packages/lib/jest.setup.js
+++ b/packages/lib/jest.setup.js
@@ -16,12 +16,22 @@ try {
 	console.warn('sqlite-vec unavailable in tests on this platform:', error.message);
 }
 
+// onnxruntime-node powers the local embedding model. Same loading story as
+// sqlite-vec: bundled with desktop only, optional everywhere else, wrapped
+// in try/catch so CI runners without a prebuilt skip the tests cleanly.
+let onnxRuntime = null;
+try {
+	onnxRuntime = require('onnxruntime-node');
+} catch (error) {
+	console.warn('onnxruntime-node unavailable in tests on this platform:', error.message);
+}
+
 // Used for testing some shared components
 const React = require('react');
 
 require('../../jest.base-setup.js')();
 
-shimInit({ pdfJs, sharp, nodeSqlite, sqliteVec, React, appVersion: () => packageInfo.version });
+shimInit({ pdfJs, sharp, nodeSqlite, sqliteVec, onnxRuntime, React, appVersion: () => packageInfo.version });
 
 global.afterEach(async () => {
 	await afterEachCleanUp();

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -34,6 +34,7 @@
     "jest": "29.7.0",
     "jest-expect-message": "1.1.3",
     "jsdom": "26.1.0",
+    "onnxruntime-node": "1.26.0",
     "pdfjs-dist": "3.11.174",
     "react": "19.1.5",
     "react-dom": "19.1.5",

--- a/packages/lib/services/ai/EmbeddingModelDownloader.test.ts
+++ b/packages/lib/services/ai/EmbeddingModelDownloader.test.ts
@@ -59,8 +59,7 @@ describe('EmbeddingModelDownloader', () => {
 		shim.fetchBlob = (async (_url: string, options: any) => {
 			await fs.copy(tarballPath, options.path);
 			return { ok: true, status: 200, path: options.path };
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- fetchBlob returns a discriminated union of node/blob response shapes
-		}) as any;
+		});
 	});
 
 	afterEach(async () => {
@@ -86,12 +85,10 @@ describe('EmbeddingModelDownloader', () => {
 
 		// Count fetchBlob calls in a second run.
 		let calls = 0;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- fetchBlob spy mirrors the loose typing of its callers
 		shim.fetchBlob = (async () => {
 			calls++;
 			return { ok: true, status: 200 };
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See above
-		}) as any;
+		});
 
 		const path = await ensureModelDownloaded(fakeModel);
 		expect(calls).toBe(0);
@@ -113,8 +110,7 @@ describe('EmbeddingModelDownloader', () => {
 	});
 
 	it('throws a clear error when the server returns a non-2xx response', async () => {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See above
-		shim.fetchBlob = (async () => ({ ok: false, status: 404 })) as any;
+		shim.fetchBlob = (async () => ({ ok: false, status: 404 }));
 		await expect(ensureModelDownloaded(fakeModel)).rejects.toThrow(/HTTP 404/);
 	});
 
@@ -140,8 +136,7 @@ describe('EmbeddingModelDownloader', () => {
 			}
 			await fs.copy(tarballPath, options.path);
 			return { ok: true, status: 200 };
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See above
-		}) as any;
+		});
 
 		const samples: { bytesDownloaded: number }[] = [];
 		await ensureModelDownloaded(fakeModel, {

--- a/packages/lib/services/ai/EmbeddingModelDownloader.test.ts
+++ b/packages/lib/services/ai/EmbeddingModelDownloader.test.ts
@@ -1,0 +1,154 @@
+import { setupDatabaseAndSynchronizer, switchClient, createTempDir } from '../../testing/test-utils';
+import * as fs from 'fs-extra';
+import * as tar from 'tar';
+import Setting from '../../models/Setting';
+import shim from '../../shim';
+import {
+	ensureModelDownloaded,
+	localModelPath,
+	removeCachedModel,
+	ModelDescriptor,
+} from './EmbeddingModelDownloader';
+
+// The downloader test never touches the real network. We build a tiny
+// model-shaped tarball on disk and stub shim.fetchBlob to "download" it by
+// copying that tarball into the requested destination. Everything past that
+// (extract, marker check, cleanup) runs against the real fs.
+
+describe('EmbeddingModelDownloader', () => {
+
+	let tempDir: string;
+	let tarballPath: string;
+	let originalFetchBlob: typeof shim.fetchBlob;
+
+	const fakeModel: ModelDescriptor = {
+		id: 'fake-test-model',
+		archiveName: 'fake-test-model',
+		downloadUrl: 'https://example.invalid/fake-test-model.tar.gz',
+	};
+
+	const buildFakeModelTarball = async (): Promise<string> => {
+		// Build a directory laid out like the real model archive: a top-level
+		// folder named after the model with a config.json marker file inside.
+		const stagingDir = `${tempDir}/staging`;
+		const modelDir = `${stagingDir}/${fakeModel.archiveName}`;
+		await fs.ensureDir(modelDir);
+		await fs.writeFile(`${modelDir}/config.json`, '{"_fake":true}');
+		await fs.writeFile(`${modelDir}/tokenizer.json`, '{}');
+
+		const archive = `${tempDir}/${fakeModel.archiveName}.tar.gz`;
+		await tar.create({ gzip: true, cwd: stagingDir, file: archive }, [fakeModel.archiveName]);
+		return archive;
+	};
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+
+		tempDir = await createTempDir();
+		// Point cacheDir at our scratch dir so the downloader can't pollute
+		// other tests' cache state.
+		Setting.setConstant('cacheDir', tempDir);
+
+		tarballPath = await buildFakeModelTarball();
+
+		// Stub fetchBlob: instead of going to the network, copy our local
+		// fake tarball to the requested destination.
+		originalFetchBlob = shim.fetchBlob;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- fetchBlob's options bag is loosely typed across implementations
+		shim.fetchBlob = (async (_url: string, options: any) => {
+			await fs.copy(tarballPath, options.path);
+			return { ok: true, status: 200, path: options.path };
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- fetchBlob returns a discriminated union of node/blob response shapes
+		}) as any;
+	});
+
+	afterEach(async () => {
+		shim.fetchBlob = originalFetchBlob;
+		await fs.remove(tempDir);
+	});
+
+	it('returns null from localModelPath when nothing is cached', async () => {
+		expect(await localModelPath(fakeModel)).toBeNull();
+	});
+
+	it('downloads, extracts, and exposes the model directory', async () => {
+		const path = await ensureModelDownloaded(fakeModel);
+		expect(path).toMatch(/fake-test-model$/);
+		expect(await fs.pathExists(`${path}/config.json`)).toBe(true);
+		expect(await fs.pathExists(`${path}/tokenizer.json`)).toBe(true);
+		// Tarball cleanup happens after successful extract.
+		expect(await fs.pathExists(`${tempDir}/ai/embedding-models/${fakeModel.archiveName}.tar.gz`)).toBe(false);
+	});
+
+	it('is idempotent: a second call returns the same path without re-downloading', async () => {
+		await ensureModelDownloaded(fakeModel);
+
+		// Count fetchBlob calls in a second run.
+		let calls = 0;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- fetchBlob spy mirrors the loose typing of its callers
+		shim.fetchBlob = (async () => {
+			calls++;
+			return { ok: true, status: 200 };
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See above
+		}) as any;
+
+		const path = await ensureModelDownloaded(fakeModel);
+		expect(calls).toBe(0);
+		expect(await fs.pathExists(`${path}/config.json`)).toBe(true);
+	});
+
+	it('removes any stale partial state before re-downloading', async () => {
+		// Simulate a partial extract left over from a previous crash: directory
+		// exists but is missing the marker file.
+		const targetDir = `${tempDir}/ai/embedding-models/${fakeModel.archiveName}`;
+		await fs.ensureDir(targetDir);
+		await fs.writeFile(`${targetDir}/leftover.bin`, 'garbage');
+		expect(await localModelPath(fakeModel)).toBeNull();
+
+		const path = await ensureModelDownloaded(fakeModel);
+		expect(await fs.pathExists(`${path}/config.json`)).toBe(true);
+		// Leftover from the prior failed attempt must be gone.
+		expect(await fs.pathExists(`${targetDir}/leftover.bin`)).toBe(false);
+	});
+
+	it('throws a clear error when the server returns a non-2xx response', async () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See above
+		shim.fetchBlob = (async () => ({ ok: false, status: 404 })) as any;
+		await expect(ensureModelDownloaded(fakeModel)).rejects.toThrow(/HTTP 404/);
+	});
+
+	it('removeCachedModel deletes the extracted directory', async () => {
+		await ensureModelDownloaded(fakeModel);
+		expect(await localModelPath(fakeModel)).not.toBeNull();
+
+		await removeCachedModel(fakeModel);
+		expect(await localModelPath(fakeModel)).toBeNull();
+	});
+
+	it('reports progress via the onProgress callback', async () => {
+		// Re-stub fetchBlob to actually exercise downloadController so we
+		// observe chunk callbacks. We simulate a streaming download by
+		// invoking handleChunk a few times before copying the tarball.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See above
+		shim.fetchBlob = (async (_url: string, options: any) => {
+			const ctrl = options.downloadController;
+			if (ctrl?.handleChunk) {
+				const onData = ctrl.handleChunk({ destroy: () => {} });
+				onData({ length: 1000 });
+				onData({ length: 500 });
+			}
+			await fs.copy(tarballPath, options.path);
+			return { ok: true, status: 200 };
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See above
+		}) as any;
+
+		const samples: { bytesDownloaded: number }[] = [];
+		await ensureModelDownloaded(fakeModel, {
+			onProgress: (p) => samples.push({ bytesDownloaded: p.bytesDownloaded }),
+		});
+
+		expect(samples.length).toBeGreaterThanOrEqual(2);
+		expect(samples[samples.length - 1].bytesDownloaded).toBe(1500);
+	});
+});

--- a/packages/lib/services/ai/EmbeddingModelDownloader.test.ts
+++ b/packages/lib/services/ai/EmbeddingModelDownloader.test.ts
@@ -95,6 +95,32 @@ describe('EmbeddingModelDownloader', () => {
 		expect(await fs.pathExists(`${path}/config.json`)).toBe(true);
 	});
 
+	it('serialises concurrent calls so only one download runs', async () => {
+		let calls = 0;
+		// Slow the "download" down to widen the race window — without
+		// concurrency control, both calls would race to wipe + write the
+		// same files at the same time.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- fetchBlob spy mirrors the loose typing of its callers
+		shim.fetchBlob = (async (_url: string, options: any) => {
+			calls++;
+			await new Promise(resolve => setTimeout(resolve, 50));
+			await fs.copy(tarballPath, options.path);
+			return { ok: true, status: 200 };
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See above
+		}) as any;
+
+		const [p1, p2, p3] = await Promise.all([
+			ensureModelDownloaded(fakeModel),
+			ensureModelDownloaded(fakeModel),
+			ensureModelDownloaded(fakeModel),
+		]);
+
+		expect(calls).toBe(1);
+		expect(p1).toBe(p2);
+		expect(p2).toBe(p3);
+		expect(await fs.pathExists(`${p1}/config.json`)).toBe(true);
+	});
+
 	it('removes any stale partial state before re-downloading', async () => {
 		// Simulate a partial extract left over from a previous crash: directory
 		// exists but is missing the marker file.

--- a/packages/lib/services/ai/EmbeddingModelDownloader.ts
+++ b/packages/lib/services/ai/EmbeddingModelDownloader.ts
@@ -74,8 +74,16 @@ export const localModelPath = async (model: ModelDescriptor): Promise<string | n
 	return exists ? dir : null;
 };
 
+// Tracks in-flight downloads per model so concurrent callers share a single
+// download instead of racing on the same tarball + extract directory. Cleared
+// once the work either resolves or rejects so a later call after a failure can
+// retry from scratch.
+const inFlight: Map<string, Promise<string>> = new Map();
+
 // Downloads, verifies, and extracts the model if it isn't already on disk.
-// Safe to call repeatedly: if the cache is hot, returns immediately.
+// Safe to call repeatedly and from concurrent callers: cache hot → returns
+// immediately; cache cold → first caller does the work and the rest await
+// the same promise.
 export const ensureModelDownloaded = async (
 	model: ModelDescriptor,
 	options: EnsureOptions = {},
@@ -83,6 +91,21 @@ export const ensureModelDownloaded = async (
 	const existing = await localModelPath(model);
 	if (existing) return existing;
 
+	const pending = inFlight.get(model.id);
+	if (pending) return pending;
+
+	// eslint-disable-next-line promise/prefer-await-to-then -- .finally is the natural fit here: we need cleanup to run on both resolve and reject, without inverting the caller-facing await chain
+	const work = runDownload(model, options).finally(() => {
+		inFlight.delete(model.id);
+	});
+	inFlight.set(model.id, work);
+	return work;
+};
+
+const runDownload = async (
+	model: ModelDescriptor,
+	options: EnsureOptions,
+): Promise<string> => {
 	const fsDriver = shim.fsDriver();
 	const cacheDir = baseCacheDir();
 	await fsDriver.mkdir(cacheDir);

--- a/packages/lib/services/ai/EmbeddingModelDownloader.ts
+++ b/packages/lib/services/ai/EmbeddingModelDownloader.ts
@@ -1,0 +1,175 @@
+import Logger from '@joplin/utils/Logger';
+import Setting from '../../models/Setting';
+import shim from '../../shim';
+
+const logger = Logger.create('EmbeddingModelDownloader');
+
+// Handles downloading the local embedding model on first use and caching it
+// under the user's profile. The model itself is too large to ship with the
+// desktop installer (~140 MB), so we download it lazily the first time the
+// user enables AI.
+//
+// Cache layout (under `${cacheDir}/ai/embedding-models/`):
+//
+//   multilingual-e5-small/
+//     config.json
+//     model_quantized.onnx
+//     sentencepiece.bpe.model
+//     special_tokens_map.json
+//     tokenizer.json
+//     tokenizer_config.json
+//
+// The model directory is created by extracting the tarball published as a
+// release asset in https://github.com/joplinapp/embedding-models. Each release
+// uses the model name as both the tag and the archive filename, so the
+// download URL is fully determined by the model id.
+
+export interface ModelDescriptor {
+	// Stable identifier the indexer stores in note_embeddings_meta.model_id.
+	// When this changes, EmbeddingIndexer.handleModelChange() wipes the index.
+	id: string;
+	// File name (without `.tar.gz`) that matches the GitHub release tag AND
+	// the top-level directory inside the archive.
+	archiveName: string;
+	// Public URL the tarball is downloaded from.
+	downloadUrl: string;
+}
+
+export const MULTILINGUAL_E5_SMALL: ModelDescriptor = {
+	id: 'multilingual-e5-small',
+	archiveName: 'multilingual-e5-small',
+	downloadUrl: 'https://github.com/joplin/embedding-models/releases/download/1.0.0/multilingual-e5-small.tar.gz',
+};
+
+export interface DownloadProgress {
+	// Bytes received so far. May be partial if the server doesn't advertise
+	// Content-Length (rare with GitHub Releases, but defensive).
+	bytesDownloaded: number;
+	// Total bytes if known, else null. Use to compute a percentage when set.
+	totalBytes: number | null;
+}
+
+export type ProgressCallback = (progress: DownloadProgress)=> void;
+
+interface EnsureOptions {
+	onProgress?: ProgressCallback;
+}
+
+const baseCacheDir = () => `${Setting.value('cacheDir')}/ai/embedding-models`;
+
+const archivePath = (model: ModelDescriptor) =>
+	`${baseCacheDir()}/${model.archiveName}.tar.gz`;
+
+const modelDir = (model: ModelDescriptor) =>
+	`${baseCacheDir()}/${model.archiveName}`;
+
+// Returns the path to the local model directory if it's present and looks
+// usable (the marker file we extract is there). Returns null otherwise.
+export const localModelPath = async (model: ModelDescriptor): Promise<string | null> => {
+	const dir = modelDir(model);
+	// A successful extract always leaves config.json behind. That's our cheap
+	// "is the model cached?" check — no need to validate every file.
+	const marker = `${dir}/config.json`;
+	const exists = await shim.fsDriver().exists(marker);
+	return exists ? dir : null;
+};
+
+// Downloads, verifies, and extracts the model if it isn't already on disk.
+// Safe to call repeatedly: if the cache is hot, returns immediately.
+export const ensureModelDownloaded = async (
+	model: ModelDescriptor,
+	options: EnsureOptions = {},
+): Promise<string> => {
+	const existing = await localModelPath(model);
+	if (existing) return existing;
+
+	const fsDriver = shim.fsDriver();
+	const cacheDir = baseCacheDir();
+	await fsDriver.mkdir(cacheDir);
+
+	const tarPath = archivePath(model);
+	const targetDir = modelDir(model);
+
+	// Wipe any stale half-downloaded tarball or partially-extracted directory
+	// left over from a previous failed attempt.
+	if (await fsDriver.exists(tarPath)) await fsDriver.remove(tarPath);
+	if (await fsDriver.exists(targetDir)) await fsDriver.remove(targetDir);
+
+	logger.info(`Downloading embedding model from ${model.downloadUrl}`);
+	await downloadWithProgress(model.downloadUrl, tarPath, options.onProgress);
+
+	logger.info(`Extracting embedding model into ${cacheDir}`);
+	await fsDriver.tarExtract({ file: tarPath, cwd: cacheDir });
+
+	// Sanity check: after extraction the archive directory should exist with
+	// the marker file in place. If not, the tarball was malformed.
+	const verified = await localModelPath(model);
+	if (!verified) {
+		throw new Error(`Embedding model archive did not extract as expected (missing ${targetDir}/config.json)`);
+	}
+
+	// Tarball is no longer needed once extracted.
+	try {
+		await fsDriver.remove(tarPath);
+	} catch (error) {
+		// Non-fatal — the next download attempt will clean it up.
+		logger.warn(`Failed to delete model archive at ${tarPath}: ${error.message ?? error}`);
+	}
+
+	return verified;
+};
+
+const downloadWithProgress = async (
+	url: string,
+	destPath: string,
+	onProgress?: ProgressCallback,
+): Promise<void> => {
+	// shim.fetchBlob streams the body straight to disk and handles redirects
+	// (GitHub Releases redirects to S3, so following redirects is mandatory).
+	// We pass a minimal downloadController so the underlying node http code
+	// hands us each chunk as it arrives — that's our progress signal.
+	const downloadController = onProgress ? makeProgressController(onProgress) : undefined;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- shim.fetchBlob accepts a heterogenous options bag; the downloadController shape comes from the node implementation
+	const response: any = await shim.fetchBlob(url, {
+		path: destPath,
+		method: 'GET',
+		downloadController,
+	});
+
+	if (!response || response.ok === false) {
+		const status = response?.status ?? 'unknown';
+		throw new Error(`Failed to download embedding model: HTTP ${status}`);
+	}
+};
+
+// Minimal downloadController shape that conforms to the contract exercised by
+// shim-init-node's fetchBlob (only `handleChunk(request)` is called). We don't
+// care about the size-limit fields the real LimitedDownloadController uses —
+// they're set internally by callers that need them.
+const makeProgressController = (onProgress: ProgressCallback) => {
+	let bytesDownloaded = 0;
+	const totalBytes: number | null = null;
+	return {
+		totalBytes: 0,
+		imagesCount: 0,
+		imageCountExpected: 0,
+		maxImagesCount: 0,
+		printStats: () => { /* no-op */ },
+		limitMessage: () => '',
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- DownloadChunk type isn't re-exported; we read only .length
+		handleChunk: (_request: unknown) => (chunk: any) => {
+			bytesDownloaded += chunk.length ?? 0;
+			onProgress({ bytesDownloaded, totalBytes });
+		},
+	};
+};
+
+// Clears the cached model. Used for the future "re-download" path and to
+// reclaim disk space when AI is disabled and the user wants a clean slate.
+export const removeCachedModel = async (model: ModelDescriptor): Promise<void> => {
+	const fsDriver = shim.fsDriver();
+	const dir = modelDir(model);
+	const tar = archivePath(model);
+	if (await fsDriver.exists(dir)) await fsDriver.remove(dir);
+	if (await fsDriver.exists(tar)) await fsDriver.remove(tar);
+};

--- a/packages/lib/services/ai/EmbeddingModelDownloader.ts
+++ b/packages/lib/services/ai/EmbeddingModelDownloader.ts
@@ -151,11 +151,19 @@ const downloadWithProgress = async (
 	// (GitHub Releases redirects to S3, so following redirects is mandatory).
 	// We pass a minimal downloadController so the underlying node http code
 	// hands us each chunk as it arrives — that's our progress signal.
+	//
+	// The timeout is per-socket-idle (not total), so a 60s value means "fail
+	// after 60s of silence" — fine for a multi-minute download as long as
+	// data keeps flowing. Without it, shim.fetchBlob defaults to no timeout
+	// and a stalled connection (captive portal, dropped TCP traffic, hung
+	// proxy) would block forever and freeze every concurrent caller waiting
+	// on the shared in-flight promise.
 	const downloadController = onProgress ? makeProgressController(onProgress) : undefined;
 	const response = await shim.fetchBlob(url, {
 		path: destPath,
 		method: 'GET',
 		downloadController,
+		timeout: 60_000,
 	});
 
 	if (!response || response.ok === false) {

--- a/packages/lib/services/ai/EmbeddingModelDownloader.ts
+++ b/packages/lib/services/ai/EmbeddingModelDownloader.ts
@@ -129,8 +129,7 @@ const downloadWithProgress = async (
 	// We pass a minimal downloadController so the underlying node http code
 	// hands us each chunk as it arrives — that's our progress signal.
 	const downloadController = onProgress ? makeProgressController(onProgress) : undefined;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- shim.fetchBlob accepts a heterogenous options bag; the downloadController shape comes from the node implementation
-	const response: any = await shim.fetchBlob(url, {
+	const response = await shim.fetchBlob(url, {
 		path: destPath,
 		method: 'GET',
 		downloadController,

--- a/packages/lib/services/ai/OnnxRuntime.test.ts
+++ b/packages/lib/services/ai/OnnxRuntime.test.ts
@@ -1,0 +1,40 @@
+import shim from '../../shim';
+
+// Smoke test confirming onnxruntime-node loads cleanly through the shim. No
+// real model is loaded yet — that lands with the LocalEmbeddingProvider. The
+// goal of this test is to catch packaging/native-binary breakage early, the
+// same way SqliteVec.test does for sqlite-vec.
+
+describe('onnxruntime-node', () => {
+
+	it('is reachable via the shim', () => {
+		const ort = shim.onnxRuntime();
+		if (!ort) {
+			// eslint-disable-next-line no-console
+			console.warn('Skipping onnxruntime test: onnxruntime-node unavailable on this platform');
+			return;
+		}
+		expect(typeof ort.InferenceSession).toBe('function');
+		expect(typeof ort.Tensor).toBe('function');
+	});
+
+	it('can build a Float32 Tensor with the correct dims', () => {
+		const ort = shim.onnxRuntime();
+		if (!ort) return;
+		const data = new Float32Array([1, 2, 3, 4, 5, 6]);
+		const t = new ort.Tensor('float32', data, [2, 3]);
+		expect(t.dims).toEqual([2, 3]);
+		expect(t.type).toBe('float32');
+		expect(t.size).toBe(6);
+	});
+
+	it('exposes SessionOptions threading and optimisation flags', () => {
+		const ort = shim.onnxRuntime();
+		if (!ort) return;
+		// We can't instantiate a session without a real model file, but we
+		// can confirm InferenceSession.create exists — that's the entry
+		// point LocalEmbeddingProvider will use. The actual model load test
+		// will land alongside the provider once a real model file is in play.
+		expect(typeof ort.InferenceSession.create).toBe('function');
+	});
+});

--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -120,6 +120,8 @@ export interface ShimInitOptions {
 	nodeSqlite?: any;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- sqlite-vec is only bundled with desktop; see shim.sqliteVec_
 	sqliteVec?: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- onnxruntime-node is only bundled with desktop; see shim.onnxRuntime_
+	onnxRuntime?: any;
 	pdfJs?: PdfJs;
 	isAppleSilicon?: ()=> boolean;
 }
@@ -133,6 +135,7 @@ function shimInit(options: ShimInitOptions = null) {
 		electronBridge: null,
 		nodeSqlite: null,
 		sqliteVec: null,
+		onnxRuntime: null,
 		pdfJs: null,
 		isAppleSilicon: () => false,
 		...options,
@@ -145,6 +148,7 @@ function shimInit(options: ShimInitOptions = null) {
 
 	shim.setNodeSqlite(options.nodeSqlite);
 	shim.setSqliteVec(options.sqliteVec);
+	shim.setOnnxRuntime(options.onnxRuntime);
 
 	shim.fsDriver = () => {
 		throw new Error('Not implemented');

--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -103,6 +103,8 @@ let reactDom_: typeof ReactDom = null;
 let nodeSqlite_: any = null;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- sqlite-vec is only bundled with desktop; null on platforms that don't ship it
 let sqliteVec_: any = null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- onnxruntime-node is only bundled with desktop; null on platforms (mobile/CLI/web) that don't ship it
+let onnxRuntime_: any = null;
 
 const shim = {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Geolocation API differs across platforms (browser Geolocation, RN Geolocation module); accessed structurally
@@ -547,6 +549,19 @@ const shim = {
 
 	sqliteVec: () => {
 		return sqliteVec_;
+	},
+
+	// onnxruntime-node powers the bundled local embedding model. Only the
+	// desktop app installs it; other platforms (CLI, mobile, web) leave it
+	// unset and the embedding indexer reports the local provider as
+	// unavailable rather than crashing.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See onnxRuntime_
+	setOnnxRuntime: (onnxRuntime: any) => {
+		onnxRuntime_ = onnxRuntime;
+	},
+
+	onnxRuntime: () => {
+		return onnxRuntime_;
 	},
 
 	setReact: (react: typeof React) => {

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -320,3 +320,5 @@ Ideographs
 chunker
 idempotently
 unigrams
+sentencepiece
+heterogenous

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -321,4 +321,3 @@ chunker
 idempotently
 unigrams
 sentencepiece
-heterogenous

--- a/yarn.lock
+++ b/yarn.lock
@@ -12427,6 +12427,7 @@ __metadata:
     node-fetch: "npm:2.6.7"
     node-notifier: "npm:10.0.1"
     node-rsa: "npm:1.1.1"
+    onnxruntime-node: "npm:1.26.0"
     pdfjs-dist: "npm:3.11.174"
     pretty-bytes: "npm:5.6.0"
     re-resizable: "npm:6.11.2"
@@ -12796,6 +12797,7 @@ __metadata:
     node-notifier: "npm:10.0.1"
     node-persist: "npm:3.1.3"
     node-rsa: "npm:1.1.1"
+    onnxruntime-node: "npm:1.26.0"
     pdf-lib: "npm:1.17.1"
     pdfjs-dist: "npm:3.11.174"
     query-string: "npm:7.1.3"
@@ -20953,6 +20955,13 @@ __metadata:
   version: 0.5.16
   resolution: "adm-zip@npm:0.5.16"
   checksum: 10/e167d1b9e60cde37334efda828fa514680af9facbd4183952f36526390e5c7da9a90ca1e6880dfd3aba7b3517f1506c6178e0dc29cd630b26b98c795f97fc599
+  languageName: node
+  linkType: hard
+
+"adm-zip@npm:^0.5.16":
+  version: 0.5.17
+  resolution: "adm-zip@npm:0.5.17"
+  checksum: 10/035ea96d04376c290bed3401b67d1a2a2654996450ec9056dccc0fb194cb6a956bf7ad388d2648b0e1775338a377805601deca4bcd689658dc1d39247a1e9bdd
   languageName: node
   linkType: hard
 
@@ -33992,6 +34001,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"global-agent@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "global-agent@npm:4.1.3"
+  dependencies:
+    globalthis: "npm:^1.0.2"
+    matcher: "npm:^4.0.0"
+    semver: "npm:^7.3.5"
+    serialize-error: "npm:^8.1.0"
+  checksum: 10/ab36715c87d1afa10d005d6670461be9571a343b0e59f141ba0e88787d6bb05f922cccb38fd7f2a7391d188f4a5e97b3669aeb941fd761b68b8c8b71551d767d
+  languageName: node
+  linkType: hard
+
 "global-dirs@npm:^0.1.1":
   version: 0.1.1
   resolution: "global-dirs@npm:0.1.1"
@@ -34082,22 +34103,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globalthis@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "globalthis@npm:1.0.3"
-  dependencies:
-    define-properties: "npm:^1.1.3"
-  checksum: 10/45ae2f3b40a186600d0368f2a880ae257e8278b4c7704f0417d6024105ad7f7a393661c5c2fa1334669cd485ea44bc883a08fdd4516df2428aec40c99f52aa89
-  languageName: node
-  linkType: hard
-
-"globalthis@npm:^1.0.4":
+"globalthis@npm:^1.0.2, globalthis@npm:^1.0.4":
   version: 1.0.4
   resolution: "globalthis@npm:1.0.4"
   dependencies:
     define-properties: "npm:^1.2.1"
     gopd: "npm:^1.0.1"
   checksum: 10/1f1fd078fb2f7296306ef9dd51019491044ccf17a59ed49d375b576ca108ff37e47f3d29aead7add40763574a992f16a5367dd1e2173b8634ef18556ab719ac4
+  languageName: node
+  linkType: hard
+
+"globalthis@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "globalthis@npm:1.0.3"
+  dependencies:
+    define-properties: "npm:^1.1.3"
+  checksum: 10/45ae2f3b40a186600d0368f2a880ae257e8278b4c7704f0417d6024105ad7f7a393661c5c2fa1334669cd485ea44bc883a08fdd4516df2428aec40c99f52aa89
   languageName: node
   linkType: hard
 
@@ -40942,6 +40963,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"matcher@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "matcher@npm:4.0.0"
+  dependencies:
+    escape-string-regexp: "npm:^4.0.0"
+  checksum: 10/d338aff31d8dfd3626873e43777f46b123579734d53bb8d18d64b08a822ba5e8d39f5fe2e23403258e6143aa0cbe20a15662720d825cd0d3af961d5a44230328
+  languageName: node
+  linkType: hard
+
 "math-intrinsics@npm:^1.1.0":
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
@@ -45003,6 +45033,25 @@ __metadata:
   version: 0.0.2
   resolution: "only@npm:0.0.2"
   checksum: 10/e2ad03e486534dc6bfb983393be83125a4669052b4a19a353eb00475b46971fb238a18223f2b609fe0d1bcb61ff8373964ccac64d05cbf970865299f655ed0ba
+  languageName: node
+  linkType: hard
+
+"onnxruntime-common@npm:1.26.0":
+  version: 1.26.0
+  resolution: "onnxruntime-common@npm:1.26.0"
+  checksum: 10/d1bab04546e069c898ab7b541a662f5e5bc6f5e58781ff62a752aa902da7d495aabe80549fe6e123198ef81d409cf484acbcc052affd41db6f3ddc041deeb2e8
+  languageName: node
+  linkType: hard
+
+"onnxruntime-node@npm:1.26.0":
+  version: 1.26.0
+  resolution: "onnxruntime-node@npm:1.26.0"
+  dependencies:
+    adm-zip: "npm:^0.5.16"
+    global-agent: "npm:^4.1.3"
+    onnxruntime-common: "npm:1.26.0"
+  checksum: 10/4f2944124457ecf0fec2200532817ddc448136d76ed72e68eab312feac45cc631899ea2bb21935267c54cdae3a0cddb1ed7359edcb633fbc080fb09ad0a0021e
+  conditions: (os=win32 | os=darwin | os=linux)
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds the download-and-extract pipeline for the local embedding model that will power on-device semantic search. On first use of AI features, the desktop app fetches a ~140 MB tarball from the [`joplin/embedding-models`](https://github.com/joplin/embedding-models) GitHub release and extracts it under the user's cache directory.

The downloader is idempotent (no-op if the model is already cached), cleans up partial state from previous failed attempts, and exposes a progress callback so a future settings UI can show download status. Tests stub the network and exercise the real extract logic against a locally-built tarball.

No user-visible change yet — the downloader is wired but nothing calls it. The `LocalEmbeddingProvider` that consumes it lands in a follow-up.