### PR TITLE
Mobile, Desktop, Cli: Resolves #15772: Update note lock session state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1688,6 +1688,7 @@ packages/lib/services/noteLock/NoteLockKey.js
 packages/lib/services/noteLock/NoteLockNote.js
 packages/lib/services/noteLock/NoteLockService.test.js
 packages/lib/services/noteLock/NoteLockService.js
+packages/lib/services/noteLock/NoteLockSession.test.js
 packages/lib/services/noteLock/NoteLockSession.js
 packages/lib/services/noteLock/isNoteLockEnabled.js
 packages/lib/services/ocr/OcrDriverBase.js

--- a/.gitignore
+++ b/.gitignore
@@ -1688,6 +1688,7 @@ packages/lib/services/noteLock/NoteLockKey.js
 packages/lib/services/noteLock/NoteLockNote.js
 packages/lib/services/noteLock/NoteLockService.test.js
 packages/lib/services/noteLock/NoteLockService.js
+packages/lib/services/noteLock/NoteLockSession.js
 packages/lib/services/noteLock/isNoteLockEnabled.js
 packages/lib/services/ocr/OcrDriverBase.js
 packages/lib/services/ocr/OcrService.test.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1714,6 +1714,7 @@ packages/lib/services/noteLock/NoteLockKey.js
 packages/lib/services/noteLock/NoteLockNote.js
 packages/lib/services/noteLock/NoteLockService.test.js
 packages/lib/services/noteLock/NoteLockService.js
+packages/lib/services/noteLock/NoteLockSession.js
 packages/lib/services/noteLock/isNoteLockEnabled.js
 packages/lib/services/ocr/OcrDriverBase.js
 packages/lib/services/ocr/OcrService.test.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1714,6 +1714,7 @@ packages/lib/services/noteLock/NoteLockKey.js
 packages/lib/services/noteLock/NoteLockNote.js
 packages/lib/services/noteLock/NoteLockService.test.js
 packages/lib/services/noteLock/NoteLockService.js
