### PR TITLE
Desktop: Resolves #15720: Tests in lib package print OneNote related warnings

### DIFF
--- a/packages/lib/services/interop/InteropService.test.ts
+++ b/packages/lib/services/interop/InteropService.test.ts
@@ -85,6 +85,7 @@ function memoryExportModule() {
 }
 
 const oneNoteSimpleXpsPath = () => `${supportDir}/onenote/simple-xps.one`;
+const skipByDefault = process.env.IS_CONTINUOUS_INTEGRATION ? it : it.skip;
 
 describe('services_InteropService', () => {
 
@@ -100,7 +101,7 @@ describe('services_InteropService', () => {
 		await recreateExportDir();
 	});
 
-	it('should import OneNote files as a top-level folder when no destination folder is passed', (async () => {
+	skipByDefault('should import OneNote files as a top-level folder when no destination folder is passed', (async () => {
 		setupOneNoteDomParser();
 		const service = InteropService.instance();
 		const oneNoteModule = service.findModuleByFormat(ModuleType.Importer, 'one');
@@ -118,7 +119,7 @@ describe('services_InteropService', () => {
 	}));
 
 	// Covers the command-import.ts behavior by passing destinationFolderId directly
-	it('should import OneNote files as a top-level folder when a destination folder is passed', (async () => {
+	skipByDefault('should import OneNote files as a top-level folder when a destination folder is passed', (async () => {
 		setupOneNoteDomParser();
 		const service = InteropService.instance();
 		const destinationFolder = await Folder.save({ title: 'destination' });


### PR DESCRIPTION
Resolves #15720 

2 tests were causing a problem because they imported OneNote files. This made the tests use @joplin/onenote-converter, which is not built by default when running tests locally. The fix skips these 2 OneNote tests locally, while still running them in CI.

Note: The tests were added by me in this https://github.com/laurent22/joplin/pull/15555
You can argue that we should move the tests into `packages/lib/services/interop/InteropService_Importer_OneNote.test.ts` but I don't think it's a good idea for the simple reason that the tests are for the import function in `packages/lib/services/interop/InteropService.ts`

