### PR TITLE
Chore: Server: Update Stripe config to match new backend products

### DIFF
--- a/packages/lib/utils/joplinCloud/index.ts
+++ b/packages/lib/utils/joplinCloud/index.ts
@@ -85,6 +85,7 @@ export enum AccountType {
 	Pro = 2,
 	Team = 3,
 	Pro100Gb = 4,
+	SelfHosted = 5,
 }
 
 interface StripeBasePrice {

--- a/packages/lib/utils/joplinCloud/index.ts
+++ b/packages/lib/utils/joplinCloud/index.ts
@@ -79,11 +79,6 @@ export enum ProductType {
 	AiCredits = 'ai-credits',
 }
 
-interface StripePublicConfigBasePrice {
-	id: string;
-	currency: PriceCurrency;
-}
-
 export enum AccountType {
 	Default = 0,
 	Basic = 1,
@@ -92,29 +87,34 @@ export enum AccountType {
 	Pro100Gb = 4,
 }
 
-export interface StripePublicConfigBaseSubscriptionPrice extends StripePublicConfigBasePrice {
+interface StripeBasePrice {
+	id: string;
+	currency: PriceCurrency;
+}
+
+interface StripeBaseSubscriptionPrice extends StripeBasePrice {
 	accountType: AccountType;
 	period: PricePeriod;
 	productType: ProductType.Subscription|undefined;
 	aiCredits?: undefined;
 }
 
-export interface StripePublicConfigFixedSubscriptionPrice extends StripePublicConfigBaseSubscriptionPrice {
+export interface StripeFixedSubscriptionPrice extends StripeBaseSubscriptionPrice {
 	amount: string;
 	formattedAmount: string;
 	formattedMonthlyAmount: string;
 	amounts: undefined;
 }
 
-export interface StripePublicConfigTieredAmount {
+export interface StripeTieredAmount {
 	amount: string;
 	formattedAmount: string;
 	users: [number, number|'infinity'];
 	userRange: { min: number; max: number };
 }
 
-export interface StripePublicConfigTieredSubscriptionPrice extends StripePublicConfigBaseSubscriptionPrice {
-	amounts: StripePublicConfigTieredAmount[];
+export interface StripeTieredSubscriptionPrice extends StripeBaseSubscriptionPrice {
+	amounts: StripeTieredAmount[];
 
 	quantityMinimum: number;
 	amount: undefined;
@@ -122,18 +122,19 @@ export interface StripePublicConfigTieredSubscriptionPrice extends StripePublicC
 	formattedMonthlyAmount: undefined;
 }
 
-export type StripePublicConfigSubscriptionPrice = StripePublicConfigTieredSubscriptionPrice | StripePublicConfigFixedSubscriptionPrice;
+type StripeSubscriptionPrice = StripeTieredSubscriptionPrice | StripeFixedSubscriptionPrice;
 
-export interface StripePublicConfigAiProductPrice extends StripePublicConfigBasePrice {
+export interface StripePublicConfigAiProductPrice extends StripeBasePrice {
 	productType: ProductType.AiCredits;
 	amount: string;
 	formattedAmount: string;
 	aiCredits: number;
+
 	accountType?: undefined;
 	period?: undefined;
 }
 
-export type StripePublicConfigPrice = StripePublicConfigSubscriptionPrice | StripePublicConfigAiProductPrice;
+export type StripePublicConfigPrice = StripeSubscriptionPrice | StripePublicConfigAiProductPrice;
 
 export interface StripePublicConfig {
 	publishableKey: string;
@@ -150,7 +151,7 @@ function formatPrice(amount: string | number, currency: PriceCurrency): string {
 	throw new Error(`Unsupported currency: ${currency}`);
 }
 
-export const isTieredPrice = (p: StripePublicConfigPrice): p is StripePublicConfigTieredSubscriptionPrice => {
+export const isTieredPrice = (p: StripePublicConfigPrice): p is StripeTieredSubscriptionPrice => {
 	return 'amounts' in p;
 };
 
@@ -158,7 +159,7 @@ export function loadStripeConfig(env: string, filePath: string): StripePublicCon
 	const config: StripePublicConfig = JSON.parse(fs.readFileSync(filePath, 'utf8'))[env];
 	if (!config) throw new Error(`Invalid env: ${env}`);
 
-	const isSubscriptionPrice = (p: StripePublicConfigPrice): p is StripePublicConfigSubscriptionPrice => {
+	const isSubscriptionPrice = (p: StripePublicConfigPrice): p is StripeSubscriptionPrice => {
 		return p.productType === undefined || p.productType === ProductType.Subscription;
 	};
 
@@ -183,7 +184,7 @@ export function loadStripeConfig(env: string, filePath: string): StripePublicCon
 				productType: ProductType.Subscription,
 				formattedAmount: formatPrice(p.amount, p.currency),
 				formattedMonthlyAmount: p.period === PricePeriod.Monthly ? formatPrice(p.amount, p.currency) : formatPrice(Number(p.amount) / 12, p.currency),
-			} satisfies StripePublicConfigSubscriptionPrice;
+			} satisfies StripeSubscriptionPrice;
 		}
 		if (p.productType === ProductType.AiCredits) {
 			return {

--- a/packages/lib/utils/joplinCloud/index.ts
+++ b/packages/lib/utils/joplinCloud/index.ts
@@ -73,6 +73,39 @@ export enum PriceCurrency {
 	USD = 'USD',
 }
 
+
+export enum ProductType {
+	Subscription = 'subscription',
+	AiCredits = 'ai-credits',
+}
+
+interface StripePublicConfigBasePrice {
+	id: string;
+	currency: PriceCurrency;
+}
+
+export enum AccountType {
+	Default = 0,
+	Basic = 1,
+	Pro = 2,
+	Team = 3,
+	Pro100Gb = 4,
+}
+
+export interface StripePublicConfigBaseSubscriptionPrice extends StripePublicConfigBasePrice {
+	accountType: AccountType;
+	period: PricePeriod;
+	productType: ProductType.Subscription|undefined;
+	aiCredits?: undefined;
+}
+
+export interface StripePublicConfigFixedSubscriptionPrice extends StripePublicConfigBaseSubscriptionPrice {
+	amount: string;
+	formattedAmount: string;
+	formattedMonthlyAmount: string;
+	amounts: undefined;
+}
+
 export interface StripePublicConfigTieredAmount {
 	amount: string;
 	formattedAmount: string;
@@ -80,22 +113,7 @@ export interface StripePublicConfigTieredAmount {
 	userRange: { min: number; max: number };
 }
 
-export interface StripePublicConfigBasePrice {
-	accountType: number; // AccountType
-	id: string;
-	period: PricePeriod;
-	currency: PriceCurrency;
-}
-
-export interface StripePublicConfigFixedPrice extends StripePublicConfigBasePrice {
-	amount: string;
-	formattedAmount: string;
-	formattedMonthlyAmount: string;
-
-	amounts: undefined;
-}
-
-export interface StripePublicConfigTieredPrice extends StripePublicConfigBasePrice {
+export interface StripePublicConfigTieredSubscriptionPrice extends StripePublicConfigBaseSubscriptionPrice {
 	amounts: StripePublicConfigTieredAmount[];
 
 	quantityMinimum: number;
@@ -104,7 +122,18 @@ export interface StripePublicConfigTieredPrice extends StripePublicConfigBasePri
 	formattedMonthlyAmount: undefined;
 }
 
-export type StripePublicConfigPrice = StripePublicConfigFixedPrice | StripePublicConfigTieredPrice;
+export type StripePublicConfigSubscriptionPrice = StripePublicConfigTieredSubscriptionPrice | StripePublicConfigFixedSubscriptionPrice;
+
+export interface StripePublicConfigAiProductPrice extends StripePublicConfigBasePrice {
+	productType: ProductType.AiCredits;
+	amount: string;
+	formattedAmount: string;
+	aiCredits: number;
+	accountType?: undefined;
+	period?: undefined;
+}
+
+export type StripePublicConfigPrice = StripePublicConfigSubscriptionPrice | StripePublicConfigAiProductPrice;
 
 export interface StripePublicConfig {
 	publishableKey: string;
@@ -121,7 +150,7 @@ function formatPrice(amount: string | number, currency: PriceCurrency): string {
 	throw new Error(`Unsupported currency: ${currency}`);
 }
 
-export const isTieredPrice = (p: StripePublicConfigPrice): p is StripePublicConfigTieredPrice => {
+export const isTieredPrice = (p: StripePublicConfigPrice): p is StripePublicConfigTieredSubscriptionPrice => {
 	return 'amounts' in p;
 };
 
@@ -129,7 +158,12 @@ export function loadStripeConfig(env: string, filePath: string): StripePublicCon
 	const config: StripePublicConfig = JSON.parse(fs.readFileSync(filePath, 'utf8'))[env];
 	if (!config) throw new Error(`Invalid env: ${env}`);
 
-	const decoratePrices = (p: StripePublicConfigPrice): StripePublicConfigPrice => {
+	const isSubscriptionPrice = (p: StripePublicConfigPrice): p is StripePublicConfigSubscriptionPrice => {
+		return p.productType === undefined || p.productType === ProductType.Subscription;
+	};
+
+	const decoratePrices = (p: StripePublicConfigPrice) => {
+		const price = p;
 		if (isTieredPrice(p)) {
 			return {
 				...p,
@@ -143,11 +177,24 @@ export function loadStripeConfig(env: string, filePath: string): StripePublicCon
 				})),
 			};
 		}
-		return {
-			...p,
-			formattedAmount: formatPrice(p.amount, p.currency),
-			formattedMonthlyAmount: p.period === PricePeriod.Monthly ? formatPrice(p.amount, p.currency) : formatPrice(Number(p.amount) / 12, p.currency),
-		};
+		if (isSubscriptionPrice(p)) {
+			return {
+				...p,
+				productType: ProductType.Subscription,
+				formattedAmount: formatPrice(p.amount, p.currency),
+				formattedMonthlyAmount: p.period === PricePeriod.Monthly ? formatPrice(p.amount, p.currency) : formatPrice(Number(p.amount) / 12, p.currency),
+			} satisfies StripePublicConfigSubscriptionPrice;
+		}
+		if (p.productType === ProductType.AiCredits) {
+			return {
+				...p,
+				formattedAmount: formatPrice(p.amount, p.currency),
+			} satisfies StripePublicConfigAiProductPrice;
+		}
+
+		const exhaustivenessCheck: never = p;
+		// Use the exhaustivenessCheck to prevent unused variable warnings
+		throw new Error(`Unexpected product type: ${exhaustivenessCheck && price.productType}`);
 	};
 
 	config.prices = config.prices.map(decoratePrices);
@@ -156,11 +203,24 @@ export function loadStripeConfig(env: string, filePath: string): StripePublicCon
 	return config;
 }
 
-interface FindPriceQuery {
+
+type FindPriceQuery = {
 	accountType?: number;
 	period?: PricePeriod;
+
+	priceId?: undefined;
+}|{
+	accountType?: undefined;
+	period?: undefined;
+
 	priceId?: string;
-}
+}|{
+	accountType?: undefined;
+	period?: undefined;
+	priceId?: undefined;
+
+	productType: ProductType;
+};
 
 export function findPrice(config: StripePublicConfig, query: FindPriceQuery): StripePublicConfigPrice {
 	let output: StripePublicConfigPrice = null;
@@ -170,6 +230,8 @@ export function findPrice(config: StripePublicConfig, query: FindPriceQuery): St
 			output = prices.filter(p => p.accountType === query.accountType).find(p => p.period === query.period);
 		} else if (query.priceId) {
 			output = prices.find(p => p.id === query.priceId);
+		} else if ('productType' in query) {
+			output = prices.find(p => p.productType === query.productType);
 		} else {
 			throw new Error(`Invalid query: ${JSON.stringify(query)}`);
 		}

--- a/packages/server/src/models/UserModel.ts
+++ b/packages/server/src/models/UserModel.ts
@@ -101,6 +101,13 @@ const accountMetadata: Record<AccountType, Account> = {
 		max_item_size: 200 * MB,
 		max_total_item_size: 50 * GB,
 	},
+	[AccountType.SelfHosted]: {
+		account_type: AccountType.SelfHosted,
+		can_share_folder: 0,
+		can_receive_folder: 0,
+		max_item_size: 200 * MB,
+		max_total_item_size: 1 * MB,
+	},
 };
 
 interface AccountTypeSelectOptions {
@@ -141,6 +148,7 @@ export function accountTypeToString(accountType: AccountType): string {
 	if (accountType === AccountType.Pro) return 'Pro';
 	if (accountType === AccountType.Pro100Gb) return 'Pro 100 GB';
 	if (accountType === AccountType.Team) return 'Team';
+	if (accountType === AccountType.SelfHosted) return 'Self hosted';
 	const exhaustivenessCheck: never = accountType;
 	throw new Error(`Invalid type: ${exhaustivenessCheck}`);
 }
@@ -150,6 +158,7 @@ export const accountTypeToPlan = (accountType: AccountType): PlanName => {
 	if (accountType === AccountType.Pro) return PlanName.Pro;
 	if (accountType === AccountType.Pro100Gb) return PlanName.Pro100Gb;
 	if (accountType === AccountType.Team) return PlanName.Teams;
+	if (accountType === AccountType.SelfHosted) return PlanName.JoplinServerBusiness;
 	if (accountType === AccountType.Default) throw new Error('No plan exists for account type "Default"');
 	const exhaustivenessCheck: never = accountType;
 	throw new Error(`Invalid type: ${exhaustivenessCheck}`);

--- a/packages/server/src/models/UserModel.ts
+++ b/packages/server/src/models/UserModel.ts
@@ -38,7 +38,8 @@ const thirtyTwo = require('thirty-two');
 import config, { isUsingExternalAuth } from '../config';
 import { randomInt } from 'node:crypto';
 import { samlOwnedUserProperties } from '../utils/saml';
-import { PlanName } from '@joplin/lib/utils/joplinCloud';
+import { AccountType, PlanName } from '@joplin/lib/utils/joplinCloud';
+export { AccountType };
 
 const logger = Logger.create('UserModel');
 
@@ -50,13 +51,6 @@ interface UserEmailDetails {
 }
 
 export type GetUsersApiResponse = User;
-
-export enum AccountType {
-	Default = 0,
-	Basic = 1,
-	Pro = 2,
-	Pro100Gb = 4,
-}
 
 export interface Account {
 	account_type: number;
@@ -100,6 +94,13 @@ const accountMetadata: Record<AccountType, Account> = {
 		max_item_size: 200 * MB,
 		max_total_item_size: 100 * GB,
 	},
+	[AccountType.Team]: {
+		account_type: AccountType.Team,
+		can_share_folder: 1,
+		can_receive_folder: 1,
+		max_item_size: 200 * MB,
+		max_total_item_size: 50 * GB,
+	},
 };
 
 interface AccountTypeSelectOptions {
@@ -139,6 +140,7 @@ export function accountTypeToString(accountType: AccountType): string {
 	if (accountType === AccountType.Basic) return 'Basic';
 	if (accountType === AccountType.Pro) return 'Pro';
 	if (accountType === AccountType.Pro100Gb) return 'Pro 100 GB';
+	if (accountType === AccountType.Team) return 'Team';
 	const exhaustivenessCheck: never = accountType;
 	throw new Error(`Invalid type: ${exhaustivenessCheck}`);
 }
@@ -147,6 +149,7 @@ export const accountTypeToPlan = (accountType: AccountType): PlanName => {
 	if (accountType === AccountType.Basic) return PlanName.Basic;
 	if (accountType === AccountType.Pro) return PlanName.Pro;
 	if (accountType === AccountType.Pro100Gb) return PlanName.Pro100Gb;
+	if (accountType === AccountType.Team) return PlanName.Teams;
 	if (accountType === AccountType.Default) throw new Error('No plan exists for account type "Default"');
 	const exhaustivenessCheck: never = accountType;
 	throw new Error(`Invalid type: ${exhaustivenessCheck}`);

--- a/packages/server/stripeConfig.json
+++ b/packages/server/stripeConfig.json
@@ -79,6 +79,13 @@
 					}
 				],
 				"currency": "EUR"
+			},
+			{
+				"productType": "ai-credits",
+				"id": "price_1Tf4FvL9ZkKzC9sXpjjunUDE",
+				"amount": "2.00",
+				"aiCredits": 500000,
+				"currency": "EUR"
 			}
 		],
 		"archivedPrices": []
@@ -141,6 +148,13 @@
 				"id": "price_1TZbplLx4fybOTqJ3VmzuqmZ",
 				"period": "yearly",
 				"amount": "95.88",
+				"currency": "EUR"
+			},
+			{
+				"productType": "ai-credits",
+				"id": "price_1TkN0uLx4fybOTqJxyMwGoh7",
+				"amount": "1.99",
+				"aiCredits": 500000,
 				"currency": "EUR"
 			},
 			{


### PR DESCRIPTION
# Summary

Adds new records to `stripeConfig.json` and updates the code responsible for processing it.

The main change here is support for a one-off (rather than a subscription) product type.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
