### PR TITLE
Desktop: Resolves #15763: Reveal markup on mouseup instead of mousedown

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/replaceLinks.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceLinks.ts
@@ -55,6 +55,12 @@ const replaceLinks = [
 			}
 			return null;
 		},
+		getDecorationRange: (node, state) => {
+			const previous = node.name === 'URL' ? node.node.prevSibling : null;
+			if (previous?.name !== 'LinkMark') return null;
+			if (state.sliceDoc(previous.from, previous.to) !== '(') return null;
+			return [previous.to, node.to];
+		},
 	}),
 ];
 

--- a/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts
@@ -16,13 +16,13 @@ export const makeInlineReplaceExtension = (extensionSpec: ReplacementExtension) 
 	private mouseSelectionInProgress = false;
 
 	public constructor(private view: EditorView) {
-		view.contentDOM.addEventListener('mousedown', this.onMouseDown, true);
+		view.dom.addEventListener('mousedown', this.onMouseDown, true);
 		view.dom.ownerDocument.addEventListener('mouseup', this.onMouseUp);
 		this.updateDecorations(view);
 	}
 
 	public destroy() {
-		this.view.contentDOM.removeEventListener('mousedown', this.onMouseDown, true);
+		this.view.dom.removeEventListener('mousedown', this.onMouseDown, true);
 		this.view.dom.ownerDocument.removeEventListener('mouseup', this.onMouseUp);
 	}
 
@@ -140,13 +140,13 @@ export const makeInlineReplaceExtension = (extensionSpec: ReplacementExtension) 
 	}
 
 	public update(update: ViewUpdate) {
-		if (this.mouseSelectionInProgress && update.selectionSet && !update.docChanged) {
-			return;
-		}
-
 		const forceUpdate = update.transactions.some(transaction => (
 			transaction.effects.some(effect => effect.is(updateInlineDecorationsEffect))
 		));
+		if (this.mouseSelectionInProgress && update.selectionSet && update.state.selection.main.empty && !update.docChanged) {
+			return;
+		}
+
 		if (update.docChanged || update.viewportChanged || update.selectionSet || forceUpdate) {
 			this.updateDecorations(update.view);
 		}

--- a/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts
@@ -142,8 +142,9 @@ export const makeInlineReplaceExtension = (extensionSpec: ReplacementExtension) 
 	public update(update: ViewUpdate) {
 		const forceUpdate = update.transactions.some(transaction => (
 			transaction.effects.some(effect => effect.is(updateInlineDecorationsEffect))
+			|| extensionSpec.shouldFullReRender?.(transaction)
 		));
-		if (this.mouseSelectionInProgress && update.selectionSet && update.state.selection.main.empty && !update.docChanged) {
+		if (this.mouseSelectionInProgress && update.selectionSet && update.state.selection.main.empty && !update.docChanged && !forceUpdate) {
 			return;
 		}
 

--- a/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts
@@ -4,18 +4,67 @@
 import { EditorView, Decoration, DecorationSet, WidgetType } from '@codemirror/view';
 import { ViewPlugin, ViewUpdate } from '@codemirror/view';
 import { syntaxTree } from '@codemirror/language';
-import { Range } from '@codemirror/state';
+import { Range, StateEffect } from '@codemirror/state';
 import { SyntaxNodeRef } from '@lezer/common';
 import { ReplacementExtension } from '../types';
 import nodeIntersectsSelection from './nodeIntersectsSelection';
 
+const updateInlineDecorationsEffect = StateEffect.define();
 
 export const makeInlineReplaceExtension = (extensionSpec: ReplacementExtension) => ViewPlugin.fromClass(class {
 	public decorations: DecorationSet;
+	private mouseSelectionInProgress = false;
 
-	public constructor(view: EditorView) {
+	public constructor(private view: EditorView) {
+		view.contentDOM.addEventListener('mousedown', this.onMouseDown, true);
+		view.dom.ownerDocument.addEventListener('mouseup', this.onMouseUp);
 		this.updateDecorations(view);
 	}
+
+	public destroy() {
+		this.view.contentDOM.removeEventListener('mousedown', this.onMouseDown, true);
+		this.view.dom.ownerDocument.removeEventListener('mouseup', this.onMouseUp);
+	}
+
+	private onMouseDown = (event: MouseEvent) => {
+		if (event.button === 0) {
+			this.mouseSelectionInProgress = true;
+		}
+	};
+
+	private onMouseUp = () => {
+		if (this.mouseSelectionInProgress) {
+			const selection = this.view.state.selection.main;
+			let coveredTo = selection.from;
+			this.decorations.between(selection.from, selection.to, (from, to, decoration) => {
+				if (!Object.keys(decoration.spec).length && from <= coveredTo) {
+					coveredTo = Math.max(coveredTo, to);
+				}
+			});
+
+			let selectionUpdate = !selection.empty && coveredTo >= selection.to ? { anchor: selection.head } : undefined;
+			const line = this.view.state.doc.lineAt(selection.from);
+			syntaxTree(this.view.state).iterate({
+				from: line.from,
+				to: line.to,
+				enter: node => {
+					if (selectionUpdate || node.name !== 'Link') return;
+					const closingBracket = node.node.getChildren('LinkMark').find(mark => (
+						this.view.state.sliceDoc(mark.from, mark.to) === ']'
+					));
+					if (closingBracket && selection.from >= closingBracket.from && selection.to <= node.to) {
+						selectionUpdate = { anchor: node.to };
+					}
+				},
+			});
+
+			this.mouseSelectionInProgress = false;
+			this.view.dispatch({
+				selection: selectionUpdate,
+				effects: updateInlineDecorationsEffect.of(null),
+			});
+		}
+	};
 
 	private updateDecorations(view: EditorView) {
 		const doc = view.state.doc;
@@ -91,7 +140,14 @@ export const makeInlineReplaceExtension = (extensionSpec: ReplacementExtension) 
 	}
 
 	public update(update: ViewUpdate) {
-		if (update.docChanged || update.viewportChanged || update.selectionSet) {
+		if (this.mouseSelectionInProgress && update.selectionSet && !update.docChanged) {
+			return;
+		}
+
+		const forceUpdate = update.transactions.some(transaction => (
+			transaction.effects.some(effect => effect.is(updateInlineDecorationsEffect))
+		));
+		if (update.docChanged || update.viewportChanged || update.selectionSet || forceUpdate) {
 			this.updateDecorations(update.view);
 		}
 	}


### PR DESCRIPTION
Resolves #15763

I changed inline markup show from mousedown to mouseup. The cursor issue was not caused by mousedown.

Another issue: hidden link text was selected by accident. For `[Joplin website](https://joplinapp.org)`, user sees only `Joplin website`, but CodeMirror sees full Markdown. Small mouse move could select hidden end part, like `[Joplin website|](https://joplinapp.org)|`. After Markdown was shown, hidden selection became highlighted text. Fix: on mouseup, if selected text is only hidden text, change it back to one cursor before showing Markdown.

Another issue: cursor did not go to the link end. After the hidden-selection fix, clicking at the end of shown `Joplin website` could still leave cursor before hidden link end: `[Joplin website|](https://joplinapp.org)`. Fix: only for that end-click case, move cursor to full link end: `[Joplin website](https://joplinapp.org)|`. Middle click still stays inside link text.

Another issue: I also fixed links with space after `(`, like `[label]( url)`. That space stayed visible while URL was hidden, so end click could put cursor near `(` or URL. Fix: hide that space with URL.

https://github.com/user-attachments/assets/bd788681-ecee-4786-aa57-690153c48e66

