### PR TITLE
Web: Display fewer sync options when hosted on app.joplincloud.com

### DIFF
--- a/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
+++ b/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
@@ -49,7 +49,7 @@ const styles = StyleSheet.create({
 });
 
 const isAppJoplinCloud = () => {
-	return Platform.OS === 'web' && location.origin === 'https://app.joplincloud.com';
+	return Setting.value('isJoplinCloudWebApp');
 };
 
 const useShouldShowOtherButton = () => {

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -185,6 +185,7 @@ const buildStartupTasks = (
 		Setting.setConstant('sync.9.apiKey', '');
 		Setting.setConstant('sync.10.apiKey', '');
 		Setting.setConstant('sync.11.apiKey', '');
+		Setting.setConstant('isJoplinCloudWebApp', Platform.OS === 'web' && location.origin === 'https://app.joplincloud.com');
 	});
 	addTask('buildStartupTasks/make resource directory', async () => {
 		await shim.fsDriver().mkdir(Setting.value('resourceDir'));

--- a/packages/lib/SyncTargetRegistry.ts
+++ b/packages/lib/SyncTargetRegistry.ts
@@ -14,7 +14,7 @@ export interface SyncTargetInfo {
 
 export default class SyncTargetRegistry {
 
-	private static reg_: Record<number, typeof BaseSyncTarget> = {};
+	private static reg_: Record<string, typeof BaseSyncTarget> = {};
 
 	private static get reg() {
 		return this.reg_;
@@ -74,9 +74,11 @@ export default class SyncTargetRegistry {
 		return this.reg[id].targetName();
 	}
 
-	public static idAndLabelPlainObject(os: string) {
+	public static idAndLabelPlainObject(os: string, includeKeys: string[]|null = null) {
+		includeKeys ??= Object.keys(this.reg);
+
 		const output: Record<string, string> = {};
-		for (const n in this.reg) {
+		for (const n of includeKeys) {
 			if (!this.reg.hasOwnProperty(n)) continue;
 			const info = this.infoById(this.reg[n].id());
 			if (info.classRef.unsupportedPlatforms().indexOf(os) >= 0) {

--- a/packages/lib/models/Setting.test.ts
+++ b/packages/lib/models/Setting.test.ts
@@ -583,7 +583,7 @@ describe('models/Setting', () => {
 
 	test('should limit listed sync targets on app.joplincloud.com', async () => {
 		Setting.setConstant('isJoplinCloudWebApp', true);
-		expect(Setting.enumOptionValues('sync.target')).toEqual(['0', '9', '10', '11']);
+		expect(Setting.enumOptionValues('sync.target')).toEqual(['0', '10']);
 
 		// Should list other sync targets on other apps
 		Setting.setConstant('isJoplinCloudWebApp', false);

--- a/packages/lib/models/Setting.test.ts
+++ b/packages/lib/models/Setting.test.ts
@@ -580,4 +580,16 @@ describe('models/Setting', () => {
 		expect(Setting.value('editor.imageRendering')).toBe(true);
 		expect(Setting.value(testSettingId)).toBe(false);
 	});
+
+	test('should limit listed sync targets on app.joplincloud.com', async () => {
+		Setting.setConstant('isJoplinCloudWebApp', true);
+		expect(Setting.enumOptionValues('sync.target')).toEqual(['0', '9', '10', '11']);
+
+		// Should list other sync targets on other apps
+		Setting.setConstant('isJoplinCloudWebApp', false);
+		const fullSyncOptions = Setting.enumOptionValues('sync.target');
+		expect(fullSyncOptions).toContain('0');
+		expect(fullSyncOptions).toContain('5');
+		expect(fullSyncOptions).toContain('10');
+	});
 });

--- a/packages/lib/models/Setting.test.ts
+++ b/packages/lib/models/Setting.test.ts
@@ -582,14 +582,18 @@ describe('models/Setting', () => {
 	});
 
 	test('should limit listed sync targets on app.joplincloud.com', async () => {
-		Setting.setConstant('isJoplinCloudWebApp', true);
-		expect(Setting.enumOptionValues('sync.target')).toEqual(['0', '10']);
+		try {
+			Setting.setConstant('isJoplinCloudWebApp', true);
+			expect(Setting.enumOptionValues('sync.target')).toEqual(['0', '10']);
 
-		// Should list other sync targets on other apps
-		Setting.setConstant('isJoplinCloudWebApp', false);
-		const fullSyncOptions = Setting.enumOptionValues('sync.target');
-		expect(fullSyncOptions).toContain('0');
-		expect(fullSyncOptions).toContain('5');
-		expect(fullSyncOptions).toContain('10');
+			// Should list other sync targets on other apps
+			Setting.setConstant('isJoplinCloudWebApp', false);
+			const fullSyncOptions = Setting.enumOptionValues('sync.target');
+			expect(fullSyncOptions).toContain('0');
+			expect(fullSyncOptions).toContain('5');
+			expect(fullSyncOptions).toContain('10');
+		} finally {
+			Setting.setConstant('isJoplinCloudWebApp', false);
+		}
 	});
 });

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -63,6 +63,7 @@ export interface Constants {
 	syncVersion: number;
 	startupDevPlugins: string[];
 	isSubProfile: boolean;
+	isJoplinCloudWebApp: boolean;
 
 	'sync.9.apiKey': string;
 	'sync.10.apiKey': string;
@@ -305,6 +306,7 @@ class Setting extends BaseModel {
 		syncVersion: 3,
 		startupDevPlugins: [],
 		isSubProfile: false,
+		isJoplinCloudWebApp: false,
 
 		'sync.9.apiKey': '',
 		'sync.10.apiKey': '',

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -22,6 +22,10 @@ const showVoiceTypingSettings = (settings: VoiceTypingSettingSlice) => (
 	shim.mobilePlatform() === 'android' && !!settings['buildFlag.voiceTypingEnabled']
 );
 
+const show3rdPartySyncSettings = (Setting: typeof SettingType) => {
+	return !Setting.value('isJoplinCloudWebApp');
+};
+
 export enum CameraDirection {
 	Back,
 	Front,
@@ -130,7 +134,12 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 				return appType !== 'cli' ? null : _('The target to synchronise to. Each sync target may have additional parameters which are named as `sync.NUM.NAME` (all documented below).');
 			},
 			options: () => {
-				return SyncTargetRegistry.idAndLabelPlainObject(platform);
+				if (show3rdPartySyncSettings(Setting)) {
+					return SyncTargetRegistry.idAndLabelPlainObject(platform);
+				} else {
+					// Only the Joplin-related sync targets are shown on app.joplincloud.com:
+					return SyncTargetRegistry.idAndLabelPlainObject(platform, ['0', '9', '10', '11']);
+				}
 			},
 			optionsOrder: () => {
 				return SyncTargetRegistry.optionsOrder();

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -138,7 +138,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 					return SyncTargetRegistry.idAndLabelPlainObject(platform);
 				} else {
 					// Only the Joplin-related sync targets are shown on app.joplincloud.com:
-					return SyncTargetRegistry.idAndLabelPlainObject(platform, ['0', '9', '10', '11']);
+					return SyncTargetRegistry.idAndLabelPlainObject(platform, ['0', '10']);
 				}
 			},
 			optionsOrder: () => {


### PR DESCRIPTION
# Problem

It has been requested that the Joplin web hosted on `app.joplincloud.com` only be able to sync with Joplin Cloud. See the related [forum post](https://discourse.joplinapp.org/t/https-app-joplincloud-com-not-syncing-to-nextcloud/49838/2).

# Solution

- Detect whether the web app is running on `app.joplincloud.com`.
- If it is, hide the non-Joplin Cloud/server sync options on the settings screen.
- Keep self-hosted versions of the web app as-is.

# Testing

1. Run the web app with `yarn serve-web`.
2. Open the synchronization settings screen. Verify that the full list of sync targets is shown.
3. Run `joplin.Setting.setConstant('isJoplinCloudWebApp', true)` in the dev tools.
4. Close and open the synchronization settings screen. Verify that only the Joplin Cloud sync target is shown:
  
  <img width="348" height="162" alt="Screenshot: Dropdown lists Joplin Cloud and (None)" src="https://github.com/user-attachments/assets/4e4e3cb6-0813-434f-86c4-77eee8439f8c" />


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
