### PR TITLE
Chore: Server: Allow the `tagServerLatest` script to push to other repositories

### DIFF
--- a/packages/tools/tagServerLatest.ts
+++ b/packages/tools/tagServerLatest.ts
@@ -13,14 +13,6 @@ async function main(version: string, imageName: string) {
 	};
 
 	try {
-		await doManifestQuiet('inspect', `${imageName}:amd64-${version}`);
-		await doManifestQuiet('inspect', `${imageName}:arm64-${version}`);
-	} catch (error) {
-		console.error('Failed to inspect existing tags. Does the version', version, 'exist?');
-		throw error;
-	}
-
-	try {
 		await doManifestQuiet('rm', `${imageName}:latest`);
 	} catch (_error) {
 		// The local manifest may not exist (e.g. first run, or after a previous push),

--- a/packages/tools/tagServerLatest.ts
+++ b/packages/tools/tagServerLatest.ts
@@ -1,30 +1,60 @@
 import { execCommand } from '@joplin/utils';
+import yargs = require('yargs');
+import { hideBin } from 'yargs/helpers';
 
-async function main() {
-	const argv = require('yargs').argv;
-	if (!argv._.length) throw new Error('Version number is required');
+async function main(version: string, imageName: string) {
+	console.log('Marking version', version, 'of image', imageName, 'as latest...');
 
-	const version = argv._[0];
-
-	const imageName = 'joplin/server';
+	const doManifest = (...args: string[]) => {
+		return execCommand(['docker', 'manifest', ...args]);
+	};
+	const doManifestQuiet = (...args: string[]) => {
+		return execCommand(['docker', 'manifest', ...args], { quiet: true });
+	};
 
 	try {
-		await execCommand('docker manifest rm joplin/server:latest', { quiet: true });
+		await doManifestQuiet('inspect', `${imageName}:amd64-${version}`);
+		await doManifestQuiet('inspect', `${imageName}:arm64-${version}`);
+	} catch (error) {
+		console.error('Failed to inspect existing tags. Does the version', version, 'exist?');
+		throw error;
+	}
+
+	try {
+		await doManifestQuiet('rm', `${imageName}:latest`);
 	} catch (_error) {
 		// The local manifest may not exist (e.g. first run, or after a previous push),
 		// in which case `docker manifest rm` fails. That's fine — we're about to recreate it.
 	}
-	await execCommand(`docker manifest create ${imageName}:latest ${imageName}:arm64-${version} ${imageName}:amd64-${version}`);
-	await execCommand(`docker manifest annotate ${imageName}:latest ${imageName}:arm64-${version} --arch arm64`);
-	await execCommand(`docker manifest annotate ${imageName}:latest ${imageName}:amd64-${version} --arch amd64`);
-	await execCommand(`docker manifest push ${imageName}:latest`);
+	await doManifest('create', `${imageName}:latest`, `${imageName}:arm64-${version}`, `${imageName}:amd64-${version}`);
+	await doManifest('annotate', `${imageName}:latest`, `${imageName}:arm64-${version}`, '--arch=arm64');
+	await doManifest('annotate', `${imageName}:latest`, `${imageName}:amd64-${version}`, '--arch=amd64');
+	await doManifest('push', `${imageName}:latest`);
 }
 
 if (require.main === module) {
-// eslint-disable-next-line promise/prefer-await-to-then -- Old code before rule was applied
-	main().catch((error) => {
-		console.error('Fatal error');
-		console.error(error);
-		process.exit(1);
-	});
+	void (async () => {
+		try {
+			const args = await yargs(hideBin(process.argv))
+				.usage('$0 [image-version]', 'Tags a specific image version with latest', yargs => {
+					return yargs
+						.positional('image-version', {
+							type: 'string',
+							describe: 'Version of the image to set as latest',
+						})
+						.option('image-name', {
+							type: 'string',
+							describe: 'Docker image name to act on',
+							default: 'joplin/server',
+						});
+				})
+				.demandOption('image-version')
+				.parse();
+			await main(args['image-version'] as string, args['image-name'] as string);
+		} catch (error) {
+			console.error('Fatal error');
+			console.error(error);
+			process.exit(1);
+		}
+	})();
 }


### PR DESCRIPTION
# Problem

- The `tagServerLatest` command is currently hardcoded to update the `latest` tag in `joplin/server`.
- `tagServerLatest` may behave unexpectedly if called using a tag name that contains spaces or other special characters.

# Solution

- Update `tagServerLatest` to accept an `image-name` option, specifying the Docker repo/image to publish to.
- Update `tagServerLatest` to run commands using an arguments array, rather than using string interpolation.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

Valid prefixes:

- `All` — change applies to all client apps (Desktop, Mobile and CLI)
- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Plugin Repo` — the plugin repository
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets two areas, separate them with commas — for example "Desktop, Mobile". If it applies to all client apps, use "All".

-->
