### PR TITLE
Chore: Revert "unknown" types to "any" in plugin API

### DIFF
--- a/packages/lib/services/plugins/api/JoplinData.ts
+++ b/packages/lib/services/plugins/api/JoplinData.ts
@@ -54,7 +54,8 @@ export default class JoplinData {
 		this.plugin = plugin;
 	}
 
-	private serializeApiBody(body: unknown) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: body can be any serialisable value
+	private serializeApiBody(body: any) {
 		if (typeof body !== 'string') { return JSON.stringify(body); }
 		return body;
 	}
@@ -75,19 +76,23 @@ export default class JoplinData {
 		return path.join('/');
 	}
 
-	public async get(path: Path, query: Record<string, unknown> = null) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: query/body are arbitrary user-provided values
+	public async get(path: Path, query: any = null) {
 		return this.api_.route(RequestMethod.GET, this.pathToString(path), query);
 	}
 
-	public async post(path: Path, query: Record<string, unknown> = null, body: unknown = null, files: RequestFile[] = null) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: query/body are arbitrary user-provided values
+	public async post(path: Path, query: any = null, body: any = null, files: RequestFile[] = null) {
 		return this.api_.route(RequestMethod.POST, this.pathToString(path), query, this.serializeApiBody(body), files);
 	}
 
-	public async put(path: Path, query: Record<string, unknown> = null, body: unknown = null, files: RequestFile[] = null) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: query/body are arbitrary user-provided values
+	public async put(path: Path, query: any = null, body: any = null, files: RequestFile[] = null) {
 		return this.api_.route(RequestMethod.PUT, this.pathToString(path), query, this.serializeApiBody(body), files);
 	}
 
-	public async delete(path: Path, query: Record<string, unknown> = null) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: query/body are arbitrary user-provided values
+	public async delete(path: Path, query: any = null) {
 		return this.api_.route(RequestMethod.DELETE, this.pathToString(path), query);
 	}
 

