### PR TITLE
Mobile, Desktop, Cli: Resolves #15714: Index locked note resources

### DIFF
--- a/packages/lib/models/Note.test.ts
+++ b/packages/lib/models/Note.test.ts
@@ -1,4 +1,4 @@
-import Setting, { Env } from './Setting';
+import Setting from './Setting';
 import BaseModel from '../BaseModel';
 import shim from '../shim';
 import markdownUtils from '../markdownUtils';
@@ -38,6 +38,7 @@ describe('models/Note', () => {
 		NoteLockKey.destroyInstance();
 		NoteLockService.destroyInstance();
 		EncryptionService.instance_ = encryptionService();
+		Setting.setValue('featureFlag.noteLock', true);
 	});
 
 	it('should find resource and note IDs', (async () => {
@@ -249,6 +250,15 @@ describe('models/Note', () => {
 		expect(Note.previewFields()).not.toContain('extracted_resource_ids');
 	});
 
+	it('should serialize and unserialize extracted resource IDs', () => {
+		const resourceId1 = '06894e83b8f84d3d8cbe0f1587f9e226';
+		const resourceId2 = '06894e83b8f84d3d8cbe0f1587f9e227';
+
+		expect(Note.serializeExtractedResourceIds([resourceId1, ` ${resourceId2} `, resourceId1, 'invalid'])).toBe(`${resourceId1},${resourceId2}`);
+		expect(Note.unserializeExtractedResourceIds(` ${resourceId1}, ${resourceId2},${resourceId1},invalid`)).toEqual([resourceId1, resourceId2]);
+		expect(Note.unserializeExtractedResourceIds('')).toEqual([]);
+	});
+
 	it('should store note lock ciphertext while decrypting only gated loads', async () => {
 		await NoteLockKey.instance().create('123456');
 		const resourceId1 = '06894e83b8f84d3d8cbe0f1587f9e226';
@@ -301,12 +311,8 @@ describe('models/Note', () => {
 			is_locked: 1,
 		}, { useNoteLock: true });
 
-		Setting.setConstant('env', Env.Prod);
-		try {
-			expect((await Note.load(note.id, { useNoteLock: true })).body).toBe(note.body);
-		} finally {
-			Setting.setConstant('env', Env.Dev);
-		}
+		Setting.setValue('featureFlag.noteLock', false);
+		expect((await Note.load(note.id, { useNoteLock: true })).body).toBe(note.body);
 	});
 
 	it('should fail closed when note lock encryption cannot decrypt or encrypt', async () => {

--- a/packages/lib/models/Note.test.ts
+++ b/packages/lib/models/Note.test.ts
@@ -250,13 +250,29 @@ describe('models/Note', () => {
 		expect(Note.previewFields()).not.toContain('extracted_resource_ids');
 	});
 
-	it('should serialize and unserialize extracted resource IDs', () => {
-		const resourceId1 = '06894e83b8f84d3d8cbe0f1587f9e226';
-		const resourceId2 = '06894e83b8f84d3d8cbe0f1587f9e227';
+	const resourceId1 = '06894e83b8f84d3d8cbe0f1587f9e226';
+	const resourceId2 = '06894e83b8f84d3d8cbe0f1587f9e227';
 
-		expect(Note.serializeExtractedResourceIds([resourceId1, ` ${resourceId2} `, resourceId1, 'invalid'])).toBe(`${resourceId1},${resourceId2}`);
-		expect(Note.unserializeExtractedResourceIds(` ${resourceId1}, ${resourceId2},${resourceId1},invalid`)).toEqual([resourceId1, resourceId2]);
-		expect(Note.unserializeExtractedResourceIds('')).toEqual([]);
+	test.each<[string[], string]>([
+		[[], ''],
+		[[' '], ''],
+		[[resourceId1], resourceId1],
+		[[` ${resourceId1} `, resourceId2], `${resourceId1},${resourceId2}`],
+		[[resourceId1, resourceId1, 'invalid'], resourceId1],
+	])('should serialize extracted resource IDs: %j', (resourceIds, expected) => {
+		expect(Note.serializeExtractedResourceIds(resourceIds)).toBe(expected);
+	});
+
+	test.each<[string, string[]]>([
+		['', []],
+		[' ', []],
+		[',,', []],
+		[resourceId1, [resourceId1]],
+		[`${resourceId1},,${resourceId2}`, [resourceId1, resourceId2]],
+		[` ${resourceId1}, ${resourceId2} `, [resourceId1, resourceId2]],
+		[`${resourceId1},${resourceId1},invalid`, [resourceId1]],
+	])('should unserialize extracted resource IDs: %j', (serializedIds, expected) => {
+		expect(Note.unserializeExtractedResourceIds(serializedIds)).toEqual(expected);
 	});
 
 	it('should store note lock ciphertext while decrypting only gated loads', async () => {

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -28,6 +28,7 @@ import { MarkupToHtml } from '@joplin/renderer';
 import { ALL_NOTES_FILTER_ID } from '../reserved-ids';
 import NoteLockNote from '../services/noteLock/NoteLockNote';
 import isNoteLockEnabled from '../services/noteLock/isNoteLockEnabled';
+import isItemId from './utils/isItemId';
 
 export interface PreviewsOrder {
 	by: string;
@@ -173,6 +174,15 @@ export default class Note extends BaseItem {
 		}
 
 		return unique(itemIds);
+	}
+
+	public static serializeExtractedResourceIds(resourceIds: string[]) {
+		return unique(resourceIds.map(id => id.trim()).filter(id => !!isItemId(id))).join(',');
+	}
+
+	public static unserializeExtractedResourceIds(serializedIds: string) {
+		if (!serializedIds) return [];
+		return unique(serializedIds.split(',').map(id => id.trim()).filter(id => !!isItemId(id)));
 	}
 
 	public static async linkedItems(body: string) {
@@ -839,7 +849,7 @@ export default class Note extends BaseItem {
 		// in the item_changes table
 		const oldNote = !isNew && o.id ? await Note.load(o.id) : null;
 		if (isNoteLockEnabled() && !!options?.useNoteLock) {
-			await NoteLockNote.prepareForSave(o, this.linkedItemIds, isNew);
+			await NoteLockNote.prepareForSave(o, this.linkedItemIds, this.serializeExtractedResourceIds, isNew);
 		}
 
 		syncDebugLog.info('Save Note: P:', oldNote);

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -2233,6 +2233,13 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			appTypes: [AppType.Mobile],
 		},
 
+		'featureFlag.noteLock': {
+			value: false,
+			type: SettingItemType.Bool,
+			public: false,
+			storage: SettingStorage.File,
+		},
+
 		'featureFlag.autoUpdaterServiceEnabled': {
 			value: false,
 			type: SettingItemType.Bool,

--- a/packages/lib/services/ResourceService.test.ts
+++ b/packages/lib/services/ResourceService.test.ts
@@ -8,7 +8,7 @@ import Note from '../models/Note';
 import Resource from '../models/Resource';
 import SearchEngine from './search/SearchEngine';
 import { loadMasterKeysFromSettings, setupAndEnableEncryption } from './e2ee/utils';
-import Setting, { Env } from '../models/Setting';
+import Setting from '../models/Setting';
 
 describe('services/ResourceService', () => {
 
@@ -148,38 +148,34 @@ describe('services/ResourceService', () => {
 			parent_id: folder1.id,
 			body: `encrypted body [](:/${resource2.id})`,
 			is_locked: 1,
-			extracted_resource_ids: `${resource1.id},not-a-resource-id,${folder1.id}`,
+			extracted_resource_ids: ` ${resource1.id},not-a-resource-id,${folder1.id},${resource1.id} `,
 		});
 
-		Setting.setConstant('env', Env.Prod);
-		try {
-			await service.indexNoteResources();
+		Setting.setValue('featureFlag.noteLock', false);
+		await service.indexNoteResources();
 
-			expect(await NoteResource.associatedNoteIds(resource1.id)).toEqual([note1.id]);
-			expect(await NoteResource.associatedNoteIds(resource2.id)).toEqual([]);
-			expect(await NoteResource.associatedNoteIds('not-a-resource-id')).toEqual([]);
-			expect(await NoteResource.associatedNoteIds(folder1.id)).toEqual([]);
+		expect(await NoteResource.associatedNoteIds(resource1.id)).toEqual([note1.id]);
+		expect(await NoteResource.associatedNoteIds(resource2.id)).toEqual([]);
+		expect(await NoteResource.associatedNoteIds('not-a-resource-id')).toEqual([]);
+		expect(await NoteResource.associatedNoteIds(folder1.id)).toEqual([]);
 
-			await Note.save({
-				id: note1.id,
-				body: 'modified encrypted body',
-			});
-			await service.indexNoteResources();
+		await Note.save({
+			id: note1.id,
+			body: 'modified encrypted body',
+		});
+		await service.indexNoteResources();
 
-			expect(await NoteResource.associatedNoteIds(resource1.id)).toEqual([note1.id]);
+		expect(await NoteResource.associatedNoteIds(resource1.id)).toEqual([note1.id]);
 
-			await Note.save({
-				id: note1.id,
-				body: 'encrypted body',
-				is_locked: 1,
-				extracted_resource_ids: '',
-			});
-			await service.indexNoteResources();
+		await Note.save({
+			id: note1.id,
+			body: 'encrypted body',
+			is_locked: 1,
+			extracted_resource_ids: '',
+		});
+		await service.indexNoteResources();
 
-			expect(await NoteResource.associatedNoteIds(resource1.id)).toEqual([]);
-		} finally {
-			Setting.setConstant('env', Env.Dev);
-		}
+		expect(await NoteResource.associatedNoteIds(resource1.id)).toEqual([]);
 	}));
 
 	it('should continue indexing after a locked encrypted note', (async () => {

--- a/packages/lib/services/ResourceService.test.ts
+++ b/packages/lib/services/ResourceService.test.ts
@@ -8,6 +8,7 @@ import Note from '../models/Note';
 import Resource from '../models/Resource';
 import SearchEngine from './search/SearchEngine';
 import { loadMasterKeysFromSettings, setupAndEnableEncryption } from './e2ee/utils';
+import Setting, { Env } from '../models/Setting';
 
 describe('services/ResourceService', () => {
 
@@ -134,6 +135,94 @@ describe('services/ResourceService', () => {
 		const after = (await NoteResource.all())[0];
 
 		expect(before.last_seen_time).toBe(after.last_seen_time);
+	}));
+
+	it('should index locked note resources when note lock is disabled', (async () => {
+		const service = new ResourceService();
+
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const resource1 = await shim.createResourceFromPath(`${supportDir}/photo.jpg`);
+		const resource2 = await shim.createResourceFromPath(`${supportDir}/welcome.pdf`);
+		const note1 = await Note.save({
+			title: 'locked note',
+			parent_id: folder1.id,
+			body: `encrypted body [](:/${resource2.id})`,
+			is_locked: 1,
+			extracted_resource_ids: `${resource1.id},not-a-resource-id,${folder1.id}`,
+		});
+
+		Setting.setConstant('env', Env.Prod);
+		try {
+			await service.indexNoteResources();
+
+			expect(await NoteResource.associatedNoteIds(resource1.id)).toEqual([note1.id]);
+			expect(await NoteResource.associatedNoteIds(resource2.id)).toEqual([]);
+			expect(await NoteResource.associatedNoteIds('not-a-resource-id')).toEqual([]);
+			expect(await NoteResource.associatedNoteIds(folder1.id)).toEqual([]);
+
+			await Note.save({
+				id: note1.id,
+				body: 'modified encrypted body',
+			});
+			await service.indexNoteResources();
+
+			expect(await NoteResource.associatedNoteIds(resource1.id)).toEqual([note1.id]);
+
+			await Note.save({
+				id: note1.id,
+				body: 'encrypted body',
+				is_locked: 1,
+				extracted_resource_ids: '',
+			});
+			await service.indexNoteResources();
+
+			expect(await NoteResource.associatedNoteIds(resource1.id)).toEqual([]);
+		} finally {
+			Setting.setConstant('env', Env.Dev);
+		}
+	}));
+
+	it('should continue indexing after a locked encrypted note', (async () => {
+		const service = new ResourceService();
+
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const lockedResource = await shim.createResourceFromPath(`${supportDir}/photo.jpg`);
+		const normalResource = await shim.createResourceFromPath(`${supportDir}/welcome.pdf`);
+		const lockedNote = await Note.save({
+			title: 'locked note',
+			parent_id: folder1.id,
+			body: 'encrypted body',
+			encryption_applied: 1,
+			is_locked: 1,
+			extracted_resource_ids: lockedResource.id,
+		});
+		const normalNote = await Note.save({
+			title: 'normal note',
+			parent_id: folder1.id,
+			body: `[](:/${normalResource.id})`,
+		});
+
+		await service.indexNoteResources();
+
+		expect(await NoteResource.associatedNoteIds(lockedResource.id)).toEqual([lockedNote.id]);
+		expect(await NoteResource.associatedNoteIds(normalResource.id)).toEqual([normalNote.id]);
+	}));
+
+	it('should index locked note resources after sync', (async () => {
+		const resource = await shim.createResourceFromPath(`${supportDir}/photo.jpg`);
+		const note = await Note.save({
+			title: 'locked note',
+			body: 'encrypted body',
+			is_locked: 1,
+			extracted_resource_ids: resource.id,
+		});
+		await synchronizer().start();
+
+		await switchClient(2);
+		await synchronizer().start();
+		await resourceService().indexNoteResources();
+
+		expect(await NoteResource.associatedNoteIds(resource.id)).toEqual([note.id]);
 	}));
 
 	it('should not delete resources that are associated with an encrypted note', (async () => {

--- a/packages/lib/services/ResourceService.ts
+++ b/packages/lib/services/ResourceService.ts
@@ -56,7 +56,7 @@ export default class ResourceService extends BaseService {
 				if (!changes.length) break;
 
 				const noteIds = changes.map(a => a.item_id);
-				const notes = await Note.modelSelectAll(`SELECT id, title, body, encryption_applied FROM notes WHERE id IN (${Note.escapeIdsForSql(noteIds)})`);
+				const notes = await Note.modelSelectAll(`SELECT id, title, body, encryption_applied, is_locked, extracted_resource_ids FROM notes WHERE id IN (${Note.escapeIdsForSql(noteIds)})`);
 
 				const noteById = (noteId: string) => {
 					for (let i = 0; i < notes.length; i++) {
@@ -77,16 +77,19 @@ export default class ResourceService extends BaseService {
 						const note = noteById(change.item_id);
 
 						if (note) {
-							if (note.encryption_applied) {
+							if (note.is_locked) {
+								const noteBody = note.extracted_resource_ids.split(',').map((id: string) => `[](:/${id})`).join(' ');
+								await this.setAssociatedResources(note.id, noteBody);
+							} else if (note.encryption_applied) {
 								// If we hit an encrypted note, abort processing for now.
 								// Note will eventually get decrypted and processing can resume then.
 								// This is a limitation of the change tracking system - we cannot skip a change
 								// and keep processing the rest since we only keep track of "lastProcessedChangeId".
 								foundNoteWithEncryption = true;
 								break;
+							} else {
+								await this.setAssociatedResources(note.id, note.body);
 							}
-
-							await this.setAssociatedResources(note.id, note.body);
 						} else {
 							this.logger().warn(`ResourceService::indexNoteResources: A change was recorded for a note that has been deleted: ${change.item_id}`);
 						}

--- a/packages/lib/services/ResourceService.ts
+++ b/packages/lib/services/ResourceService.ts
@@ -78,7 +78,8 @@ export default class ResourceService extends BaseService {
 
 						if (note) {
 							if (note.is_locked) {
-								const noteBody = note.extracted_resource_ids.split(',').map((id: string) => `[](:/${id})`).join(' ');
+								// Recreate note links so setAssociatedResources can validate that each ID belongs to a resource.
+								const noteBody = Note.unserializeExtractedResourceIds(note.extracted_resource_ids).map(id => `[](:/${id})`).join(' ');
 								await this.setAssociatedResources(note.id, noteBody);
 							} else if (note.encryption_applied) {
 								// If we hit an encrypted note, abort processing for now.

--- a/packages/lib/services/noteLock/NoteLockNote.ts
+++ b/packages/lib/services/noteLock/NoteLockNote.ts
@@ -1,5 +1,4 @@
 import { NoteEntity } from '../database/types';
-import isItemId from '../../models/utils/isItemId';
 import NoteLockService from './NoteLockService';
 
 export default class NoteLockNote {
@@ -27,7 +26,7 @@ export default class NoteLockNote {
 		return note;
 	}
 
-	public static async prepareForSave(note: NoteEntity, linkedItemIds: (body: string)=> string[], isNew: boolean) {
+	public static async prepareForSave(note: NoteEntity, linkedItemIds: (body: string)=> string[], serializeResourceIds: (resourceIds: string[])=> string, isNew: boolean) {
 		if (!note) throw new Error('Gated note lock save is missing note');
 		// Gated saves for existing notes should be based on a loaded note, so missing lock state is a logic error.
 		if (note.is_locked === undefined && !isNew) throw new Error('Gated note lock save is missing lock state');
@@ -36,7 +35,7 @@ export default class NoteLockNote {
 
 		const plainTextBody = note.body ?? '';
 		if (isLocked) {
-			note.extracted_resource_ids = linkedItemIds(plainTextBody).filter(id => !!isItemId(id)).join(',');
+			note.extracted_resource_ids = serializeResourceIds(linkedItemIds(plainTextBody));
 			note.body = await NoteLockService.instance().encryptString(plainTextBody);
 		}
 	}

--- a/packages/lib/services/noteLock/isNoteLockEnabled.ts
+++ b/packages/lib/services/noteLock/isNoteLockEnabled.ts
@@ -1,7 +1,7 @@
-import Setting, { Env } from '../../models/Setting';
+import Setting from '../../models/Setting';
 
 const isNoteLockEnabled = () => {
-	return Setting.value('env') === Env.Dev;
+	return Setting.value('featureFlag.noteLock');
 };
 
 export default isNoteLockEnabled;


### PR DESCRIPTION
## Summary

Resolves #15714.

Uses `extracted_resource_ids` to rebuild resource associations for locked notes.

A locked note's stored body is ciphertext, so the normal resource scanner cannot read its links. Without the associations, attachments used only by that note could be treated as unused.

This handling stays active when note lock is disabled because locked notes may already exist locally or arrive through sync.

## Changes

- includes `is_locked` and `extracted_resource_ids` in the ResourceService note query
- rebuilds locked-note associations from `extracted_resource_ids` using the existing validation path
- keeps normal unlocked-note indexing unchanged
- allows locked E2EE notes to be indexed without blocking later note changes
- adds focused tests for feature-disabled behavior, invalid IDs, association updates, and cross-client sync

This does not change `NoteResource.orphanResources()`.

## Testing

- `node .yarn/releases/yarn-4.16.0.cjs workspace @joplin/lib tsc`
- `node .yarn/releases/yarn-4.16.0.cjs workspace @joplin/lib test --runInBand services/ResourceService.test.js`
- `node .yarn/releases/yarn-4.16.0.cjs eslint packages/lib/services/ResourceService.ts packages/lib/services/ResourceService.test.ts`

## Manual testing

Did a manual desktop pass with two clean profiles syncing through a filesystem target.

Profile A created a notebook and a note with an image attachment, then synced. Profile B synced from the same target and received the note and attachment correctly. I edited the note on profile B, synced again, then synced profile A and confirmed the edit came back with the attachment still present.

No sync errors.


https://github.com/user-attachments/assets/7374f798-af75-4b64-89f4-9416e7cd2fdc



## AI Assistance Disclosure

I used AI tools while working on this PR, mainly for code review, checking the diff for scope issues, and sanity-checking the test plan. I went through the changes myself, kept the PR limited to resource association indexing, and understand the code being submitted.