### PR TITLE
Plugins: Add semantic search plugin API (joplin.ai.search)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1552,6 +1552,8 @@ packages/lib/services/ai/EmbeddingModelDownloader.js
 packages/lib/services/ai/LocalEmbeddingProvider.test.js
 packages/lib/services/ai/LocalEmbeddingProvider.js
 packages/lib/services/ai/OnnxRuntime.test.js
+packages/lib/services/ai/SearchService.test.js
+packages/lib/services/ai/SearchService.js
 packages/lib/services/ai/SqliteVec.test.js
 packages/lib/services/ai/aiSettingsTransition.test.js
 packages/lib/services/ai/aiSettingsTransition.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1578,6 +1578,8 @@ packages/lib/services/ai/EmbeddingModelDownloader.js
 packages/lib/services/ai/LocalEmbeddingProvider.test.js
 packages/lib/services/ai/LocalEmbeddingProvider.js
 packages/lib/services/ai/OnnxRuntime.test.js
+packages/lib/services/ai/SearchService.test.js
+packages/lib/services/ai/SearchService.js
 packages/lib/services/ai/SqliteVec.test.js
 packages/lib/services/ai/aiSettingsTransition.test.js
 packages/lib/services/ai/aiSettingsTransition.js

--- a/packages/lib/models/NoteEmbedding.ts
+++ b/packages/lib/models/NoteEmbedding.ts
@@ -233,6 +233,24 @@ export default class NoteEmbedding extends BaseModel {
 		return results;
 	}
 
