### PR TITLE
Server: Speed up batch deletes by using whereIn instead of OR chains

### DIFF
--- a/packages/server/src/models/BaseModel.ts
+++ b/packages/server/src/models/BaseModel.ts
@@ -409,12 +409,10 @@ export default abstract class BaseModel<T> {
 		if (!ids.length) throw new Error('no id provided');
 
 		await this.withTransaction(async () => {
-			const query = this.db(this.tableName).where({ id: ids[0] });
-			for (let i = 1; i < ids.length; i++) {
-				await query.orWhere({ id: ids[i] });
-			}
-
-			const deletedCount = await query.del();
+			// Use whereIn rather than chaining orWhere in a loop: the latter
+			// builds a giant OR clause that's expensive for both Knex to
+			// assemble and Postgres to parse.
+			const deletedCount = await this.db(this.tableName).whereIn('id', ids as (string|number)[]).del();
 			if (!options.allowNoOp && deletedCount !== ids.length) throw new Error(`${ids.length} row(s) should have been deleted but ${deletedCount} row(s) were deleted. ID: ${id}`);
 		}, 'BaseModel::delete');
 	}


### PR DESCRIPTION
The "Process orphaned items" task was triggering "Transaction did not complete" warnings on busy instances, because the batch delete inside the transaction was taking longer than 10 seconds. The root cause is in `BaseModel.delete`, which built its WHERE clause by looping over the ids and chaining `.orWhere({ id })` for each one. With a few thousand ids this produces a huge `id = $1 OR id = $2 OR ...` clause that's slow for Knex to assemble in JS and slow for Postgres to parse on the way in.

This change replaces the loop with a single `whereIn('id', ids)` call. The resulting SQL is a single short clause with an array parameter, which is dramatically cheaper end-to-end. The fix applies to every batch delete in the server, not just the orphan task.