### PR TITLE
Desktop: Resolves #15716: Published note issued from an imported .one file breaks UI

### DIFF
--- a/packages/server/public/css/items/note.css
+++ b/packages/server/public/css/items/note.css
@@ -9,6 +9,10 @@
 	box-shadow: 0px 2px 8px #cccccc;
 }
 
+.note-main {
+	position: relative;
+}
+
 .page-note .note-main {
 	margin-top: 2em;
 	max-width: 840px;


### PR DESCRIPTION
Resolves #15716 

~~Fixed the layout on the published note page which was not expanding to take the full height. Which caused the footer to be in the middle of the text content~~ Moved to https://github.com/laurent22/joplin/issues/15804
<img width="1309" height="751" alt="image" src="https://github.com/user-attachments/assets/435f02d5-7ce8-4262-a809-16afba773b58" /> 


 Also, notes imported from `one` file were positioned `absolute` without the `note-main` container having position `relative` which caused the note content to end up wrong positioned. Adding `position:relative` to  `note-main` fixed the issue
 
 Before: (The onenote title was hidden behind the banner)
<img width="1510" height="788" alt="image" src="https://github.com/user-attachments/assets/6eacff6a-9053-49c7-8098-a0e49c84b7b5" />

 After:
<img width="1512" height="792" alt="image" src="https://github.com/user-attachments/assets/d28f8100-2f8e-4914-959b-c4e3b4da210c" />
