### PR TITLE
Mobile: Adjust UI padding to match the mobile app redesign

### DIFF
--- a/packages/app-mobile/components/DialogManager/PromptDialog.tsx
+++ b/packages/app-mobile/components/DialogManager/PromptDialog.tsx
@@ -4,6 +4,7 @@ import { DialogType, ButtonDialogData } from './types';
 import { StyleSheet, ViewStyle } from 'react-native';
 import { useMemo } from 'react';
 import PromptButton from './PromptButton';
+import { themeStyle } from '../global-style';
 
 interface Props {
 	dialog: ButtonDialogData;
@@ -11,32 +12,39 @@ interface Props {
 	themeId: number;
 }
 
-const useStyles = (isMenu: boolean) => {
+const useStyles = (themeId: number, isMenu: boolean) => {
 	return useMemo(() => {
+		const theme = themeStyle(themeId);
+
 		return StyleSheet.create({
 
 			dialogContent: {
-				paddingBottom: 14,
+				paddingBottom: theme.marginBottom,
+				paddingTop: 0, // Applied by the parent
 			},
 			dialogActions: {
-				paddingBottom: 14,
+				paddingBottom: theme.marginBottom,
 				paddingTop: 4,
+				paddingLeft: theme.marginLeft,
+				paddingRight: theme.marginRight,
 
 				...(isMenu ? {
 					flexDirection: 'column',
 					alignItems: 'stretch',
-				} : {}),
+				} : {
+					gap: theme.marginSmall,
+				}),
 			},
 			dialogLabel: {
 				textAlign: isMenu ? 'center' : undefined,
 			},
 		});
-	}, [isMenu]);
+	}, [isMenu, themeId]);
 };
 
 const PromptDialog: React.FC<Props> = ({ dialog, containerStyle, themeId }) => {
 	const isMenu = dialog.type === DialogType.Menu;
-	const styles = useStyles(isMenu);
+	const styles = useStyles(themeId, isMenu);
 
 	const buttons = dialog.buttons.map((button, index) => {
 		return <PromptButton

--- a/packages/app-mobile/components/DialogManager/index.tsx
+++ b/packages/app-mobile/components/DialogManager/index.tsx
@@ -37,7 +37,7 @@ const useStyles = (themeId: number) => {
 			dialogContainer: {
 				backgroundColor: theme.backgroundColor,
 				borderRadius: theme.borderRadius,
-				paddingTop: theme.borderRadius,
+				paddingTop: theme.marginTop,
 				marginLeft: 4,
 				marginRight: 4,
 			},

--- a/packages/app-mobile/components/global-style.ts
+++ b/packages/app-mobile/components/global-style.ts
@@ -124,7 +124,7 @@ function extraStyles(theme: BaseTheme) {
 		backgroundColor5: theme.backgroundColor5 ?? theme.color4,
 
 		backgroundColorHover4: Color(theme.color4).alpha(0.12).rgb().string(),
-		borderRadius: 24,
+		borderRadius: 8,
 	};
 }
 

--- a/packages/app-mobile/components/global-style.ts
+++ b/packages/app-mobile/components/global-style.ts
@@ -34,6 +34,8 @@ export type ThemeStyle = BaseTheme & typeof baseStyle & {
 	marginTop: number;
 	marginBottom: number;
 	borderRadius: number;
+	itemMarginBottom: number;
+	itemMarginTop: number;
 	icon: TextStyle;
 	lineInput: ViewStyle;
 	buttonRow: ViewStyle;

--- a/packages/app-mobile/components/global-style.ts
+++ b/packages/app-mobile/components/global-style.ts
@@ -10,11 +10,14 @@ const baseStyle = {
 	fontSize: 16,
 	fontSizeLarger: 18,
 	fontSizeLarge: 20,
-	margin: 16, // No text and no interactive component should be within this margin
-	marginSmall: 12,
-	itemMarginTop: 10,
-	itemMarginBottom: 10,
 	fontSizeSmaller: 14,
+
+	margin: 16, // No text and no interactive component should be within this margin
+	// Smaller margins for spacing between/around items:
+	marginSmall: 8,
+	itemMarginTop: 12,
+	itemMarginBottom: 12,
+
 	disabledOpacity: 0.2,
 	lineHeight: '1.6em',
 	listTabSize: '1.7em',

--- a/packages/app-mobile/components/global-style.ts
+++ b/packages/app-mobile/components/global-style.ts
@@ -15,8 +15,7 @@ const baseStyle = {
 	margin: 16, // No text and no interactive component should be within this margin
 	// Smaller margins for spacing between/around items:
 	marginSmall: 8,
-	itemMarginTop: 12,
-	itemMarginBottom: 12,
+	itemMargin: 12,
 
 	disabledOpacity: 0.2,
 	lineHeight: '1.6em',
@@ -111,6 +110,9 @@ function extraStyles(theme: BaseTheme) {
 		marginLeft: baseStyle.margin,
 		marginTop: baseStyle.margin,
 		marginBottom: baseStyle.margin,
+
+		itemMarginTop: baseStyle.itemMargin,
+		itemMarginBottom: baseStyle.itemMargin,
 
 		icon,
 		lineInput,

--- a/packages/app-mobile/components/global-style.ts
+++ b/packages/app-mobile/components/global-style.ts
@@ -15,7 +15,8 @@ const baseStyle = {
 	margin: 16, // No text and no interactive component should be within this margin
 	// Smaller margins for spacing between/around items:
 	marginSmall: 8,
-	itemMargin: 12,
+	itemMarginTop: 12,
+	itemMarginBottom: 12,
 
 	disabledOpacity: 0.2,
 	lineHeight: '1.6em',
@@ -110,9 +111,6 @@ function extraStyles(theme: BaseTheme) {
 		marginLeft: baseStyle.margin,
 		marginTop: baseStyle.margin,
 		marginBottom: baseStyle.margin,
-
-		itemMarginTop: baseStyle.itemMargin,
-		itemMarginBottom: baseStyle.itemMargin,
 
 		icon,
 		lineInput,

--- a/packages/app-mobile/components/global-style.ts
+++ b/packages/app-mobile/components/global-style.ts
@@ -15,7 +15,7 @@ const baseStyle = {
 	margin: 16, // No text and no interactive component should be within this margin
 	// Smaller margins for spacing between/around items:
 	marginSmall: 8,
-	itemMargin: 12,
+	marginMedium: 12,
 
 	disabledOpacity: 0.2,
 	lineHeight: '1.6em',
@@ -111,8 +111,8 @@ function extraStyles(theme: BaseTheme) {
 		marginTop: baseStyle.margin,
 		marginBottom: baseStyle.margin,
 
-		itemMarginTop: baseStyle.itemMargin,
-		itemMarginBottom: baseStyle.itemMargin,
+		itemMarginTop: baseStyle.marginMedium,
+		itemMarginBottom: baseStyle.marginMedium,
 
 		icon,
 		lineInput,

--- a/packages/app-mobile/components/global-style.ts
+++ b/packages/app-mobile/components/global-style.ts
@@ -10,7 +10,8 @@ const baseStyle = {
 	fontSize: 16,
 	fontSizeLarger: 18,
 	fontSizeLarge: 20,
-	margin: 15, // No text and no interactive component should be within this margin
+	margin: 16, // No text and no interactive component should be within this margin
+	marginSmall: 12,
 	itemMarginTop: 10,
 	itemMarginBottom: 10,
 	fontSizeSmaller: 14,

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -546,8 +546,8 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			color: theme.color,
 			fontWeight: 'bold',
 			fontSize: theme.fontSize,
-			paddingTop: 10, // Added for iOS (Not needed for Android??)
-			paddingBottom: 10, // Added for iOS (Not needed for Android??)
+			paddingTop: theme.itemMarginTop, // Added for iOS (Not needed for Android??)
+			paddingBottom: theme.itemMarginBottom, // Added for iOS (Not needed for Android??)
 		};
 
 		this.styles_[cacheKey] = StyleSheet.create(styles);


### PR DESCRIPTION
# Problem

A proposed redesign of the mobile app uses slightly different padding/margins than the current design.

# Solution

- Adjust the padding/margins of the mobile app to more closely match the redesign.
- Add new `marginMedium` (12dp) and `marginSmall` (8dp) values.
  - `itemMarginTop` and `itemMarginBottom` are now derived from `marginMedium`.

> [!NOTE]
>
> This pull request **decreases** the space available for the note body by about 4px. Options to keep the note body size the same include:
> - Keeping the note title padding at 10px: This would mean that it no longer matches the size of items in the note list.
> - Keeping the note list item padding at 10px.

# Screenshots

## Web

|Before | After |
|-------|-------|
| <img width="408" height="692" alt="notebook list sidebar" src="https://github.com/user-attachments/assets/c6e9b821-12ab-41af-bb33-f1d1e77ab15f" /> | <img width="407" height="694" alt="notebook list sidebar, about the same" src="https://github.com/user-attachments/assets/c56e36fe-3e15-48ba-a95c-0d813e0bcb19" /> |
| <img width="406" height="689" alt="notebook management confirm dialog" src="https://github.com/user-attachments/assets/7e501fcd-0216-4cd2-ac34-8c5af674ddb3" />| <img width="407" height="692" alt="notebook management confirm dialog, smaller padding" src="https://github.com/user-attachments/assets/320619ef-4aa2-45ca-8884-1d109dc24e13" /> |
|<img width="405" height="689" alt="image" src="https://github.com/user-attachments/assets/f51a4cd8-d415-404a-8f09-b30ff4cb8925" />| <img width="407" height="690" alt="plugin manage/delete" src="https://github.com/user-attachments/assets/c19964d5-e704-431a-a63e-ce3f7cd2752e" /> |
|<img width="407" height="691" alt="image" src="https://github.com/user-attachments/assets/01fa0b28-ca89-4154-bc8b-f5ed337476f8" />| <img width="410" height="694" alt="plugin about screen" src="https://github.com/user-attachments/assets/a2925a68-1088-4967-9728-32962404ca52" /> |
|<img width="406" height="691" alt="image" src="https://github.com/user-attachments/assets/d1bee018-c3e0-4991-a0ea-c1862d8d51a6" />| <img width="408" height="693" alt="note list, showing 15 notes" src="https://github.com/user-attachments/assets/35b3fb68-6f96-41fa-880f-17ca1c644234" /> |
|<img width="409" height="692" alt="note editor" src="https://github.com/user-attachments/assets/9924d2a9-d85d-45fa-a87e-fe6de2230e8e" />| <img width="409" height="691" alt="note editor" src="https://github.com/user-attachments/assets/4385b896-7a14-4cf2-ba4f-83cb9974d3a7" /> |
| <img width="406" height="692" alt="image" src="https://github.com/user-attachments/assets/b5b68356-9d93-4e7e-b0a3-390eb5970ad0" />|  <img width="408" height="691" alt="revision viewer" src="https://github.com/user-attachments/assets/6b260eb8-2a1d-47b8-abb3-655497df5248" />|

## iOS

| Before | After |
|--------|-------|
| <img width="368" height="748" alt="sort notes by dialog, vertical screen orientation" src="https://github.com/user-attachments/assets/e2bb3a49-d767-4b06-b538-13212bb5f416" />| <img width="375" height="757" alt="sort notes by dialog, corners are less round" src="https://github.com/user-attachments/assets/2c5b668a-88e2-40d5-8c2a-7ef8bb295ecb" /> |
| <img width="753" height="385" alt="sort notes by dialog, horizontal screen orientation" src="https://github.com/user-attachments/assets/3a94e93c-e0b3-46c8-ad54-1239aad3fbdc" /> | <img width="751" height="380" alt="sort notes by dialog, roughly the same" src="https://github.com/user-attachments/assets/3869444d-75be-497d-889b-7f9363db7578" /> |
| <img width="366" height="748" alt="note editor, portrait" src="https://github.com/user-attachments/assets/02ea66c2-009f-4f10-a2ce-ad1edba94e85" /> | <img width="365" height="748" alt="note editor in portrait orientation, corners are less rounded" src="https://github.com/user-attachments/assets/7ac99959-1190-4655-91f9-421b9080be8e" /> |
| <img width="751" height="374" alt="note editor, landscape" src="https://github.com/user-attachments/assets/ba37d12d-1ad3-4c5b-b10c-68e89998c117" />| <img width="751" height="377" alt="note editor, landscape, after" src="https://github.com/user-attachments/assets/cab616a6-8661-496e-8f0b-c2f2c38e1b17" /> |

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
