### PR TITLE
Mobile, Desktop, Cli: Resolves #15722: Give conflict_note_states table a numeric primary key and set note_id as unique

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1596,6 +1596,7 @@ packages/lib/services/database/migrations/49.js
 packages/lib/services/database/migrations/50.js
 packages/lib/services/database/migrations/51.js
 packages/lib/services/database/migrations/52.js
+packages/lib/services/database/migrations/53.js
 packages/lib/services/database/migrations/index.js
 packages/lib/services/database/sqlStringToLines.js
 packages/lib/services/database/types.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1622,6 +1622,7 @@ packages/lib/services/database/migrations/49.js
 packages/lib/services/database/migrations/50.js
 packages/lib/services/database/migrations/51.js
 packages/lib/services/database/migrations/52.js
+packages/lib/services/database/migrations/53.js
 packages/lib/services/database/migrations/index.js
 packages/lib/services/database/sqlStringToLines.js
 packages/lib/services/database/types.js

--- a/packages/lib/services/database/migrations/53.ts
+++ b/packages/lib/services/database/migrations/53.ts
@@ -1,0 +1,22 @@
+import { SqlQuery } from '../types';
+
+// Recreate conflict_note_states with a numeric auto-increment primary key, to
+// match the convention used by the other tables. note_id keeps its uniqueness
+// through a UNIQUE constraint. The table was added in migration 51 and hasn't
+// shipped in a release yet, so it is safe to drop and recreate it rather than
+// migrate the rows
+
+export default (): (SqlQuery|string)[] => {
+	return [
+		'DROP TABLE IF EXISTS conflict_note_states',
+		`CREATE TABLE conflict_note_states (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			note_id TEXT NOT NULL UNIQUE,
+			base_body TEXT NOT NULL DEFAULT "",
+			base_title TEXT NOT NULL DEFAULT "",
+			remote_body TEXT NOT NULL DEFAULT "",
+			remote_title TEXT NOT NULL DEFAULT "",
+			remote_updated_time INT NOT NULL DEFAULT 0
+		)`,
+	];
+};

--- a/packages/lib/services/database/migrations/index.ts
+++ b/packages/lib/services/database/migrations/index.ts
@@ -10,6 +10,7 @@ import migration49 from './49';
 import migration50 from './50';
 import migration51 from './51';
 import migration52 from './52';
+import migration53 from './53';
 
 import { Migration } from '../types';
 
@@ -25,6 +26,7 @@ const index: Migration[] = [
 	migration50,
 	migration51,
 	migration52,
+	migration53,
 ];
 
 export default index;

--- a/packages/lib/services/database/types.ts
+++ b/packages/lib/services/database/types.ts
@@ -99,7 +99,8 @@ export interface AlarmEntity {
 export interface ConflictNoteStateEntity {
   'base_body'?: string;
   'base_title'?: string;
-  'note_id'?: string | null;
+  'id'?: number | null;
+  'note_id'?: string;
   'remote_body'?: string;
   'remote_title'?: string;
   'remote_updated_time'?: number;
@@ -707,15 +708,6 @@ export const databaseSchema: DatabaseTables = {
 		updated_time: { type: 'number' },
 		type_: { type: 'number' },
 	},
-	conflict_note_states: {
-		base_body: { type: 'string' },
-		base_title: { type: 'string' },
-		note_id: { type: 'string' },
-		remote_body: { type: 'string' },
-		remote_title: { type: 'string' },
-		remote_updated_time: { type: 'number' },
-		type_: { type: 'number' },
-	},
 	note_embeddings_meta: {
 		chunk_index: { type: 'number' },
 		chunk_text: { type: 'string' },
@@ -723,6 +715,16 @@ export const databaseSchema: DatabaseTables = {
 		id: { type: 'number' },
 		model_id: { type: 'string' },
 		note_id: { type: 'string' },
+		type_: { type: 'number' },
+	},
+	conflict_note_states: {
+		base_body: { type: 'string' },
+		base_title: { type: 'string' },
+		id: { type: 'number' },
+		note_id: { type: 'string' },
+		remote_body: { type: 'string' },
+		remote_title: { type: 'string' },
+		remote_updated_time: { type: 'number' },
 		type_: { type: 'number' },
 	},
 };


### PR DESCRIPTION
Fixes #15722
### PR Summary 
PR #15565 [Migration 51] added the conflict_note_states table using note_id as its primary key. That works fine for the lookups we do today, but it goes against the convention we follow everywhere else in Joplin as mentioned in [comment](https://github.com/laurent22/joplin/pull/15669#pullrequestreview-4523953232)

This adds migration 53 to bring the table in line. It now has an id INTEGER PRIMARY KEY AUTOINCREMENT, and note_id keeps a UNIQUE constraint so the existing byNoteId lookup and the insert or replace upsert in the model keep working exactly as before

Since migration 51 hasn't shipped in any released version yet, there is no real data to preserve, so the migration just drops the table and recreates it with the new shape rather than copying

I also updated the generated database types so the entity and schema map include the new id column.
### Testing: 

No new tests needed. The conflict_note_states table is already covered in migration 51