### PR TITLE
Server: Harden user-content responses against XSS via uploaded resources

### DIFF
--- a/packages/server/src/routes/index/items.test.ts
+++ b/packages/server/src/routes/index/items.test.ts
@@ -100,5 +100,8 @@ describe('index_items', () => {
 		expect(safe.response.get('Content-Type')).toBe('image/png');
 		expect(safe.response.get('Content-Disposition').startsWith('inline;')).toBe(true);
 		expect(safe.response.get('X-Content-Type-Options')).toBe('nosniff');
+		const safeCsp = safe.response.get('Content-Security-Policy');
+		expect(safeCsp).toContain('default-src \'none\'');
+		expect(safeCsp).toContain('sandbox');
 	});
 });

--- a/packages/server/src/routes/index/items.test.ts
+++ b/packages/server/src/routes/index/items.test.ts
@@ -1,5 +1,5 @@
-import { beforeAllDb, afterAllTests, beforeEachDb, createItemTree, createUserAndSession, parseHtml, expectHttpError, expectNoHttpError, createItem } from '../../utils/testing/testUtils';
-import { execRequest } from '../../utils/testing/apiUtils';
+import { beforeAllDb, afterAllTests, beforeEachDb, createItemTree, createUserAndSession, parseHtml, expectHttpError, expectNoHttpError, createItem, createResource, models } from '../../utils/testing/testUtils';
+import { execRequest, execRequestC } from '../../utils/testing/apiUtils';
 import { Uuid } from '../../services/database/types';
 import { makeNoteSerializedBody } from '../../utils/testing/serializedItems';
 
@@ -75,5 +75,30 @@ describe('index_items', () => {
 		await expectHttpError(async () => {
 			await requestItem(session2.id);
 		}, 404);
+	});
+
+	test('should sanitise response headers when serving user-controlled MIME types', async () => {
+		const { user, session } = await createUserAndSession(1);
+
+		const resource = await createResource(session.id, {
+			id: '000000000000000000000000000000E1',
+		}, '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>');
+
+		await models().item().saveForUser(user.id, { id: resource.id, mime_type: 'image/svg+xml' });
+
+		const dangerous = await execRequestC(session.id, 'GET', `items/${resource.id}/content`);
+		expect(dangerous.response.get('Content-Type')).toBe('application/octet-stream');
+		expect(dangerous.response.get('Content-Disposition').startsWith('attachment;')).toBe(true);
+		expect(dangerous.response.get('X-Content-Type-Options')).toBe('nosniff');
+		const csp = dangerous.response.get('Content-Security-Policy');
+		expect(csp).toContain('default-src \'none\'');
+		expect(csp).toContain('sandbox');
+
+		await models().item().saveForUser(user.id, { id: resource.id, mime_type: 'image/png' });
+
+		const safe = await execRequestC(session.id, 'GET', `items/${resource.id}/content`);
+		expect(safe.response.get('Content-Type')).toBe('image/png');
+		expect(safe.response.get('Content-Disposition').startsWith('inline;')).toBe(true);
+		expect(safe.response.get('X-Content-Type-Options')).toBe('nosniff');
 	});
 });

