### PR TITLE
Mobile: Fixes #15618: Fix sharing to Joplin when opening in edit mode with the RTE enabled

### DIFF
--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -305,12 +305,12 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent) => {
 	if (defaultState === 'view') mode = 'view';
 	if (defaultState === 'edit') mode = 'edit';
 
-	// Prevent trashed notes from opening in edit mode.
-	if (note?.deleted_time) {
+	// Prevent trashed notes and notes created via sharing from opening in edit mode.
+	if (note?.deleted_time || comp.props.sharedData) {
 		mode = 'view';
 	}
 
-	if (isProvisionalNote && !comp.props.sharedData) {
+	if (isProvisionalNote) {
 		mode = 'edit';
 		comp.scheduleFocusUpdate();
 	}

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -310,7 +310,7 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent) => {
 		mode = 'view';
 	}
 
-	if (isProvisionalNote) {
+	if (isProvisionalNote && !comp.props.sharedData) {
 		mode = 'edit';
 		comp.scheduleFocusUpdate();
 	}


### PR DESCRIPTION
Prior to Joplin 3.6 on mobile, using the 'Share To' function in an app to share to Joplin (eg. sharing a Chrome webpage) would always create the note in view mode. In Joplin 3.6, the introduction of the persisted view / edit state when opening notes, means that the share to function can now create a note directly in edit mode. While this works for the MDE, this does not work correctly for the RTE, because when the note contents are updated with the shared data after the editor has loaded, it does not currently trigger a reload of the RTE. This results in the note contents being blank, until the note is exited and reloaded, which will result in the data being lost if the user modifies the note contents before doing so.

This PR fixes this behaviour by making the 'Share To' function always create the note in view mode, as per existing behaviour prior to Joplin 3.6.

This fixes https://github.com/laurent22/joplin/issues/15618

### Testing

Verified on Android that regardless of the value of the Default view / edit state setting, the 'Share To' function will always initialise the note in view mode when the note is created, which populates the contents correctly.

See video:

https://github.com/user-attachments/assets/09538df2-2f79-4fb0-9983-119eac32f042