### PR TITLE
Desktop: Add local embedding provider for note indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1549,6 +1549,8 @@ packages/lib/services/ai/EmbeddingIndexer.test.js
 packages/lib/services/ai/EmbeddingIndexer.js
 packages/lib/services/ai/EmbeddingModelDownloader.test.js
 packages/lib/services/ai/EmbeddingModelDownloader.js
+packages/lib/services/ai/LocalEmbeddingProvider.test.js
+packages/lib/services/ai/LocalEmbeddingProvider.js
 packages/lib/services/ai/OnnxRuntime.test.js
 packages/lib/services/ai/SqliteVec.test.js
 packages/lib/services/ai/aiSettingsTransition.test.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1575,6 +1575,8 @@ packages/lib/services/ai/EmbeddingIndexer.test.js
 packages/lib/services/ai/EmbeddingIndexer.js
 packages/lib/services/ai/EmbeddingModelDownloader.test.js
 packages/lib/services/ai/EmbeddingModelDownloader.js
+packages/lib/services/ai/LocalEmbeddingProvider.test.js
+packages/lib/services/ai/LocalEmbeddingProvider.js
 packages/lib/services/ai/OnnxRuntime.test.js
 packages/lib/services/ai/SqliteVec.test.js
 packages/lib/services/ai/aiSettingsTransition.test.js

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "pdfjs-dist@*": "patch:pdfjs-dist@npm%3A3.11.174#./.yarn/patches/pdfjs-dist-npm-3.11.174-67f2fee6d6.patch",
     "pdfjs-dist@3.11.174": "patch:pdfjs-dist@npm%3A3.11.174#./.yarn/patches/pdfjs-dist-npm-3.11.174-67f2fee6d6.patch",
     "canvas@npm:^2.11.2": "link:./.yarn/joplin-empty-package/",
+    "@xenova/transformers/sharp": "link:./.yarn/joplin-empty-package/",
     "node-gyp@npm:^9.0.0": "11.2.0",
     "node-forge@npm:^1": "1.3.2",
     "node-forge@npm:^1.3.0": "1.3.2",

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -66,6 +66,8 @@ import OcrDriverBase from '@joplin/lib/services/ocr/OcrDriverBase';
 import PerformanceLogger from '@joplin/lib/PerformanceLogger';
 import Note from '@joplin/lib/models/Note';
 import Resource from '@joplin/lib/models/Resource';
+import AiService from '@joplin/lib/services/ai/AiService';
+import LocalEmbeddingProvider from '@joplin/lib/services/ai/LocalEmbeddingProvider';
 
 const perfLogger = PerformanceLogger.create();
 