--- a/packages/server/src/routes/index/shares.link.test.ts
+++ b/packages/server/src/routes/index/shares.link.test.ts
@@ -28,6 +28,11 @@ type_: 4`,
 };
 
 async function getShareContent(shareId: string, query: Record<string, string> = {}): Promise<string | Buffer> {
+	const context = await getShareResponse(shareId, query);
+	return context.response.body as string | Buffer;
+}
+
+async function getShareResponse(shareId: string, query: Record<string, string> = {}) {
 	const context = await koaAppContext({
 		request: {
 			method: 'GET',
@@ -37,7 +42,7 @@ async function getShareContent(shareId: string, query: Record<string, string> = 
 	});
 	await routeHandler(context);
 	await checkContextError(context);
-	return context.response.body as string | Buffer;
+	return context;
 }
 
 describe('shares.link', () => {
@@ -242,6 +247,65 @@ describe('shares.link', () => {
 
 			await expectNotThrow(async () => getShareContent(share.id));
 		}
+	});
+
+	// A shared SVG resource with an empty title must not be served inline with image/svg+xml,
+	// otherwise its embedded script would run in the Joplin Server origin.
+	test('should not serve attacker-controlled resource content inline', async () => {
+		const { session } = await createUserAndSession();
+
+		const svgPayload = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>';
+
+		const resource = await createResource(session.id, {
+			id: '000000000000000000000000000000E1',
+			title: '',
+			mime: 'image/svg+xml',
+			file_extension: 'svg',
+		}, svgPayload);
+
+		const noteItem = await createNote(session.id, {
+			id: '00000000000000000000000000000001',
+			body: `![x](:/${resource.jop_id})`,
+		});
+
+		const share = await postApi<Share>(session.id, 'shares', {
+			type: ShareType.Note,
+			note_id: noteItem.jop_id,
+		});
+
+		const context = await getShareResponse(share.id, { resource_id: '000000000000000000000000000000E1' });
+		expect(context.response.get('Content-Type')).toBe('application/octet-stream');
+		expect(context.response.get('Content-Disposition').startsWith('attachment;')).toBe(true);
+		expect(context.response.get('X-Content-Type-Options')).toBe('nosniff');
+		const csp = context.response.get('Content-Security-Policy');
+		expect(csp).toContain('default-src \'none\'');
+		expect(csp).toContain('sandbox');
+	});
+
+	test('should serve safe resource mimes inline with hardened headers', async () => {
+		const { session } = await createUserAndSession();
+
+		const resource = await createResource(session.id, {
+			id: '000000000000000000000000000000E1',
+			title: 'photo.png',
+			mime: 'image/png',
+			file_extension: 'png',
+		}, 'fake-png-bytes');
+
+		const noteItem = await createNote(session.id, {
+			id: '00000000000000000000000000000001',
+			body: `![x](:/${resource.jop_id})`,
+		});
+
+		const share = await postApi<Share>(session.id, 'shares', {
+			type: ShareType.Note,
+			note_id: noteItem.jop_id,
+		});
+
+		const context = await getShareResponse(share.id, { resource_id: '000000000000000000000000000000E1' });
+		expect(context.response.get('Content-Type')).toBe('image/png');
+		expect(context.response.get('Content-Disposition').startsWith('inline;')).toBe(true);
+		expect(context.response.get('X-Content-Type-Options')).toBe('nosniff');
 	});
 
 	test('should throw an error if owner of share is disabled', async () => {

--- a/packages/server/src/routes/index/shares.link.test.ts
+++ b/packages/server/src/routes/index/shares.link.test.ts
@@ -306,6 +306,9 @@ describe('shares.link', () => {
 		expect(context.response.get('Content-Type')).toBe('image/png');
 		expect(context.response.get('Content-Disposition').startsWith('inline;')).toBe(true);
 		expect(context.response.get('X-Content-Type-Options')).toBe('nosniff');
+		const csp = context.response.get('Content-Security-Policy');
+		expect(csp).toContain('default-src \'none\'');
+		expect(csp).toContain('sandbox');
 	});
 
 	test('should throw an error if owner of share is disabled', async () => {

--- a/packages/server/src/routes/index/shares.ts
+++ b/packages/server/src/routes/index/shares.ts
@@ -6,7 +6,7 @@ import { ErrorForbidden, ErrorNotFound } from '../../utils/errors';
 import { Item, Share } from '../../services/database/types';
 import { ModelType } from '@joplin/lib/BaseModel';
 import { FileViewerResponse, renderItem as renderJoplinItem } from '../../utils/joplinUtils';
-import { friendlySafeFilename } from '@joplin/lib/path-utils';
+import { safeUserContentResponse } from '../../utils/userContentResponse';
 
 async function renderItem(context: AppContext, item: Item, share: Share): Promise<FileViewerResponse> {
 	if (item.jop_type === ModelType.Note) {
@@ -19,11 +19,6 @@ async function renderItem(context: AppContext, item: Item, share: Share): Promis
 		size: item.content_size,
 		filename: '',
 	};
-}
-
-function createContentDispositionHeader(filename: string) {
-	const encoded = encodeURIComponent(friendlySafeFilename(filename, null, true));
-	return `attachment; filename*=UTF-8''${encoded}; filename="${encoded}"`;
 }
 
 const router: Router = new Router(RouteType.Web);
@@ -55,9 +50,21 @@ router.get('shares/:id', async (path: SubPath, ctx: AppContext) => {
 	ctx.joplin.models.share().checkShareUrl(share, ctx.URL.origin);
 
 	ctx.response.body = result.body;
-	ctx.response.set('Content-Type', result.mime);
 	ctx.response.set('Content-Length', result.size.toString());
-	if (result.filename) ctx.response.set('Content-disposition', createContentDispositionHeader(result.filename));
+
+	// Note HTML is server-rendered, so it can be served as-is. Resource
+	// attachments use user-controlled MIME/filename and must be sanitized.
+	const isRenderedNoteHtml = item.jop_type === ModelType.Note && !ctx.query.resource_id;
+	if (isRenderedNoteHtml) {
+		ctx.response.set('Content-Type', result.mime);
+	} else {
+		const safe = safeUserContentResponse(result.mime, result.filename);
+		ctx.response.set('Content-Type', safe.mime);
+		ctx.response.set('Content-Disposition', safe.contentDisposition);
+		ctx.response.set('Content-Security-Policy', safe.contentSecurityPolicy);
+		ctx.response.set('X-Content-Type-Options', safe.xContentTypeOptions);
+	}
+
 	return new Response(ResponseType.KoaResponse, ctx.response);
 }, RouteType.UserContent);
 

--- a/packages/server/src/routes/index/shares.ts
+++ b/packages/server/src/routes/index/shares.ts
@@ -6,7 +6,7 @@ import { ErrorForbidden, ErrorNotFound } from '../../utils/errors';
 import { Item, Share } from '../../services/database/types';
 import { ModelType } from '@joplin/lib/BaseModel';
 import { FileViewerResponse, renderItem as renderJoplinItem } from '../../utils/joplinUtils';
-import { safeUserContentResponse } from '../../utils/userContentResponse';
+import safeUserContentResponse from '../../utils/safeUserContentResponse';
 
 async function renderItem(context: AppContext, item: Item, share: Share): Promise<FileViewerResponse> {
 	if (item.jop_type === ModelType.Note) {

--- a/packages/server/src/utils/routeUtils.ts
+++ b/packages/server/src/utils/routeUtils.ts
@@ -10,6 +10,7 @@ import { stripOffQueryParameters } from './urlUtils';
 import { hasOwnProperty } from '@joplin/utils/object';
 
 import { ltrimSlashes, rtrimSlashes } from '@joplin/lib/path-utils';
+import { safeUserContentResponse } from './userContentResponse';
 
 function dirname(path: string): string {
 	if (!path) throw new Error('Path is empty');
@@ -309,8 +310,15 @@ interface KoaResponseLike {
 
 export function respondWithItemContent(koaResponse: KoaResponseLike, item: Item, content: Buffer): Response {
 	koaResponse.body = item.jop_type > 0 ? content.toString() : content;
-	koaResponse.set('Content-Type', item.mime_type);
 	koaResponse.set('Content-Length', content.byteLength);
+
+	// mime_type is user-controlled, so sanitize to prevent inline script execution.
+	const safe = safeUserContentResponse(item.mime_type, item.name || '');
+	koaResponse.set('Content-Type', safe.mime);
+	koaResponse.set('Content-Disposition', safe.contentDisposition);
+	koaResponse.set('Content-Security-Policy', safe.contentSecurityPolicy);
+	koaResponse.set('X-Content-Type-Options', safe.xContentTypeOptions);
+
 	return new Response(ResponseType.KoaResponse, koaResponse);
 }
 

--- a/packages/server/src/utils/routeUtils.ts
+++ b/packages/server/src/utils/routeUtils.ts
@@ -10,7 +10,7 @@ import { stripOffQueryParameters } from './urlUtils';
 import { hasOwnProperty } from '@joplin/utils/object';
 
 import { ltrimSlashes, rtrimSlashes } from '@joplin/lib/path-utils';
-import { safeUserContentResponse } from './userContentResponse';
+import safeUserContentResponse from './safeUserContentResponse';
 
 function dirname(path: string): string {
 	if (!path) throw new Error('Path is empty');

--- a/packages/server/src/utils/safeUserContentResponse.ts
+++ b/packages/server/src/utils/safeUserContentResponse.ts
@@ -27,26 +27,19 @@ const safeInlineMimeTypes = new Set<string>([
 	'application/pdf',
 ]);
 
-export interface SafeContentResponse {
-	mime: string;
-	contentDisposition: string;
-	contentSecurityPolicy: string;
-	xContentTypeOptions: string;
-}
-
-function normalizeMime(mime: string) {
+const normalizeMime = (mime: string) => {
 	if (!mime) return '';
 	return mime.split(';')[0].trim().toLowerCase();
-}
+};
 
-function safeFilename(filename: string) {
+const safeFilename = (filename: string) => {
 	const encoded = encodeURIComponent(friendlySafeFilename(filename || '', null, true));
 	return `filename*=UTF-8''${encoded}; filename="${encoded}"`;
-}
+};
 
 // Returns safe response headers for serving user-uploaded content. All four
 // fields must be applied together.
-export function safeUserContentResponse(rawMime: string, filename: string): SafeContentResponse {
+export default (rawMime: string, filename: string) => {
 	const mime = normalizeMime(rawMime);
 	const isSafeInline = safeInlineMimeTypes.has(mime);
 
@@ -59,4 +52,4 @@ export function safeUserContentResponse(rawMime: string, filename: string): Safe
 		contentSecurityPolicy: 'default-src \'none\'; img-src \'self\' data:; media-src \'self\' data:; style-src \'unsafe-inline\'; sandbox',
 		xContentTypeOptions: 'nosniff',
 	};
-}
+};

--- a/packages/server/src/utils/userContentResponse.ts
+++ b/packages/server/src/utils/userContentResponse.ts
@@ -34,12 +34,12 @@ export interface SafeContentResponse {
 	xContentTypeOptions: string;
 }
 
-function normalizeMime(mime: string): string {
+function normalizeMime(mime: string) {
 	if (!mime) return '';
 	return mime.split(';')[0].trim().toLowerCase();
 }
 
-function safeFilename(filename: string): string {
+function safeFilename(filename: string) {
 	const encoded = encodeURIComponent(friendlySafeFilename(filename || '', null, true));
 	return `filename*=UTF-8''${encoded}; filename="${encoded}"`;
 }

--- a/packages/server/src/utils/userContentResponse.ts
+++ b/packages/server/src/utils/userContentResponse.ts
@@ -1,0 +1,62 @@
+import { friendlySafeFilename } from '@joplin/lib/path-utils';
+
+// Anything not in this allow-list (notably image/svg+xml and text/html) is
+// served as application/octet-stream with attachment disposition, to prevent
+// script execution from user-uploaded resources.
+const safeInlineMimeTypes = new Set<string>([
+	'image/png',
+	'image/jpeg',
+	'image/jpg',
+	'image/gif',
+	'image/webp',
+	'image/bmp',
+	'image/x-icon',
+	'image/vnd.microsoft.icon',
+	'image/avif',
+	'image/heic',
+	'image/heif',
+	'audio/mpeg',
+	'audio/mp4',
+	'audio/ogg',
+	'audio/wav',
+	'audio/webm',
+	'audio/flac',
+	'video/mp4',
+	'video/webm',
+	'video/ogg',
+	'application/pdf',
+]);
+
+export interface SafeContentResponse {
+	mime: string;
+	contentDisposition: string;
+	contentSecurityPolicy: string;
+	xContentTypeOptions: string;
+}
+
+function normalizeMime(mime: string): string {
+	if (!mime) return '';
+	return mime.split(';')[0].trim().toLowerCase();
+}
+
+function safeFilename(filename: string): string {
+	const encoded = encodeURIComponent(friendlySafeFilename(filename || '', null, true));
+	return `filename*=UTF-8''${encoded}; filename="${encoded}"`;
+}
+
+// Returns safe response headers for serving user-uploaded content. All four
+// fields must be applied together.
+export function safeUserContentResponse(rawMime: string, filename: string): SafeContentResponse {
+	const mime = normalizeMime(rawMime);
+	const isSafeInline = safeInlineMimeTypes.has(mime);
+
+	const outputMime = isSafeInline ? mime : 'application/octet-stream';
+	const disposition = isSafeInline ? 'inline' : 'attachment';
+
+	return {
+		mime: outputMime,
+		contentDisposition: `${disposition}; ${safeFilename(filename)}`,
+		contentSecurityPolicy: 'default-src \'none\'; img-src \'self\' data:; media-src \'self\' data:; style-src \'unsafe-inline\'; sandbox',
+		xContentTypeOptions: 'nosniff',
+	};
+}

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -329,3 +329,5 @@ doesnotexist
 asar
 agentic
 tiebreak
+heic
+heif


### PR DESCRIPTION
The published-share endpoint and the items-content endpoint both wrote the response Content-Type from user-controlled metadata, with no nosniff header and only a `frame-ancestors` CSP, and they only set `Content-Disposition: attachment` when the resource had a non-empty title. An attacker could upload an SVG resource with an empty title and `mime: image/svg+xml`, publish the note, and have any viewer's browser execute the SVG's embedded script in the Joplin Server origin.

This change introduces a `safeUserContentResponse` helper that only serves a small allow-list of MIME types inline (common images, audio, video, PDF) and forces everything else to `application/octet-stream` with `Content-Disposition: attachment`. All responses also gain `X-Content-Type-Options: nosniff` and a strict `default-src 'none'; … sandbox` CSP. The helper is applied to both the public share resource path and `respondWithItemContent`. Server-rendered note HTML is unaffected. Regression tests cover the SVG payload and a benign PNG.