### PR TITLE
Server: Fix "password has not been changed" warning not shown in some cases where it should be

### DIFF
--- a/packages/server/src/middleware/notificationHandler.ts
+++ b/packages/server/src/middleware/notificationHandler.ts
@@ -9,17 +9,32 @@ import { helpUrl, profileUrl } from '../utils/urlUtils';
 import { userFlagToString } from '../models/UserFlagModel';
 import renderMarkdown from '../utils/renderMarkdown';
 import config from '../config';
+import { unique } from '../utils/array';
 
 const logger = Logger.create('notificationHandler');
 
 async function handleChangeAdminPasswordNotification(ctx: AppContext) {
 	if (!ctx.joplin.owner.is_admin) return;
 
-	const defaultAdmin = await ctx.joplin.models.user().login(defaultAdminEmail, config().defaultAdminPassword);
+	const findInsecureAdminPassword = async () => {
+		// Check both the user-set default admin password and 'admin' -- the config's defaultAdminPassword
+		// is only applied on first startup:
+		const dangerousPasswords = unique([config().defaultAdminPassword, 'admin']);
+		for (const password of dangerousPasswords) {
+			const admin = await ctx.joplin.models.user().login(defaultAdminEmail, password);
+			if (admin) {
+				return password;
+			}
+		}
+
+		return null;
+	};
+
 	const notificationModel = ctx.joplin.models.notification();
 
-	if (defaultAdmin) {
-		const knownInsecurePassword = config().defaultAdminPassword === 'admin';
+	const foundAdminPassword = await findInsecureAdminPassword();
+	if (foundAdminPassword) {
+		const knownInsecurePassword = foundAdminPassword === 'admin';
 		let message;
 		if (knownInsecurePassword) {
 			message = _('The default admin password is insecure and has not been changed! [Change it now](%s)', profileUrl());


### PR DESCRIPTION
# Problem

The "password has not been changed" warning was not shown for the admin account in some cases where it should have been. In particular, if:
1. a user started Joplin Server for the first time **without** `DEFAULT_ADMIN_PASSWORD` set, and
2. the user set `DEFAULT_ADMIN_PASSWORD` **without** manually changing the admin account's password

then the admin account would continue to use the password `admin`, without displaying a warning in the UI. This is because `DEFAULT_ADMIN_PASSWORD` only takes effect on first startup and the password notification always checks against the same `DEFAULT_ADMIN_PASSWORD`.

**Context**: https://github.com/laurent22/joplin/pull/15655 added support for configuring the default admin password with a `DEFAULT_ADMIN_PASSWORD` environment variable. This environment variable takes effect at first startup, when initializing the admin account.

# Solution

Check the default password `admin`, even if the user has configured a different `DEFAULT_ADMIN_PASSWORD`, when deciding whether to display the default password warning banner.

# Testing

**Existing automated test**: An existing automated test verifies that the password warning banner is shown, with the default admin password of `admin`.

**Manual testing**:
1. Remove/clear the database (`rm db-dev.sqlite`)
2. Start Joplin Server with the default default admin password.
3. Sign in to the Joplin Server web UI.
4. Verify that the default password warning banner is visible.
5. Stop Joplin Server.
6. Restart Joplin Server with `DEFAULT_ADMIN_PASSWORD=some-other-password`
7. Sign in to the Joplin Server web UI.
8. Verify that the default password warning banner is visible.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
