### PR TITLE
Desktop: Resolves #15578: OneNote Import: Handwriting/pen strokes imported incorrectly

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1110,8 +1110,9 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 				// when the note content is updated externally.
 				const offsetBookmarkId = 2;
 				const bookmark = editor.selection.getBookmark(offsetBookmarkId);
-				if (result.html.includes('ink-text') || result.html.includes('ink-space') || result.html.includes('container-outline')) {
+				if (new DOMParser().parseFromString(result.html, 'text/html').querySelector('.ink-text, .ink-space, .container-outline') && !editor.getDoc().head.querySelector('style[data-joplin-onenote-content-style="true"]')) {
 					const styleElement = editor.getDoc().createElement('style');
+					styleElement.setAttribute('data-joplin-onenote-content-style', 'true');
 					styleElement.textContent = '.ink-text, .ink-space { display: inline-block; position: relative; vertical-align: bottom; } .container-outline { font-family: Calibri, sans-serif; font-size: 6pt; font-weight: normal; }';
 					editor.getDoc().head.appendChild(styleElement);
 				}
@@ -1665,4 +1666,3 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 };
 
 export default forwardRef(TinyMCE);
-

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1113,10 +1113,11 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 
 				// This is a workaround to inject missing ink style for OneNote imported notes.
 				// See https://github.com/laurent22/joplin/issues/15578 for more details.
-				const hasOneNoteInkContentStyle = !!editor.getDoc().head.querySelector('style[data-joplin-onenote-content-style="true"]');
+				const oneNoteInkContentStyleId = 'joplin-onenote-content-style';
+				const hasOneNoteInkContentStyle = !!editor.getDoc().getElementById(oneNoteInkContentStyleId);
 				if (!hasOneNoteInkContentStyle && new DOMParser().parseFromString(result.html, 'text/html').querySelector('.ink-text, .ink-space, .container-outline')) {
 					const styleElement = editor.getDoc().createElement('style');
-					styleElement.setAttribute('data-joplin-onenote-content-style', 'true');
+					styleElement.id = oneNoteInkContentStyleId;
 					styleElement.textContent = '.ink-text, .ink-space { display: inline-block; position: relative; vertical-align: bottom; } .container-outline { font-family: Calibri, sans-serif; font-size: 6pt; font-weight: normal; }';
 					editor.getDoc().head.appendChild(styleElement);
 				}

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1110,6 +1110,11 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 				// when the note content is updated externally.
 				const offsetBookmarkId = 2;
 				const bookmark = editor.selection.getBookmark(offsetBookmarkId);
+				if (result.html.includes('ink-text') || result.html.includes('ink-space') || result.html.includes('container-outline')) {
+					const styleElement = editor.getDoc().createElement('style');
+					styleElement.textContent = '.ink-text, .ink-space { display: inline-block; position: relative; vertical-align: bottom; } .container-outline { font-family: Calibri, sans-serif; font-size: 6pt; font-weight: normal; }';
+					editor.getDoc().head.appendChild(styleElement);
+				}
 				const htmlAndCss = [
 					`<style>${result.cssStrings?.join('\n')}</style>`,
 					preprocessHtml(result.html),

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1110,6 +1110,9 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 				// when the note content is updated externally.
 				const offsetBookmarkId = 2;
 				const bookmark = editor.selection.getBookmark(offsetBookmarkId);
+
+				// This is a workaround to inject missing ink style for OneNote imported notes.
+				// See https://github.com/laurent22/joplin/pull/15681 for more details.
 				if (new DOMParser().parseFromString(result.html, 'text/html').querySelector('.ink-text, .ink-space, .container-outline') && !editor.getDoc().head.querySelector('style[data-joplin-onenote-content-style="true"]')) {
 					const styleElement = editor.getDoc().createElement('style');
 					styleElement.setAttribute('data-joplin-onenote-content-style', 'true');

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1112,8 +1112,9 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 				const bookmark = editor.selection.getBookmark(offsetBookmarkId);
 
 				// This is a workaround to inject missing ink style for OneNote imported notes.
-				// See https://github.com/laurent22/joplin/pull/15681 for more details.
-				if (new DOMParser().parseFromString(result.html, 'text/html').querySelector('.ink-text, .ink-space, .container-outline') && !editor.getDoc().head.querySelector('style[data-joplin-onenote-content-style="true"]')) {
+				// See https://github.com/laurent22/joplin/issues/15578 for more details.
+				const hasOneNoteInkContentStyle = !!editor.getDoc().head.querySelector('style[data-joplin-onenote-content-style="true"]');
+				if (!hasOneNoteInkContentStyle && new DOMParser().parseFromString(result.html, 'text/html').querySelector('.ink-text, .ink-space, .container-outline')) {
 					const styleElement = editor.getDoc().createElement('style');
 					styleElement.setAttribute('data-joplin-onenote-content-style', 'true');
 					styleElement.textContent = '.ink-text, .ink-space { display: inline-block; position: relative; vertical-align: bottom; } .container-outline { font-family: Calibri, sans-serif; font-size: 6pt; font-weight: normal; }';


### PR DESCRIPTION
Resolves #15578 

I switched it to "Draft" as it requires more discussion.

This commit <https://github.com/laurent22/joplin/commit/81f5a8463e95046e649cd4ec8adb9865fae9e3e0> changed the behavior to pass the bodyOnly for RTE to avoid crash caused by `<div id="rendered-md">...</div>` and added 
```
const htmlAndCss = [
	`<style>${result.cssStrings?.join('\n')}</style>`,
	preprocessHtml(result.html),
].join('\n');
editor.setContent(htmlAndCss);
```
From my quick search, tinyMCE may not render styles correctly if in body unless using a specific configuration. 

We have 2 possible fixes:
- The first one is in the importer level where we put those specific missing ink styles as inline styles. BUT this one will not fix old imported broken notes. 
- The second fix consist of injecting the ink style in head if the body contains ink elements