### PR TITLE
Mobile: Fixes #11479: Harden share to Joplin logic, to prevent overwriting existing notes in certain cases

### DIFF
--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -353,7 +353,9 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent) => {
 shared.initState = async function(comp: BaseNoteScreenComponent) {
 	const note = await shared.reloadNote(comp);
 
-	if (comp.props.sharedData && note) {
+	// Ensure that only empty notes created for shared content are populated with sharedData, because in some cases
+	// existing notes can be overwritten by the shared data. See https://github.com/laurent22/joplin/issues/11479
+	if (comp.props.sharedData && note && note.title.length === 0 && note.body.length === 0) {
 		// Use the note returned by reloadNote directly to avoid a race condition where
 		// comp.state.note is still the initial empty note (Note.new() with parent_id='')
 		// because React hasn't flushed reloadNote's setState yet. Without this, the
@@ -370,7 +372,7 @@ shared.initState = async function(comp: BaseNoteScreenComponent) {
 		}
 		if (fieldsToSave.title !== undefined || fieldsToSave.body !== undefined) {
 			await Note.save(fieldsToSave);
-			comp.setState({ note: updatedNote, lastSavedNote: updatedNote });
+			comp.setState({ note: updatedNote, lastSavedNote: { ...updatedNote } });
 		}
 		if (comp.props.sharedData.resources) {
 			for (let i = 0; i < comp.props.sharedData.resources.length; i++) {


### PR DESCRIPTION
It is possible in some cases for the share to Joplin function to overwrite existing notes. Although the root cause for this is not clear, the reason for notes being able to be overwritten is due to there being no safeguard in the sharing logic to ensure that the note which is updated with the shared data matches the provisional note which was created to store the data.

This PR protects against this scenario by only applying the note content replacement with the shared data if the loaded note has an empty title and body. This ensures that no note data can ever be lost by using the share to function. Additionally, when updating the lastSavedNote property upon updating a note with shared data, I noticed the property is not set to a shallow copy of the note object as is done in other places. I have updated this for correctness and to prevent possible issues being introduced in future.

This partially fixes https://github.com/laurent22/joplin/issues/11479. Note there looks to be 2 issues references in the issue. This PR addresses the possibility to overwrite notes with the share to function, but does not address the issue whereby various notes are cycled on the note screen during the sync.

### Testing

**Behaviour before the change, following reproduction steps:**

https://github.com/user-attachments/assets/40bcdf3e-c480-454c-8233-9267e0d8c7b5

**Behaviour after the change:**

https://github.com/user-attachments/assets/6f9f6f17-2cc3-4e4b-a0d7-8eeebdb9e489

