### PR TITLE
Desktop, Mobile: Slightly adjust button colors and add new theme variable

### DIFF
--- a/packages/lib/services/style/themeToCss.test.ts
+++ b/packages/lib/services/style/themeToCss.test.ts
@@ -62,6 +62,9 @@ const input: Theme = {
 	headerBackgroundColor: '#ffffff',
 	textSelectionColor: '#a0a0ff',
 	colorBright2: '#ffffff',
+
+	backgroundColor6: '#e3eaff',
+	color6: '#2c5be5',
 };
 
 const expected = `
@@ -71,6 +74,7 @@ const expected = `
 	--joplin-background-color2: #313640;
 	--joplin-background-color3: #F4F5F6;
 	--joplin-background-color4: #ffffff;
+	--joplin-background-color6: #e3eaff;
 	--joplin-background-color-hover3: #CBDAF1;
 	--joplin-background-color-transparent: rgba(255,255,255,0.9);
 	--joplin-background-color-transparent2: rgba(0, 0, 0, 0.1);
@@ -84,6 +88,7 @@ const expected = `
 	--joplin-color2: #ffffff;
 	--joplin-color3: #738598;
 	--joplin-color4: #2D6BDC;
+	--joplin-color6: #2c5be5;
 	--joplin-color-bright2: #ffffff;
 	--joplin-color-correct: green;
 	--joplin-color-error: red;

--- a/packages/lib/services/style/themeToCss.test.ts
+++ b/packages/lib/services/style/themeToCss.test.ts
@@ -39,6 +39,7 @@ const input: Theme = {
 	// Color scheme "4" is used for secondary-style buttons. It makes a white
 	// button with blue text.
 	backgroundColor4: '#ffffff',
+	backgroundColor4Dimmed: '#e3eaff',
 	color4: '#2D6BDC',
 
 	raisedBackgroundColor: '#e5e5e5',
@@ -62,9 +63,6 @@ const input: Theme = {
 	headerBackgroundColor: '#ffffff',
 	textSelectionColor: '#a0a0ff',
 	colorBright2: '#ffffff',
-
-	backgroundColor6: '#e3eaff',
-	color6: '#2c5be5',
 };
 
 const expected = `
@@ -74,7 +72,7 @@ const expected = `
 	--joplin-background-color2: #313640;
 	--joplin-background-color3: #F4F5F6;
 	--joplin-background-color4: #ffffff;
-	--joplin-background-color6: #e3eaff;
+	--joplin-background-color4-dimmed: #e3eaff;
 	--joplin-background-color-hover3: #CBDAF1;
 	--joplin-background-color-transparent: rgba(255,255,255,0.9);
 	--joplin-background-color-transparent2: rgba(0, 0, 0, 0.1);
@@ -88,7 +86,6 @@ const expected = `
 	--joplin-color2: #ffffff;
 	--joplin-color3: #738598;
 	--joplin-color4: #2D6BDC;
-	--joplin-color6: #2c5be5;
 	--joplin-color-bright2: #ffffff;
 	--joplin-color-correct: green;
 	--joplin-color-error: red;

