### PR TITLE
Desktop: Fixes #15665: Fix macOS window stays closed after application switch

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -455,10 +455,10 @@ export default class ElectronAppWrapper {
 
 					if (w.isFullScreen()) {
 						// leave fullscreen, then hide
-						w.once('leave-full-screen', () => w.hide());
+						w.once('leave-full-screen', () => this.electronApp_.hide());
 						w.setFullScreen(false);
 					} else {
-						w.hide();
+						this.electronApp_.hide();
 					}
 				}
 			} else {
@@ -950,7 +950,11 @@ export default class ElectronAppWrapper {
 		});
 
 		this.electronApp_.on('activate', () => {
-			this.win_.show();
+			if (this.win_) this.win_.show();
+		});
+
+		this.electronApp_.on('did-become-active', () => {
+			if (this.win_) this.win_.show();
 		});
 
 		this.electronApp_.on('open-url', (event: import('electron').Event, url: string) => {

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -950,11 +950,11 @@ export default class ElectronAppWrapper {
 		});
 
 		this.electronApp_.on('activate', () => {
-			if (this.win_) this.win_.show();
+			if (this.win_ && !this.win_.isDestroyed()) this.win_.show();
 		});
 
 		this.electronApp_.on('did-become-active', () => {
-			if (this.win_) this.win_.show();
+			if (this.win_ && !this.win_.isDestroyed()) this.win_.show();
 		});
 
 		this.electronApp_.on('open-url', (event: import('electron').Event, url: string) => {


### PR DESCRIPTION
### Overview
This PR fixes Joplin issue #15665 on macOS where closing the main window (e.g. via `Cmd+W` or clicking the window's close button) would hide the window, but switching back to Joplin using `Cmd+Tab` failed to reopen it. 

### Cause
When the window is closed on macOS, the app uses `w.hide()`. Because the window is hidden but the application itself is still considered to have open (though hidden) windows by the OS/Electron, switching back to Joplin via `Cmd+Tab` does not trigger Electron's `activate` event. Consequently, the window remained hidden until the user explicitly clicked the Joplin Dock icon.

### Solution
1. **Hide Application on Close**: Updated the macOS window close handler in `ElectronAppWrapper.ts` to call `this.electronApp_.hide()` instead of just `w.hide()`. Hiding the application itself matches native macOS behavior (similar to `Cmd+H`), which allows macOS to naturally restore and unhide the application window when `Cmd+Tab` is used.
2. **Handle `did-become-active`**: Added a listener for the `did-become-active` Electron event to ensure the window is safely restored and shown (`this.win_.show()`) when the app becomes active.

### Verification / Testing
- **Local Manual Test**:
  1. Started Joplin desktop app locally.
  2. Closed the main window using `Cmd+W`.
  3. Switched to another application (e.g., Chrome) using `Cmd+Tab`.
  4. Switched back to Joplin using `Cmd+Tab`.
  5. Verified that the main window automatically reappears.
- **Linting & Compilation**: All checks pass (`eslint` and `tsc --noEmit` run cleanly on the changes).