--- a/packages/lib/services/plugins/api/JoplinPlugins.ts
+++ b/packages/lib/services/plugins/api/JoplinPlugins.ts
@@ -84,9 +84,9 @@ export default class JoplinPlugins {
 	/**
 	 * @deprecated Use joplin.require()
 	 */
-	public require(_path: string): unknown {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: returns whatever native module the plugin requires; concretely replaced inside the sandbox
+	public require(_path: string): any {
 		// Just a stub. Implementation has to be done within plugin process, in plugin_index.js
-		return undefined;
 	}
 
 }

--- a/packages/lib/services/plugins/api/JoplinSettings.ts
+++ b/packages/lib/services/plugins/api/JoplinSettings.ts
@@ -149,9 +149,11 @@ export default class JoplinSettings {
 	/**
 	 * Gets setting values (only applies to setting you registered from your plugin)
 	 */
-	public async values(keys: string[] | string): Promise<Record<string, unknown>> {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: setting values are heterogeneous per setting; plugin authors narrow at use site
+	public async values(keys: string[] | string): Promise<Record<string, any>> {
 		if (typeof keys === 'string') keys = [keys];
-		const output: Record<string, unknown> = {};
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See above
+		const output: Record<string, any> = {};
 		for (const key of keys) {
 			output[key] = Setting.value(getPluginNamespacedSettingKey(this.plugin_.id, key));
 		}
@@ -165,14 +167,16 @@ export default class JoplinSettings {
 	 * it is recommended to use the `values()` function instead - it will be much faster than
 	 * calling `value()` multiple times.
 	 */
-	public async value(key: string): Promise<unknown> {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: setting values are heterogeneous per setting; plugin authors narrow at use site
+	public async value(key: string): Promise<any> {
 		return Setting.value(getPluginNamespacedSettingKey(this.plugin_.id, key));
 	}
 
 	/**
 	 * Sets a setting value (only applies to setting you registered from your plugin)
 	 */
-	public async setValue(key: string, value: unknown) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: see above
+	public async setValue(key: string, value: any) {
 		return Setting.setValue(getPluginNamespacedSettingKey(this.plugin_.id, key), value);
 	}
 
@@ -183,7 +187,8 @@ export default class JoplinSettings {
 	 *
 	 * https://github.com/laurent22/joplin/blob/dev/packages/lib/models/settings/builtInMetadata.ts
 	 */
-	public async globalValues(keys: string[]): Promise<unknown[]> {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: setting values are heterogeneous; plugin authors narrow at use site
+	public async globalValues(keys: string[]): Promise<any[]> {
 		const output: (string|number|boolean|undefined)[] = [];
 		for (const key of keys) {
 			output.push(Setting.isSecureKey(key) ? undefined : Setting.value(key));
@@ -194,7 +199,8 @@ export default class JoplinSettings {
 	/**
 	 * @deprecated Use joplin.settings.globalValues()
 	 */
-	public async globalValue(key: string): Promise<unknown> {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: setting values are heterogeneous; plugin authors narrow at use site
+	public async globalValue(key: string): Promise<any> {
 		if (Setting.isSecureKey(key)) return undefined;
 		return Setting.value(key);
 	}

--- a/packages/lib/services/plugins/api/JoplinViewsEditor.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsEditor.ts
@@ -260,7 +260,8 @@ export default class JoplinViewsEditors {
 	/**
 	 * See [[JoplinViewPanels]]
 	 */
-	public postMessage(handle: ViewHandle, message: unknown): void {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: messages exchanged with webview can be of any serialisable type
+	public postMessage(handle: ViewHandle, message: any): void {
 		return this.controller(handle).postMessage(message);
 	}
 

--- a/packages/lib/services/plugins/api/JoplinViewsPanels.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsPanels.ts
@@ -103,7 +103,8 @@ export default class JoplinViewsPanels {
 	 *
 	 * It is particularly useful when the webview needs to react to events emitted by the plugin or the joplin api.
 	 */
-	public postMessage(handle: ViewHandle, message: unknown): void {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: messages exchanged with webview can be of any serialisable type
+	public postMessage(handle: ViewHandle, message: any): void {
 		return this.controller(handle).postMessage(message);
 	}
 

--- a/packages/lib/services/plugins/api/noteListType.ts
+++ b/packages/lib/services/plugins/api/noteListType.ts
@@ -16,7 +16,8 @@ export type RenderNoteView = Record<string, any>;
 
 export interface OnChangeEvent {
 	elementId: string;
-	value: unknown;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: value depends on the input element type
+	value: any;
 	noteId: string;
 }
 

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -186,12 +186,14 @@ export interface ExportContext {
 	/**
 	 * You can attach your own custom data using this property - it will then be passed to each event handler, allowing you to keep state from one event to the next.
 	 */
-	userData?: unknown;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: userData is arbitrary per-plugin state
+	userData?: any;
 }
 
 export interface ImportContext {
 	sourcePath: string;
-	options: Record<string, unknown>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: import options are arbitrary per-importer
+	options: any;
 	warnings: string[];
 }
 
@@ -200,7 +202,8 @@ export interface ImportContext {
 // =================================================================
 
 export interface Script {
-	onStart?(event: Record<string, unknown>): Promise<void>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: event payload shape depends on the host context
+	onStart?(event: any): Promise<void>;
 }
 
 export interface Disposable {
@@ -305,7 +308,8 @@ export interface MenuItem {
 	 * Arguments that should be passed to the command. They will be as rest
 	 * parameters.
 	 */
-	commandArgs?: unknown[];
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: command args depend on the command
+	commandArgs?: any[];
 
 	/**
 	 * Set to "separator" to create a divider line
@@ -358,12 +362,14 @@ export type ViewHandle = string;
 
 export interface EditorCommand {
 	name: string;
-	value?: unknown;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: command value depends on the command
+	value?: any;
 }
 
 export interface DialogResult {
 	id: ButtonId;
-	formData?: Record<string, unknown>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: form data shape depends on the dialog
+	formData?: any;
 }
 
 export enum ToastType {
@@ -655,7 +661,8 @@ export interface ContentScriptContext {
 }
 
 export interface ContentScriptModuleLoadedEvent {
-	userData?: unknown;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plugin API: userData is arbitrary per-plugin state
+	userData?: any;
 }
 
 export interface ContentScriptModule {


### PR DESCRIPTION
Using "unknown" means plugins that update to the new API would break