+packages/lib/services/noteLock/NoteLockSession.test.js
 packages/lib/services/noteLock/NoteLockSession.js
 packages/lib/services/noteLock/isNoteLockEnabled.js
 packages/lib/services/ocr/OcrDriverBase.js

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -139,9 +139,9 @@ export default class BaseApplication {
 		ResourceService.isRunningInBackground_ = false;
 		// ResourceService.isRunningInBackground_ = false;
 		ResourceFetcher.instance_ = null;
-		NoteLockKey.destroyInstance();
-		NoteLockSession.destroyInstance();
 		NoteLockService.destroyInstance();
+		NoteLockSession.destroyInstance();
+		NoteLockKey.destroyInstance();
 		EncryptionService.instance_ = null;
 		DecryptionWorker.instance_ = null;
 

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -72,6 +72,7 @@ import getAppName from './getAppName';
 import PerformanceLogger from './PerformanceLogger';
 import Synchronizer from './Synchronizer';
 import NoteLockKey from './services/noteLock/NoteLockKey';
+import NoteLockSession from './services/noteLock/NoteLockSession';
 import NoteLockService from './services/noteLock/NoteLockService';
 
 const appLogger: LoggerWrapper = Logger.create('App');
@@ -139,6 +140,7 @@ export default class BaseApplication {
 		// ResourceService.isRunningInBackground_ = false;
 		ResourceFetcher.instance_ = null;
 		NoteLockKey.destroyInstance();
+		NoteLockSession.destroyInstance();
 		NoteLockService.destroyInstance();
 		EncryptionService.instance_ = null;
 		DecryptionWorker.instance_ = null;

--- a/packages/lib/models/Note.test.ts
+++ b/packages/lib/models/Note.test.ts
@@ -22,6 +22,7 @@ import getConflictFolderId from './utils/getConflictFolderId';
 import Revision from './Revision';
 import RevisionService from '../services/RevisionService';
 import NoteLockKey from '../services/noteLock/NoteLockKey';
+import NoteLockSession from '../services/noteLock/NoteLockSession';
 import NoteLockService from '../services/noteLock/NoteLockService';
 import EncryptionService from '../services/e2ee/EncryptionService';
 
@@ -36,6 +37,7 @@ describe('models/Note', () => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);
 		NoteLockKey.destroyInstance();
+		NoteLockSession.destroyInstance();
 		NoteLockService.destroyInstance();
 		EncryptionService.instance_ = encryptionService();
 		Setting.setValue('featureFlag.noteLock', true);
@@ -277,6 +279,7 @@ describe('models/Note', () => {
 
 	it('should store note lock ciphertext while decrypting only gated loads', async () => {
 		await NoteLockKey.instance().create('123456');
+		await NoteLockSession.instance().unlock('123456');
 		const resourceId1 = '06894e83b8f84d3d8cbe0f1587f9e226';
 		const resourceId2 = '06894e83b8f84d3d8cbe0f1587f9e227';
 		const plainTextBody = `secret [](:/${resourceId1}) [](:/${resourceId2})`;
@@ -322,6 +325,7 @@ describe('models/Note', () => {
 
 	it('should not decrypt locked notes while the feature is disabled', async () => {
 		await NoteLockKey.instance().create('123456');
+		await NoteLockSession.instance().unlock('123456');
 		const note = await Note.save({
 			body: 'secret',
 			is_locked: 1,
@@ -333,20 +337,22 @@ describe('models/Note', () => {
 
 	it('should fail closed when note lock encryption cannot decrypt or encrypt', async () => {
 		const noteLockKey = NoteLockKey.instance();
+		const session = NoteLockSession.instance();
 		await noteLockKey.create('123456');
+		await session.unlock('123456');
 		const note = await Note.save({
 			body: 'secret',
 			is_locked: 1,
 		}, { useNoteLock: true });
 
-		noteLockKey.lock();
+		session.lock();
 		await expect(Note.save({
 			body: 'must not be stored',
 			is_locked: 1,
-		}, { useNoteLock: true })).rejects.toThrow('Note lock key is not unlocked');
+		}, { useNoteLock: true })).rejects.toThrow('Note lock session is locked');
 		expect(await Note.all()).toHaveLength(1);
 
-		await noteLockKey.unlock('123456');
+		await session.unlock('123456');
 		const corruptedBody = `${note.body}invalid`;
 		await db().exec('UPDATE notes SET body = ? WHERE id = ?', [corruptedBody, note.id]);
 		await expect(Note.load(note.id, { useNoteLock: true })).rejects.toThrow();
@@ -371,6 +377,7 @@ describe('models/Note', () => {
 		});
 
 		await NoteLockKey.instance().create('123456');
+		await NoteLockSession.instance().unlock('123456');
 		await Note.save({
 			...await Note.load(note.id),
 			is_locked: 1,

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -2249,7 +2249,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			storage: SettingStorage.File,
 		},
 
-		'noteLock.autoLockOnSwitch': {
+		'noteLock.lockOnNoteSwitch': {
 			value: false,
 			type: SettingItemType.Bool,
 			public: false,

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -2249,6 +2249,13 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			storage: SettingStorage.File,
 		},
 
+		'noteLock.autoLockOnSwitch': {
+			value: false,
+			type: SettingItemType.Bool,
+			public: false,
+			storage: SettingStorage.File,
+		},
+
 		'featureFlag.autoUpdaterServiceEnabled': {
 			value: false,
 			type: SettingItemType.Bool,

--- a/packages/lib/services/noteLock/NoteLockKey.ts
+++ b/packages/lib/services/noteLock/NoteLockKey.ts
@@ -85,6 +85,7 @@ export default class NoteLockKey {
 	public endExport() {
 		this.exportingCount_ = Math.max(0, this.exportingCount_ - 1);
 		if (!this.exportingCount_ && this.locked_) this.clearKey_();
+		this.lockIfKeyChanged_();
 	}
 
 	private clearKey_() {

--- a/packages/lib/services/noteLock/NoteLockKey.ts
+++ b/packages/lib/services/noteLock/NoteLockKey.ts
@@ -3,7 +3,7 @@ import EncryptionService from '../e2ee/EncryptionService';
 import { MasterKeyEntity } from '../e2ee/types';
 import { localSyncInfo, saveLocalSyncInfo } from '../synchronizer/syncInfoUtils';
 
-interface DecryptedNoteLockKey {
+export interface DecryptedNoteLockKey {
 	id: string;
 	plainText: string;
 }
@@ -11,11 +11,6 @@ interface DecryptedNoteLockKey {
 export default class NoteLockKey {
 
 	public static instance_: NoteLockKey = null;
-
-	private decryptedKey_: string = null;
-	private keyId_: string = null;
-	private exportingCount_ = 0;
-	private locked_ = true;
 
 	private constructor(private encryptionService_: EncryptionService = EncryptionService.instance()) {}
 
@@ -27,7 +22,6 @@ export default class NoteLockKey {
 	}
 
 	public static destroyInstance() {
-		this.instance_?.clearKey_();
 		this.instance_ = null;
 	}
 
@@ -47,74 +41,24 @@ export default class NoteLockKey {
 		syncInfo.noteLockKey = key;
 		saveLocalSyncInfo(syncInfo);
 
-		if (this.keyId_ && this.keyId_ !== key.id) this.clearKey_();
-
 		return key;
 	}
 
 	public async create(password: string) {
 		if (this.load()) throw new Error('Note lock key already exists');
-		return this.createNewKey_(password);
+		return this.save(await this.encryptionService_.generateMasterKey(password));
 	}
 
 	public async reset(password: string) {
-		return this.createNewKey_(password);
+		return this.save(await this.encryptionService_.generateMasterKey(password));
 	}
 
-	public async unlock(password: string) {
+	public async decrypt(password: string): Promise<DecryptedNoteLockKey> {
 		const key = this.load();
 		if (!key) throw new Error('Note lock key has not been created');
 		if (!key.id) throw new Error('Note lock key does not have an ID');
 
-		const decryptedKey = await this.encryptionService_.decryptMasterKeyContent(key, password);
-		this.keyId_ = key.id;
-		this.decryptedKey_ = decryptedKey;
-		this.locked_ = false;
-	}
-
-	public lock() {
-		this.locked_ = true;
-		if (this.exportingCount_) return;
-		this.clearKey_();
-	}
-
-	public startExport() {
-		this.exportingCount_++;
-	}
-
-	public endExport() {
-		this.exportingCount_ = Math.max(0, this.exportingCount_ - 1);
-		if (!this.exportingCount_ && this.locked_) this.clearKey_();
-		this.lockIfKeyChanged_();
-	}
-
-	private clearKey_() {
-		this.keyId_ = null;
-		this.decryptedKey_ = null;
-		this.locked_ = true;
-	}
-
-	private lockIfKeyChanged_() {
-		if (this.keyId_ && this.keyId_ !== this.load()?.id) this.lock();
-	}
-
-	public isUnlocked() {
-		this.lockIfKeyChanged_();
-		return !this.locked_ && !!this.decryptedKey_;
-	}
-
-	public decryptedKey(): DecryptedNoteLockKey {
-		this.lockIfKeyChanged_();
-		if (!this.decryptedKey_ || (!this.exportingCount_ && this.locked_)) throw new Error('Note lock key is not unlocked');
-		return {
-			id: this.keyId_,
-			plainText: this.decryptedKey_,
-		};
-	}
-
-	private async createNewKey_(password: string) {
-		const key = this.save(await this.encryptionService_.generateMasterKey(password));
-		await this.unlock(password);
-		return key;
+		const plainText = await this.encryptionService_.decryptMasterKeyContent(key, password);
+		return { id: key.id, plainText };
 	}
 }

--- a/packages/lib/services/noteLock/NoteLockKey.ts
+++ b/packages/lib/services/noteLock/NoteLockKey.ts
@@ -14,7 +14,7 @@ export default class NoteLockKey {
 
 	private decryptedKey_: string = null;
 	private keyId_: string = null;
-	private exporting_ = false;
+	private exportingCount_ = 0;
 	private locked_ = true;
 
 	private constructor(private encryptionService_: EncryptionService = EncryptionService.instance()) {}
@@ -27,8 +27,7 @@ export default class NoteLockKey {
 	}
 
 	public static destroyInstance() {
-		this.instance_?.setExporting(false);
-		this.instance_?.lock();
+		this.instance_?.clearKey_();
 		this.instance_ = null;
 	}
 
@@ -75,13 +74,17 @@ export default class NoteLockKey {
 
 	public lock() {
 		this.locked_ = true;
-		if (this.exporting_) return;
+		if (this.exportingCount_) return;
 		this.clearKey_();
 	}
 
-	public setExporting(exporting: boolean) {
-		this.exporting_ = exporting;
-		if (!this.exporting_ && this.locked_) this.clearKey_();
+	public startExport() {
+		this.exportingCount_++;
+	}
+
+	public endExport() {
+		this.exportingCount_ = Math.max(0, this.exportingCount_ - 1);
+		if (!this.exportingCount_ && this.locked_) this.clearKey_();
 	}
 
 	private clearKey_() {
@@ -90,20 +93,18 @@ export default class NoteLockKey {
 		this.locked_ = true;
 	}
 
-	private clearKeyIfChanged_() {
-		if (this.keyId_ && this.keyId_ !== this.load()?.id) this.clearKey_();
+	private lockIfKeyChanged_() {
+		if (this.keyId_ && this.keyId_ !== this.load()?.id) this.lock();
 	}
 
 	public isUnlocked() {
-		this.clearKeyIfChanged_();
-		if (!this.exporting_ && this.locked_ && this.decryptedKey_) this.clearKey_();
+		this.lockIfKeyChanged_();
 		return !this.locked_ && !!this.decryptedKey_;
 	}
 
 	public decryptedKey(): DecryptedNoteLockKey {
-		this.clearKeyIfChanged_();
-		if (!this.exporting_ && !this.isUnlocked()) throw new Error('Note lock key is not unlocked');
-		if (!this.decryptedKey_) throw new Error('Note lock key is not unlocked');
+		this.lockIfKeyChanged_();
+		if (!this.decryptedKey_ || (!this.exportingCount_ && this.locked_)) throw new Error('Note lock key is not unlocked');
 		return {
 			id: this.keyId_,
 			plainText: this.decryptedKey_,

--- a/packages/lib/services/noteLock/NoteLockKey.ts
+++ b/packages/lib/services/noteLock/NoteLockKey.ts
@@ -14,7 +14,8 @@ export default class NoteLockKey {
 
 	private decryptedKey_: string = null;
 	private keyId_: string = null;
-	private unlockExpiryTimestamp_: number = null;
+	private exporting_ = false;
+	private locked_ = true;
 
 	private constructor(private encryptionService_: EncryptionService = EncryptionService.instance()) {}
 
@@ -26,6 +27,7 @@ export default class NoteLockKey {
 	}
 
 	public static destroyInstance() {
+		this.instance_?.setExporting(false);
 		this.instance_?.lock();
 		this.instance_ = null;
 	}
@@ -46,21 +48,21 @@ export default class NoteLockKey {
 		syncInfo.noteLockKey = key;
 		saveLocalSyncInfo(syncInfo);
 
-		if (this.keyId_ && this.keyId_ !== key.id) this.lock();
+		if (this.keyId_ && this.keyId_ !== key.id) this.clearKey_();
 
 		return key;
 	}
 
-	public async create(password: string, unlockExpiryTimestamp: number = null) {
+	public async create(password: string) {
 		if (this.load()) throw new Error('Note lock key already exists');
-		return this.createNewKey_(password, unlockExpiryTimestamp);
+		return this.createNewKey_(password);
 	}
 
-	public async reset(password: string, unlockExpiryTimestamp: number = null) {
-		return this.createNewKey_(password, unlockExpiryTimestamp);
+	public async reset(password: string) {
+		return this.createNewKey_(password);
 	}
 
-	public async unlock(password: string, unlockExpiryTimestamp: number = null) {
+	public async unlock(password: string) {
 		const key = this.load();
 		if (!key) throw new Error('Note lock key has not been created');
 		if (!key.id) throw new Error('Note lock key does not have an ID');
@@ -68,36 +70,49 @@ export default class NoteLockKey {
 		const decryptedKey = await this.encryptionService_.decryptMasterKeyContent(key, password);
 		this.keyId_ = key.id;
 		this.decryptedKey_ = decryptedKey;
-		this.unlockExpiryTimestamp_ = unlockExpiryTimestamp;
+		this.locked_ = false;
 	}
 
 	public lock() {
+		this.locked_ = true;
+		if (this.exporting_) return;
+		this.clearKey_();
+	}
+
+	public setExporting(exporting: boolean) {
+		this.exporting_ = exporting;
+		if (!this.exporting_ && this.locked_) this.clearKey_();
+	}
+
+	private clearKey_() {
 		this.keyId_ = null;
 		this.decryptedKey_ = null;
-		this.unlockExpiryTimestamp_ = null;
+		this.locked_ = true;
+	}
+
+	private clearKeyIfChanged_() {
+		if (this.keyId_ && this.keyId_ !== this.load()?.id) this.clearKey_();
 	}
 
 	public isUnlocked() {
-		this.invalidateExpiredKey_();
-		if (this.keyId_ && this.keyId_ !== this.load()?.id) this.lock();
-		return !!this.decryptedKey_;
+		this.clearKeyIfChanged_();
+		if (!this.exporting_ && this.locked_ && this.decryptedKey_) this.clearKey_();
+		return !this.locked_ && !!this.decryptedKey_;
 	}
 
 	public decryptedKey(): DecryptedNoteLockKey {
-		if (!this.isUnlocked()) throw new Error('Note lock key is not unlocked');
+		this.clearKeyIfChanged_();
+		if (!this.exporting_ && !this.isUnlocked()) throw new Error('Note lock key is not unlocked');
+		if (!this.decryptedKey_) throw new Error('Note lock key is not unlocked');
 		return {
 			id: this.keyId_,
 			plainText: this.decryptedKey_,
 		};
 	}
 
-	private async createNewKey_(password: string, unlockExpiryTimestamp: number = null) {
+	private async createNewKey_(password: string) {
 		const key = this.save(await this.encryptionService_.generateMasterKey(password));
-		await this.unlock(password, unlockExpiryTimestamp);
+		await this.unlock(password);
 		return key;
-	}
-
-	private invalidateExpiredKey_() {
-		if (this.unlockExpiryTimestamp_ !== null && this.unlockExpiryTimestamp_ <= Date.now()) this.lock();
 	}
 }

--- a/packages/lib/services/noteLock/NoteLockKey.ts
+++ b/packages/lib/services/noteLock/NoteLockKey.ts
@@ -49,6 +49,8 @@ export default class NoteLockKey {
 		return this.save(await this.encryptionService_.generateMasterKey(password));
 	}
 
+	// Rotate through NoteLockSession.reset() rather than calling this directly, so the session locks
+	// and drops the old key as part of the rotation.
 	public async reset(password: string) {
 		return this.save(await this.encryptionService_.generateMasterKey(password));
 	}

--- a/packages/lib/services/noteLock/NoteLockService.test.ts
+++ b/packages/lib/services/noteLock/NoteLockService.test.ts
@@ -3,6 +3,7 @@ import { afterAllCleanUp, encryptionService, fileContentEqual, setupDatabaseAndS
 import EncryptionService from '../e2ee/EncryptionService';
 import { localSyncInfo, saveLocalSyncInfo } from '../synchronizer/syncInfoUtils';
 import NoteLockKey from './NoteLockKey';
+import NoteLockSession from './NoteLockSession';
 import NoteLockService from './NoteLockService';
 
 describe('NoteLockService', () => {
@@ -12,6 +13,7 @@ describe('NoteLockService', () => {
 		await setupDatabaseAndSynchronizer(2);
 		await switchClient(1);
 		NoteLockKey.destroyInstance();
+		NoteLockSession.destroyInstance();
 		NoteLockService.destroyInstance();
 		EncryptionService.instance_ = encryptionService();
 	});
@@ -23,8 +25,10 @@ describe('NoteLockService', () => {
 	it('should encrypt and decrypt strings and files without loading an E2EE master key', async () => {
 		const encryptionServiceInstance = EncryptionService.instance();
 		const noteLockKey = NoteLockKey.instance();
+		const session = NoteLockSession.instance();
 		const service = NoteLockService.instance();
 		await noteLockKey.create('123456');
+		await session.unlock('123456');
 
 		const cipherText = await service.encryptString('some secret');
 		expect(await service.decryptString(cipherText)).toBe('some secret');
@@ -42,49 +46,79 @@ describe('NoteLockService', () => {
 
 	it('should clear cached key data and only rotate on reset', async () => {
 		const noteLockKey = NoteLockKey.instance();
+		const session = NoteLockSession.instance();
 		const firstKey = await noteLockKey.create('123456');
 		await expect(noteLockKey.create('123456')).rejects.toThrow('Note lock key already exists');
 
-		noteLockKey.lock();
-		expect(noteLockKey.isUnlocked()).toBe(false);
-		await expect(noteLockKey.unlock('wrong password')).rejects.toThrow();
+		await session.unlock('123456');
+		session.lock();
+		expect(session.isUnlocked()).toBe(false);
+		await expect(session.unlock('wrong password')).rejects.toThrow();
 
 		const secondKey = await noteLockKey.reset('654321');
 		expect(secondKey.id).not.toBe(firstKey.id);
-		expect(noteLockKey.isUnlocked()).toBe(true);
+		await session.unlock('654321');
+		expect(session.isUnlocked()).toBe(true);
 	});
 
-	it('should defer clearing key data while exporting', async () => {
+	it('should keep the key available to a lease after locking', async () => {
 		const noteLockKey = NoteLockKey.instance();
+		const session = NoteLockSession.instance();
 		const service = NoteLockService.instance();
 		await noteLockKey.create('123456');
+		await session.unlock('123456');
 		const cipherText = await service.encryptString('some secret');
 
-		noteLockKey.startExport();
-		expect(noteLockKey.isUnlocked()).toBe(true);
-		noteLockKey.endExport();
-		expect(noteLockKey.isUnlocked()).toBe(true);
+		await session.withKeyHeld(async () => {
+			expect(session.isUnlocked()).toBe(true);
+		});
+		expect(session.isUnlocked()).toBe(true);
 
-		noteLockKey.startExport();
-		noteLockKey.lock();
+		await session.withKeyHeld(async () => {
+			session.lock();
+			expect(session.isUnlocked()).toBe(false);
+			expect(await service.decryptString(cipherText)).toBe('some secret');
+		});
 
-		expect(noteLockKey.isUnlocked()).toBe(false);
-		expect(await service.decryptString(cipherText)).toBe('some secret');
-
-		noteLockKey.endExport();
-
-		expect(noteLockKey.isUnlocked()).toBe(false);
-		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock key is not unlocked');
+		expect(session.isUnlocked()).toBe(false);
+		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock session is locked');
 	});
 
-	it('should defer a synced key change until all exports finish', async () => {
+	it('should release the lease when a held callback throws', async () => {
 		const noteLockKey = NoteLockKey.instance();
+		const session = NoteLockSession.instance();
+		await noteLockKey.create('123456');
+		await session.unlock('123456');
+
+		await expect(session.withKeyHeld(async () => {
+			throw new Error('boom');
+		})).rejects.toThrow('boom');
+
+		session.lock();
+		expect(() => session.decryptedKey()).toThrow('Note lock session is locked');
+	});
+
+	it('should leave the session locked after create and reset until explicitly unlocked', async () => {
+		const noteLockKey = NoteLockKey.instance();
+		const session = NoteLockSession.instance();
+
+		await noteLockKey.create('123456');
+		expect(session.isUnlocked()).toBe(false);
+
+		await session.unlock('123456');
+		expect(session.isUnlocked()).toBe(true);
+
+		await noteLockKey.reset('654321');
+		expect(session.isUnlocked()).toBe(false);
+	});
+
+	it('should not serve a key that changed before the lease started', async () => {
+		const noteLockKey = NoteLockKey.instance();
+		const session = NoteLockSession.instance();
 		const service = NoteLockService.instance();
 		await noteLockKey.create('123456');
+		await session.unlock('123456');
 		const cipherText = await service.encryptString('some secret');
-
-		noteLockKey.startExport();
-		noteLockKey.startExport();
 
 		const syncInfo = localSyncInfo();
 		syncInfo.noteLockKey = {
@@ -93,39 +127,89 @@ describe('NoteLockService', () => {
 		};
 		saveLocalSyncInfo(syncInfo);
 
-		expect(noteLockKey.isUnlocked()).toBe(false);
-		expect(await service.decryptString(cipherText)).toBe('some secret');
-
-		noteLockKey.endExport();
-		expect(await service.decryptString(cipherText)).toBe('some secret');
-
-		noteLockKey.endExport();
-		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock key is not unlocked');
+		await session.withKeyHeld(async () => {
+			await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock session is locked');
+		});
 	});
 
-	it('should clear a synced key change when the final export ends', async () => {
+	it('should reject unlocking while a lease holds the key', async () => {
 		const noteLockKey = NoteLockKey.instance();
+		const session = NoteLockSession.instance();
+		await noteLockKey.create('123456');
+		await session.unlock('123456');
+
+		await session.withKeyHeld(async () => {
+			await expect(session.unlock('123456')).rejects.toThrow('Cannot unlock the note lock session while an operation is holding the key');
+		});
+	});
+
+	it('should hold the key until the last overlapping lease finishes out of order', async () => {
+		const noteLockKey = NoteLockKey.instance();
+		const session = NoteLockSession.instance();
 		const service = NoteLockService.instance();
-		const originalKey = await noteLockKey.create('123456');
+		await noteLockKey.create('123456');
+		await session.unlock('123456');
 		const cipherText = await service.encryptString('some secret');
 
-		noteLockKey.startExport();
-		const syncInfo = localSyncInfo();
-		syncInfo.noteLockKey = {
-			...originalKey,
-			id: '0123456789abcdef0123456789abcdef',
-		};
-		saveLocalSyncInfo(syncInfo);
-		noteLockKey.endExport();
+		let releaseFirst: ()=> void = () => {};
+		let releaseSecond: ()=> void = () => {};
+		const firstGate = new Promise<void>(resolve => { releaseFirst = resolve; });
+		const secondGate = new Promise<void>(resolve => { releaseSecond = resolve; });
 
+		const firstLease = session.withKeyHeld(async () => { await firstGate; });
+		const secondLease = session.withKeyHeld(async () => { await secondGate; });
+
+		session.lock();
+		expect(session.isUnlocked()).toBe(false);
+
+		releaseFirst();
+		await firstLease;
+		// While any lease is in flight the held key is process-wide: even this caller, which is
+		// outside the lease, can still decrypt. Intentional for now; to be scoped to the leased
+		// operation when export integration lands.
+		expect(await service.decryptString(cipherText)).toBe('some secret');
+
+		releaseSecond();
+		await secondLease;
+		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock session is locked');
+	});
+
+	it('should defer a synced key change until the final lease ends, then clear it', async () => {
+		const noteLockKey = NoteLockKey.instance();
+		const session = NoteLockSession.instance();
+		const service = NoteLockService.instance();
+		const originalKey = await noteLockKey.create('123456');
+		await session.unlock('123456');
+		const cipherText = await service.encryptString('some secret');
+
+		await session.withKeyHeld(async () => {
+			await session.withKeyHeld(async () => {
+				const syncInfo = localSyncInfo();
+				syncInfo.noteLockKey = {
+					...syncInfo.noteLockKey,
+					id: '0123456789abcdef0123456789abcdef',
+				};
+				saveLocalSyncInfo(syncInfo);
+
+				// Visible session reads as locked, but the in-flight lease still gets the key.
+				expect(session.isUnlocked()).toBe(false);
+				expect(await service.decryptString(cipherText)).toBe('some secret');
+			});
+
+			expect(await service.decryptString(cipherText)).toBe('some secret');
+		});
+
+		// Once every lease is done the key is cleared and stays cleared even if the original returns.
+		const syncInfo = localSyncInfo();
 		syncInfo.noteLockKey = originalKey;
 		saveLocalSyncInfo(syncInfo);
-		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock key is not unlocked');
+		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock session is locked');
 	});
 
 	it('should sync the encrypted note lock key without loading it into the E2EE registry', async () => {
 		const createdKey = await NoteLockKey.instance().create('123456');
 		NoteLockKey.destroyInstance();
+		NoteLockSession.destroyInstance();
 		NoteLockService.destroyInstance();
 		await synchronizerStart();
 
@@ -135,7 +219,7 @@ describe('NoteLockService', () => {
 
 		const syncedKey = NoteLockKey.instance();
 		expect(syncedKey.load()).toEqual(createdKey);
-		expect(syncedKey.isUnlocked()).toBe(false);
+		expect(NoteLockSession.instance().isUnlocked()).toBe(false);
 		expect(EncryptionService.instance().loadedMasterKeysCount()).toBe(0);
 	});
 });

--- a/packages/lib/services/noteLock/NoteLockService.test.ts
+++ b/packages/lib/services/noteLock/NoteLockService.test.ts
@@ -6,6 +6,19 @@ import NoteLockKey from './NoteLockKey';
 import NoteLockSession from './NoteLockSession';
 import NoteLockService, { ScopedNoteLockService } from './NoteLockService';
 
+const unlockedSession = async (password = '123456') => {
+	const session = NoteLockSession.instance();
+	await NoteLockKey.instance().create(password);
+	expect(await session.unlock(password)).toBe(true);
+	return session;
+};
+
+const changeSyncedKeyId = (id: string) => {
+	const syncInfo = localSyncInfo();
+	syncInfo.noteLockKey = { ...syncInfo.noteLockKey, id };
+	saveLocalSyncInfo(syncInfo);
+};
+
 describe('NoteLockService', () => {
 
 	beforeEach(async () => {
@@ -49,10 +62,8 @@ describe('NoteLockService', () => {
 	});
 
 	it('should keep a held operation working after the session locks, refuse the session-backed service, and revoke the scoped service afterwards', async () => {
-		const session = NoteLockSession.instance();
 		const service = NoteLockService.instance();
-		await NoteLockKey.instance().create('123456');
-		await session.unlock('123456');
+		const session = await unlockedSession();
 		const cipherText = await service.encryptString('some secret');
 
 		let escaped: ScopedNoteLockService = null;
@@ -61,6 +72,8 @@ describe('NoteLockService', () => {
 			session.lock();
 			await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock session is locked');
 			expect(await scoped.decryptString(cipherText)).toBe('some secret');
+			const lockedEncryptedText = await scoped.encryptString('encrypted while locked');
+			expect(await scoped.decryptString(lockedEncryptedText)).toBe('encrypted while locked');
 		});
 
 		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock session is locked');
@@ -68,20 +81,47 @@ describe('NoteLockService', () => {
 	});
 
 	it('should keep a held operation on its captured key when the synced key changes, and fail the session-backed service closed', async () => {
-		const session = NoteLockSession.instance();
 		const service = NoteLockService.instance();
-		await NoteLockKey.instance().create('123456');
-		await session.unlock('123456');
+		await unlockedSession();
 		const cipherText = await service.encryptString('some secret');
 
 		await NoteLockService.withDecryptedKey(async scoped => {
-			const syncInfo = localSyncInfo();
-			syncInfo.noteLockKey = { ...syncInfo.noteLockKey, id: '0123456789abcdef0123456789abcdef' };
-			saveLocalSyncInfo(syncInfo);
+			changeSyncedKeyId('0123456789abcdef0123456789abcdef');
 
 			expect(await scoped.decryptString(cipherText)).toBe('some secret');
 			await expect(service.encryptString('unrelated')).rejects.toThrow('Note lock session is locked');
+			await expect(scoped.encryptString('unrelated')).rejects.toThrow('Note lock key changed during operation');
 		});
+	});
+
+	it('should fail a held encrypt closed while a reset is in progress', async () => {
+		const session = await unlockedSession();
+
+		await NoteLockService.withDecryptedKey(async scoped => {
+			// Don't await yet: reset() sets the rotating flag synchronously before its first await, which is
+			// what the held encrypt below needs to observe.
+			const resetting = session.reset('654321');
+			await expect(scoped.encryptString('some secret')).rejects.toThrow('Note lock key changed during operation');
+			await resetting;
+		});
+	});
+
+	it('should fail a held encryptFile closed and remove its output if the key rotates mid-encrypt', async () => {
+		await unlockedSession();
+
+		const sourcePath = `${supportDir}/photo.jpg`;
+		const destPath = `${Setting.value('tempDir')}/note-lock-rotate-mid-encrypt.crypted`;
+		const fsDriver = EncryptionService.instance().fsDriver();
+
+		await NoteLockService.withDecryptedKey(async scoped => {
+			// Don't await yet: encryptFile() doesn't reach its own first await until after the pre-check, so
+			// this mutation is guaranteed to land before the post-check below runs.
+			const encrypting = scoped.encryptFile(sourcePath, destPath);
+			changeSyncedKeyId('0123456789abcdef0123456789abcdef');
+			await expect(encrypting).rejects.toThrow('Note lock key changed during operation');
+		});
+
+		expect(await fsDriver.exists(destPath)).toBe(false);
 	});
 
 	it('should propagate errors from a held operation and still revoke the scoped service', async () => {

--- a/packages/lib/services/noteLock/NoteLockService.test.ts
+++ b/packages/lib/services/noteLock/NoteLockService.test.ts
@@ -124,6 +124,23 @@ describe('NoteLockService', () => {
 		expect(await fsDriver.exists(destPath)).toBe(false);
 	});
 
+	it('should fail the live service closed and remove its output if the key rotates mid-encrypt', async () => {
+		await unlockedSession();
+		const service = NoteLockService.instance();
+
+		const sourcePath = `${supportDir}/photo.jpg`;
+		const destPath = `${Setting.value('tempDir')}/note-lock-rotate-mid-encrypt-live.crypted`;
+		const fsDriver = EncryptionService.instance().fsDriver();
+
+		// Don't await yet: encryptFile() doesn't reach its own first await until after the pre-check, so this
+		// mutation is guaranteed to land before the post-check below runs.
+		const encrypting = service.encryptFile(sourcePath, destPath);
+		changeSyncedKeyId('0123456789abcdef0123456789abcdef');
+		await expect(encrypting).rejects.toThrow('Note lock key changed during operation');
+
+		expect(await fsDriver.exists(destPath)).toBe(false);
+	});
+
 	it('should propagate errors from a held operation and still revoke the scoped service', async () => {
 		const session = NoteLockSession.instance();
 		await NoteLockKey.instance().create('123456');

--- a/packages/lib/services/noteLock/NoteLockService.test.ts
+++ b/packages/lib/services/noteLock/NoteLockService.test.ts
@@ -48,12 +48,32 @@ describe('NoteLockService', () => {
 		expect(noteLockKey.isUnlocked()).toBe(false);
 		await expect(noteLockKey.unlock('wrong password')).rejects.toThrow();
 
-		await noteLockKey.unlock('123456', Date.now() - 1);
-		expect(noteLockKey.isUnlocked()).toBe(false);
-
 		const secondKey = await noteLockKey.reset('654321');
 		expect(secondKey.id).not.toBe(firstKey.id);
 		expect(noteLockKey.isUnlocked()).toBe(true);
+	});
+
+	it('should defer clearing key data while exporting', async () => {
+		const noteLockKey = NoteLockKey.instance();
+		const service = NoteLockService.instance();
+		await noteLockKey.create('123456');
+		const cipherText = await service.encryptString('some secret');
+
+		noteLockKey.setExporting(true);
+		expect(noteLockKey.isUnlocked()).toBe(true);
+		noteLockKey.setExporting(false);
+		expect(noteLockKey.isUnlocked()).toBe(true);
+
+		noteLockKey.setExporting(true);
+		noteLockKey.lock();
+
+		expect(noteLockKey.isUnlocked()).toBe(false);
+		expect(await service.decryptString(cipherText)).toBe('some secret');
+
+		noteLockKey.setExporting(false);
+
+		expect(noteLockKey.isUnlocked()).toBe(false);
+		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock key is not unlocked');
 	});
 
 	it('should sync the encrypted note lock key without loading it into the E2EE registry', async () => {

--- a/packages/lib/services/noteLock/NoteLockService.test.ts
+++ b/packages/lib/services/noteLock/NoteLockService.test.ts
@@ -1,20 +1,19 @@
 import Setting from '../../models/Setting';
-import { afterAllCleanUp, encryptionService, fileContentEqual, setupDatabaseAndSynchronizer, supportDir, switchClient, synchronizerStart } from '../../testing/test-utils';
+import { afterAllCleanUp, encryptionService, fileContentEqual, setupDatabaseAndSynchronizer, supportDir, switchClient } from '../../testing/test-utils';
 import EncryptionService from '../e2ee/EncryptionService';
 import { localSyncInfo, saveLocalSyncInfo } from '../synchronizer/syncInfoUtils';
 import NoteLockKey from './NoteLockKey';
 import NoteLockSession from './NoteLockSession';
-import NoteLockService from './NoteLockService';
+import NoteLockService, { ScopedNoteLockService } from './NoteLockService';
 
 describe('NoteLockService', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
-		await setupDatabaseAndSynchronizer(2);
 		await switchClient(1);
-		NoteLockKey.destroyInstance();
-		NoteLockSession.destroyInstance();
 		NoteLockService.destroyInstance();
+		NoteLockSession.destroyInstance();
+		NoteLockKey.destroyInstance();
 		EncryptionService.instance_ = encryptionService();
 	});
 
@@ -44,203 +43,58 @@ describe('NoteLockService', () => {
 		expect(encryptionServiceInstance.loadedMasterKeysCount()).toBe(0);
 	});
 
-	it('should clear cached key data and only rotate on reset', async () => {
-		const noteLockKey = NoteLockKey.instance();
-		const session = NoteLockSession.instance();
-		const firstKey = await noteLockKey.create('123456');
-		await expect(noteLockKey.create('123456')).rejects.toThrow('Note lock key already exists');
-
-		await session.unlock('123456');
-		session.lock();
-		expect(session.isUnlocked()).toBe(false);
-		await expect(session.unlock('wrong password')).rejects.toThrow();
-
-		const secondKey = await noteLockKey.reset('654321');
-		expect(secondKey.id).not.toBe(firstKey.id);
-		await session.unlock('654321');
-		expect(session.isUnlocked()).toBe(true);
+	it('should refuse to run a held operation while the session is locked', async () => {
+		await NoteLockKey.instance().create('123456');
+		await expect(NoteLockService.withDecryptedKey(async () => {})).rejects.toThrow('Note lock session is locked');
 	});
 
-	it('should keep the key available to a lease after locking', async () => {
-		const noteLockKey = NoteLockKey.instance();
+	it('should keep a held operation working after the session locks, refuse the session-backed service, and revoke the scoped service afterwards', async () => {
 		const session = NoteLockSession.instance();
 		const service = NoteLockService.instance();
-		await noteLockKey.create('123456');
+		await NoteLockKey.instance().create('123456');
 		await session.unlock('123456');
 		const cipherText = await service.encryptString('some secret');
 
-		await session.withKeyHeld(async () => {
-			expect(session.isUnlocked()).toBe(true);
-		});
-		expect(session.isUnlocked()).toBe(true);
-
-		await session.withKeyHeld(async () => {
+		let escaped: ScopedNoteLockService = null;
+		await NoteLockService.withDecryptedKey(async scoped => {
+			escaped = scoped;
 			session.lock();
-			expect(session.isUnlocked()).toBe(false);
-			expect(await service.decryptString(cipherText)).toBe('some secret');
+			await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock session is locked');
+			expect(await scoped.decryptString(cipherText)).toBe('some secret');
 		});
 
-		expect(session.isUnlocked()).toBe(false);
 		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock session is locked');
+		await expect(escaped.decryptString(cipherText)).rejects.toThrow('Note lock operation key is no longer available');
 	});
 
-	it('should release the lease when a held callback throws', async () => {
-		const noteLockKey = NoteLockKey.instance();
+	it('should keep a held operation on its captured key when the synced key changes, and fail the session-backed service closed', async () => {
 		const session = NoteLockSession.instance();
-		await noteLockKey.create('123456');
+		const service = NoteLockService.instance();
+		await NoteLockKey.instance().create('123456');
+		await session.unlock('123456');
+		const cipherText = await service.encryptString('some secret');
+
+		await NoteLockService.withDecryptedKey(async scoped => {
+			const syncInfo = localSyncInfo();
+			syncInfo.noteLockKey = { ...syncInfo.noteLockKey, id: '0123456789abcdef0123456789abcdef' };
+			saveLocalSyncInfo(syncInfo);
+
+			expect(await scoped.decryptString(cipherText)).toBe('some secret');
+			await expect(service.encryptString('unrelated')).rejects.toThrow('Note lock session is locked');
+		});
+	});
+
+	it('should propagate errors from a held operation and still revoke the scoped service', async () => {
+		const session = NoteLockSession.instance();
+		await NoteLockKey.instance().create('123456');
 		await session.unlock('123456');
 
-		await expect(session.withKeyHeld(async () => {
+		let escaped: ScopedNoteLockService = null;
+		await expect(NoteLockService.withDecryptedKey(async scoped => {
+			escaped = scoped;
 			throw new Error('boom');
 		})).rejects.toThrow('boom');
 
-		session.lock();
-		expect(() => session.decryptedKey()).toThrow('Note lock session is locked');
-	});
-
-	it('should leave the session locked after create and reset until explicitly unlocked', async () => {
-		const noteLockKey = NoteLockKey.instance();
-		const session = NoteLockSession.instance();
-
-		await noteLockKey.create('123456');
-		expect(session.isUnlocked()).toBe(false);
-
-		await session.unlock('123456');
-		expect(session.isUnlocked()).toBe(true);
-
-		await noteLockKey.reset('654321');
-		expect(session.isUnlocked()).toBe(false);
-	});
-
-	it('should not serve a key that changed before the lease started', async () => {
-		const noteLockKey = NoteLockKey.instance();
-		const session = NoteLockSession.instance();
-		const service = NoteLockService.instance();
-		await noteLockKey.create('123456');
-		await session.unlock('123456');
-		const cipherText = await service.encryptString('some secret');
-
-		const syncInfo = localSyncInfo();
-		syncInfo.noteLockKey = {
-			...syncInfo.noteLockKey,
-			id: '0123456789abcdef0123456789abcdef',
-		};
-		saveLocalSyncInfo(syncInfo);
-
-		await session.withKeyHeld(async () => {
-			await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock session is locked');
-		});
-	});
-
-	it('should reject unlocking while a lease holds the key', async () => {
-		const noteLockKey = NoteLockKey.instance();
-		const session = NoteLockSession.instance();
-		await noteLockKey.create('123456');
-		await session.unlock('123456');
-
-		await session.withKeyHeld(async () => {
-			await expect(session.unlock('123456')).rejects.toThrow('Cannot unlock the note lock session while an operation is holding the key');
-		});
-	});
-
-	it('should stay locked when locked while an unlock is in flight', async () => {
-		const noteLockKey = NoteLockKey.instance();
-		const session = NoteLockSession.instance();
-		await noteLockKey.create('123456');
-
-		let releaseDecrypt: ()=> void = () => {};
-		const decryptGate = new Promise<void>(resolve => { releaseDecrypt = resolve; });
-		const realDecrypt = noteLockKey.decrypt.bind(noteLockKey);
-		jest.spyOn(noteLockKey, 'decrypt').mockImplementation(async password => {
-			await decryptGate;
-			return realDecrypt(password);
-		});
-
-		const unlocking = session.unlock('123456');
-		session.lock();
-		releaseDecrypt();
-		await unlocking;
-
-		expect(session.isUnlocked()).toBe(false);
-	});
-
-	it('should hold the key until the last overlapping lease finishes out of order', async () => {
-		const noteLockKey = NoteLockKey.instance();
-		const session = NoteLockSession.instance();
-		const service = NoteLockService.instance();
-		await noteLockKey.create('123456');
-		await session.unlock('123456');
-		const cipherText = await service.encryptString('some secret');
-
-		let releaseFirst: ()=> void = () => {};
-		let releaseSecond: ()=> void = () => {};
-		const firstGate = new Promise<void>(resolve => { releaseFirst = resolve; });
-		const secondGate = new Promise<void>(resolve => { releaseSecond = resolve; });
-
-		const firstLease = session.withKeyHeld(async () => { await firstGate; });
-		const secondLease = session.withKeyHeld(async () => { await secondGate; });
-
-		session.lock();
-		expect(session.isUnlocked()).toBe(false);
-
-		releaseFirst();
-		await firstLease;
-		// While any lease is in flight the held key is process-wide: even this caller, which is
-		// outside the lease, can still decrypt. Intentional for now; to be scoped to the leased
-		// operation when export integration lands.
-		expect(await service.decryptString(cipherText)).toBe('some secret');
-
-		releaseSecond();
-		await secondLease;
-		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock session is locked');
-	});
-
-	it('should defer a synced key change until the final lease ends, then clear it', async () => {
-		const noteLockKey = NoteLockKey.instance();
-		const session = NoteLockSession.instance();
-		const service = NoteLockService.instance();
-		const originalKey = await noteLockKey.create('123456');
-		await session.unlock('123456');
-		const cipherText = await service.encryptString('some secret');
-
-		await session.withKeyHeld(async () => {
-			await session.withKeyHeld(async () => {
-				const syncInfo = localSyncInfo();
-				syncInfo.noteLockKey = {
-					...syncInfo.noteLockKey,
-					id: '0123456789abcdef0123456789abcdef',
-				};
-				saveLocalSyncInfo(syncInfo);
-
-				// Visible session reads as locked, but the in-flight lease still gets the key.
-				expect(session.isUnlocked()).toBe(false);
-				expect(await service.decryptString(cipherText)).toBe('some secret');
-			});
-
-			expect(await service.decryptString(cipherText)).toBe('some secret');
-		});
-
-		// Once every lease is done the key is cleared and stays cleared even if the original returns.
-		const syncInfo = localSyncInfo();
-		syncInfo.noteLockKey = originalKey;
-		saveLocalSyncInfo(syncInfo);
-		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock session is locked');
-	});
-
-	it('should sync the encrypted note lock key without loading it into the E2EE registry', async () => {
-		const createdKey = await NoteLockKey.instance().create('123456');
-		NoteLockKey.destroyInstance();
-		NoteLockSession.destroyInstance();
-		NoteLockService.destroyInstance();
-		await synchronizerStart();
-
-		await switchClient(2);
-		EncryptionService.instance_ = encryptionService();
-		await synchronizerStart();
-
-		const syncedKey = NoteLockKey.instance();
-		expect(syncedKey.load()).toEqual(createdKey);
-		expect(NoteLockSession.instance().isUnlocked()).toBe(false);
-		expect(EncryptionService.instance().loadedMasterKeysCount()).toBe(0);
+		await expect(escaped.decryptString('does not matter')).rejects.toThrow('Note lock operation key is no longer available');
 	});
 });

--- a/packages/lib/services/noteLock/NoteLockService.test.ts
+++ b/packages/lib/services/noteLock/NoteLockService.test.ts
@@ -103,6 +103,26 @@ describe('NoteLockService', () => {
 		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock key is not unlocked');
 	});
 
+	it('should clear a synced key change when the final export ends', async () => {
+		const noteLockKey = NoteLockKey.instance();
+		const service = NoteLockService.instance();
+		const originalKey = await noteLockKey.create('123456');
+		const cipherText = await service.encryptString('some secret');
+
+		noteLockKey.startExport();
+		const syncInfo = localSyncInfo();
+		syncInfo.noteLockKey = {
+			...originalKey,
+			id: '0123456789abcdef0123456789abcdef',
+		};
+		saveLocalSyncInfo(syncInfo);
+		noteLockKey.endExport();
+
+		syncInfo.noteLockKey = originalKey;
+		saveLocalSyncInfo(syncInfo);
+		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock key is not unlocked');
+	});
+
 	it('should sync the encrypted note lock key without loading it into the E2EE registry', async () => {
 		const createdKey = await NoteLockKey.instance().create('123456');
 		NoteLockKey.destroyInstance();

--- a/packages/lib/services/noteLock/NoteLockService.test.ts
+++ b/packages/lib/services/noteLock/NoteLockService.test.ts
@@ -1,6 +1,7 @@
 import Setting from '../../models/Setting';
 import { afterAllCleanUp, encryptionService, fileContentEqual, setupDatabaseAndSynchronizer, supportDir, switchClient, synchronizerStart } from '../../testing/test-utils';
 import EncryptionService from '../e2ee/EncryptionService';
+import { localSyncInfo, saveLocalSyncInfo } from '../synchronizer/syncInfoUtils';
 import NoteLockKey from './NoteLockKey';
 import NoteLockService from './NoteLockService';
 
@@ -59,20 +60,46 @@ describe('NoteLockService', () => {
 		await noteLockKey.create('123456');
 		const cipherText = await service.encryptString('some secret');
 
-		noteLockKey.setExporting(true);
+		noteLockKey.startExport();
 		expect(noteLockKey.isUnlocked()).toBe(true);
-		noteLockKey.setExporting(false);
+		noteLockKey.endExport();
 		expect(noteLockKey.isUnlocked()).toBe(true);
 
-		noteLockKey.setExporting(true);
+		noteLockKey.startExport();
 		noteLockKey.lock();
 
 		expect(noteLockKey.isUnlocked()).toBe(false);
 		expect(await service.decryptString(cipherText)).toBe('some secret');
 
-		noteLockKey.setExporting(false);
+		noteLockKey.endExport();
 
 		expect(noteLockKey.isUnlocked()).toBe(false);
+		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock key is not unlocked');
+	});
+
+	it('should defer a synced key change until all exports finish', async () => {
+		const noteLockKey = NoteLockKey.instance();
+		const service = NoteLockService.instance();
+		await noteLockKey.create('123456');
+		const cipherText = await service.encryptString('some secret');
+
+		noteLockKey.startExport();
+		noteLockKey.startExport();
+
+		const syncInfo = localSyncInfo();
+		syncInfo.noteLockKey = {
+			...syncInfo.noteLockKey,
+			id: '0123456789abcdef0123456789abcdef',
+		};
+		saveLocalSyncInfo(syncInfo);
+
+		expect(noteLockKey.isUnlocked()).toBe(false);
+		expect(await service.decryptString(cipherText)).toBe('some secret');
+
+		noteLockKey.endExport();
+		expect(await service.decryptString(cipherText)).toBe('some secret');
+
+		noteLockKey.endExport();
 		await expect(service.decryptString(cipherText)).rejects.toThrow('Note lock key is not unlocked');
 	});
 

--- a/packages/lib/services/noteLock/NoteLockService.test.ts
+++ b/packages/lib/services/noteLock/NoteLockService.test.ts
@@ -143,6 +143,27 @@ describe('NoteLockService', () => {
 		});
 	});
 
+	it('should stay locked when locked while an unlock is in flight', async () => {
+		const noteLockKey = NoteLockKey.instance();
+		const session = NoteLockSession.instance();
+		await noteLockKey.create('123456');
+
+		let releaseDecrypt: ()=> void = () => {};
+		const decryptGate = new Promise<void>(resolve => { releaseDecrypt = resolve; });
+		const realDecrypt = noteLockKey.decrypt.bind(noteLockKey);
+		jest.spyOn(noteLockKey, 'decrypt').mockImplementation(async password => {
+			await decryptGate;
+			return realDecrypt(password);
+		});
+
+		const unlocking = session.unlock('123456');
+		session.lock();
+		releaseDecrypt();
+		await unlocking;
+
+		expect(session.isUnlocked()).toBe(false);
+	});
+
 	it('should hold the key until the last overlapping lease finishes out of order', async () => {
 		const noteLockKey = NoteLockKey.instance();
 		const session = NoteLockSession.instance();

--- a/packages/lib/services/noteLock/NoteLockService.test.ts
+++ b/packages/lib/services/noteLock/NoteLockService.test.ts
@@ -9,7 +9,7 @@ import NoteLockService, { ScopedNoteLockService } from './NoteLockService';
 const unlockedSession = async (password = '123456') => {
 	const session = NoteLockSession.instance();
 	await NoteLockKey.instance().create(password);
-	expect(await session.unlock(password)).toBe(true);
+	await session.unlock(password);
 	return session;
 };
 

--- a/packages/lib/services/noteLock/NoteLockService.ts
+++ b/packages/lib/services/noteLock/NoteLockService.ts
@@ -25,12 +25,12 @@ export default class NoteLockService {
 	public static async withDecryptedKey<T>(callback: (service: ScopedNoteLockService)=> Promise<T>) {
 		const key = NoteLockSession.instance().decryptedKey();
 		const scoped = new NoteLockService(EncryptionService.instance(), () => key);
-		const decryptor: ScopedNoteLockService = {
+		const decryptView: ScopedNoteLockService = {
 			decryptString: cipherText => scoped.decryptString(cipherText),
 			decryptFile: (srcPath, destPath) => scoped.decryptFile(srcPath, destPath),
 		};
 		try {
-			return await callback(decryptor);
+			return await callback(decryptView);
 		} finally {
 			scoped.revoke_();
 		}

--- a/packages/lib/services/noteLock/NoteLockService.ts
+++ b/packages/lib/services/noteLock/NoteLockService.ts
@@ -1,5 +1,5 @@
 import EncryptionService, { EncryptOptions } from '../e2ee/EncryptionService';
-import NoteLockKey from './NoteLockKey';
+import NoteLockSession from './NoteLockSession';
 
 export default class NoteLockService {
 
@@ -7,14 +7,14 @@ export default class NoteLockService {
 
 	private constructor(
 		private encryptionService_: EncryptionService,
-		private noteLockKey_: NoteLockKey,
+		private noteLockSession_: NoteLockSession,
 	) {}
 
 	public static instance() {
 		if (!this.instance_) {
 			const encryptionService = EncryptionService.instance();
-			const noteLockKey = NoteLockKey.instance();
-			this.instance_ = new NoteLockService(encryptionService, noteLockKey);
+			const noteLockSession = NoteLockSession.instance();
+			this.instance_ = new NoteLockService(encryptionService, noteLockSession);
 		}
 		return this.instance_;
 	}
@@ -40,7 +40,7 @@ export default class NoteLockService {
 	}
 
 	private encryptionOptions_(): EncryptOptions {
-		const key = this.noteLockKey_.decryptedKey();
+		const key = this.noteLockSession_.decryptedKey();
 		return {
 			masterKeyId: key.id,
 			decryptedMasterKey: key.plainText,

--- a/packages/lib/services/noteLock/NoteLockService.ts
+++ b/packages/lib/services/noteLock/NoteLockService.ts
@@ -1,4 +1,5 @@
 import EncryptionService, { EncryptOptions } from '../e2ee/EncryptionService';
+import { DecryptedNoteLockKey } from './NoteLockKey';
 import NoteLockSession from './NoteLockSession';
 
 export default class NoteLockService {
@@ -7,20 +8,40 @@ export default class NoteLockService {
 
 	private constructor(
 		private encryptionService_: EncryptionService,
-		private noteLockSession_: NoteLockSession,
+		private keySource_: ()=> DecryptedNoteLockKey,
 	) {}
 
 	public static instance() {
 		if (!this.instance_) {
-			const encryptionService = EncryptionService.instance();
-			const noteLockSession = NoteLockSession.instance();
-			this.instance_ = new NoteLockService(encryptionService, noteLockSession);
+			const session = NoteLockSession.instance();
+			this.instance_ = new NoteLockService(EncryptionService.instance(), () => session.decryptedKey());
 		}
 		return this.instance_;
 	}
 
+	// Decrypt-only by design: a scoped op reads at-rest data (which a key rotation mid-operation doesn't change)
+	// but never writes, so it can't encrypt with a stale key — writes go through the live session and fail closed.
+	// Callers must await every scoped op: one that's started but not awaited still holds its captured key copy.
+	public static async withDecryptedKey<T>(callback: (service: ScopedNoteLockService)=> Promise<T>) {
+		const key = NoteLockSession.instance().decryptedKey();
+		const scoped = new NoteLockService(EncryptionService.instance(), () => key);
+		const decryptor: ScopedNoteLockService = {
+			decryptString: cipherText => scoped.decryptString(cipherText),
+			decryptFile: (srcPath, destPath) => scoped.decryptFile(srcPath, destPath),
+		};
+		try {
+			return await callback(decryptor);
+		} finally {
+			scoped.revoke_();
+		}
+	}
+
 	public static destroyInstance() {
 		this.instance_ = null;
+	}
+
+	private revoke_() {
+		this.keySource_ = () => { throw new Error('Note lock operation key is no longer available'); };
 	}
 
 	public async encryptString(plainText: string) {
@@ -40,10 +61,12 @@ export default class NoteLockService {
 	}
 
 	private encryptionOptions_(): EncryptOptions {
-		const key = this.noteLockSession_.decryptedKey();
+		const key = this.keySource_();
 		return {
 			masterKeyId: key.id,
 			decryptedMasterKey: key.plainText,
 		};
 	}
 }
+
+export type ScopedNoteLockService = Pick<NoteLockService, 'decryptString' | 'decryptFile'>;

--- a/packages/lib/services/noteLock/NoteLockService.ts
+++ b/packages/lib/services/noteLock/NoteLockService.ts
@@ -9,6 +9,7 @@ export default class NoteLockService {
 	private constructor(
 		private encryptionService_: EncryptionService,
 		private keySource_: ()=> DecryptedNoteLockKey,
+		private assertCanEncrypt_: (keyId: string)=> void = () => {},
 	) {}
 
 	public static instance() {
@@ -19,18 +20,21 @@ export default class NoteLockService {
 		return this.instance_;
 	}
 
-	// Decrypt-only by design: a scoped op reads at-rest data (which a key rotation mid-operation doesn't change)
-	// but never writes, so it can't encrypt with a stale key — writes go through the live session and fail closed.
+	// Decrypt reuses the key captured at scope start, since at-rest ciphertext doesn't change if the key rotates.
+	// Encrypt is guarded by the session instead, so a lock alone won't interrupt it but a real rotation will.
 	// Callers must await every scoped op: one that's started but not awaited still holds its captured key copy.
 	public static async withDecryptedKey<T>(callback: (service: ScopedNoteLockService)=> Promise<T>) {
-		const key = NoteLockSession.instance().decryptedKey();
-		const scoped = new NoteLockService(EncryptionService.instance(), () => key);
-		const decryptView: ScopedNoteLockService = {
+		const session = NoteLockSession.instance();
+		const key = session.decryptedKey();
+		const scoped = new NoteLockService(EncryptionService.instance(), () => key, keyId => session.assertCanEncryptWith(keyId));
+		const scopedView: ScopedNoteLockService = {
 			decryptString: cipherText => scoped.decryptString(cipherText),
 			decryptFile: (srcPath, destPath) => scoped.decryptFile(srcPath, destPath),
+			encryptString: plainText => scoped.encryptString(plainText),
+			encryptFile: (srcPath, destPath) => scoped.encryptFile(srcPath, destPath),
 		};
 		try {
-			return await callback(decryptView);
+			return await callback(scopedView);
 		} finally {
 			scoped.revoke_();
 		}
@@ -45,23 +49,34 @@ export default class NoteLockService {
 	}
 
 	public async encryptString(plainText: string) {
-		return this.encryptionService_.encryptString(plainText, this.encryptionOptions_());
+		const key = this.keySource_();
+		this.assertCanEncrypt_(key.id);
+		const cipherText = await this.encryptionService_.encryptString(plainText, this.encryptionOptions_(key));
+		this.assertCanEncrypt_(key.id);
+		return cipherText;
 	}
 
 	public async decryptString(cipherText: string) {
-		return this.encryptionService_.decryptString(cipherText, this.encryptionOptions_());
+		return this.encryptionService_.decryptString(cipherText, this.encryptionOptions_(this.keySource_()));
 	}
 
 	public async encryptFile(srcPath: string, destPath: string) {
-		return this.encryptionService_.encryptFile(srcPath, destPath, this.encryptionOptions_());
+		const key = this.keySource_();
+		this.assertCanEncrypt_(key.id);
+		await this.encryptionService_.encryptFile(srcPath, destPath, this.encryptionOptions_(key));
+		try {
+			this.assertCanEncrypt_(key.id);
+		} catch (error) {
+			await this.encryptionService_.fsDriver().unlink(destPath);
+			throw error;
+		}
 	}
 
 	public async decryptFile(srcPath: string, destPath: string) {
-		return this.encryptionService_.decryptFile(srcPath, destPath, this.encryptionOptions_());
+		return this.encryptionService_.decryptFile(srcPath, destPath, this.encryptionOptions_(this.keySource_()));
 	}
 
-	private encryptionOptions_(): EncryptOptions {
-		const key = this.keySource_();
+	private encryptionOptions_(key: DecryptedNoteLockKey): EncryptOptions {
 		return {
 			masterKeyId: key.id,
 			decryptedMasterKey: key.plainText,
@@ -69,4 +84,4 @@ export default class NoteLockService {
 	}
 }
 
-export type ScopedNoteLockService = Pick<NoteLockService, 'decryptString' | 'decryptFile'>;
+export type ScopedNoteLockService = Pick<NoteLockService, 'encryptString' | 'encryptFile' | 'decryptString' | 'decryptFile'>;

--- a/packages/lib/services/noteLock/NoteLockService.ts
+++ b/packages/lib/services/noteLock/NoteLockService.ts
@@ -9,13 +9,13 @@ export default class NoteLockService {
 	private constructor(
 		private encryptionService_: EncryptionService,
 		private keySource_: ()=> DecryptedNoteLockKey,
-		private assertCanEncrypt_: (keyId: string)=> void = () => {},
+		private assertCanEncrypt_: (keyId: string)=> void,
 	) {}
 
 	public static instance() {
 		if (!this.instance_) {
 			const session = NoteLockSession.instance();
-			this.instance_ = new NoteLockService(EncryptionService.instance(), () => session.decryptedKey());
+			this.instance_ = new NoteLockService(EncryptionService.instance(), () => session.decryptedKey(), keyId => session.assertCanEncryptWith(keyId));
 		}
 		return this.instance_;
 	}

--- a/packages/lib/services/noteLock/NoteLockSession.test.ts
+++ b/packages/lib/services/noteLock/NoteLockSession.test.ts
@@ -8,7 +8,7 @@ import NoteLockService from './NoteLockService';
 const unlockedSession = async (password = '123456') => {
 	const session = NoteLockSession.instance();
 	await NoteLockKey.instance().create(password);
-	expect(await session.unlock(password)).toBe(true);
+	await session.unlock(password);
 	return session;
 };
 
@@ -67,14 +67,14 @@ describe('NoteLockSession', () => {
 		const firstKey = await NoteLockKey.instance().create('123456');
 		expect(session.isUnlocked()).toBe(false);
 
-		expect(await session.unlock('123456')).toBe(true);
+		await session.unlock('123456');
 		expect(session.isUnlocked()).toBe(true);
 
 		const secondKey = await session.reset('654321');
 		expect(secondKey.id).not.toBe(firstKey.id);
 		expect(session.isUnlocked()).toBe(false);
 
-		expect(await session.unlock('654321')).toBe(true);
+		await session.unlock('654321');
 		expect(session.isUnlocked()).toBe(true);
 	});
 
@@ -107,7 +107,7 @@ describe('NoteLockSession', () => {
 		session.lock();
 		release();
 
-		expect(await unlocking).toBe(false);
+		await expect(unlocking).rejects.toThrow('locked while unlocking');
 		expect(session.isUnlocked()).toBe(false);
 	});
 
@@ -120,7 +120,7 @@ describe('NoteLockSession', () => {
 		NoteLockSession.destroyInstance();
 		release();
 
-		expect(await unlocking).toBe(false);
+		await expect(unlocking).rejects.toThrow('locked while unlocking');
 		expect(session.isUnlocked()).toBe(false);
 	});
 
@@ -134,7 +134,7 @@ describe('NoteLockSession', () => {
 		changeSyncedKeyId('0123456789abcdef0123456789abcdef');
 		release();
 
-		expect(await unlocking).toBe(false);
+		await expect(unlocking).rejects.toThrow('key changed while unlocking');
 		expect(session.isUnlocked()).toBe(false);
 	});
 
@@ -147,7 +147,7 @@ describe('NoteLockSession', () => {
 		await session.reset('654321');
 		release();
 
-		expect(await unlocking).toBe(false);
+		await expect(unlocking).rejects.toThrow('locked while unlocking');
 		expect(session.isUnlocked()).toBe(false);
 	});
 
@@ -156,11 +156,10 @@ describe('NoteLockSession', () => {
 		const releaseRotation = gateKeyGeneration();
 
 		const resetting = session.reset('654321');
-		const unlockResult = await session.unlock('123456');
+		await expect(session.unlock('123456')).rejects.toThrow('reset is in progress');
 		releaseRotation();
 		await resetting;
 
-		expect(unlockResult).toBe(false);
 		expect(session.isUnlocked()).toBe(false);
 	});
 

--- a/packages/lib/services/noteLock/NoteLockSession.test.ts
+++ b/packages/lib/services/noteLock/NoteLockSession.test.ts
@@ -1,0 +1,194 @@
+import { afterAllCleanUp, encryptionService, setupDatabaseAndSynchronizer, switchClient, synchronizerStart } from '../../testing/test-utils';
+import EncryptionService from '../e2ee/EncryptionService';
+import { localSyncInfo, saveLocalSyncInfo } from '../synchronizer/syncInfoUtils';
+import NoteLockKey, { DecryptedNoteLockKey } from './NoteLockKey';
+import NoteLockSession from './NoteLockSession';
+import NoteLockService from './NoteLockService';
+
+const unlockedSession = async (password = '123456') => {
+	const session = NoteLockSession.instance();
+	await NoteLockKey.instance().create(password);
+	expect(await session.unlock(password)).toBe(true);
+	return session;
+};
+
+const changeSyncedKeyId = (id: string) => {
+	const syncInfo = localSyncInfo();
+	syncInfo.noteLockKey = { ...syncInfo.noteLockKey, id };
+	saveLocalSyncInfo(syncInfo);
+};
+
+// Gates NoteLockKey.decrypt() so a lock, reset or teardown can be forced to land while an unlock is
+// still awaiting. Returns a function that lets the decryption resolve.
+const gateDecrypt = (result?: DecryptedNoteLockKey) => {
+	let release: ()=> void = () => {};
+	const gate = new Promise<void>(resolve => { release = resolve; });
+	const key = NoteLockKey.instance();
+	const realDecrypt = key.decrypt.bind(key);
+	jest.spyOn(key, 'decrypt').mockImplementation(async password => {
+		await gate;
+		return result ?? realDecrypt(password);
+	});
+	return release;
+};
+
+// Gates generateMasterKey() so a reset can be held mid-rotation, with the old key still persisted,
+// while another unlock or reset races it. Returns a function that lets the rotation resolve.
+const gateKeyGeneration = () => {
+	let release: ()=> void = () => {};
+	const gate = new Promise<void>(resolve => { release = resolve; });
+	const encryption = EncryptionService.instance();
+	const realGenerate = encryption.generateMasterKey.bind(encryption);
+	jest.spyOn(encryption, 'generateMasterKey').mockImplementation(async (password, options) => {
+		await gate;
+		return realGenerate(password, options);
+	});
+	return release;
+};
+
+describe('NoteLockSession', () => {
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await setupDatabaseAndSynchronizer(2);
+		await switchClient(1);
+		NoteLockService.destroyInstance();
+		NoteLockSession.destroyInstance();
+		NoteLockKey.destroyInstance();
+		EncryptionService.instance_ = encryptionService();
+	});
+
+	afterAll(async () => {
+		await afterAllCleanUp();
+	});
+
+	it('should stay locked after create and reset until explicitly unlocked', async () => {
+		const session = NoteLockSession.instance();
+		const firstKey = await NoteLockKey.instance().create('123456');
+		expect(session.isUnlocked()).toBe(false);
+
+		expect(await session.unlock('123456')).toBe(true);
+		expect(session.isUnlocked()).toBe(true);
+
+		const secondKey = await session.reset('654321');
+		expect(secondKey.id).not.toBe(firstKey.id);
+		expect(session.isUnlocked()).toBe(false);
+
+		expect(await session.unlock('654321')).toBe(true);
+		expect(session.isUnlocked()).toBe(true);
+	});
+
+	it('should reject an incorrect password and stay locked', async () => {
+		const session = NoteLockSession.instance();
+		await NoteLockKey.instance().create('123456');
+		await expect(session.unlock('wrong password')).rejects.toThrow();
+		expect(session.isUnlocked()).toBe(false);
+	});
+
+	it('should lock and clear the key', async () => {
+		const session = await unlockedSession();
+		session.lock();
+		expect(session.isUnlocked()).toBe(false);
+		expect(() => session.decryptedKey()).toThrow('Note lock session is locked');
+	});
+
+	it('should lock when the synced key changes', async () => {
+		const session = await unlockedSession();
+		changeSyncedKeyId('0123456789abcdef0123456789abcdef');
+		expect(session.isUnlocked()).toBe(false);
+	});
+
+	it('should stay locked when locked while an unlock is in flight', async () => {
+		const session = NoteLockSession.instance();
+		await NoteLockKey.instance().create('123456');
+		const release = gateDecrypt();
+
+		const unlocking = session.unlock('123456');
+		session.lock();
+		release();
+
+		expect(await unlocking).toBe(false);
+		expect(session.isUnlocked()).toBe(false);
+	});
+
+	it('should not repopulate the key when destroyed mid-unlock', async () => {
+		const session = NoteLockSession.instance();
+		await NoteLockKey.instance().create('123456');
+		const release = gateDecrypt();
+
+		const unlocking = session.unlock('123456');
+		NoteLockSession.destroyInstance();
+		release();
+
+		expect(await unlocking).toBe(false);
+		expect(session.isUnlocked()).toBe(false);
+	});
+
+	it('should not install a key that was replaced by sync while unlocking', async () => {
+		const session = NoteLockSession.instance();
+		const originalKey = await NoteLockKey.instance().create('123456');
+		// Generation is unchanged here, but the loaded id no longer matches the decrypted one.
+		const release = gateDecrypt({ id: originalKey.id, plainText: 'plaintext' });
+
+		const unlocking = session.unlock('123456');
+		changeSyncedKeyId('0123456789abcdef0123456789abcdef');
+		release();
+
+		expect(await unlocking).toBe(false);
+		expect(session.isUnlocked()).toBe(false);
+	});
+
+	it('should not install a key that was reset while unlocking', async () => {
+		const session = NoteLockSession.instance();
+		const originalKey = await NoteLockKey.instance().create('123456');
+		const release = gateDecrypt({ id: originalKey.id, plainText: 'plaintext' });
+
+		const unlocking = session.unlock('123456');
+		await session.reset('654321');
+		release();
+
+		expect(await unlocking).toBe(false);
+		expect(session.isUnlocked()).toBe(false);
+	});
+
+	it('should reject an old-password unlock that races a reset mid-rotation', async () => {
+		const session = await unlockedSession();
+		const releaseRotation = gateKeyGeneration();
+
+		const resetting = session.reset('654321');
+		const unlockResult = await session.unlock('123456');
+		releaseRotation();
+		await resetting;
+
+		expect(unlockResult).toBe(false);
+		expect(session.isUnlocked()).toBe(false);
+	});
+
+	it('should reject a reset that overlaps another rotation', async () => {
+		const session = await unlockedSession();
+		const releaseRotation = gateKeyGeneration();
+
+		const firstReset = session.reset('654321');
+		await expect(session.reset('abcdef')).rejects.toThrow('A note lock key reset is already in progress');
+		releaseRotation();
+		await firstReset;
+
+		expect(session.isUnlocked()).toBe(false);
+	});
+
+	it('should sync the encrypted note lock key without auto-unlocking or loading it into the E2EE registry', async () => {
+		const createdKey = await NoteLockKey.instance().create('123456');
+		NoteLockService.destroyInstance();
+		NoteLockSession.destroyInstance();
+		NoteLockKey.destroyInstance();
+		await synchronizerStart();
+
+		await switchClient(2);
+		EncryptionService.instance_ = encryptionService();
+		await synchronizerStart();
+
+		expect(NoteLockKey.instance().load()).toEqual(createdKey);
+		expect(NoteLockSession.instance().isUnlocked()).toBe(false);
+		expect(EncryptionService.instance().loadedMasterKeysCount()).toBe(0);
+	});
+});

--- a/packages/lib/services/noteLock/NoteLockSession.ts
+++ b/packages/lib/services/noteLock/NoteLockSession.ts
@@ -68,4 +68,9 @@ export default class NoteLockSession {
 			plainText: this.key_.plainText,
 		};
 	}
+
+	// A lock clears key_ but not the persisted key, so this only fails on a real rotation, or one in progress.
+	public assertCanEncryptWith(keyId: string) {
+		if (this.rotating_ || this.noteLockKey_.load()?.id !== keyId) throw new Error('Note lock key changed during operation');
+	}
 }

--- a/packages/lib/services/noteLock/NoteLockSession.ts
+++ b/packages/lib/services/noteLock/NoteLockSession.ts
@@ -1,0 +1,79 @@
+import NoteLockKey, { DecryptedNoteLockKey } from './NoteLockKey';
+
+export default class NoteLockSession {
+
+	public static instance_: NoteLockSession = null;
+
+	private decryptedKey_: string = null;
+	private keyId_: string = null;
+	private leaseCount_ = 0;
+	private locked_ = true;
+
+	private constructor(private noteLockKey_: NoteLockKey = NoteLockKey.instance()) {}
+
+	public static instance() {
+		if (!this.instance_) {
+			this.instance_ = new NoteLockSession();
+		}
+		return this.instance_;
+	}
+
+	public static destroyInstance() {
+		this.instance_?.clearKey_();
+		this.instance_ = null;
+	}
+
+	public async unlock(password: string) {
+		if (this.leaseCount_) throw new Error('Cannot unlock the note lock session while an operation is holding the key');
+		const decrypted = await this.noteLockKey_.decrypt(password);
+		this.keyId_ = decrypted.id;
+		this.decryptedKey_ = decrypted.plainText;
+		this.locked_ = false;
+	}
+
+	public lock() {
+		this.locked_ = true;
+		if (this.leaseCount_) return;
+		this.clearKey_();
+	}
+
+	// Holds the decrypted key for the duration of the callback if the session locks or the synced
+	// key changes meanwhile. A key change that happened before the lease starts is not deferred, so
+	// it is applied first and the lease then runs on a locked session. The key is only cleared once
+	// the final lease ends.
+	public async withKeyHeld<T>(callback: ()=> Promise<T>): Promise<T> {
+		this.lockIfKeyChanged_();
+		this.leaseCount_++;
+		try {
+			return await callback();
+		} finally {
+			this.leaseCount_ = Math.max(0, this.leaseCount_ - 1);
+			if (!this.leaseCount_ && this.locked_) this.clearKey_();
+			this.lockIfKeyChanged_();
+		}
+	}
+
+	private clearKey_() {
+		this.keyId_ = null;
+		this.decryptedKey_ = null;
+		this.locked_ = true;
+	}
+
+	private lockIfKeyChanged_() {
+		if (this.keyId_ && this.keyId_ !== this.noteLockKey_.load()?.id) this.lock();
+	}
+
+	public isUnlocked() {
+		this.lockIfKeyChanged_();
+		return !this.locked_ && !!this.decryptedKey_;
+	}
+
+	public decryptedKey(): DecryptedNoteLockKey {
+		this.lockIfKeyChanged_();
+		if (!this.decryptedKey_ || (!this.leaseCount_ && this.locked_)) throw new Error('Note lock session is locked');
+		return {
+			id: this.keyId_,
+			plainText: this.decryptedKey_,
+		};
+	}
+}

--- a/packages/lib/services/noteLock/NoteLockSession.ts
+++ b/packages/lib/services/noteLock/NoteLockSession.ts
@@ -8,6 +8,7 @@ export default class NoteLockSession {
 	private keyId_: string = null;
 	private leaseCount_ = 0;
 	private locked_ = true;
+	private lockGeneration_ = 0;
 
 	private constructor(private noteLockKey_: NoteLockKey = NoteLockKey.instance()) {}
 
@@ -25,7 +26,11 @@ export default class NoteLockSession {
 
 	public async unlock(password: string) {
 		if (this.leaseCount_) throw new Error('Cannot unlock the note lock session while an operation is holding the key');
+		// Decryption yields, so a lock can land mid-await. Without this check a late unlock would
+		// silently reopen a session the caller already locked.
+		const generation = this.lockGeneration_;
 		const decrypted = await this.noteLockKey_.decrypt(password);
+		if (this.lockGeneration_ !== generation || this.leaseCount_) return;
 		this.keyId_ = decrypted.id;
 		this.decryptedKey_ = decrypted.plainText;
 		this.locked_ = false;
@@ -33,6 +38,7 @@ export default class NoteLockSession {
 
 	public lock() {
 		this.locked_ = true;
+		this.lockGeneration_++;
 		if (this.leaseCount_) return;
 		this.clearKey_();
 	}

--- a/packages/lib/services/noteLock/NoteLockSession.ts
+++ b/packages/lib/services/noteLock/NoteLockSession.ts
@@ -4,11 +4,9 @@ export default class NoteLockSession {
 
 	public static instance_: NoteLockSession = null;
 
-	private decryptedKey_: string = null;
-	private keyId_: string = null;
-	private leaseCount_ = 0;
-	private locked_ = true;
+	private key_: DecryptedNoteLockKey = null;
 	private lockGeneration_ = 0;
+	private rotating_ = false;
 
 	private constructor(private noteLockKey_: NoteLockKey = NoteLockKey.instance()) {}
 
@@ -20,66 +18,54 @@ export default class NoteLockSession {
 	}
 
 	public static destroyInstance() {
-		this.instance_?.clearKey_();
+		// lock() bumps the generation so a mid-decrypt unlock() cannot repopulate a torn-down session.
+		this.instance_?.lock();
 		this.instance_ = null;
 	}
 
+	// Re-checks state after the await so a lock, reset, synced change or teardown that raced in can't install a stale key.
 	public async unlock(password: string) {
-		if (this.leaseCount_) throw new Error('Cannot unlock the note lock session while an operation is holding the key');
-		// Decryption yields, so a lock can land mid-await. Without this check a late unlock would
-		// silently reopen a session the caller already locked.
+		if (this.rotating_) return false;
 		const generation = this.lockGeneration_;
 		const decrypted = await this.noteLockKey_.decrypt(password);
-		if (this.lockGeneration_ !== generation || this.leaseCount_) return;
-		this.keyId_ = decrypted.id;
-		this.decryptedKey_ = decrypted.plainText;
-		this.locked_ = false;
+		if (this.rotating_ || this.lockGeneration_ !== generation || this.noteLockKey_.load()?.id !== decrypted.id) return false;
+		this.key_ = decrypted;
+		return true;
 	}
 
 	public lock() {
-		this.locked_ = true;
 		this.lockGeneration_++;
-		if (this.leaseCount_) return;
-		this.clearKey_();
+		this.key_ = null;
 	}
 
-	// Holds the decrypted key for the duration of the callback if the session locks or the synced
-	// key changes meanwhile. A key change that happened before the lease starts is not deferred, so
-	// it is applied first and the lease then runs on a locked session. The key is only cleared once
-	// the final lease ends.
-	public async withKeyHeld<T>(callback: ()=> Promise<T>): Promise<T> {
-		this.lockIfKeyChanged_();
-		this.leaseCount_++;
+	// Blocks unlock during rotation so the still-persisted old key can't be unlocked before the new one is saved.
+	public async reset(password: string) {
+		if (this.rotating_) throw new Error('A note lock key reset is already in progress');
+		this.rotating_ = true;
+		this.lock();
 		try {
-			return await callback();
+			return await this.noteLockKey_.reset(password);
 		} finally {
-			this.leaseCount_ = Math.max(0, this.leaseCount_ - 1);
-			if (!this.leaseCount_ && this.locked_) this.clearKey_();
-			this.lockIfKeyChanged_();
+			this.lock();
+			this.rotating_ = false;
 		}
 	}
 
-	private clearKey_() {
-		this.keyId_ = null;
-		this.decryptedKey_ = null;
-		this.locked_ = true;
-	}
-
 	private lockIfKeyChanged_() {
-		if (this.keyId_ && this.keyId_ !== this.noteLockKey_.load()?.id) this.lock();
+		if (this.key_ && this.key_.id !== this.noteLockKey_.load()?.id) this.lock();
 	}
 
 	public isUnlocked() {
 		this.lockIfKeyChanged_();
-		return !this.locked_ && !!this.decryptedKey_;
+		return !!this.key_;
 	}
 
 	public decryptedKey(): DecryptedNoteLockKey {
 		this.lockIfKeyChanged_();
-		if (!this.decryptedKey_ || (!this.leaseCount_ && this.locked_)) throw new Error('Note lock session is locked');
+		if (!this.key_) throw new Error('Note lock session is locked');
 		return {
-			id: this.keyId_,
-			plainText: this.decryptedKey_,
+			id: this.key_.id,
+			plainText: this.key_.plainText,
 		};
 	}
 }

--- a/packages/lib/services/noteLock/NoteLockSession.ts
+++ b/packages/lib/services/noteLock/NoteLockSession.ts
@@ -23,14 +23,16 @@ export default class NoteLockSession {
 		this.instance_ = null;
 	}
 
-	// Re-checks state after the await so a lock, reset, synced change or teardown that raced in can't install a stale key.
+	// Re-checks state after the await so a lock, reset, synced change or teardown that raced in
+	// can't install a stale key. A reset that starts mid-decrypt also locks, so the generation
+	// check covers it.
 	public async unlock(password: string) {
-		if (this.rotating_) return false;
+		if (this.rotating_) throw new Error('Cannot unlock: a note lock key reset is in progress');
 		const generation = this.lockGeneration_;
 		const decrypted = await this.noteLockKey_.decrypt(password);
-		if (this.rotating_ || this.lockGeneration_ !== generation || this.noteLockKey_.load()?.id !== decrypted.id) return false;
+		if (this.lockGeneration_ !== generation) throw new Error('Cannot unlock: the session was locked while unlocking');
+		if (this.noteLockKey_.load()?.id !== decrypted.id) throw new Error('Cannot unlock: the note lock key changed while unlocking');
 		this.key_ = decrypted;
-		return true;
 	}
 
 	public lock() {

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -327,3 +327,4 @@ huggingface
 stdio
 doesnotexist
 asar
+decryptor

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -327,4 +327,3 @@ huggingface
 stdio
 doesnotexist
 asar
-decryptor


### PR DESCRIPTION
## Summary

Resolves #15772.

Updates note lock session handling after the unlock-timeout design was removed.

This splits the old `NoteLockKey` into two classes: `NoteLockKey` loads the key and encrypts/decrypts it, and `NoteLockSession` owns the locked/unlocked state. A note is locked or unlocked; a key is encrypted or decrypted.

Note lock now uses explicit locked/unlocked state instead of a timeout.

It also changes how an operation gets the key while it runs. `NoteLockService.withDecryptedKey(callback)` captures the decrypted key once and hands the callback a scoped view. Decrypt always uses that captured key, since a key change mid-operation doesn't affect already-encrypted data. Encrypt is guarded: it checks the captured key against the key currently persisted on disk, not the live session (which is cleared by a lock), so a lock alone doesn't interrupt it but a real key rotation, or one still in progress, fails closed and removes any output already written. The view is revoked as soon as the callback finishes.

The same guard now also covers the plain, non-scoped service, so an ordinary encrypt racing a key rotation fails closed the same way instead of silently writing under a stale key.

Making the encrypt and the eventual save one atomic unit is not part of this PR, that's for the later bulk/export PR, since the save happens after the encrypt.

Adds the hidden `noteLock.lockOnNoteSwitch` setting for the upcoming UI work.

Does not add desktop UI, mobile UI, or the export flow. The InteropService/export wiring will use `withDecryptedKey` and lands in the later export-guardrail PR.

## Changes

- splits `NoteLockKey` into `NoteLockKey` (load, encrypt/decrypt the key) and `NoteLockSession` (locked/unlocked state)
- replaces the unlock-expiry timeout with explicit locked/unlocked state
- replaces the per-operation key handling with `NoteLockService.withDecryptedKey(callback)`: a key scoped to one operation, exposing decrypt and guarded encrypt, revoked when the callback settles
- adds a guard so both scoped and plain encryption fail closed on a real key rotation, or one in progress, while tolerating a mere lock, and clean up any output already written if the key changed mid-encrypt
- adds hidden `noteLock.lockOnNoteSwitch`, default off
- updates and splits the note lock tests for the new session/service behaviour

## Testing

- `yarn workspace @joplin/lib tsc`
- `yarn workspace @joplin/lib test NoteLockService`
- `yarn workspace @joplin/lib test NoteLockSession`
- `yarn workspace @joplin/lib test models/Note.test`
- `yarn eslint` on the changed files

## AI Assistance Disclosure

I used AI tools while working on this PR for code suggestions and review, checking scope and tests, and drafting parts of this description, including the disclosure. I reviewed the final changes and reran the tests listed above myself.
