### PR TITLE
Server: Add OrphanTrace logging to investigate orphaned items bug

### DIFF
--- a/packages/server/src/models/ItemModel.ts
+++ b/packages/server/src/models/ItemModel.ts
@@ -1069,6 +1069,9 @@ export default class ItemModel extends BaseModel<Item> {
 			}
 
 			modelLogger.info(`processOrphanedItems: Batch ${batchNum} - Found ${orphanedItems.length} orphaned items`);
+			for (const o of orphanedItems) {
+				modelLogger.info(`OrphanTrace: found orphan item=${o.id} owner=${o.owner_id} name=${o.name}`);
+			}
 
 			const userIds: string[] = unique(orphanedItems.map(i => i.owner_id));
 			const users = await this.models().user().loadByIds(userIds, { fields: ['id'] });

--- a/packages/server/src/models/ShareModel.ts
+++ b/packages/server/src/models/ShareModel.ts
@@ -216,7 +216,10 @@ export default class ShareModel extends BaseModel<Share> {
 			try {
 				await this.models().userItem().add(shareUserId, itemId, { queryContext: { uniqueConstraintErrorLoggingDisabled: true } });
 			} catch (error) {
-				if (!isUniqueConstraintError(error)) throw error;
+				if (!isUniqueConstraintError(error)) {
+					logger.error(`OrphanTrace: addUserItem failed user=${shareUserId} item=${itemId}`, error);
+					throw error;
+				}
 			}
 		};
 
@@ -227,6 +230,7 @@ export default class ShareModel extends BaseModel<Share> {
 				if (error.httpCode === ErrorNotFound.httpCode) {
 					logger.warn('Could not remove a user item because it has already been removed:', error);
 				} else {
+					logger.error(`OrphanTrace: removeUserItem failed user=${shareUserId} item=${itemId}`, error);
 					throw error;
 				}
 			}
@@ -298,6 +302,13 @@ export default class ShareModel extends BaseModel<Share> {
 						if (shareUserId === change.user_id) continue;
 						await addUserItem(shareUserId, item.id);
 					}
+				}
+
+				// Cross-check: is the item owner still in user_items? If not,
+				// this transition just produced an orphan.
+				const ownerUserItem = await this.models().userItem().byUserAndItemId(item.owner_id, item.id);
+				if (!ownerUserItem) {
+					logger.error(`OrphanTrace: handleUpdated produced orphan item=${item.id} owner=${item.owner_id} previousShare=${previousShareId} nextShare=${nextShareId} changeUser=${change.user_id}`);
 				}
 			} finally {
 				perfTimer.pop();


### PR DESCRIPTION
Adds tagged log entries to help track down the long-standing orphaned-items bug. All entries are prefixed with `OrphanTrace:` so they can be filtered as a single stream. Only fires on errors or anomalies — no per-operation logging on the hot path.

Instrumented:

- `addUserItem` / `removeUserItem` in `updateSharedItems3` — log on unrecoverable failure.
- `handleUpdated` — runs a canary after each share transition; logs an error if the item owner ended up without a `user_items` row.
- `processOrphanedItems` — logs `item=X owner=Y name=Z` for every orphan the janitor finds.

**How to use this once deployed:**

After a few days, grep production logs:

- `OrphanTrace: produced orphan` — real-time orphan creation events. If these appear, the share-update task is the bug, and the log line gives the exact item/owner/share context.
- `OrphanTrace: found orphan` — orphans caught by the janitor. If these appear without matching `produced orphan` entries, the bug is in the live item-write path (likely `saveFromRawContent`), not in `handleUpdated`.
- `OrphanTrace: ...failed` — bubble-ups from the share task; uncommon but worth knowing about.

## Instruction for Claude once data has been gathered

Chat title: "Debug orphaned items query timeout"

**Resuming the orphaned-items investigation in Joplin Server**

A few days ago I deployed `OrphanTrace:` logging across the share-update and orphan-cleanup code paths in [packages/server/src/models/ShareModel.ts](vscode-webview://1crhv3gotc2i4a8fdv07jjgip0krkvpj4mbq6g24l7uv1q7sqro0/packages/server/src/models/ShareModel.ts) and [packages/server/src/models/ItemModel.ts](vscode-webview://1crhv3gotc2i4a8fdv07jjgip0krkvpj4mbq6g24l7uv1q7sqro0/packages/server/src/models/ItemModel.ts) to investigate why ~0.0008% of items end up with no corresponding `user_items` row. Background:

- The maintainer comment at [ItemModel.ts:1036](vscode-webview://1crhv3gotc2i4a8fdv07jjgip0krkvpj4mbq6g24l7uv1q7sqro0/packages/server/src/models/ItemModel.ts#L1036) suspects share/move/unshare flows but says it can't be reproduced.
- An earlier Explore agent investigation identified `handleUpdated` in `updateSharedItems3` (ShareModel.ts ~line 273) as the highest-likelihood culprit (95% confidence) — specifically, the sequence where it removes user_items for the previous share's members then adds for the new share's members, with the item owner potentially being skipped.
- Active log entries: `OrphanTrace: addUserItem failed`, `OrphanTrace: removeUserItem failed`, `OrphanTrace: handleUpdated produced orphan` (canary), `OrphanTrace: found orphan` (janitor).

**I've now gathered production logs. Here's what I found:** {{paste log greps or summary here — counts of each OrphanTrace line, examples of `produced orphan` and `found orphan` entries with their item/owner/share IDs, and whether the two correlate}}

**Decide what to do next based on the data:**

- **If `produced orphan` entries appeared:** the share-transition path is the bug. Walk through the specific cases from the logs — look at the `item`, `owner`, `previousShare`, `nextShare`, and `changeUser` values to figure out which branch of `handleUpdated` failed to add the owner. Propose a fix that ensures the item owner always retains a `user_items` row through a transition, and write a test that reproduces the exact case from the logs.
- **If `produced orphan` never appeared but `found orphan` did:** the bug is elsewhere — most likely in the live item-write path (`saveFromRawContent` / `saveForUser` in ItemModel.ts). Move the investigation there: re-read the savepoint logic around the `saveForUser` call, look for paths where the items row gets persisted but the user_items row doesn't. Consider adding a similar canary check at the end of `saveForUser`.
- **If neither appeared but orphans still exist in the DB:** the bug is in a path I haven't instrumented at all. Re-run an Explore agent to widen the search, especially around user deletion, bulk delete operations, and the `processUserDeletions` task.
- **If `failed` entries appeared:** unrelated to orphans but worth understanding — investigate those errors separately.

Whatever the verdict, also clean up the now-unused `OrphanTrace:` log lines (or keep the canary if useful as a permanent guard). Don't leave debug logging in indefinitely.