### PR TITLE
Mobile: Fixes #15729: Hide private feature flags

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -647,7 +647,7 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 				Clipboard.setString(versionInfoText);
 			});
 
-			const featureFlagKeys = Setting.featureFlagKeys(AppType.Mobile);
+			const featureFlagKeys = Setting.featureFlagKeys(AppType.Mobile).filter(key => Setting.isPublic(key));
 			if (featureFlagKeys.length) {
 				const headerKey = 'featureFlags';
 				const featureFlagsTitle = _('Feature flags');

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -517,7 +517,7 @@ class Setting extends BaseModel {
 	}
 
 	public static featureFlagKeys(appType: AppType): string[] {
-		const keys = this.keys(true, appType);
+		const keys = this.keys(false, appType);
 		return keys.filter(k => k.indexOf('featureFlag.') === 0);
 	}
 

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -517,7 +517,7 @@ class Setting extends BaseModel {
 	}
 
 	public static featureFlagKeys(appType: AppType): string[] {
-		const keys = this.keys(false, appType);
+		const keys = this.keys(true, appType);
 		return keys.filter(k => k.indexOf('featureFlag.') === 0);
 	}
 


### PR DESCRIPTION
Fixes private feature flags being shown in mobile settings by only listing public feature flags, matching the desktop behaviour.
Tested on mobile web and confirmed private flags no longer appear.