+	// Loads the stored vectors for a note's chunks, in chunk-index order.
+	// Used by the search service for noteId-based queries — re-using the
+	// already-indexed vectors avoids both re-embedding and the asymmetry
+	// you'd otherwise get from running them through embedQuery().
+	public static async vectorsByNoteId(noteId: string): Promise<number[][]> {
+		this.requireVec();
+		if (!await this.vecTableExists()) return [];
+		const rows = await this.db().selectAll<{ embedding: string }>(
+			`SELECT vec_to_json(v.embedding) AS embedding
+			 FROM note_embeddings_vec v
+			 JOIN note_embeddings_meta m ON m.id = v.rowid
+			 WHERE m.note_id = ?
+			 ORDER BY m.chunk_index ASC`,
+			[noteId],
+		);
+		return rows.map(r => JSON.parse(r.embedding) as number[]);
+	}
+
 	// Drops every embedding from both tables. Used when the embedding model
 	// changes — the existing vectors are no longer comparable to anything new.
 	public static async clearAll() {

--- a/packages/lib/services/ai/LocalEmbeddingProvider.ts
+++ b/packages/lib/services/ai/LocalEmbeddingProvider.ts
@@ -91,13 +91,22 @@ export default class LocalEmbeddingProvider implements EmbeddingProvider {
 	}
 
 	public async embed(texts: string[]): Promise<number[][]> {
+		return this.runEmbed(texts, 'passage: ');
+	}
+
+	public async embedQuery(texts: string[]): Promise<number[][]> {
+		return this.runEmbed(texts, 'query: ');
+	}
+
+	private async runEmbed(texts: string[], prefix: string): Promise<number[][]> {
 		if (!texts.length) return [];
 
 		await this.ensureInitialised();
 
-		// e5 indexing prefix. Without this, retrieval quality drops noticeably
-		// (it's part of the model's training contract).
-		const prefixed = texts.map(t => `passage: ${t}`);
+		// e5 is trained with asymmetric prefixes — "passage: " for indexed
+		// documents, "query: " for search inputs. Mixing them up doesn't
+		// crash but does measurably hurt retrieval quality.
+		const prefixed = texts.map(t => `${prefix}${t}`);
 
 		const tokenized = this.tokenizer_!(prefixed, {
 			padding: true,

--- a/packages/lib/services/ai/SearchService.test.ts
+++ b/packages/lib/services/ai/SearchService.test.ts
@@ -92,7 +92,7 @@ describe('SearchService', () => {
 		expect(results).toEqual([]);
 	});
 
-	it('restricts to a notebook when scope is notebook', async () => {
+	it('restricts to a folder when scope is folder', async () => {
 		if (skipIfNoVec()) return;
 		const { folderB, carNote } = await seed();
 
@@ -101,7 +101,7 @@ describe('SearchService', () => {
 			// — the test provider is bigram-based, so we want a near-identical
 			// phrase to produce hits above the loose threshold.
 			query: { text: 'sedans and SUVs share roads' },
-			scope: { type: 'notebook', folderId: folderB.id },
+			scope: { type: 'folder', folderId: folderB.id },
 			relevance: 'loose',
 		});
 

--- a/packages/lib/services/ai/SearchService.test.ts
+++ b/packages/lib/services/ai/SearchService.test.ts
@@ -1,0 +1,225 @@
+import { setupDatabaseAndSynchronizer, switchClient, db, msleep } from '../../testing/test-utils';
+import Folder from '../../models/Folder';
+import Note from '../../models/Note';
+import Tag from '../../models/Tag';
+import ItemChange from '../../models/ItemChange';
+import AiService from './AiService';
+import EmbeddingIndexer from './EmbeddingIndexer';
+import SearchService from './SearchService';
+import TestEmbeddingProvider from './testing/TestEmbeddingProvider';
+
+// End-to-end: index a small corpus with the test embedding provider, then
+// confirm SearchService returns the expected notes for text + noteId queries
+// across the supported scopes. The test provider is bigram-based, so similar
+// strings rank higher than unrelated ones — good enough to verify ranking
+// behaviour, not the model itself.
+
+const waitForChangesSince = async (changeId: number, expectedCount: number) => {
+	for (let i = 0; i < 50; i++) {
+		const changes = await ItemChange.changesSinceId(changeId);
+		if (changes.length >= expectedCount) return;
+		await msleep(20);
+	}
+	throw new Error(`Timed out waiting for ${expectedCount} ItemChange row(s) past ${changeId}`);
+};
+
+describe('SearchService', () => {
+
+	let provider: TestEmbeddingProvider;
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+		// Use a higher dimension and a 'loose' default threshold during the
+		// search so the bigram-based test provider can produce non-zero
+		// similarity. minScore is small enough to admit anything that overlaps.
+		provider = new TestEmbeddingProvider({ dimension: 64 });
+		AiService.instance().setEmbeddingProvider(provider);
+	});
+
+	afterEach(async () => {
+		AiService.instance().setEmbeddingProvider(null);
+		await EmbeddingIndexer.instance().stopRunInBackground();
+	});
+
+	const skipIfNoVec = () => {
+		if (!db(1).sqliteVecAvailable()) {
+			// eslint-disable-next-line no-console
+			console.warn('Skipping SearchService test: sqlite-vec unavailable');
+			return true;
+		}
+		return false;
+	};
+
+	const seed = async () => {
+		const folderA = await Folder.save({ title: 'A' });
+		const folderB = await Folder.save({ title: 'B' });
+		const catNote = await Note.save({ title: 'Cats', body: 'cats and kittens love yarn', parent_id: folderA.id });
+		const dogNote = await Note.save({ title: 'Dogs', body: 'dogs and puppies chase sticks', parent_id: folderA.id });
+		const carNote = await Note.save({ title: 'Cars', body: 'sedans and SUVs share roads', parent_id: folderB.id });
+		await waitForChangesSince(0, 3);
+		await EmbeddingIndexer.instance().maintenance();
+		return { folderA, folderB, catNote, dogNote, carNote };
+	};
+
+	it('throws when no embedding provider is active', async () => {
+		AiService.instance().setEmbeddingProvider(null);
+		await expect(SearchService.instance().search({ query: { text: 'anything' } }))
+			.rejects.toThrow(/No embedding provider/);
+	});
+
+	it('returns the closest note first for a text query', async () => {
+		if (skipIfNoVec()) return;
+		const { catNote } = await seed();
+
+		const results = await SearchService.instance().search({
+			query: { text: 'kittens and cats' },
+			relevance: 'loose',
+		});
+
+		expect(results.length).toBeGreaterThan(0);
+		expect(results[0].noteId).toBe(catNote.id);
+		// Scores are cosine similarity in [0, 1]; ranking must be descending.
+		for (let i = 1; i < results.length; i++) {
+			expect(results[i].score).toBeLessThanOrEqual(results[i - 1].score);
+		}
+	});
+
+	it('returns nothing for an empty query string', async () => {
+		if (skipIfNoVec()) return;
+		await seed();
+		const results = await SearchService.instance().search({ query: { text: '   ' } });
+		expect(results).toEqual([]);
+	});
+
+	it('restricts to a notebook when scope is notebook', async () => {
+		if (skipIfNoVec()) return;
+		const { folderB, carNote } = await seed();
+
+		const results = await SearchService.instance().search({
+			// Query phrased to maximise bigram overlap with the carNote body
+			// — the test provider is bigram-based, so we want a near-identical
+			// phrase to produce hits above the loose threshold.
+			query: { text: 'sedans and SUVs share roads' },
+			scope: { type: 'notebook', folderId: folderB.id },
+			relevance: 'loose',
+		});
+
+		// Whatever comes back, it must be from folder B only.
+		for (const r of results) {
+			expect(r.noteId).toBe(carNote.id);
+		}
+	});
+
+	it('restricts to a tag when scope is tag', async () => {
+		if (skipIfNoVec()) return;
+		const { catNote, dogNote } = await seed();
+		const tag = await Tag.save({ title: 'pets' });
+		await Tag.addNote(tag.id, catNote.id);
+		await Tag.addNote(tag.id, dogNote.id);
+
+		const results = await SearchService.instance().search({
+			query: { text: 'cats kittens' },
+			scope: { type: 'tag', tagId: tag.id },
+			relevance: 'loose',
+		});
+
+		const seen = new Set(results.map(r => r.noteId));
+		expect(seen.size).toBeGreaterThan(0);
+		for (const id of seen) {
+			expect([catNote.id, dogNote.id]).toContain(id);
+		}
+	});
+
+	it('returns an empty array when the tag has no notes', async () => {
+		if (skipIfNoVec()) return;
+		await seed();
+		const tag = await Tag.save({ title: 'unused' });
+		const results = await SearchService.instance().search({
+			query: { text: 'cats' },
+			scope: { type: 'tag', tagId: tag.id },
+			relevance: 'loose',
+		});
+		expect(results).toEqual([]);
+	});
+
+	it('reuses indexed vectors when querying by noteId', async () => {
+		if (skipIfNoVec()) return;
+		const { catNote } = await seed();
+
+		// A noteId query reuses the note's stored chunks as the query vectors,
+		// so it should never call embed() / embedQuery() on the provider.
+		let embedCalls = 0;
+		let embedQueryCalls = 0;
+		class CountingProvider extends TestEmbeddingProvider {
+			public async embed(texts: string[]) { embedCalls++; return super.embed(texts); }
+			public async embedQuery(texts: string[]) { embedQueryCalls++; return super.embed(texts); }
+		}
+		AiService.instance().setEmbeddingProvider(new CountingProvider({ dimension: 64 }));
+
+		const results = await SearchService.instance().search({
+			query: { noteId: catNote.id },
+			relevance: 'loose',
+		});
+
+		expect(embedCalls).toBe(0);
+		expect(embedQueryCalls).toBe(0);
+		// The note compared against its own vectors should always score
+		// itself as a top hit.
+		expect(results.length).toBeGreaterThan(0);
+		expect(results[0].noteId).toBe(catNote.id);
+	});
+
+	it('returns an empty array when querying by a noteId that has no embeddings', async () => {
+		if (skipIfNoVec()) return;
+		const folder = await Folder.save({ title: 'f' });
+		const note = await Note.save({ body: 'never indexed', parent_id: folder.id });
+		// Skipping the indexer run on purpose — no embeddings exist for this note.
+		const results = await SearchService.instance().search({
+			query: { noteId: note.id },
+			relevance: 'loose',
+		});
+		expect(results).toEqual([]);
+	});
+
+	it('strict relevance returns fewer, higher-quality results than loose', async () => {
+		if (skipIfNoVec()) return;
+		await seed();
+		const loose = await SearchService.instance().search({
+			query: { text: 'cats kittens yarn' },
+			relevance: 'loose',
+		});
+		const strict = await SearchService.instance().search({
+			query: { text: 'cats kittens yarn' },
+			relevance: 'strict',
+		});
+		// strict may legitimately return zero if no score clears 0.55 with the
+		// test provider's bigram embedding; assert only the monotonic property.
+		expect(strict.length).toBeLessThanOrEqual(loose.length);
+	});
+
+	it('uses embedQuery when the provider exposes it', async () => {
+		if (skipIfNoVec()) return;
+		const { catNote } = await seed();
+		// Subclass that records whether embedQuery was reached. Returns the
+		// same vector embed() would produce so the search still finds something.
+		let embedQueryCalls = 0;
+		class SpyProvider extends TestEmbeddingProvider {
+			public async embedQuery(texts: string[]) {
+				embedQueryCalls++;
+				return this.embed(texts);
+			}
+		}
+		const spy = new SpyProvider({ dimension: 64 });
+		AiService.instance().setEmbeddingProvider(spy);
+
+		const results = await SearchService.instance().search({
+			query: { text: 'cats kittens' },
+			relevance: 'loose',
+		});
+
+		expect(embedQueryCalls).toBe(1);
+		// Sanity-check the search still produced a result.
+		expect(results.some(r => r.noteId === catNote.id)).toBe(true);
+	});
+});

--- a/packages/lib/services/ai/SearchService.test.ts
+++ b/packages/lib/services/ai/SearchService.test.ts
@@ -96,16 +96,16 @@ describe('SearchService', () => {
 		if (skipIfNoVec()) return;
 		const { folderB, carNote } = await seed();
 
+		// Query by the note's own id — guarantees a hit (self-match) so the
+		// "scope restricts results" check below is non-vacuous. Bigram-only
+		// text queries can return zero results past the threshold.
 		const results = await SearchService.instance().search({
-			// Query phrased to maximise bigram overlap with the carNote body
-			// — the test provider is bigram-based, so we want a near-identical
-			// phrase to produce hits above the loose threshold.
-			query: { text: 'sedans and SUVs share roads' },
+			query: { noteId: carNote.id },
 			scope: { type: 'folder', folderId: folderB.id },
 			relevance: 'loose',
 		});
 
-		// Whatever comes back, it must be from folder B only.
+		expect(results.length).toBeGreaterThan(0);
 		for (const r of results) {
 			expect(r.noteId).toBe(carNote.id);
 		}

--- a/packages/lib/services/ai/SearchService.ts
+++ b/packages/lib/services/ai/SearchService.ts
@@ -1,0 +1,137 @@
+import Logger from '@joplin/utils/Logger';
+import NoteEmbedding from '../../models/NoteEmbedding';
+import Note from '../../models/Note';
+import Tag from '../../models/Tag';
+import AiService from './AiService';
+import { EmbeddingProvider } from './types';
+import { SearchOptions, SearchQuery, SearchRelevance, SearchResult, SearchScope } from '../plugins/api/types';
+
+export type { SearchOptions, SearchQuery, SearchRelevance, SearchResult, SearchScope };
+
+const logger = Logger.create('SearchService');
+
+// Semantic search over the local embedding index. Used by the plugin API
+// (joplin.ai.search) and, eventually, by core features that want to query
+// the vector index without going through the chat layer.
+//
+// The "relevance" preset is the public contract: it maps to model-specific
+// (k, minScore) values. Plugins target the preset; we own the mapping. When
+// the bundled model changes, we re-tune the table and plugins keep working.
+
+interface RelevanceTuning {
+	k: number;
+	minScore: number;
+}
+
+// Defaults from the spec, calibrated for multilingual-e5-small. When more
+// models are supported, this becomes a per-model map keyed by modelId.
+const RELEVANCE_DEFAULTS: Record<SearchRelevance, RelevanceTuning> = {
+	strict: { k: 5, minScore: 0.55 },
+	normal: { k: 10, minScore: 0.40 },
+	loose: { k: 20, minScore: 0.25 },
+};
+
+const cosineFromDistance = (distance: number): number => {
+	// sqlite-vec returns cosine distance (1 - cosine similarity) for the
+	// default cosine metric. Clamp to [0, 1] so a tiny floating-point
+	// negative distance from a perfect-match self-query doesn't surface as
+	// a >1 score.
+	const score = 1 - distance;
+	if (score < 0) return 0;
+	if (score > 1) return 1;
+	return score;
+};
+
+export default class SearchService {
+
+	private static instance_: SearchService;
+
+	public static instance(): SearchService {
+		if (!this.instance_) this.instance_ = new SearchService();
+		return this.instance_;
+	}
+
+	public async search(options: SearchOptions): Promise<SearchResult[]> {
+		const provider = AiService.instance().getActiveEmbeddingProvider();
+		if (!provider) {
+			throw new Error('No embedding provider is active. Enable AI features in Settings → AI.');
+		}
+
+		const relevance = options.relevance ?? 'normal';
+		const tuning = RELEVANCE_DEFAULTS[relevance];
+
+		const queryVectors = await this.resolveQueryVectors(options.query, provider);
+		if (!queryVectors.length) return [];
+
+		const noteIds = await this.resolveScope(options.scope);
+		// Scope resolved to an explicit empty list (e.g. tag with no notes).
+		// similaritySearch treats an empty noteIds as "search within nothing"
+		// — return early without hitting the vec table.
+		if (noteIds && noteIds.length === 0) return [];
+
+		// Merge results across multiple query vectors (the `{ noteId }` query
+		// produces one vector per chunk). Per (noteId, chunkIndex) we keep the
+		// best score seen, then sort and trim to k.
+		const best = new Map<string, SearchResult>();
+		for (const queryVector of queryVectors) {
+			const hits = await NoteEmbedding.similaritySearch(queryVector, {
+				k: tuning.k,
+				noteIds: noteIds ?? undefined,
+			});
+			for (const hit of hits) {
+				const score = cosineFromDistance(hit.distance);
+				if (score < tuning.minScore) continue;
+				const key = `${hit.noteId}:${hit.chunkIndex}`;
+				const existing = best.get(key);
+				if (!existing || score > existing.score) {
+					best.set(key, {
+						noteId: hit.noteId,
+						chunkIndex: hit.chunkIndex,
+						chunkText: hit.chunkText,
+						score,
+					});
+				}
+			}
+		}
+
+		return Array.from(best.values())
+			.sort((a, b) => b.score - a.score)
+			.slice(0, tuning.k);
+	}
+
+	private async resolveQueryVectors(
+		query: SearchQuery,
+		provider: EmbeddingProvider,
+	): Promise<number[][]> {
+		if ('text' in query) {
+			if (!query.text.trim()) return [];
+			// Use the query-side encoding when the provider exposes one (e5
+			// and friends). Otherwise fall back to the symmetric path.
+			const embedQuery = provider.embedQuery?.bind(provider) ?? provider.embed.bind(provider);
+			return embedQuery([query.text]);
+		}
+
+		// noteId query: reuse the note's already-indexed chunks as the query
+		// vector(s). Avoids re-embedding (cheap, and matches what the indexer
+		// stored — so the math is symmetric).
+		const vectors = await NoteEmbedding.vectorsByNoteId(query.noteId);
+		if (!vectors.length) {
+			logger.info(`No embeddings indexed for note ${query.noteId} — returning empty result`);
+		}
+		return vectors;
+	}
+
+	private async resolveScope(scope: SearchScope | undefined): Promise<string[] | null> {
+		if (!scope || scope.type === 'all') return null;
+		switch (scope.type) {
+		case 'note':
+			return [scope.noteId];
+		case 'notebook': {
+			const notes = await Note.previews(scope.folderId, { fields: ['id'] });
+			return notes.map(n => n.id);
+		}
+		case 'tag':
+			return Tag.noteIds(scope.tagId);
+		}
+	}
+}

--- a/packages/lib/services/ai/SearchService.ts
+++ b/packages/lib/services/ai/SearchService.ts
@@ -32,11 +32,13 @@ const RELEVANCE_DEFAULTS: Record<SearchRelevance, RelevanceTuning> = {
 };
 
 const cosineFromDistance = (distance: number): number => {
-	// sqlite-vec returns cosine distance (1 - cosine similarity) for the
-	// default cosine metric. Clamp to [0, 1] so a tiny floating-point
-	// negative distance from a perfect-match self-query doesn't surface as
-	// a >1 score.
-	const score = 1 - distance;
+	// vec0 stores its distance as L2 (Euclidean) by default. The vectors we
+	// index are L2-normalised, so the exact relation L2² = 2·(1 − cosine)
+	// holds and we recover cosine similarity as 1 − d²/2. Clamp to [0, 1]
+	// so floating-point slop on perfect-match self-queries doesn't surface
+	// negatives or values above 1 — and so an opposing-vector edge case
+	// (cosine = −1) maps to 0 rather than a negative score.
+	const score = 1 - (distance * distance) / 2;
 	if (score < 0) return 0;
 	if (score > 1) return 1;
 	return score;

--- a/packages/lib/services/ai/SearchService.ts
+++ b/packages/lib/services/ai/SearchService.ts
@@ -126,7 +126,7 @@ export default class SearchService {
 		switch (scope.type) {
 		case 'note':
 			return [scope.noteId];
-		case 'notebook': {
+		case 'folder': {
 			const notes = await Note.previews(scope.folderId, { fields: ['id'] });
 			return notes.map(n => n.id);
 		}

--- a/packages/lib/services/ai/types.ts
+++ b/packages/lib/services/ai/types.ts
@@ -48,4 +48,10 @@ export interface EmbeddingProvider {
 	dimension: number;
 	classification: ProviderClassification;
 	embed(texts: string[]): Promise<number[][]>;
+	// Optional query-side embedding. Some models (e5 family) get noticeably
+	// better retrieval when documents and queries are encoded with different
+	// prefixes; this method lets the provider apply the query-side one.
+	// Providers without an asymmetric setup can omit it — callers fall back
+	// to embed().
+	embedQuery?(texts: string[]): Promise<number[][]>;
 }

--- a/packages/lib/services/plugins/api/Joplin.ts
+++ b/packages/lib/services/plugins/api/Joplin.ts
@@ -129,7 +129,8 @@ export default class Joplin {
 	}
 
 	/**
-	 * Access to AI features (chat completions and token usage). See {@link JoplinAi}.
+	 * Access to AI features: chat completions and semantic search over the
+	 * local embeddings index. See {@link JoplinAi}.
 	 *
 	 * <span class="platform-desktop">desktop</span>
 	 */

--- a/packages/lib/services/plugins/api/JoplinAi.ts
+++ b/packages/lib/services/plugins/api/JoplinAi.ts
@@ -1,7 +1,8 @@
 /* eslint-disable multiline-comment-style */
 
 import AiService from '../../ai/AiService';
-import { ChatMessage, ChatOptions } from './types';
+import SearchService from '../../ai/SearchService';
+import { ChatMessage, ChatOptions, SearchOptions, SearchResult } from './types';
 
 /**
  * Provides access to AI models configured by the user. The active provider
@@ -51,6 +52,42 @@ export default class JoplinAi {
 	public async chat(messages: ChatMessage[], options?: ChatOptions): Promise<string> {
 		const result = await AiService.instance().chat(messages, options);
 		return result.text;
+	}
+
+	/**
+	 * Runs a semantic search against the locally-indexed embeddings and
+	 * returns matching chunks ranked by similarity.
+	 *
+	 * The `query` is either plain text (which gets embedded internally) or
+	 * `{ noteId }`, which reuses the note's already-indexed chunks as the
+	 * query — useful for "find related notes" / tag suggestion / semantic
+	 * graph use cases without spending another embedding pass.
+	 *
+	 * The `scope` restricts the search: `'all'` (default), `'note'`,
+	 * `'notebook'` (by folder id), or `'tag'` (by tag id). Trashed and
+	 * conflict notes are excluded from results.
+	 *
+	 * The `relevance` preset controls how strict the match is:
+	 * `'strict' | 'normal' | 'loose'`. Joplin owns the mapping from preset
+	 * to model-specific (k, minScore) — plugins write against the preset
+	 * and stay compatible when the bundled model changes.
+	 *
+	 * Throws when AI features are disabled or no embedding provider is
+	 * active (e.g. ONNX failed to load on this platform).
+	 *
+	 * @example
+	 * ```typescript
+	 * const results = await joplin.ai.search({
+	 *     query: { text: 'pizza dough hydration' },
+	 *     relevance: 'normal',
+	 * });
+	 * for (const r of results) {
+	 *     console.log(r.score, r.noteId, r.chunkText.slice(0, 80));
+	 * }
+	 * ```
+	 */
+	public async search(options: SearchOptions): Promise<SearchResult[]> {
+		return SearchService.instance().search(options);
 	}
 
 }

--- a/packages/lib/services/plugins/api/JoplinAi.ts
+++ b/packages/lib/services/plugins/api/JoplinAi.ts
@@ -64,8 +64,8 @@ export default class JoplinAi {
 	 * graph use cases without spending another embedding pass.
 	 *
 	 * The `scope` restricts the search: `'all'` (default), `'note'`,
-	 * `'notebook'` (by folder id), or `'tag'` (by tag id). Trashed and
-	 * conflict notes are excluded from results.
+	 * `'folder'` (by folder id), or `'tag'` (by tag id).
+	 * Trashed and conflict notes are excluded from results.
 	 *
 	 * The `relevance` preset controls how strict the match is:
 	 * `'strict' | 'normal' | 'loose'`. Joplin owns the mapping from preset

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -996,7 +996,7 @@ export type SearchRelevance = 'strict' | 'normal' | 'loose';
  * - `all`: every indexed note (default).
  * - `note`: a single note (rarely useful directly — mainly an internal
  *   building block).
- * - `notebook`: all notes in the given folder.
+ * - `folder`: all notes in the given folder (a "notebook" in the UI).
  * - `tag`: all notes tagged with the given tag.
  *
  * Trashed and conflict notes are always excluded.
@@ -1004,7 +1004,7 @@ export type SearchRelevance = 'strict' | 'normal' | 'loose';
 export type SearchScope =
 	| { type: 'all' }
 	| { type: 'note'; noteId: string }
-	| { type: 'notebook'; folderId: string }
+	| { type: 'folder'; folderId: string }
 	| { type: 'tag'; tagId: string };
 
 /**

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -982,3 +982,60 @@ export interface ChatOptions {
 	/** Maximum number of tokens to generate. Provider default if omitted. */
 	maxTokens?: number;
 }
+
+/**
+ * Relevance preset for semantic search. Maps internally to model-specific
+ * `(k, minScore)` tuning — the preset is the public contract so plugins keep
+ * working when the bundled embedding model changes.
+ */
+export type SearchRelevance = 'strict' | 'normal' | 'loose';
+
+/**
+ * Where to look for matches.
+ *
+ * - `all`: every indexed note (default).
+ * - `note`: a single note (rarely useful directly — mainly an internal
+ *   building block).
+ * - `notebook`: all notes in the given folder.
+ * - `tag`: all notes tagged with the given tag.
+ *
+ * Trashed and conflict notes are always excluded.
+ */
+export type SearchScope =
+	| { type: 'all' }
+	| { type: 'note'; noteId: string }
+	| { type: 'notebook'; folderId: string }
+	| { type: 'tag'; tagId: string };
+
+/**
+ * What to search for: free text (embedded internally), or an existing note
+ * whose stored chunks are reused as the query — useful for "related notes",
+ * tag suggestions, and graph-style use cases without a second embedding pass.
+ */
+export type SearchQuery =
+	| { text: string }
+	| { noteId: string };
+
+/**
+ * Parameters for {@link JoplinAi.search}.
+ */
+export interface SearchOptions {
+	query: SearchQuery;
+	scope?: SearchScope;
+	relevance?: SearchRelevance;
+}
+
+/**
+ * A single hit from {@link JoplinAi.search}.
+ */
+export interface SearchResult {
+	noteId: string;
+	chunkIndex: number;
+	chunkText: string;
+	/**
+	 * Cosine similarity in `[0, 1]`. Higher means more similar. Plugins should
+	 * use this for ranking but not as an absolute threshold — that's what the
+	 * `relevance` preset is for.
+	 */
+	score: number;
+}


### PR DESCRIPTION
Fourth piece of the AI primitives work, sitting on top of the local embedding index from #15683. This is the part that exposes the index to plugins so they can do semantic search over the user's notes.

## Summary

- `joplin.ai.search({ query, scope?, relevance? })` — returns ranked chunks with their source note ID, chunk text, and similarity score. Plugins target a `relevance` preset (`'strict' | 'normal' | 'loose'`); Joplin owns the mapping to model-specific `(k, minScore)` so plugins stay compatible when the bundled model is re-tuned.
- `query` is either `{ text }` (embedded internally) or `{ noteId }` (reuses the note's already-indexed chunks as the query vector — useful for "related notes" / tag suggestion / semantic graph without a second embedding pass).
- `scope` is `'all'` (default), `'note'`, `'folder'` (by folder id), or `'tag'` (by tag id). Trashed and conflict notes are always excluded.
- Result shape is `{ noteId, chunkIndex, chunkText, score }` — never rendered note objects, so a future FTS + vector hybrid ranker can fuse results without breaking the API.

## API-shape decisions
- Score is documented as cosine similarity in `[0, 1]`, opaque, "use for ranking but not as an absolute threshold." That's what the `relevance` preset is for, and keeps room to swap ranking under the hood.
- No raw `k` / `minScore` knobs — those would leak model-specific magic numbers into plugin code.
