### PR TITLE
Mobile, Desktop, Cli: Resolves #15737: Exclude locked notes from search indexes

### DIFF
--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -570,11 +570,11 @@ export default class Note extends BaseItem {
 	}
 
 	// Count of notes that are eligible for indexing (anything searchable):
-	// not trashed, not in conflict. Used by the AI status reporter as the
+	// not trashed, not in conflict, and not locked. Used by the AI status reporter as the
 	// denominator in "N / total indexed".
 	public static async indexableCount() {
 		const r = await this.db().selectOne(
-			'SELECT count(*) as total FROM notes WHERE (deleted_time IS NULL OR deleted_time = 0) AND (is_conflict IS NULL OR is_conflict = 0)',
+			'SELECT count(*) as total FROM notes WHERE (deleted_time IS NULL OR deleted_time = 0) AND (is_conflict IS NULL OR is_conflict = 0) AND is_locked = 0',
 		);
 		return r && r.total ? r.total : 0;
 	}

--- a/packages/lib/models/NoteEmbedding.ts
+++ b/packages/lib/models/NoteEmbedding.ts
@@ -92,6 +92,7 @@ export default class NoteEmbedding extends BaseModel {
 			`SELECT n.id FROM notes n
 			 WHERE (n.deleted_time IS NULL OR n.deleted_time = 0)
 			   AND (n.is_conflict IS NULL OR n.is_conflict = 0)
+			   AND n.is_locked = 0
 			   AND NOT EXISTS (SELECT 1 FROM note_embeddings_meta m WHERE m.note_id = n.id)${excludeSql}
 			 LIMIT ?`,
 			[...excludeIds, limit],

--- a/packages/lib/services/ai/EmbeddingIndexer.test.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.test.ts
@@ -126,6 +126,23 @@ describe('EmbeddingIndexer', () => {
 		expect(await NoteEmbedding.countByNoteId(note.id)).toBe(0);
 	});
 
+	it('removes embeddings for a locked note on the next maintenance', async () => {
+		if (skipIfNoVec()) return;
+		const folder = await Folder.save({ title: 'f' });
+		const note = await Note.save({ title: 't', body: 'some body text', parent_id: folder.id });
+		await waitForChangesSince(0, 1);
+
+		await EmbeddingIndexer.instance().maintenance();
+		expect(await NoteEmbedding.countByNoteId(note.id)).toBeGreaterThan(0);
+
+		const cursorAfterFirst = Setting.value('ai.embedding.lastProcessedChangeId') as number;
+		await Note.save({ id: note.id, is_locked: 1 });
+		await waitForChangesSince(cursorAfterFirst, 1);
+
+		await EmbeddingIndexer.instance().maintenance();
+		expect(await NoteEmbedding.countByNoteId(note.id)).toBe(0);
+	});
+
 	it('skips trashed and conflict notes', async () => {
 		if (skipIfNoVec()) return;
 		const folder = await Folder.save({ title: 'f' });
@@ -287,15 +304,20 @@ describe('EmbeddingIndexer', () => {
 		const folder = await Folder.save({ title: 'f' });
 		await Note.save({ title: 'A', body: 'apples', parent_id: folder.id });
 		await Note.save({ title: 'B', body: 'bananas', parent_id: folder.id });
-		await waitForChangesSince(0, 2);
+		const locked = await Note.save({ title: 'C', body: 'cherries', parent_id: folder.id, is_locked: 1 });
+		await waitForChangesSince(0, 3);
 		const lastChange = await ItemChange.lastChangeId();
 		Setting.setValue('ai.embedding.lastProcessedChangeId', lastChange);
 
 		await EmbeddingIndexer.instance().maintenance();
+		await EmbeddingIndexer.instance().maintenance();
 
-		// Both notes should be indexed via the backfill path even though no
+		// The unlocked notes should be indexed via the backfill path even though no
 		// new item_changes were available.
 		expect(await NoteEmbedding.distinctNoteIdCount()).toBe(2);
+		expect(await NoteEmbedding.countByNoteId(locked.id)).toBe(0);
+		expect(Setting.value('ai.embedding.initialScanDone')).toBe(true);
+		expect((await EmbeddingIndexer.instance().getStatus()).totalNotes).toBe(2);
 	});
 
 	it('skips a note that fails during the initial scan instead of looping on it', async () => {

--- a/packages/lib/services/ai/EmbeddingIndexer.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.ts
@@ -91,7 +91,7 @@ export default class EmbeddingIndexer {
 			indexerState = 'idle';
 		}
 
-		// Both counts exclude trashed/conflict notes so the displayed ratio
+		// Both counts exclude trashed, conflict, and locked notes so the displayed ratio
 		// matches the indexer's universe.
 		const notesIndexed = await NoteEmbedding.distinctNoteIdCount();
 		const totalNotes = await Note.indexableCount();
@@ -207,7 +207,7 @@ export default class EmbeddingIndexer {
 
 	private async indexNote(noteId: string, provider: EmbeddingProvider) {
 		const note = await Note.load(noteId) as NoteEntity | null;
-		if (!note || note.is_conflict || (note.deleted_time && note.deleted_time > 0)) {
+		if (!note || note.is_locked || note.is_conflict || (note.deleted_time && note.deleted_time > 0)) {
 			await NoteEmbedding.deleteByNoteId(noteId);
 			return;
 		}

--- a/packages/lib/services/search/SearchEngine.test.ts
+++ b/packages/lib/services/search/SearchEngine.test.ts
@@ -71,10 +71,12 @@ describe('services/SearchEngine', () => {
 
 		const n1 = await Note.save({ title: 'a' });
 		const n2 = await Note.save({ title: 'b' });
+		await Note.save({ title: 'locked', is_locked: 1 });
 		await engine.syncTables();
 		rows = await engine.search('a');
 		expect(rows.length).toBe(1);
 		expect(rows[0].title).toBe('a');
+		expect(await engine.search('locked')).toEqual([]);
 
 		await Note.delete(n1.id);
 		await engine.syncTables();
@@ -99,6 +101,14 @@ describe('services/SearchEngine', () => {
 		await engine.syncTables();
 		rows = await engine.search('c');
 		expect(rows.length).toBe(1);
+
+		await Note.save({ id: n2.id, is_locked: 1 });
+		await engine.syncTables();
+		expect(await engine.search('c')).toEqual([]);
+
+		await Note.save({ id: n2.id, is_locked: 0 });
+		await engine.syncTables();
+		expect((await engine.search('c')).length).toBe(1);
 	}));
 
 	it('should, after initial indexing, save the last change ID', (async () => {

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -133,7 +133,7 @@ export default class SearchEngine {
 	}
 
 	private async doInitialNoteIndexing_() {
-		const notes = await this.db().selectAll<NoteEntity>('SELECT id FROM notes WHERE is_conflict = 0 AND encryption_applied = 0 AND deleted_time = 0');
+		const notes = await this.db().selectAll<NoteEntity>('SELECT id FROM notes WHERE is_conflict = 0 AND encryption_applied = 0 AND is_locked = 0 AND deleted_time = 0');
 		const noteIds = notes.map(n => n.id);
 
 		const lastChangeId = await ItemChange.lastChangeId();
@@ -146,7 +146,7 @@ export default class SearchEngine {
 			const notes = await Note.modelSelectAll(`
 				SELECT ${SearchEngine.relevantFields}
 				FROM notes
-				WHERE id IN (${BaseModel.escapeIdsForSql(currentIds)}) AND is_conflict = 0 AND encryption_applied = 0 AND deleted_time = 0`);
+				WHERE id IN (${BaseModel.escapeIdsForSql(currentIds)}) AND is_conflict = 0 AND encryption_applied = 0 AND is_locked = 0 AND deleted_time = 0`);
 			const queries = [];
 
 			for (let i = 0; i < notes.length; i++) {
@@ -231,7 +231,7 @@ export default class SearchEngine {
 				const noteIds = changes.map(a => a.item_id);
 				const notes = await Note.modelSelectAll(`
 					SELECT ${SearchEngine.relevantFields}
-					FROM notes WHERE id IN (${Note.escapeIdsForSql(noteIds)}) AND is_conflict = 0 AND encryption_applied = 0 AND deleted_time = 0`,
+					FROM notes WHERE id IN (${Note.escapeIdsForSql(noteIds)}) AND is_conflict = 0 AND encryption_applied = 0 AND is_locked = 0 AND deleted_time = 0`,
 				);
 
 				for (let i = 0; i < changes.length; i++) {


### PR DESCRIPTION
## Summary

Resolves #15737.

Excludes locked notes from the normal search index and the AI note embedding index.

Locked note bodies are stored as ciphertext, so they should not stay searchable or be sent through the embedding indexer. When a note becomes locked, the existing indexed rows are removed on the next indexing pass.

This does not add lock UI, export/import handling, or API/CLI guardrails.

## Changes

- excludes locked notes from initial search indexing
- excludes locked notes from search indexing after note changes
- removes stale search rows when a note becomes locked
- excludes locked notes from AI embedding backfill
- removes stale embeddings when a note becomes locked
- keeps normal unlocked-note indexing unchanged

## Testing

- `node .yarn/releases/yarn-4.16.0.cjs workspace @joplin/lib test --runInBand services/search/SearchEngine.test.js`
- `node .yarn/releases/yarn-4.16.0.cjs workspace @joplin/lib test --runInBand services/ai/EmbeddingIndexer.test.js`
- `node .yarn/releases/yarn-4.16.0.cjs workspace @joplin/lib tsc`

## AI Assistance Disclosure

I used AI tools while working on this PR, mainly for code review, checking the diff for scope issues, and sanity-checking the test plan. I went through the changes myself, kept the PR limited to search/indexing behavior, and understand the code being submitted.