### PR TITLE
Desktop: Resolves #15690: Padding between bottom of setting screen and button bar doesn't appear

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/style.scss
+++ b/packages/app-desktop/gui/ConfigScreen/style.scss
@@ -54,6 +54,8 @@
 	overflow: auto;
 	padding: var(--joplin-config-screen-padding);
 	padding-top: 0;
+	padding-bottom: 0;
+	align-items: flex-start;
 	display: flex;
 	flex: 1;
 


### PR DESCRIPTION
Resolves #15690 

Problem: settings container flex behavior stretch child section to full height. Bottom padding show in DevTools, but no real space on screen.

Added `align-items: flex-start` which fix the padding not showing at all
Added padding-bottom: 0 to achieve `We need to increase the padding at the bottom of the screen, so that it's the same as on the left side`

If we want it to be perfectly the same we need to:
- Remove the margin of the last element
- Remove the margin of it's parent
- Add the padding to `config-screen-settings-container`

<img width="1341" height="842" alt="image" src="https://github.com/user-attachments/assets/a398b43b-e432-4018-a0ac-21a4554da6f2" />

Because the layouts are reused in different pages I preferred the first fix even tho it's not perfect
