### PR TITLE
Desktop: Fixes #15727: Fix toggle editors shortcut when editor is focused

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1372,8 +1372,14 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 		};
 
 		// Keypress means that a printable key (letter, digit, etc.) has been
-		// pressed so we want to always trigger onChange in this case
-		function onKeypress() {
+		// pressed so we want to always trigger onChange in this case. Except on
+		// Windows/Linux, Ctrl+Alt also produces AltGr characters, so our own
+		// Ctrl+Alt shortcuts (e.g. "Toggle editors") fire this event too even
+		// though they don't insert any text.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TinyMCE editor instance / event types are looser than the published @types/tinymce (we use APIs not in the published types: getDoc, getWin, formatter, ui.registry, undoManager extensions)
+		function onKeypress(event: any) {
+			if (event.ctrlKey && event.altKey && !event.getModifierState('AltGraph')) return;
+
 			onChangeHandler();
 		}
 


### PR DESCRIPTION
Fixes #15727

**The bug**
"Toggle Editors" does nothing when triggered from the Rich Text editor, the button just greys out for about a second and the editor stays the same.

**Cause**
On Windows, Ctrl+Alt (the modifier combo behind the default Toggle Editors shortcut) is also how AltGr keyboard layouts type special characters. So pressing the shortcut while focus is inside the WYSIWYG editor makes TinyMCE's `keypress` handler think real text was typed, which marks the note as "saving" for about a second. The Toggle Editors command refuses to run while a note is saving, so it silently no-ops during that window.

**Fix**
In `TinyMCE.tsx`'s `onKeypress` handler, ignore the event when it's a Ctrl+Alt combo that isn't genuine AltGr input (checked with `event.getModifierState('AltGraph')`), instead of treating every keypress as a content change.

**Manual test plan** (no automated test, this is UI/focus-state behaviour that's awkward to unit test cleanly)
1. New note -> Rich Text editor -> click into the body -> press the Toggle Editors shortcut. Editor should switch to Markdown immediately, no grey-out delay.
2. Repeat a few times in both directions to make sure it's not a one-off.
3. Type normal text, and try Bold/Italic/lists, in the Rich Text editor, confirm the note still saves normally.
4. If you have a keyboard layout that uses AltGr, confirm AltGr-produced characters still get typed and still mark the note as changed.
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
