### PR TITLE
Desktop: Fixes #15761: Fix renderer crash loop when sqlite-vec is unavailable 

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/controls/AiIndexStatus.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/AiIndexStatus.tsx
@@ -23,6 +23,7 @@ const indexerStateLabel = (s: IndexStatus['indexerState']) => {
 	case 'running': return _('Indexing…');
 	case 'ai-disabled': return _('AI is disabled');
 	case 'index-disabled': return _('Indexing is disabled');
+	case 'vector-search-unavailable': return _('Vector search is not available on this platform');
 	}
 };
 

--- a/packages/lib/models/NoteEmbedding.ts
+++ b/packages/lib/models/NoteEmbedding.ts
@@ -45,8 +45,16 @@ export default class NoteEmbedding extends BaseModel {
 		return this.db() as JoplinDatabase;
 	}
 
+	// Single source of truth for "can we use vector search?". Callers that
+	// would otherwise throw (the indexer, search APIs) should gate on this and
+	// no-op when it's false, so users on platforms without sqlite-vec don't
+	// get a flood of failed-to-index errors.
+	public static vectorSearchAvailable(): boolean {
+		return this.joplinDb().sqliteVecAvailable();
+	}
+
 	private static requireVec() {
-		if (!this.joplinDb().sqliteVecAvailable()) {
+		if (!this.vectorSearchAvailable()) {
 			throw new Error('Vector search is unavailable: sqlite-vec extension is not loaded on this platform');
 		}
 	}

--- a/packages/lib/services/ai/EmbeddingIndexer.test.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.test.ts
@@ -330,6 +330,25 @@ describe('EmbeddingIndexer', () => {
 		expect(Setting.value('ai.embedding.initialScanDone')).toBe(true);
 	});
 
+	it('does not start in background when vector search is unavailable', async () => {
+		// On platforms where the sqlite-vec extension fails to load (see
+		// #15761) the indexer would otherwise pull every note into the
+		// expensive embedding provider and then throw at saveChunks — burning
+		// CPU/memory on every tick for no result. Confirm we bail at startup
+		// and surface the state to the UI instead.
+		Setting.setValue('ai.enabled', true);
+		const spy = jest.spyOn(NoteEmbedding, 'vectorSearchAvailable').mockReturnValue(false);
+		try {
+			await EmbeddingIndexer.instance().runInBackground();
+			const status = await EmbeddingIndexer.instance().getStatus();
+			expect(status.indexerState).toBe('vector-search-unavailable');
+		} finally {
+			spy.mockRestore();
+			Setting.setValue('ai.enabled', false);
+			await EmbeddingIndexer.instance().stopRunInBackground();
+		}
+	});
+
 	it('getStatus counts indexed vs total notes and excludes trashed ones', async () => {
 		if (skipIfNoVec()) return;
 		const folder = await Folder.save({ title: 'f' });

--- a/packages/lib/services/ai/EmbeddingIndexer.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.ts
@@ -46,6 +46,17 @@ export default class EmbeddingIndexer {
 
 	public async runInBackground() {
 		if (this.isRunningInBackground_) return;
+
+		// Without sqlite-vec we can run the embedding provider (potentially
+		// expensive ONNX inference) but have nowhere to store the vectors, so
+		// every note would fail at saveChunks. Bail before starting the timer
+		// so we don't burn CPU/memory for nothing on platforms where the
+		// extension didn't load (see #15761).
+		if (!NoteEmbedding.vectorSearchAvailable()) {
+			logger.warn('Not starting background indexer: sqlite-vec extension is not loaded on this platform');
+			return;
+		}
+
 		this.isRunningInBackground_ = true;
 
 		logger.info('Starting background indexer');
@@ -85,6 +96,8 @@ export default class EmbeddingIndexer {
 			indexerState = 'ai-disabled';
 		} else if (!Setting.value('ai.embedding.enabled')) {
 			indexerState = 'index-disabled';
+		} else if (!NoteEmbedding.vectorSearchAvailable()) {
+			indexerState = 'vector-search-unavailable';
 		} else if (this.maintenanceRunning_) {
 			indexerState = 'running';
 		} else {

--- a/packages/lib/services/ai/types.ts
+++ b/packages/lib/services/ai/types.ts
@@ -36,7 +36,7 @@ export interface ChatProvider {
 export type ProviderModelDownloadStatus = 'not-started' | 'downloading' | 'downloaded';
 
 export type ModelDownloadStatus = ProviderModelDownloadStatus | 'unavailable';
-export type IndexerState = 'idle' | 'running' | 'ai-disabled' | 'index-disabled';
+export type IndexerState = 'idle' | 'running' | 'ai-disabled' | 'index-disabled' | 'vector-search-unavailable';
 export interface IndexStatus {
 	modelDownloadStatus: ModelDownloadStatus;
 	indexerState: IndexerState;


### PR DESCRIPTION
On platforms where the sqlite-vec extension fails to load, the embedding indexer would still start: every maintenance tick pulled every note in the vault, ran the ONNX local embedding model on each one, and then threw at the save step because the vector table couldn't be created. On a sizeable vault that's a lot of CPU and memory burned for no result on every tick, plus a flood of "Vector search is unavailable" warnings in the log. The reporter saw the renderer crash repeatedly under this load.

The fix is to gate the indexer on vector search actually being available. `EmbeddingIndexer.runInBackground()` now checks `NoteEmbedding.vectorSearchAvailable()` up front and bails before scheduling any work, and `getStatus()` reports a new `vector-search-unavailable` state so the settings panel can tell the user why indexing isn't happening rather than leaving the UI on "Idle".