### PR TITLE
Mobile, Desktop, Cli: Preserve customised note history settings when syncing across clients

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -541,10 +541,14 @@ export default class Synchronizer {
 
 					// console.info('NEW', newInfo);
 
-					if (newInfo.revisionServiceEnabled !== localInfo.revisionServiceEnabled) {
+					// Only copy a synced revisionService.* value back to the local
+					// Setting when it carries a real timestamp; a timestamp of 0
+					// means no client has explicitly set it, so we must not
+					// overwrite a customised local value with a migration default.
+					if (newInfo.revisionServiceEnabled !== localInfo.revisionServiceEnabled && newInfo.keyTimestamp('revisionServiceEnabled') > 0) {
 						Setting.setValue('revisionService.enabled', newInfo.revisionServiceEnabled);
 					}
-					if (newInfo.revisionServiceTtlDays !== localInfo.revisionServiceTtlDays) {
+					if (newInfo.revisionServiceTtlDays !== localInfo.revisionServiceTtlDays && newInfo.keyTimestamp('revisionServiceTtlDays') > 0) {
 						Setting.setValue('revisionService.ttlDays', newInfo.revisionServiceTtlDays);
 					}
 

--- a/packages/lib/services/synchronizer/Synchronizer.revisions.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.revisions.test.ts
@@ -329,4 +329,25 @@ describe('Synchronizer.revisions', () => {
 		await synchronizerStart();
 		expect(Setting.value('revisionService.enabled')).toBe(true);
 	}));
+
+	it('should not overwrite a customised local ttlDays with another client default', (async () => {
+		// Regression: a client that has never customised revisionService.ttlDays
+		// must not push its default over another client's customised value.
+		const changeSetting = (key: string, value: unknown) => {
+			Setting.setValue(key, value);
+			onRevisionServiceSettingsChanged(key, value);
+		};
+
+		changeSetting('revisionService.ttlDays', 30);
+		await synchronizerStart();
+
+		await switchClient(2);
+		expect(Setting.value('revisionService.ttlDays')).toBe(90);
+		await synchronizerStart();
+		expect(Setting.value('revisionService.ttlDays')).toBe(30);
+
+		await switchClient(1);
+		await synchronizerStart();
+		expect(Setting.value('revisionService.ttlDays')).toBe(30);
+	}));
 });

--- a/packages/lib/services/synchronizer/syncInfoUtils.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.ts
@@ -96,10 +96,16 @@ export async function migrateLocalSyncInfo(db: JoplinDatabase) {
 	//   most likely not what the user wants.
 	syncInfo.setKeyTimestamp('e2ee', 0);
 	syncInfo.setKeyTimestamp('activeMasterKeyId', 0);
-	syncInfo.revisionServiceEnabled = Setting.value('revisionService.enabled');
-	syncInfo.revisionServiceTtlDays = Setting.value('revisionService.ttlDays');
-	syncInfo.setKeyTimestamp('revisionServiceEnabled', 0);
-	syncInfo.setKeyTimestamp('revisionServiceTtlDays', 0);
+
+	// For revisionService.*: stamp the timestamp only when the local value
+	// has been customised. A default value uploaded with a real timestamp
+	// would overwrite another client's customised value on first sync.
+	const localRevisionEnabled = Setting.value('revisionService.enabled');
+	const localRevisionTtlDays = Setting.value('revisionService.ttlDays');
+	syncInfo.revisionServiceEnabled = localRevisionEnabled;
+	syncInfo.revisionServiceTtlDays = localRevisionTtlDays;
+	syncInfo.setKeyTimestamp('revisionServiceEnabled', localRevisionEnabled === Setting.settingMetadata('revisionService.enabled').value ? 0 : Date.now());
+	syncInfo.setKeyTimestamp('revisionServiceTtlDays', localRevisionTtlDays === Setting.settingMetadata('revisionService.ttlDays').value ? 0 : Date.now());
 
 	await saveLocalSyncInfo(syncInfo);
 }


### PR DESCRIPTION
PR #14449 introduced syncing of `revisionService.enabled` and `revisionService.ttlDays` via `info.json`, but on first sync after upgrade it could silently reset a customised value back to the default. The migration uploaded each client's local value with `updatedTime: 0`, and the post-sync merge then copied that timestamp-0 default back into the local `Setting`, overwriting whatever the user had previously chosen. This pattern works fine for `e2ee` and `activeMasterKeyId` because those live only in the sync info, but `revisionService.*` also exists as a regular `Setting`, so the copy-back step makes the timestamp-0 default destructive.

The fix is in two places. At migration time, we now only stamp `updatedTime: 0` when the local value matches the built-in default — a customised local value is stamped with `Date.now()` so it propagates correctly to other clients. After syncing, we only copy a `revisionService.*` value from the merged sync info back into the local `Setting` when its timestamp is greater than zero, meaning some client has explicitly set it. A regression test covers the round-trip: a customised value on one client propagates to a fresh client and survives a sync back to the original.