--- a/packages/lib/themes/dark.ts
+++ b/packages/lib/themes/dark.ts
@@ -42,6 +42,7 @@ const theme: Theme = {
 	// button with blue text.
 	backgroundColor4: '#1D2024',
 	color4: '#789FE9',
+	backgroundColor4Dimmed: '#303543',
 
 	raisedBackgroundColor: '#474747',
 	raisedColor: '#ffffff',
@@ -61,9 +62,6 @@ const theme: Theme = {
 
 	headerBackgroundColor: '#2D3136',
 	textSelectionColor: '#00AEFF',
-
-	backgroundColor6: '#303543',
-	color6: '#8bb1fb',
 };
 
 export default theme;

--- a/packages/lib/themes/dark.ts
+++ b/packages/lib/themes/dark.ts
@@ -61,6 +61,9 @@ const theme: Theme = {
 
 	headerBackgroundColor: '#2D3136',
 	textSelectionColor: '#00AEFF',
+
+	backgroundColor6: '#303543',
+	color6: '#8bb1fb',
 };
 
 export default theme;

--- a/packages/lib/themes/light.ts
+++ b/packages/lib/themes/light.ts
@@ -39,7 +39,7 @@ const theme: Theme = {
 	// Color scheme "4" is used for secondary-style buttons. It makes a white
 	// button with blue text.
 	backgroundColor4: '#ffffff',
-	color4: '#2D6BDC',
+	color4: '#2D5BE5',
 	backgroundColor4Dimmed: '#e3eaff',
 
 	raisedBackgroundColor: '#e5e5e5',

--- a/packages/lib/themes/light.ts
+++ b/packages/lib/themes/light.ts
@@ -40,6 +40,7 @@ const theme: Theme = {
 	// button with blue text.
 	backgroundColor4: '#ffffff',
 	color4: '#2D6BDC',
+	backgroundColor4Dimmed: '#e3eaff',
 
 	raisedBackgroundColor: '#e5e5e5',
 	raisedColor: '#222222',
@@ -62,10 +63,6 @@ const theme: Theme = {
 	headerBackgroundColor: '#F0F0F0',
 	textSelectionColor: '#0096FF',
 	colorBright2: '#ffffff',
-
-	// Light blue buttons
-	backgroundColor6: '#e3eaff',
-	color6: '#2c5be5',
 };
 
 export default theme;

--- a/packages/lib/themes/light.ts
+++ b/packages/lib/themes/light.ts
@@ -62,6 +62,10 @@ const theme: Theme = {
 	headerBackgroundColor: '#F0F0F0',
 	textSelectionColor: '#0096FF',
 	colorBright2: '#ffffff',
+
+	// Light blue buttons
+	backgroundColor6: '#e3eaff',
+	color6: '#2c5be5',
 };
 
 export default theme;

--- a/packages/lib/themes/solarizedDark.ts
+++ b/packages/lib/themes/solarizedDark.ts
@@ -25,6 +25,7 @@ const theme: Theme = {
 	color3: '#93a1a1',
 
 	backgroundColor4: '#073642',
+	backgroundColor4Dimmed: '#073642',
 	color4: '#93a1a1',
 
 	raisedBackgroundColor: '#073642',
@@ -39,9 +40,6 @@ const theme: Theme = {
 
 	codeMirrorTheme: 'solarized dark',
 	codeThemeCss: 'atom-one-dark-reasonable.css',
-
-	backgroundColor6: '#073642',
-	color6: '#eee8d5',
 };
 
 export default theme;

--- a/packages/lib/themes/solarizedDark.ts
+++ b/packages/lib/themes/solarizedDark.ts
@@ -39,6 +39,9 @@ const theme: Theme = {
 
 	codeMirrorTheme: 'solarized dark',
 	codeThemeCss: 'atom-one-dark-reasonable.css',
+
+	backgroundColor6: '#073642',
+	color6: '#eee8d5',
 };
 
 export default theme;

--- a/packages/lib/themes/solarizedLight.ts
+++ b/packages/lib/themes/solarizedLight.ts
@@ -33,8 +33,9 @@ const theme: Theme = {
 	codeMirrorTheme: 'solarized light',
 	codeThemeCss: 'atom-one-light.css',
 
-	backgroundColor6: '#eee8d5',
-	color6: '#073642',
+	backgroundColor4Dimmed: '#eee8d5',
+	backgroundColor4: '#eee8d5',
+	color4: '#073642',
 };
 
 export default theme;

--- a/packages/lib/themes/solarizedLight.ts
+++ b/packages/lib/themes/solarizedLight.ts
@@ -32,6 +32,9 @@ const theme: Theme = {
 
 	codeMirrorTheme: 'solarized light',
 	codeThemeCss: 'atom-one-light.css',
+
+	backgroundColor6: '#eee8d5',
+	color6: '#073642',
 };
 
 export default theme;

--- a/packages/lib/themes/solarizedLight.ts
+++ b/packages/lib/themes/solarizedLight.ts
@@ -34,8 +34,6 @@ const theme: Theme = {
 	codeThemeCss: 'atom-one-light.css',
 
 	backgroundColor4Dimmed: '#eee8d5',
-	backgroundColor4: '#eee8d5',
-	color4: '#073642',
 };
 
 export default theme;

--- a/packages/lib/themes/type.ts
+++ b/packages/lib/themes/type.ts
@@ -69,4 +69,8 @@ export interface Theme {
 	headerBackgroundColor: string;
 	textSelectionColor: string;
 	colorBright2: string;
+
+	// Light blue buttons
+	backgroundColor6: string;
+	color6: string;
 }

--- a/packages/lib/themes/type.ts
+++ b/packages/lib/themes/type.ts
@@ -40,8 +40,9 @@ export interface Theme {
 
 	// Color scheme "4" is used for secondary-style buttons. It makes a white
 	// button with blue text.
-	backgroundColor4: string;
 	color4: string;
+	backgroundColor4: string;
+	backgroundColor4Dimmed: string;
 
 	backgroundColor5?: string;
 	color5?: string;
@@ -69,8 +70,4 @@ export interface Theme {
 	headerBackgroundColor: string;
 	textSelectionColor: string;
 	colorBright2: string;
-
-	// Light blue buttons
-	backgroundColor6: string;
-	color6: string;
 }


### PR DESCRIPTION
# Problem

https://github.com/laurent22/joplin/pull/15736 and https://github.com/laurent22/joplin/pull/15706 both need the same new theme colors.

#15706, for example, uses `#2d5be5` on `#e3eaff` for the "cancel" button in dialogs:
<img width="148" height="83" alt="screenshot: cancel button with a light blue background" src="https://github.com/user-attachments/assets/9b0a17cf-e91c-4604-be25-f40b53acf1c4" />


# Solution


This pull request adjusts the existing `color4` theme variable to match the color used by the "cancel" buttons and adds a new `backgroundColor4Dimmed` variable, matching the "cancel" button background.

> [!NOTE]
>
> This pull request contains most of the theme changes from https://github.com/laurent22/joplin/pull/15706. It's a separate pull request from #15706 to help avoid conflicts and naming differences when merging #15736 and #15706.

# Screenshots

## Desktop

| Component | Before | After |
|-----------|--------|-------|
| New note/to-do buttons | <img width="504" height="160" alt="image" src="https://github.com/user-attachments/assets/6e1d31d9-34c7-4e4e-ad2c-951c11112497" /> | <img width="504" height="160" alt="image" src="https://github.com/user-attachments/assets/267f42cb-5f89-40ae-a626-3490f9d6077f" /> |
| Settings screen buttons (disabled) | <img width="764" height="104" alt="image" src="https://github.com/user-attachments/assets/c0938e21-7164-4758-b004-7c5ab146f14f" /> | <img width="764" height="104" alt="slightly darker, but still dimmed, okay/cancel/apply buttons" src="https://github.com/user-attachments/assets/630aaeb4-8333-48e1-9330-f630ee7ecac2" /> |
| Settings screen buttons (enabled) | <img width="764" height="104" alt="image" src="https://github.com/user-attachments/assets/22c2bf30-e3b1-450a-bd28-08964d8248de" /> | <img width="764" height="104" alt="slightly darker settings screen okay/cancel/apply buttons" src="https://github.com/user-attachments/assets/e498c358-54eb-4cb5-b30e-5c7cd31c7a83" /> |

<!-- outdated --
## The colors

- **In light mode**: `#2c5be5` on `#e3eaff` ([4.67:1 contrast](https://webaim.org/resources/contrastchecker/?fcolor=2C5BE5&bcolor=E3EAFF)).
- **In dark mode**: `#8bb1fb` on `#303543` ([5.69:1 contrast](https://webaim.org/resources/contrastchecker/?fcolor=8BB1FB&bcolor=303543)).
- **In solarized dark mode**: `#eee8d5` on `#073642` ([10.6:1 contrast](https://webaim.org/resources/contrastchecker/?fcolor=EEE8D5&bcolor=073642)).
- **In solarized light mode**: `#073642` on `#eee8d5` ([10.6:1 contrast](https://webaim.org/resources/contrastchecker/?fcolor=073642&bcolor=EEE8D5)).
-->
