### PR TITLE
Cli: Fixes #15738: Fix `version` command when published to NPM

### DIFF
--- a/packages/app-cli/app/cli-integration-tests.test.ts
+++ b/packages/app-cli/app/cli-integration-tests.test.ts
@@ -14,7 +14,7 @@ import { loadKeychainServiceAndSettings } from '@joplin/lib/services/SettingUtil
 import shimInitCli from './utils/shimInitCli';
 
 const baseDir = `${dirname(__dirname)}/tests/cli-integration`;
-const joplinAppPath = `${__dirname}/main.js`;
+const joplinAppPath = `${__dirname}/build/main.js`;
 
 shimInitCli({ nodeSqlite, appVersion: () => require('../package.json').version, keytar: null, sharp: null, React: null, electronBridge: null, pdfJs: null });
 require('@joplin/lib/testing/test-utils');

--- a/packages/app-cli/app/command-version.ts
+++ b/packages/app-cli/app/command-version.ts
@@ -1,24 +1,6 @@
 import BaseCommand from './base-command';
 import { _ } from '@joplin/lib/locale';
 import versionInfo from '@joplin/lib/versionInfo';
-import { pathExists } from 'fs-extra';
-import { readFile } from 'fs/promises';
-import { join } from 'path';
-
-// The package.json file is stored in a different locations depending on whether
-// the CLI app is published to NPM.
-const loadPackageJson = async () => {
-	const packageJsonPaths = ['./package.json', '../package.json'];
-	for (const path of packageJsonPaths) {
-		const fullPath = join(__dirname, path);
-		if (await pathExists(fullPath)) {
-			return JSON.parse(
-				await readFile(fullPath, 'utf-8'),
-			);
-		}
-	}
-	throw new Error('Unable to find package.json');
-};
 
 class Command extends BaseCommand {
 	public override usage() {
@@ -30,9 +12,7 @@ class Command extends BaseCommand {
 	}
 
 	public override async action() {
-		this.stdout(
-			versionInfo(await loadPackageJson(), {}).message,
-		);
+		this.stdout(versionInfo(require('./package.json'), {}).message);
 	}
 }
 

--- a/packages/app-cli/app/command-version.ts
+++ b/packages/app-cli/app/command-version.ts
@@ -12,6 +12,8 @@ class Command extends BaseCommand {
 	}
 
 	public override async action() {
+		// The relative path to package.json is from the built version of this command
+		// in app-cli/build/command-version.js (see https://github.com/laurent22/joplin/issues/15738):
 		this.stdout(versionInfo(require('./package.json'), {}).message);
 	}
 }

--- a/packages/app-cli/app/command-version.ts
+++ b/packages/app-cli/app/command-version.ts
@@ -1,6 +1,24 @@
 import BaseCommand from './base-command';
 import { _ } from '@joplin/lib/locale';
 import versionInfo from '@joplin/lib/versionInfo';
+import { pathExists } from 'fs-extra';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+// The package.json file is stored in a different locations depending on whether
+// the CLI app is published to NPM.
+const loadPackageJson = async () => {
+	const packageJsonPaths = ['./package.json', '../package.json'];
+	for (const path of packageJsonPaths) {
+		const fullPath = join(__dirname, path);
+		if (await pathExists(fullPath)) {
+			return JSON.parse(
+				await readFile(fullPath, 'utf-8'),
+			);
+		}
+	}
+	throw new Error('Unable to find package.json');
+};
 
 class Command extends BaseCommand {
 	public override usage() {
@@ -12,7 +30,9 @@ class Command extends BaseCommand {
 	}
 
 	public override async action() {
-		this.stdout(versionInfo(require('../package.json'), {}).message);
+		this.stdout(
+			versionInfo(await loadPackageJson(), {}).message,
+		);
 	}
 }
 


### PR DESCRIPTION
# Problem

The CLI app's `version` command is broken: When published to NPM, the `version` command cannot find the CLI app's `package.json` file.

This is a regression from https://github.com/laurent22/joplin/commit/cda4073bfcb8b2dccebe4268f0e97dbd93071639:
- cda4073bfcb8b2dccebe4268f0e97dbd93071639 fixed issues with the CLI end-to-end tests and enabled them in CI.
- In doing so, it was observed that the `version` command failed in end-to-end tests, attempting to [require a non-existent file](https://github.com/laurent22/joplin/blob/3d5d82081a09975149e9daeb2c19589ded2c2f40/packages/app-cli/app/command-version.ts#L15). In response, `command-version.ts` was adjusted to import `../package.json` instead of `./package.json`.
- However, while this fixed the `command-version.js` in `packages/app-cli/app/`, it **broke** the built `packages/app-cli/build/command-version.js` (but only when published to NPM).

# Solution

- Update the end-to-end tests to run the CLI app from the correct entrypoint: `packages/app-cli/build/main.js` instead of `packages/app-cli/main.js`. The `main.js` in `build/` is the file that will be published to NPM.
   - Previously, the end-to-end tests ran `app-cli/main.js` directly, which used `app/command-version.js`. The end-to-end tests now run `app-cli/build/main.js`, which uses `app-cli/build/command-version.js`.
- Update the `version` command to expect a `package.json` file in the current directory (as was the case before cda4073bfcb8b2dccebe4268f0e97dbd93071639).

Fixes #15738.

# Testing

From `packages/app-cli/`:
1. Verify that `yarn test cli-integration-tests` passes.
2. Verify that running `node build/main.js version` prints version information.
3. Remove `packages/app-cli/package.json`.
4. Verify that running `node build/main.js version` prints version information.
   - This uses the `package.json` file in `build/`.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
