### PR TITLE
Plugins: Fixes #15710: removed semver and used regex for version check

### DIFF
--- a/packages/generator-joplin/generators/app/templates/package_TEMPLATE.json
+++ b/packages/generator-joplin/generators/app/templates/package_TEMPLATE.json
@@ -20,8 +20,6 @@
     "copy-webpack-plugin": "^11.0.0",
     "fs-extra": "^10.1.0",
     "glob": "^8.0.3",
-    "semver": "^7.5.4",
-    "@types/semver": "^7.5.4",
     "tar": "^6.1.11",
     "ts-loader": "^9.3.1",
     "typescript": "^4.8.2",

--- a/packages/generator-joplin/generators/app/templates/script/publish/steps/verifyBuild.ts
+++ b/packages/generator-joplin/generators/app/templates/script/publish/steps/verifyBuild.ts
@@ -2,7 +2,6 @@ import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { valid } from 'semver';
 import logger from '../utils/logger';
 
 const distCommand = 'npm run dist';
@@ -50,7 +49,8 @@ const validateMetadata = async () => {
 		throw new Error('Plugin name must start with \'joplin-plugin-\' in package.json');
 	}
 
-	if (!version || !valid(version)) {
+	const semverRegex = /^\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?$/;
+	if (!version || !semverRegex.test(version)) {
 		throw new Error(`Invalid plugin version: '${version}'. Must follow semver format.`);
 	}
 


### PR DESCRIPTION
# Problem
Fixes #15710 
`verifyBuild.ts` in generator-joplin used the semver package for version validation, adding an unnecessary dependency to every plugin generated by generator-joplin.

# Solution
Replaced `semver.valid()` with a regex `(/^\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?$/)` that covers the same semver format. Removed semver and @types/semver from `package_TEMPLATE.json`. Behaviour is identical.

# Test Plan
Manually verified the regex against valid versions and invalid ones .