@@ -783,6 +785,16 @@ class Application extends BaseApplication {
 		await this.setupIntegrationTestUtils();
 
 		bridge().setLogFilePath(Logger.globalLogger.logFilePath());
+
+		// Install the local embedding provider before applySettingsSideEffects()
+		// — applyEmbeddingIndexerState() consults AiService for an active
+		// provider, so the indexer will silently sit idle if we wire it up after.
+		// Only install when ONNX is actually available; otherwise embeddings
+		// remain unavailable and the indexer stays off.
+		if (shim.onnxRuntime()) {
+			AiService.instance().setEmbeddingProvider(new LocalEmbeddingProvider());
+		}
+
 		await this.applySettingsSideEffects();
 
 		if (Setting.value('sync.upgradeState') === Setting.SYNC_UPGRADE_STATE_MUST_DO) {

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -220,6 +220,7 @@
   "dependencies": {
     "@electron/remote": "2.1.3",
     "@joplin/onenote-converter": "~3.7",
+    "@xenova/transformers": "2.17.2",
     "@xyflow/react": "12.10.2",
     "fs-extra": "11.3.4",
     "keytar": "7.9.0",

--- a/packages/app-desktop/tools/bundleJs.ts
+++ b/packages/app-desktop/tools/bundleJs.ts
@@ -30,7 +30,7 @@ const makeBuildContext = (entryPoint: string, renderer: boolean, addDebugStats: 
 				// in the final bundle.
 				name: 'joplin--relative-imports-for-externals',
 				setup: build => {
-					const externalRegex = /^(.*\.node|sqlite3|node-fetch|electron|@electron\/remote\/.*|electron\/.*|@mapbox\/node-pre-gyp|jsdom|onnxruntime-node)$/;
+					const externalRegex = /^(.*\.node|sqlite3|node-fetch|electron|@electron\/remote\/.*|electron\/.*|@mapbox\/node-pre-gyp|jsdom|onnxruntime-node|@xenova\/transformers)$/;
 					build.onResolve({ filter: externalRegex }, args => {
 						// Electron packages don't need relative requires
 						if (args.path === 'electron' || args.path.startsWith('electron/')) {

--- a/packages/lib/jest.setup.js
+++ b/packages/lib/jest.setup.js
@@ -13,15 +13,21 @@ const packageInfo = require('./package.json');
 // Silent on failure: Jest re-runs this file per test, so warning here floods
 // CI logs with duplicates. Any test that actually needs these modules already
 // has its own skip-if-unavailable logic.
+// Only suppress MODULE_NOT_FOUND (the expected "no prebuilt for this platform"
+// case). Anything else — ABI mismatches, corrupt installs — should surface.
 let sqliteVec = null;
 try {
 	sqliteVec = require('sqlite-vec');
-} catch (_error) { /* expected on platforms without a prebuilt */ }
+} catch (error) {
+	if (error.code !== 'MODULE_NOT_FOUND') throw error;
+}
 
 let onnxRuntime = null;
 try {
 	onnxRuntime = require('onnxruntime-node');
-} catch (_error) { /* expected on platforms without a prebuilt */ }
+} catch (error) {
+	if (error.code !== 'MODULE_NOT_FOUND') throw error;
+}
 
 // Used for testing some shared components
 const React = require('react');

--- a/packages/lib/jest.setup.js
+++ b/packages/lib/jest.setup.js
@@ -5,26 +5,23 @@ const nodeSqlite = require('sqlite3');
 const pdfJs = require('pdfjs-dist');
 const packageInfo = require('./package.json');
 
-// sqlite-vec is only bundled with the desktop app in production. We pull it in
-// here so tests covering the embeddings index have a working extension to load.
-// Wrapped in try/catch so platforms without a prebuilt (e.g. Linux ARM CI runners)
-// don't crash the whole suite — they just skip the vector-specific tests.
+// sqlite-vec and onnxruntime-node are only bundled with the desktop app in
+// production. We pull them in here so tests covering the embeddings index +
+// local model have working modules to load. Wrapped in try/catch so platforms
+// without a prebuilt (e.g. macOS x64, where onnxruntime-node ships no binary)
+// don't crash the whole suite — they just skip the relevant tests.
+// Silent on failure: Jest re-runs this file per test, so warning here floods
+// CI logs with duplicates. Any test that actually needs these modules already
+// has its own skip-if-unavailable logic.
 let sqliteVec = null;
 try {
 	sqliteVec = require('sqlite-vec');
-} catch (error) {
-	console.warn('sqlite-vec unavailable in tests on this platform:', error.message);
-}
+} catch (_error) { /* expected on platforms without a prebuilt */ }
 
-// onnxruntime-node powers the local embedding model. Same loading story as
-// sqlite-vec: bundled with desktop only, optional everywhere else, wrapped
-// in try/catch so CI runners without a prebuilt skip the tests cleanly.
 let onnxRuntime = null;
 try {
 	onnxRuntime = require('onnxruntime-node');
-} catch (error) {
-	console.warn('onnxruntime-node unavailable in tests on this platform:', error.message);
-}
+} catch (_error) { /* expected on platforms without a prebuilt */ }
 
 // Used for testing some shared components
 const React = require('react');

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,8 +12,9 @@
     "tsc": "tsc --project tsconfig.json",
     "watch": "tsc --watch --preserveWatchOutput --project tsconfig.json",
     "generatePluginTypes": "rm -rf ./plugin_types && yarn tsc --declaration --declarationDir ./plugin_types --project tsconfig.json",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "test-ci": "yarn test"
+    "test": "jest",
+    "test-ci": "yarn test",
+    "testEmbeddingProvider": "JOPLIN_RUN_REAL_EMBEDDING_TEST=1 NODE_OPTIONS=--experimental-vm-modules jest LocalEmbeddingProvider"
   },
   "devDependencies": {
     "@testing-library/dom": "10.4.1",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,7 +12,7 @@
     "tsc": "tsc --project tsconfig.json",
     "watch": "tsc --watch --preserveWatchOutput --project tsconfig.json",
     "generatePluginTypes": "rm -rf ./plugin_types && yarn tsc --declaration --declarationDir ./plugin_types --project tsconfig.json",
-    "test": "jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test-ci": "yarn test"
   },
   "devDependencies": {
@@ -31,6 +31,7 @@
     "@types/react": "19.1.10",
     "@types/react-dom": "19.1.7",
     "@types/uuid": "11.0.0",
+    "@xenova/transformers": "2.17.2",
     "jest": "29.7.0",
     "jest-expect-message": "1.1.3",
     "jsdom": "26.1.0",

--- a/packages/lib/services/ai/EmbeddingModelDownloader.test.ts
+++ b/packages/lib/services/ai/EmbeddingModelDownloader.test.ts
@@ -28,16 +28,16 @@ describe('EmbeddingModelDownloader', () => {
 	};
 
 	const buildFakeModelTarball = async (): Promise<string> => {
-		// Build a directory laid out like the real model archive: a top-level
-		// folder named after the model with a config.json marker file inside.
+		// Lay out the staging dir to match the real archive: files at the
+		// archive root, no top-level wrapper directory. The downloader
+		// extracts into modelDir(model) directly.
 		const stagingDir = `${tempDir}/staging`;
-		const modelDir = `${stagingDir}/${fakeModel.archiveName}`;
-		await fs.ensureDir(modelDir);
-		await fs.writeFile(`${modelDir}/config.json`, '{"_fake":true}');
-		await fs.writeFile(`${modelDir}/tokenizer.json`, '{}');
+		await fs.ensureDir(stagingDir);
+		await fs.writeFile(`${stagingDir}/config.json`, '{"_fake":true}');
+		await fs.writeFile(`${stagingDir}/tokenizer.json`, '{}');
 
 		const archive = `${tempDir}/${fakeModel.archiveName}.tar.gz`;
-		await tar.create({ gzip: true, cwd: stagingDir, file: archive }, [fakeModel.archiveName]);
+		await tar.create({ gzip: true, cwd: stagingDir, file: archive }, ['config.json', 'tokenizer.json']);
 		return archive;
 	};
 

--- a/packages/lib/services/ai/EmbeddingModelDownloader.ts
+++ b/packages/lib/services/ai/EmbeddingModelDownloader.ts
@@ -121,8 +121,13 @@ const runDownload = async (
 	logger.info(`Downloading embedding model from ${model.downloadUrl}`);
 	await downloadWithProgress(model.downloadUrl, tarPath, options.onProgress);
 
-	logger.info(`Extracting embedding model into ${cacheDir}`);
-	await fsDriver.tarExtract({ file: tarPath, cwd: cacheDir });
+	// The published tarball stores files at the archive root (no top-level
+	// directory) so we have to create the target dir ourselves and extract
+	// into it. If we extracted into cacheDir the model files would spill into
+	// the cache root and clobber any sibling model.
+	logger.info(`Extracting embedding model into ${targetDir}`);
+	await fsDriver.mkdir(targetDir);
+	await fsDriver.tarExtract({ file: tarPath, cwd: targetDir });
 
 	// Sanity check: after extraction the archive directory should exist with
 	// the marker file in place. If not, the tarball was malformed.

--- a/packages/lib/services/ai/LocalEmbeddingProvider.test.ts
+++ b/packages/lib/services/ai/LocalEmbeddingProvider.test.ts
@@ -1,14 +1,8 @@
 import { setupDatabaseAndSynchronizer, switchClient } from '../../testing/test-utils';
 import LocalEmbeddingProvider, { meanPoolAndNormalise } from './LocalEmbeddingProvider';
 
-// The unit tests run against a fully stubbed ONNX runtime + tokenizer, so they
-// neither touch the network nor require the real 140 MB model. The point of
-// these tests is to verify the wiring (provider → tokenizer → ort.run → mean
-// pool → normalise), not the model's quality.
-//
-// A gated real-model integration test lives at the bottom (skipped unless
-// JOPLIN_RUN_REAL_EMBEDDING_TEST=1) — that one downloads the actual model and
-// embeds a few strings end-to-end.
+// Default tests use stubbed ONNX + tokenizer (no network, no 140 MB model).
+// The bottom test opts in to the real download via JOPLIN_RUN_REAL_EMBEDDING_TEST=1.
 
 interface FakeTokenized {
 	input_ids: { data: BigInt64Array; dims: number[] };
@@ -138,28 +132,10 @@ describe('LocalEmbeddingProvider', () => {
 		expect(out[0]).toEqual([0, 0]);
 	});
 
-	// Gated smoke test that downloads the real model and walks through enough
-	// of the pipeline to prove the artefact is well-formed (download URL,
-	// tarball layout, tokenizer load, ONNX session creation). Skipped by
-	// default because it pulls ~140 MB and takes a while; enable locally with:
-	//   yarn testEmbeddingProvider
-	// (which sets JOPLIN_RUN_REAL_EMBEDDING_TEST + NODE_OPTIONS=--experimental-vm-modules
-	// — the latter lets Jest's sandbox satisfy the dynamic ESM import of
-	// @xenova/transformers).
-	//
-	// We deliberately stop short of calling embed() under Jest. ONNX's
-	// InferenceSession returns Float32Array values from outside Jest's VM
-	// realm, and `new ort.Tensor(...)` rejects them as "wrong type" — a
-	// well-known Jest sandbox / cross-realm quirk that does NOT happen in
-	// Electron. For true end-to-end inference verification, run the app
-	// with AI enabled and watch the indexer produce vectors.
-	// Only run when BOTH the opt-in env var and the required NODE_OPTIONS are
-	// set. Anything less and we skip (with a clear comment elsewhere telling
-	// people to run `yarn testEmbeddingProvider`) — better than failing loudly
-	// when a developer is just running the suite normally.
-	const realModelOptIn = process.env.JOPLIN_RUN_REAL_EMBEDDING_TEST === '1'
-		&& (process.env.NODE_OPTIONS ?? '').includes('--experimental-vm-modules');
-	(realModelOptIn ? it : it.skip)(
+	// Stops short of running inference: ONNX's output Float32Array crosses
+	// Jest's VM realm and `new ort.Tensor(...)` rejects it as wrong-type. This
+	// does NOT happen in Electron; verify full inference there.
+	(process.env.JOPLIN_RUN_REAL_EMBEDDING_TEST === '1' ? it : it.skip)(
 		'downloads and loads the real model (gated)',
 		async () => {
 			const provider = new LocalEmbeddingProvider();

--- a/packages/lib/services/ai/LocalEmbeddingProvider.test.ts
+++ b/packages/lib/services/ai/LocalEmbeddingProvider.test.ts
@@ -1,0 +1,175 @@
+import { setupDatabaseAndSynchronizer, switchClient } from '../../testing/test-utils';
+import LocalEmbeddingProvider, { meanPoolAndNormalise } from './LocalEmbeddingProvider';
+
+// The unit tests run against a fully stubbed ONNX runtime + tokenizer, so they
+// neither touch the network nor require the real 140 MB model. The point of
+// these tests is to verify the wiring (provider → tokenizer → ort.run → mean
+// pool → normalise), not the model's quality.
+//
+// A gated real-model integration test lives at the bottom (skipped unless
+// JOPLIN_RUN_REAL_EMBEDDING_TEST=1) — that one downloads the actual model and
+// embeds a few strings end-to-end.
+
+interface FakeTokenized {
+	input_ids: { data: BigInt64Array; dims: number[] };
+	attention_mask: { data: BigInt64Array; dims: number[] };
+}
+
+const makeFakeTokenizer = (perTextTokenCount: number) => {
+	return (texts: string[]): FakeTokenized => {
+		const batch = texts.length;
+		const seqLen = perTextTokenCount;
+		const ids = new BigInt64Array(batch * seqLen);
+		const mask = new BigInt64Array(batch * seqLen);
+		for (let b = 0; b < batch; b++) {
+			for (let t = 0; t < seqLen; t++) {
+				ids[b * seqLen + t] = BigInt(((b + 1) * (t + 1)) % 100);
+				mask[b * seqLen + t] = BigInt(1);
+			}
+		}
+		return {
+			input_ids: { data: ids, dims: [batch, seqLen] },
+			attention_mask: { data: mask, dims: [batch, seqLen] },
+		};
+	};
+};
+
+const HIDDEN = 8;
+
+const makeFakeOnnxRuntime = () => {
+	class FakeTensor {
+		public data: Float32Array | BigInt64Array;
+		public dims: number[];
+		public constructor(_type: string, data: Float32Array | BigInt64Array | number[], dims: number[]) {
+			this.data = Array.isArray(data) ? new Float32Array(data) : data;
+			this.dims = dims;
+		}
+	}
+
+	const session = {
+		run: async (feeds: Record<string, FakeTensor>) => {
+			const [batch, seqLen] = feeds.input_ids.dims;
+			const out = new Float32Array(batch * seqLen * HIDDEN);
+			// Deterministic: each token's hidden vector is a function of the
+			// (token value, hidden index) so different inputs produce different
+			// pooled outputs and we can assert order-sensitivity.
+			const ids = feeds.input_ids.data as BigInt64Array;
+			for (let b = 0; b < batch; b++) {
+				for (let t = 0; t < seqLen; t++) {
+					const idVal = Number(ids[b * seqLen + t]);
+					for (let h = 0; h < HIDDEN; h++) {
+						out[(b * seqLen + t) * HIDDEN + h] = (idVal + h + 1) / 100;
+					}
+				}
+			}
+			return {
+				last_hidden_state: {
+					data: out,
+					dims: [batch, seqLen, HIDDEN],
+				},
+			};
+		},
+	};
+
+	return {
+		InferenceSession: { create: async () => session },
+		Tensor: FakeTensor,
+	};
+};
+
+const norm = (v: number[]) => Math.sqrt(v.reduce((s, x) => s + x * x, 0));
+
+describe('LocalEmbeddingProvider', () => {
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+	});
+
+	it('produces unit-norm vectors of the expected shape', async () => {
+		const provider = new LocalEmbeddingProvider({
+			overrides: {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test fakes intentionally loose
+				onnxRuntime: makeFakeOnnxRuntime() as any,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test fakes intentionally loose
+				tokenizer: makeFakeTokenizer(4) as any,
+			},
+		});
+
+		const vectors = await provider.embed(['hello world', 'goodbye world']);
+		expect(vectors).toHaveLength(2);
+		expect(vectors[0]).toHaveLength(HIDDEN);
+		expect(norm(vectors[0])).toBeCloseTo(1, 5);
+		expect(norm(vectors[1])).toBeCloseTo(1, 5);
+	});
+
+	it('returns an empty array for empty input without initialising', async () => {
+		// No overrides — embed([]) must early-return before any setup runs.
+		const provider = new LocalEmbeddingProvider();
+		expect(await provider.embed([])).toEqual([]);
+	});
+
+	it('exposes the model id and dimension for the indexer', () => {
+		const provider = new LocalEmbeddingProvider();
+		expect(provider.id).toBe('local');
+		expect(provider.classification).toBe('local');
+		expect(provider.modelId).toBe('multilingual-e5-small');
+		expect(provider.dimension).toBe(384);
+	});
+
+	it('mean-pools only over masked-in tokens', () => {
+		// 1 batch, 3 tokens, 2 hidden dims. Mask out the middle token.
+		const hidden = new Float32Array([
+			1, 0, // t0
+			9, 9, // t1 (masked out — should be ignored)
+			0, 1, // t2
+		]);
+		const mask = new BigInt64Array([BigInt(1), BigInt(0), BigInt(1)]);
+		const out = meanPoolAndNormalise(hidden, [1, 3, 2], mask);
+		// Mean of [(1,0), (0,1)] = (0.5, 0.5), normalised = (√2/2, √2/2)
+		expect(out[0][0]).toBeCloseTo(Math.SQRT1_2, 5);
+		expect(out[0][1]).toBeCloseTo(Math.SQRT1_2, 5);
+	});
+
+	it('returns a zero vector (without dividing by zero) when nothing is masked in', () => {
+		const hidden = new Float32Array([1, 2, 3, 4]);
+		const mask = new BigInt64Array([BigInt(0), BigInt(0)]);
+		const out = meanPoolAndNormalise(hidden, [1, 2, 2], mask);
+		expect(out[0]).toEqual([0, 0]);
+	});
+
+	// Gated smoke test that downloads the real model and walks through enough
+	// of the pipeline to prove the artefact is well-formed (download URL,
+	// tarball layout, tokenizer load, ONNX session creation). Skipped by
+	// default because it pulls ~140 MB and takes a while; enable locally with:
+	//   yarn testEmbeddingProvider
+	// (which sets JOPLIN_RUN_REAL_EMBEDDING_TEST + NODE_OPTIONS=--experimental-vm-modules
+	// — the latter lets Jest's sandbox satisfy the dynamic ESM import of
+	// @xenova/transformers).
+	//
+	// We deliberately stop short of calling embed() under Jest. ONNX's
+	// InferenceSession returns Float32Array values from outside Jest's VM
+	// realm, and `new ort.Tensor(...)` rejects them as "wrong type" — a
+	// well-known Jest sandbox / cross-realm quirk that does NOT happen in
+	// Electron. For true end-to-end inference verification, run the app
+	// with AI enabled and watch the indexer produce vectors.
+	// Only run when BOTH the opt-in env var and the required NODE_OPTIONS are
+	// set. Anything less and we skip (with a clear comment elsewhere telling
+	// people to run `yarn testEmbeddingProvider`) — better than failing loudly
+	// when a developer is just running the suite normally.
+	const realModelOptIn = process.env.JOPLIN_RUN_REAL_EMBEDDING_TEST === '1'
+		&& (process.env.NODE_OPTIONS ?? '').includes('--experimental-vm-modules');
+	(realModelOptIn ? it : it.skip)(
+		'downloads and loads the real model (gated)',
+		async () => {
+			const provider = new LocalEmbeddingProvider();
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- white-box reach-in to drive initialise() without calling embed()
+			await (provider as any).ensureInitialised();
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ditto
+			expect((provider as any).session_).toBeTruthy();
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ditto
+			expect((provider as any).tokenizer_).toBeTruthy();
+		},
+		180_000,
+	);
+});

--- a/packages/lib/services/ai/LocalEmbeddingProvider.test.ts
+++ b/packages/lib/services/ai/LocalEmbeddingProvider.test.ts
@@ -132,9 +132,10 @@ describe('LocalEmbeddingProvider', () => {
 		expect(out[0]).toEqual([0, 0]);
 	});
 
-	// Stops short of running inference: ONNX's output Float32Array crosses
-	// Jest's VM realm and `new ort.Tensor(...)` rejects it as wrong-type. This
-	// does NOT happen in Electron; verify full inference there.
+	// Run via `yarn testEmbeddingProvider` (sets the env var + required
+	// NODE_OPTIONS=--experimental-vm-modules). Stops short of running inference:
+	// ONNX's output Float32Array crosses Jest's VM realm and `new ort.Tensor(...)`
+	// rejects it as wrong-type. This does NOT happen in Electron.
 	(process.env.JOPLIN_RUN_REAL_EMBEDDING_TEST === '1' ? it : it.skip)(
 		'downloads and loads the real model (gated)',
 		async () => {

--- a/packages/lib/services/ai/LocalEmbeddingProvider.ts
+++ b/packages/lib/services/ai/LocalEmbeddingProvider.ts
@@ -136,7 +136,14 @@ export default class LocalEmbeddingProvider implements EmbeddingProvider {
 
 	private async ensureInitialised(): Promise<void> {
 		if (this.session_ && this.tokenizer_) return;
-		this.initPromise_ ??= this.initialise();
+		// Clear initPromise_ on rejection so a transient failure (e.g. a
+		// dropped download) can be retried on the next call instead of every
+		// future call inheriting the same rejected promise.
+		// eslint-disable-next-line promise/prefer-await-to-then -- await would need a wrapper to keep the single-flight cache shape
+		this.initPromise_ ??= this.initialise().catch(error => {
+			this.initPromise_ = null;
+			throw error;
+		});
 		return this.initPromise_;
 	}
 

--- a/packages/lib/services/ai/LocalEmbeddingProvider.ts
+++ b/packages/lib/services/ai/LocalEmbeddingProvider.ts
@@ -1,0 +1,236 @@
+import Logger from '@joplin/utils/Logger';
+import shim from '../../shim';
+import { EmbeddingProvider, ProviderClassification } from './types';
+import {
+	MULTILINGUAL_E5_SMALL,
+	ModelDescriptor,
+	ProgressCallback,
+	ensureModelDownloaded,
+} from './EmbeddingModelDownloader';
+
+const logger = Logger.create('LocalEmbeddingProvider');
+
+// Runs the bundled multilingual-e5-small model locally via onnxruntime-node.
+// Tokenization is delegated to @xenova/transformers (AutoTokenizer); inference
+// runs through shim.onnxRuntime() so non-desktop builds (mobile, cli) that
+// haven't wired ONNX in degrade cleanly instead of crashing on require().
+//
+// e5 models expect inputs prefixed with "passage: " (for documents being
+// indexed) or "query: " (for search queries). For v1 we always use "passage:"
+// because this provider only feeds the indexer. When PR D adds search,
+// callers will provide pre-prefixed text or we'll add an `embedQuery()`
+// method — whichever fits the API best.
+
+// Cap ONNX thread count so background indexing doesn't peg every core on the
+// user's machine. 2 threads is a good compromise: noticeably faster than 1
+// without making the laptop fans spin during a re-index.
+const INTRA_OP_NUM_THREADS = 2;
+
+// e5-small returns 384-dim vectors. Hard-coded because the sqlite-vec table
+// dimension is fixed at first creation and we need to match it. If we ever
+// switch model, modelId changes too and the indexer rebuilds from scratch
+// against the new dimension.
+const E5_SMALL_DIMENSION = 384;
+
+interface OnnxSession {
+	run(feeds: Record<string, OnnxTensor>): Promise<Record<string, OnnxTensor>>;
+	inputNames?: string[];
+}
+
+interface OnnxTensor {
+	data: Float32Array | BigInt64Array;
+	dims: number[];
+}
+
+interface OnnxRuntime {
+	InferenceSession: {
+		create(modelPath: string, options?: unknown): Promise<OnnxSession>;
+	};
+	Tensor: new (type: string, data: Float32Array | BigInt64Array | number[], dims: number[])=> OnnxTensor;
+}
+
+interface Tokenizer {
+	(texts: string[], options?: { padding?: boolean; truncation?: boolean; max_length?: number }): {
+		input_ids: { data: BigInt64Array; dims: number[] };
+		attention_mask: { data: BigInt64Array; dims: number[] };
+		token_type_ids?: { data: BigInt64Array; dims: number[] };
+	};
+}
+
+export interface LocalEmbeddingProviderOptions {
+	model?: ModelDescriptor;
+	onDownloadProgress?: ProgressCallback;
+	// Test-only seam: lets unit tests inject a fake ONNX runtime + tokenizer
+	// without needing to download a real model. When both are set, the
+	// download + transformers.js code paths are skipped entirely.
+	overrides?: {
+		onnxRuntime?: OnnxRuntime;
+		tokenizer?: Tokenizer;
+	};
+}
+
+export default class LocalEmbeddingProvider implements EmbeddingProvider {
+
+	public readonly id = 'local';
+	public readonly classification: ProviderClassification = 'local';
+	public readonly modelId: string;
+	public readonly dimension: number = E5_SMALL_DIMENSION;
+
+	private model_: ModelDescriptor;
+	private onDownloadProgress_?: ProgressCallback;
+	private overrides_: LocalEmbeddingProviderOptions['overrides'];
+	private initPromise_: Promise<void> | null = null;
+	private session_: OnnxSession | null = null;
+	private tokenizer_: Tokenizer | null = null;
+
+	public constructor(options: LocalEmbeddingProviderOptions = {}) {
+		this.model_ = options.model ?? MULTILINGUAL_E5_SMALL;
+		this.onDownloadProgress_ = options.onDownloadProgress;
+		this.overrides_ = options.overrides;
+		this.modelId = this.model_.id;
+	}
+
+	public async embed(texts: string[]): Promise<number[][]> {
+		if (!texts.length) return [];
+
+		await this.ensureInitialised();
+
+		// e5 indexing prefix. Without this, retrieval quality drops noticeably
+		// (it's part of the model's training contract).
+		const prefixed = texts.map(t => `passage: ${t}`);
+
+		const tokenized = this.tokenizer_!(prefixed, {
+			padding: true,
+			truncation: true,
+			max_length: 512,
+		});
+
+		const ort = this.getOnnxRuntime();
+		const inputIds = new ort.Tensor('int64', tokenized.input_ids.data, tokenized.input_ids.dims);
+		const attentionMask = new ort.Tensor('int64', tokenized.attention_mask.data, tokenized.attention_mask.dims);
+
+		const feeds: Record<string, OnnxTensor> = {
+			input_ids: inputIds,
+			attention_mask: attentionMask,
+		};
+		// e5 was exported expecting token_type_ids as an input even though
+		// XLM-RoBERTa only ever uses a single segment. transformers.js
+		// doesn't emit it for XLM-R, so we synthesise a zero tensor with the
+		// same shape — that's what the model would see for any single-segment
+		// input anyway.
+		if (this.session_!.inputNames?.includes('token_type_ids')) {
+			const ttiData = tokenized.token_type_ids?.data
+				?? new BigInt64Array(tokenized.input_ids.data.length);
+			feeds.token_type_ids = new ort.Tensor('int64', ttiData, tokenized.input_ids.dims);
+		}
+
+		const output = await this.session_!.run(feeds);
+		const lastHidden = output.last_hidden_state ?? output.token_embeddings ?? Object.values(output)[0];
+
+		return meanPoolAndNormalise(
+			lastHidden.data as Float32Array,
+			lastHidden.dims,
+			tokenized.attention_mask.data,
+		);
+	}
+
+	private async ensureInitialised(): Promise<void> {
+		if (this.session_ && this.tokenizer_) return;
+		this.initPromise_ ??= this.initialise();
+		return this.initPromise_;
+	}
+
+	private async initialise(): Promise<void> {
+		const ort = this.getOnnxRuntime();
+		if (!ort) {
+			throw new Error('ONNX runtime is not available. Local embeddings require the desktop build.');
+		}
+
+		// Full-override path used by unit tests: skip disk + transformers.js
+		// entirely so the test runner doesn't need a real model directory.
+		if (this.overrides_?.onnxRuntime && this.overrides_?.tokenizer) {
+			this.session_ = await ort.InferenceSession.create('', {});
+			this.tokenizer_ = this.overrides_.tokenizer;
+			return;
+		}
+
+		const modelDir = await this.resolveModelDir();
+		logger.info(`Loading embedding model from ${modelDir}`);
+
+		const sessionOptions = {
+			executionProviders: ['cpu'],
+			intraOpNumThreads: INTRA_OP_NUM_THREADS,
+			graphOptimizationLevel: 'all',
+		};
+
+		this.session_ = await ort.InferenceSession.create(`${modelDir}/model_quantized.onnx`, sessionOptions);
+		this.tokenizer_ = await this.loadTokenizer(modelDir);
+	}
+
+	private async resolveModelDir(): Promise<string> {
+		return ensureModelDownloaded(this.model_, { onProgress: this.onDownloadProgress_ });
+	}
+
+	private getOnnxRuntime(): OnnxRuntime {
+		return (this.overrides_?.onnxRuntime ?? shim.onnxRuntime()) as OnnxRuntime;
+	}
+
+	private async loadTokenizer(modelDir: string): Promise<Tokenizer> {
+		if (this.overrides_?.tokenizer) return this.overrides_.tokenizer;
+		// transformers.js is an ESM-only package, so we can't `require()` it
+		// from this CommonJS module. A plain `await import()` is what we want
+		// but TypeScript rewrites it to `require()` under `module: commonjs`.
+		// `new Function('import(...)')` would also work but the renderer's CSP
+		// forbids unsafe-eval. So we hide the dynamic import in a sibling .js
+		// file that TypeScript can't see (and so can't rewrite).
+		// eslint-disable-next-line @typescript-eslint/no-require-imports -- the .js helper preserves a native ESM import past TS lowering
+		const dynamicImport = require('./dynamicEsmImport') as (s: string)=> Promise<{
+			env: { localModelPath: string; allowRemoteModels: boolean };
+			AutoTokenizer: { from_pretrained: (name: string)=> Promise<Tokenizer> };
+		}>;
+		const transformers = await dynamicImport('@xenova/transformers');
+		// Point transformers.js at the parent dir of the extracted model
+		// (so model_id `multilingual-e5-small` resolves to `${modelDir}`),
+		// and disable network fetches so we never silently hit huggingface.co.
+		transformers.env.localModelPath = `${modelDir}/..`;
+		transformers.env.allowRemoteModels = false;
+		const tokenizer = await transformers.AutoTokenizer.from_pretrained(this.model_.archiveName);
+		return tokenizer as Tokenizer;
+	}
+}
+
+// Mean-pools token embeddings over the attention mask, then L2-normalises.
+// Returns one vector per row. Public for test reach-in.
+export const meanPoolAndNormalise = (
+	hiddenStates: Float32Array,
+	dims: number[],
+	attentionMask: BigInt64Array,
+): number[][] => {
+	const [batch, seqLen, hidden] = dims;
+	const out: number[][] = [];
+
+	for (let b = 0; b < batch; b++) {
+		const vec = new Array<number>(hidden).fill(0);
+		let count = 0;
+		for (let t = 0; t < seqLen; t++) {
+			if (attentionMask[b * seqLen + t] === BigInt(0)) continue;
+			count++;
+			const base = (b * seqLen + t) * hidden;
+			for (let h = 0; h < hidden; h++) {
+				vec[h] += hiddenStates[base + h];
+			}
+		}
+		if (count > 0) {
+			for (let h = 0; h < hidden; h++) vec[h] /= count;
+		}
+		let norm = 0;
+		for (let h = 0; h < hidden; h++) norm += vec[h] * vec[h];
+		norm = Math.sqrt(norm);
+		if (norm > 0) {
+			for (let h = 0; h < hidden; h++) vec[h] /= norm;
+		}
+		out.push(vec);
+	}
+
+	return out;
+};

--- a/packages/lib/services/ai/dynamicEsmImport.js
+++ b/packages/lib/services/ai/dynamicEsmImport.js
@@ -1,0 +1,8 @@
+// Native ESM dynamic import that survives both TypeScript's CommonJS lowering
+// and the renderer's strict CSP (no `new Function`, no `eval`). Lives in a .js
+// file because tsc would otherwise rewrite the import() call to require(),
+// which can't load ESM-only packages like @xenova/transformers.
+
+module.exports = function dynamicEsmImport(specifier) {
+	return import(specifier);
+};

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -321,3 +321,6 @@ chunker
 idempotently
 unigrams
 sentencepiece
+xenova
+pretrained
+huggingface

--- a/yarn.lock
+++ b/yarn.lock
@@ -11447,6 +11447,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@huggingface/jinja@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@huggingface/jinja@npm:0.2.2"
+  checksum: 10/e4b38d75708e8adafa207d2348234f6a6bfbbf799dfcd8e56e8035c94c5884b9d4ec0cc52a97bd8ade98bc4fb5972d07b311716915045e4799ef9ac783966afe
+  languageName: node
+  linkType: hard
+
 "@humanfs/core@npm:^0.19.2":
   version: 0.19.2
   resolution: "@humanfs/core@npm:0.19.2"
@@ -12395,6 +12402,7 @@ __metadata:
     "@types/react-redux": "npm:7.1.34"
     "@types/semver": "npm:7.7.1"
     "@types/styled-components": "npm:5.1.36"
+    "@xenova/transformers": "npm:2.17.2"
     "@xyflow/react": "npm:12.10.2"
     async-mutex: "npm:0.5.0"
     axios: "npm:^1.7.7"
@@ -12762,6 +12770,7 @@ __metadata:
     "@types/react": "npm:19.1.10"
     "@types/react-dom": "npm:19.1.7"
     "@types/uuid": "npm:11.0.0"
+    "@xenova/transformers": "npm:2.17.2"
     adm-zip: "npm:0.5.16"
     async-mutex: "npm:0.5.0"
     base-64: "npm:1.0.0"
@@ -15429,6 +15438,78 @@ __metadata:
   version: 2.11.0
   resolution: "@popperjs/core@npm:2.11.0"
   checksum: 10/798848cb9db8eb41dde165cd63da31beba393131ab1232cd375ffdafb19b4cbab8a28607e1955d10516b4c0e8098b622e73203d2a9e04b1ea76205f9552c2ccd
+  languageName: node
+  linkType: hard
+
+"@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/aspromise@npm:1.1.2"
+  checksum: 10/8a938d84fe4889411296db66b29287bd61ea3c14c2d23e7a8325f46a2b8ce899857c5f038d65d7641805e6c1d06b495525c7faf00c44f85a7ee6476649034969
+  languageName: node
+  linkType: hard
+
+"@protobufjs/base64@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/base64@npm:1.1.2"
+  checksum: 10/c71b100daeb3c9bdccab5cbc29495b906ba0ae22ceedc200e1ba49717d9c4ab15a6256839cebb6f9c6acae4ed7c25c67e0a95e734f612b258261d1a3098fe342
+  languageName: node
+  linkType: hard
+
+"@protobufjs/codegen@npm:^2.0.4":
+  version: 2.0.5
+  resolution: "@protobufjs/codegen@npm:2.0.5"
+  checksum: 10/290335fa114f26202abc0695f279d53e2fd516b01cfd8298923591e0bda011295ff40e3582a1cda0a0f27cbc5039a0292082d5ad08872bb5d6243a614ac15c88
+  languageName: node
+  linkType: hard
+
+"@protobufjs/eventemitter@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "@protobufjs/eventemitter@npm:1.1.1"
+  checksum: 10/a54dc1aff4475ffad4fdf3235c71a553f5e40e3b4cf6a2e217151895a61cb4eb0be20d63791db22441ca25e594671f1021977133f9939540750231ff7d8e9dd6
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "@protobufjs/fetch@npm:1.1.1"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.1"
+  checksum: 10/427cf2da8c69b494b0df3b2fb1f43c97f0f71ca2c8ef8232dac7e44f2527ad0cc9cecb243eda14a918e86018bfa6d54d92252240d2b37ed205b13adb5506fa1d
+  languageName: node
+  linkType: hard
+
+"@protobufjs/float@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@protobufjs/float@npm:1.0.2"
+  checksum: 10/634c2c989da0ef2f4f19373d64187e2a79f598c5fb7991afb689d29a2ea17c14b796b29725945fa34b9493c17fb799e08ac0a7ccaae460ee1757d3083ed35187
+  languageName: node
+  linkType: hard
+
+"@protobufjs/inquire@npm:^1.1.0":
+  version: 1.1.2
+  resolution: "@protobufjs/inquire@npm:1.1.2"
+  checksum: 10/259756489c75a751552df60d18f82503d2534855646397b96b91cf15807fa852e99bd9eb73dabb64da37aec7913844032ecb031a4326d82aae622f5e4c2f8a17
+  languageName: node
+  linkType: hard
+
+"@protobufjs/path@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/path@npm:1.1.2"
+  checksum: 10/bb709567935fd385a86ad1f575aea98131bbd719c743fb9b6edd6b47ede429ff71a801cecbd64fc72deebf4e08b8f1bd8062793178cdaed3713b8d15771f9b83
+  languageName: node
+  linkType: hard
+
+"@protobufjs/pool@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/pool@npm:1.1.0"
+  checksum: 10/b9c7047647f6af28e92aac54f6f7c1f7ff31b201b4bfcc7a415b2861528854fce3ec666d7e7e10fd744da905f7d4aef2205bbcc8944ca0ca7a82e18134d00c46
+  languageName: node
+  linkType: hard
+
+"@protobufjs/utf8@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "@protobufjs/utf8@npm:1.1.1"
+  checksum: 10/ed0c3f9ff1afd602a0aed54c4c03a0b8f641686a5587d8949e088dcac653fb2019d15691ed92eef23dfdf9f4293249532d0508ecd15cef810acf026917719a19
   languageName: node
   linkType: hard
 
@@ -18901,6 +18982,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/long@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "@types/long@npm:4.0.2"
+  checksum: 10/68afa05fb20949d88345876148a76f6ccff5433310e720db51ac5ca21cb8cc6714286dbe04713840ddbd25a8b56b7a23aa87d08472fabf06463a6f2ed4967707
+  languageName: node
+  linkType: hard
+
 "@types/markdown-it@npm:13.0.9":
   version: 13.0.9
   resolution: "@types/markdown-it@npm:13.0.9"
@@ -19017,6 +19105,15 @@ __metadata:
   dependencies:
     undici-types: "npm:~5.26.4"
   checksum: 10/ebb85c6edcec78df926de27d828ecbeb1b3d77c165ceef95bfc26e171edbc1924245db4eb2d7d6230206fe6b1a1f7665714fe1c70739e9f5980d8ce31af6ef82
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:>=13.7.0":
+  version: 25.9.2
+  resolution: "@types/node@npm:25.9.2"
+  dependencies:
+    undici-types: "npm:>=7.24.0 <7.24.7"
+  checksum: 10/4ec76a3c9d51866cea5c6a5b17d52a2113b387e7fa812303bf20cc2949ff5e2b2bafcdef693c21ff8235d370ec2807961dc1075eb6bbea661916a5bbd84b6511
   languageName: node
   linkType: hard
 
@@ -20605,6 +20702,21 @@ __metadata:
     webpack-dev-server:
       optional: true
   checksum: 10/20424e5c1e664e4d7ab11facee7033bb729f6acd86493138069532934c1299c1426da72942822dedb00caca8fc60cc8aec1626e610ee0e8a9679e3614f555860
+  languageName: node
+  linkType: hard
+
+"@xenova/transformers@npm:2.17.2":
+  version: 2.17.2
+  resolution: "@xenova/transformers@npm:2.17.2"
+  dependencies:
+    "@huggingface/jinja": "npm:^0.2.2"
+    onnxruntime-node: "npm:1.14.0"
+    onnxruntime-web: "npm:1.14.0"
+    sharp: "npm:^0.32.0"
+  dependenciesMeta:
+    onnxruntime-node:
+      optional: true
+  checksum: 10/277d7450a2eebe92e6b79e5de715ac78692d0e1ea311ae27c29a689d180e4c2d18cef3ec81cd11d8fc5ee5445d7bd5574659c190b43f658c036c7f0535d037dc
   languageName: node
   linkType: hard
 
@@ -22949,7 +23061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-fs@npm:^4.5.5":
+"bare-fs@npm:^4.0.1, bare-fs@npm:^4.5.5":
   version: 4.7.2
   resolution: "bare-fs@npm:4.7.2"
   dependencies:
@@ -28565,7 +28677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
+"detect-libc@npm:^2.0.2, detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 10/b736c8d97d5d46164c0d1bed53eb4e6a3b1d8530d460211e2d52f1c552875e706c58a5376854e4e54f8b828c9cada58c855288c968522eb93ac7696d65970766
@@ -32614,6 +32726,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"flatbuffers@npm:^1.12.0":
+  version: 1.12.0
+  resolution: "flatbuffers@npm:1.12.0"
+  checksum: 10/cab05829660c89e01e4074cb07e3d1d79c1955e278221866f9e7ef28d5de89852f83a84084e4e83bac6bfac65108a261f9da36f5034a3145d8dc013c9959ed12
+  languageName: node
+  linkType: hard
+
 "flatted@npm:^3.1.0":
   version: 3.2.4
   resolution: "flatted@npm:3.2.4"
@@ -34302,6 +34421,13 @@ __metadata:
   version: 1.3.0
   resolution: "growly@npm:1.3.0"
   checksum: 10/77f9abc3a854ec628580939f004ba8f05c677f9a6c957be817525f20f68f75368c4879c64d12551f262a9a00de33fbefc4deb24f8f2124429c906ef20ec3c678
+  languageName: node
+  linkType: hard
+
+"guid-typescript@npm:^1.0.9":
+  version: 1.0.9
+  resolution: "guid-typescript@npm:1.0.9"
+  checksum: 10/829dd87866800a5138aafa0873994028bbc446eb20ff4cae6452d471a2a3d26f7025bed3eb980692c0f022fd22f95ea7396122b46b45a4b5084958505a4fc50c
   languageName: node
   linkType: hard
 
@@ -40353,6 +40479,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"long@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "long@npm:4.0.0"
+  checksum: 10/8296e2ba7bab30f9cfabb81ebccff89c819af6a7a78b4bb5a70ea411aa764ee0532f7441381549dfa6a1a98d72abe9138bfcf99f4fa41238629849bc035b845b
+  languageName: node
+  linkType: hard
+
 "longest-streak@npm:^3.0.0":
   version: 3.1.0
   resolution: "longest-streak@npm:3.1.0"
@@ -43571,6 +43704,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"napi-build-utils@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "napi-build-utils@npm:2.0.0"
+  checksum: 10/69adcdb828481737f1ec64440286013f6479d5b264e24d5439ba795f65293d0bb6d962035de07c65fae525ed7d2fcd0baab6891d8e3734ea792fec43918acf83
+  languageName: node
+  linkType: hard
+
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -43742,6 +43882,15 @@ __metadata:
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10/d3b38d16cb9ad0714d965331d0e38cef1c27750c2c3343cd3464a9ed8158501a2910ccbf2fd9fdc476e806a19dbc9e0524ff9d66a7c779d42a9752a63ba30b80
+  languageName: node
+  linkType: hard
+
+"node-addon-api@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "node-addon-api@npm:6.1.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10/8eea1d4d965930a177a0508695beb0d89b4c1d80bf330646a035357a1e8fc31e0d09686e2374996e96e757b947a7ece319f98ede3146683f162597c0bcb4df90
   languageName: node
   linkType: hard
 
@@ -45036,10 +45185,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"onnx-proto@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "onnx-proto@npm:4.0.4"
+  dependencies:
+    protobufjs: "npm:^6.8.8"
+  checksum: 10/8d9aaa53a1d24e6a7ab5b5670367edf5f88755b1bfd8dd4e46988e2e572582a6612fcbc88813dae1653f62d0203ff3727c01cbbce68cacd09d5669025a88605a
+  languageName: node
+  linkType: hard
+
 "onnxruntime-common@npm:1.26.0":
   version: 1.26.0
   resolution: "onnxruntime-common@npm:1.26.0"
   checksum: 10/d1bab04546e069c898ab7b541a662f5e5bc6f5e58781ff62a752aa902da7d495aabe80549fe6e123198ef81d409cf484acbcc052affd41db6f3ddc041deeb2e8
+  languageName: node
+  linkType: hard
+
+"onnxruntime-common@npm:~1.14.0":
+  version: 1.14.0
+  resolution: "onnxruntime-common@npm:1.14.0"
+  checksum: 10/c503bf7ec55532cb63b8dc370e533fe1a8d0c99812e2daad359ae4b99e88576f196912075c04baccc3ca3d8a252899e000f4ecf75c2418abf3ed1f0b74492c1b
+  languageName: node
+  linkType: hard
+
+"onnxruntime-node@npm:1.14.0":
+  version: 1.14.0
+  resolution: "onnxruntime-node@npm:1.14.0"
+  dependencies:
+    onnxruntime-common: "npm:~1.14.0"
+  conditions: (os=win32 | os=darwin | os=linux)
   languageName: node
   linkType: hard
 
@@ -45052,6 +45226,20 @@ __metadata:
     onnxruntime-common: "npm:1.26.0"
   checksum: 10/4f2944124457ecf0fec2200532817ddc448136d76ed72e68eab312feac45cc631899ea2bb21935267c54cdae3a0cddb1ed7359edcb633fbc080fb09ad0a0021e
   conditions: (os=win32 | os=darwin | os=linux)
+  languageName: node
+  linkType: hard
+
+"onnxruntime-web@npm:1.14.0":
+  version: 1.14.0
+  resolution: "onnxruntime-web@npm:1.14.0"
+  dependencies:
+    flatbuffers: "npm:^1.12.0"
+    guid-typescript: "npm:^1.0.9"
+    long: "npm:^4.0.0"
+    onnx-proto: "npm:^4.0.4"
+    onnxruntime-common: "npm:~1.14.0"
+    platform: "npm:^1.3.6"
+  checksum: 10/fcf4f71e6e134350e0f5adab8135be64bf8c7cfaa5909c53a95183330b6520e8c166aeff6cedefec719e230b823cf2a69da696e519d39a847d3e1c6cbb9c5a64
   languageName: node
   linkType: hard
 
@@ -46624,6 +46812,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"platform@npm:^1.3.6":
+  version: 1.3.6
+  resolution: "platform@npm:1.3.6"
+  checksum: 10/1f2d8333e23ea6a7620c828d2fc1ccbbd33e01928fb142323420506114d7325ebdeb1b38544efbf64e90ab73af0847f874d0f475b9327bcf53510fa827a4ef95
+  languageName: node
+  linkType: hard
+
 "playwright-core@npm:1.58.2":
   version: 1.58.2
   resolution: "playwright-core@npm:1.58.2"
@@ -48116,6 +48311,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prebuild-install@npm:^7.1.1":
+  version: 7.1.3
+  resolution: "prebuild-install@npm:7.1.3"
+  dependencies:
+    detect-libc: "npm:^2.0.0"
+    expand-template: "npm:^2.0.3"
+    github-from-package: "npm:0.0.0"
+    minimist: "npm:^1.2.3"
+    mkdirp-classic: "npm:^0.5.3"
+    napi-build-utils: "npm:^2.0.0"
+    node-abi: "npm:^3.3.0"
+    pump: "npm:^3.0.0"
+    rc: "npm:^1.2.7"
+    simple-get: "npm:^4.0.0"
+    tar-fs: "npm:^2.0.0"
+    tunnel-agent: "npm:^0.6.0"
+  bin:
+    prebuild-install: bin.js
+  checksum: 10/1b7e4c00d2750b532a4fc2a83ffb0c5fefa1b6f2ad071896ead15eeadc3255f5babd816949991af083cf7429e375ae8c7d1c51f73658559da36f948a020a3a11
+  languageName: node
+  linkType: hard
+
 "precinct@npm:^12.2.0":
   version: 12.2.0
   resolution: "precinct@npm:12.2.0"
@@ -48662,6 +48879,30 @@ __metadata:
   version: 1.2.4
   resolution: "proto-list@npm:1.2.4"
   checksum: 10/9cc3b46d613fa0d637033b225db1bc98e914c3c05864f7adc9bee728192e353125ef2e49f71129a413f6333951756000b0e54f299d921f02d3e9e370cc994100
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^6.8.8":
+  version: 6.11.6
+  resolution: "protobufjs@npm:6.11.6"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.2"
+    "@protobufjs/base64": "npm:^1.1.2"
+    "@protobufjs/codegen": "npm:^2.0.4"
+    "@protobufjs/eventemitter": "npm:^1.1.0"
+    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/float": "npm:^1.0.2"
+    "@protobufjs/inquire": "npm:^1.1.0"
+    "@protobufjs/path": "npm:^1.1.2"
+    "@protobufjs/pool": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.0"
+    "@types/long": "npm:^4.0.1"
+    "@types/node": "npm:>=13.7.0"
+    long: "npm:^4.0.0"
+  bin:
+    pbjs: bin/pbjs
+    pbts: bin/pbts
+  checksum: 10/05d3f71c86ba36213f2c0d55147269678aa83f7cda16e6586fc064cd92ff924fe3bdad4eecf63562d26d8660041f41e8bc304b9cc3eb0524657c5d38046b2df4
   languageName: node
   linkType: hard
 
@@ -53050,6 +53291,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sharp@npm:^0.32.0":
+  version: 0.32.6
+  resolution: "sharp@npm:0.32.6"
+  dependencies:
+    color: "npm:^4.2.3"
+    detect-libc: "npm:^2.0.2"
+    node-addon-api: "npm:^6.1.0"
+    node-gyp: "npm:latest"
+    prebuild-install: "npm:^7.1.1"
+    semver: "npm:^7.5.4"
+    simple-get: "npm:^4.0.1"
+    tar-fs: "npm:^3.0.4"
+    tunnel-agent: "npm:^0.6.0"
+  checksum: 10/f0e4a86881e590f86b05ea463229f62cd29afc2dca08b3f597889f872f118c2c456f382bf2c3e90e934b7a1d30f109cf5ed584cf5a23e79d6b6403a8dc0ebe32
+  languageName: node
+  linkType: hard
+
 "shasum-object@npm:^1.0.0":
   version: 1.0.0
   resolution: "shasum-object@npm:1.0.0"
@@ -53297,6 +53555,17 @@ __metadata:
     once: "npm:^1.3.1"
     simple-concat: "npm:^1.0.0"
   checksum: 10/5614c7b703402d877d6f3d665588e460088a8c11035d05b35c8fc75a8d660d1bba3da6eb2a305a936696b00e419ec25fe0f916544306a7a0e5618dea9d7100c7
+  languageName: node
+  linkType: hard
+
+"simple-get@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "simple-get@npm:4.0.1"
+  dependencies:
+    decompress-response: "npm:^6.0.0"
+    once: "npm:^1.3.1"
+    simple-concat: "npm:^1.0.0"
+  checksum: 10/93f1b32319782f78f2f2234e9ce34891b7ab6b990d19d8afefaa44423f5235ce2676aae42d6743fecac6c8dfff4b808d4c24fe5265be813d04769917a9a44f36
   languageName: node
   linkType: hard
 
@@ -55526,6 +55795,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tar-fs@npm:^3.0.4":
+  version: 3.1.2
+  resolution: "tar-fs@npm:3.1.2"
+  dependencies:
+    bare-fs: "npm:^4.0.1"
+    bare-path: "npm:^3.0.0"
+    pump: "npm:^3.0.0"
+    tar-stream: "npm:^3.1.5"
+  dependenciesMeta:
+    bare-fs:
+      optional: true
+    bare-path:
+      optional: true
+  checksum: 10/b358fb7061eebb42bfa6f122cf62d1bdd40dc619117863f3b59eeaa4f880dc03707014905bdb592e77176703d9045956d1ba27adda4458805f9f7cbf62015cbd
+  languageName: node
+  linkType: hard
+
 "tar-stream@npm:3.1.8":
   version: 3.1.8
   resolution: "tar-stream@npm:3.1.8"
@@ -55548,6 +55834,18 @@ __metadata:
     inherits: "npm:^2.0.3"
     readable-stream: "npm:^3.1.1"
   checksum: 10/1a52a51d240c118cbcd30f7368ea5e5baef1eac3e6b793fb1a41e6cd7319296c79c0264ccc5859f5294aa80f8f00b9239d519e627b9aade80038de6f966fec6a
+  languageName: node
+  linkType: hard
+
+"tar-stream@npm:^3.1.5":
+  version: 3.2.0
+  resolution: "tar-stream@npm:3.2.0"
+  dependencies:
+    b4a: "npm:^1.6.4"
+    bare-fs: "npm:^4.5.5"
+    fast-fifo: "npm:^1.2.0"
+    streamx: "npm:^2.15.0"
+  checksum: 10/ce57a81521de73ae7a3b7d55a08da50d6771427c249bfa89a208518e48faf5254c8fa7201a8f5419ab8bde9601a74e6dd512b31a13ec89774aec96178f99a8d3
   languageName: node
   linkType: hard
 
@@ -57581,6 +57879,13 @@ __metadata:
     object.reduce: "npm:^1.0.0"
     undertaker-registry: "npm:^1.0.0"
   checksum: 10/6cb5898b0b8fd4b094fbd6ed9c2e155f436d698fdc13f45444d5083825cc29bca7a364c5e27922366f0ce3fff7bb5b834f6ff3583f77cb655bbc3a60fee632ed
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:>=7.24.0 <7.24.7":
+  version: 7.24.6
+  resolution: "undici-types@npm:7.24.6"
+  checksum: 10/defc9538b952e3c15b8526596c591f7c1f0c7605ad27a2b7feddbea7ef2e3003f3eda2cdb051a3cb1a2185e3893100fd9cb925c799db99d48131ea63b5233d10
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23061,7 +23061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bare-fs@npm:^4.0.1, bare-fs@npm:^4.5.5":
+"bare-fs@npm:^4.5.5":
   version: 4.7.2
   resolution: "bare-fs@npm:4.7.2"
   dependencies:
@@ -28677,7 +28677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.0.2, detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
+"detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 10/b736c8d97d5d46164c0d1bed53eb4e6a3b1d8530d460211e2d52f1c552875e706c58a5376854e4e54f8b828c9cada58c855288c968522eb93ac7696d65970766
@@ -43704,13 +43704,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"napi-build-utils@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "napi-build-utils@npm:2.0.0"
-  checksum: 10/69adcdb828481737f1ec64440286013f6479d5b264e24d5439ba795f65293d0bb6d962035de07c65fae525ed7d2fcd0baab6891d8e3734ea792fec43918acf83
-  languageName: node
-  linkType: hard
-
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -43882,15 +43875,6 @@ __metadata:
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10/d3b38d16cb9ad0714d965331d0e38cef1c27750c2c3343cd3464a9ed8158501a2910ccbf2fd9fdc476e806a19dbc9e0524ff9d66a7c779d42a9752a63ba30b80
-  languageName: node
-  linkType: hard
-
-"node-addon-api@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "node-addon-api@npm:6.1.0"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10/8eea1d4d965930a177a0508695beb0d89b4c1d80bf330646a035357a1e8fc31e0d09686e2374996e96e757b947a7ece319f98ede3146683f162597c0bcb4df90
   languageName: node
   linkType: hard
 
@@ -48308,28 +48292,6 @@ __metadata:
   bin:
     prebuild-install: bin.js
   checksum: 10/6c70a2f82fbda8903497c560a761b000d861a3e772322c8bed012be0f0a084b5aaca4438a3fad1bd3a24210765f4fae06ddd89ea04dc4c034dde693cc0d9d5f4
-  languageName: node
-  linkType: hard
-
-"prebuild-install@npm:^7.1.1":
-  version: 7.1.3
-  resolution: "prebuild-install@npm:7.1.3"
-  dependencies:
-    detect-libc: "npm:^2.0.0"
-    expand-template: "npm:^2.0.3"
-    github-from-package: "npm:0.0.0"
-    minimist: "npm:^1.2.3"
-    mkdirp-classic: "npm:^0.5.3"
-    napi-build-utils: "npm:^2.0.0"
-    node-abi: "npm:^3.3.0"
-    pump: "npm:^3.0.0"
-    rc: "npm:^1.2.7"
-    simple-get: "npm:^4.0.0"
-    tar-fs: "npm:^2.0.0"
-    tunnel-agent: "npm:^0.6.0"
-  bin:
-    prebuild-install: bin.js
-  checksum: 10/1b7e4c00d2750b532a4fc2a83ffb0c5fefa1b6f2ad071896ead15eeadc3255f5babd816949991af083cf7429e375ae8c7d1c51f73658559da36f948a020a3a11
   languageName: node
   linkType: hard
 
@@ -53129,6 +53091,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sharp@link:./.yarn/joplin-empty-package/::locator=root%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "sharp@link:./.yarn/joplin-empty-package/::locator=root%40workspace%3A."
+  languageName: node
+  linkType: soft
+
 "sharp@npm:*":
   version: 0.34.3
   resolution: "sharp@npm:0.34.3"
@@ -53288,23 +53256,6 @@ __metadata:
     "@img/sharp-win32-x64":
       optional: true
   checksum: 10/d62bc638c8ad382dffc266beeaffab71457d592abeb6fdf95b512e6dcbce0abf47b8d903b4ea081f012ceb40e4462f1e219184c729329146df32a5ccec2c231f
-  languageName: node
-  linkType: hard
-
-"sharp@npm:^0.32.0":
-  version: 0.32.6
-  resolution: "sharp@npm:0.32.6"
-  dependencies:
-    color: "npm:^4.2.3"
-    detect-libc: "npm:^2.0.2"
-    node-addon-api: "npm:^6.1.0"
-    node-gyp: "npm:latest"
-    prebuild-install: "npm:^7.1.1"
-    semver: "npm:^7.5.4"
-    simple-get: "npm:^4.0.1"
-    tar-fs: "npm:^3.0.4"
-    tunnel-agent: "npm:^0.6.0"
-  checksum: 10/f0e4a86881e590f86b05ea463229f62cd29afc2dca08b3f597889f872f118c2c456f382bf2c3e90e934b7a1d30f109cf5ed584cf5a23e79d6b6403a8dc0ebe32
   languageName: node
   linkType: hard
 
@@ -53555,17 +53506,6 @@ __metadata:
     once: "npm:^1.3.1"
     simple-concat: "npm:^1.0.0"
   checksum: 10/5614c7b703402d877d6f3d665588e460088a8c11035d05b35c8fc75a8d660d1bba3da6eb2a305a936696b00e419ec25fe0f916544306a7a0e5618dea9d7100c7
-  languageName: node
-  linkType: hard
-
-"simple-get@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "simple-get@npm:4.0.1"
-  dependencies:
-    decompress-response: "npm:^6.0.0"
-    once: "npm:^1.3.1"
-    simple-concat: "npm:^1.0.0"
-  checksum: 10/93f1b32319782f78f2f2234e9ce34891b7ab6b990d19d8afefaa44423f5235ce2676aae42d6743fecac6c8dfff4b808d4c24fe5265be813d04769917a9a44f36
   languageName: node
   linkType: hard
 
@@ -55795,23 +55735,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-fs@npm:^3.0.4":
-  version: 3.1.2
-  resolution: "tar-fs@npm:3.1.2"
-  dependencies:
-    bare-fs: "npm:^4.0.1"
-    bare-path: "npm:^3.0.0"
-    pump: "npm:^3.0.0"
-    tar-stream: "npm:^3.1.5"
-  dependenciesMeta:
-    bare-fs:
-      optional: true
-    bare-path:
-      optional: true
-  checksum: 10/b358fb7061eebb42bfa6f122cf62d1bdd40dc619117863f3b59eeaa4f880dc03707014905bdb592e77176703d9045956d1ba27adda4458805f9f7cbf62015cbd
-  languageName: node
-  linkType: hard
-
 "tar-stream@npm:3.1.8":
   version: 3.1.8
   resolution: "tar-stream@npm:3.1.8"
@@ -55834,18 +55757,6 @@ __metadata:
     inherits: "npm:^2.0.3"
     readable-stream: "npm:^3.1.1"
   checksum: 10/1a52a51d240c118cbcd30f7368ea5e5baef1eac3e6b793fb1a41e6cd7319296c79c0264ccc5859f5294aa80f8f00b9239d519e627b9aade80038de6f966fec6a
-  languageName: node
-  linkType: hard
-
-"tar-stream@npm:^3.1.5":
-  version: 3.2.0
-  resolution: "tar-stream@npm:3.2.0"
-  dependencies:
-    b4a: "npm:^1.6.4"
-    bare-fs: "npm:^4.5.5"
-    fast-fifo: "npm:^1.2.0"
-    streamx: "npm:^2.15.0"
-  checksum: 10/ce57a81521de73ae7a3b7d55a08da50d6771427c249bfa89a208518e48faf5254c8fa7201a8f5419ab8bde9601a74e6dd512b31a13ec89774aec96178f99a8d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Third piece of PR C, after the ONNX runtime shim (#15670-ish) and the model downloader (#15679). This is the bit that actually turns text into vectors.

## Summary

- `LocalEmbeddingProvider` runs `multilingual-e5-small` locally through `onnxruntime-node`, with tokenization handled by `@xenova/transformers` (`AutoTokenizer.from_pretrained`).
- Caps `intraOpNumThreads` to 2 so background indexing doesn't peg every core during a re-index.
- Wired into `AiService` from `app-desktop` startup, gated on `shim.onnxRuntime()` being available — non-desktop builds (cli, mobile) degrade to "embeddings unavailable" rather than crashing.
- `EmbeddingModelDownloader` now extracts the tarball straight into the model directory rather than relying on a top-level wrapper inside the archive (matches how the published artefact is laid out).
- Added `@xenova/transformers` to the esbuild externals — it transitively pulls in `sharp` whose `.node` bindings esbuild can't bundle.

## ESM hack
`@xenova/transformers` is ESM-only. To call it from this CommonJS module without TypeScript rewriting the `import()` to `require()` (which can't load ESM), the dynamic import lives in a sibling `dynamicEsmImport.js` that tsc doesn't touch. `new Function('import(...)')` would also work but the renderer's CSP forbids `unsafe-eval`. Three lines; isolated to one file.
