### PR TITLE
Chore: Mobile: Add perf logging for NoteBodyViewer WebView load and renderer RPC

### DIFF
--- a/packages/app-mobile/components/ExtendedWebView/index.tsx
+++ b/packages/app-mobile/components/ExtendedWebView/index.tsx
@@ -139,6 +139,7 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 			injectedJavaScript={injectedJavaScript}
 			onMessage={props.onMessage}
 			onError={props.onError ?? onError}
+			onLoadStart={props.onLoadStart}
 			onLoadEnd={props.onLoadEnd}
 			onContentProcessDidTerminate={refreshWebViewAfterCrash}
 			onRenderProcessGone={refreshWebViewAfterCrash}

--- a/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
+++ b/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
@@ -91,9 +91,12 @@ function NoteBodyViewer(props: Props) {
 		showNoteLinkIcon: props.showNoteLinkIcon,
 	});
 
-	const mountTimeRef = useRef(Date.now());
+	const loadStartRef = useRef(Date.now());
+	const onLoadStart = useCallback(() => {
+		loadStartRef.current = Date.now();
+	}, []);
 	const onLoadEnd = useCallback(() => {
-		perfLogger.info(`[perf] WebView onLoadEnd fired ${Date.now() - mountTimeRef.current} ms after mount`);
+		perfLogger.info(`[perf] WebView onLoadEnd fired ${Date.now() - loadStartRef.current} ms after load start`);
 		webViewEventHandlers.onLoadEnd();
 		if (props.onLoadEnd) props.onLoadEnd();
 	}, [props.onLoadEnd, webViewEventHandlers]);
@@ -110,6 +113,7 @@ function NoteBodyViewer(props: Props) {
 				allowFileAccessFromJs={true}
 				injectedJavaScript={js}
 				mixedContentMode="always"
+				onLoadStart={onLoadStart}
 				onLoadEnd={onLoadEnd}
 				onMessage={webViewEventHandlers.onMessage}
 				hasPluginScripts={hasPluginScripts}

--- a/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
+++ b/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
@@ -16,6 +16,9 @@ import { AppState } from '../../utils/types';
 import { connect } from 'react-redux';
 import useWebViewSetup from '../../contentScripts/rendererBundle/useWebViewSetup';
 import { OnScrollCallback } from '../../contentScripts/rendererBundle/types';
+import Logger from '@joplin/utils/Logger';
+
+const perfLogger = Logger.create('NoteBodyViewer-perf');
 
 interface Props {
 	themeId: number;
@@ -88,7 +91,9 @@ function NoteBodyViewer(props: Props) {
 		showNoteLinkIcon: props.showNoteLinkIcon,
 	});
 
+	const mountTimeRef = useRef(Date.now());
 	const onLoadEnd = useCallback(() => {
+		perfLogger.info(`[perf] WebView onLoadEnd fired ${Date.now() - mountTimeRef.current} ms after mount`);
 		webViewEventHandlers.onLoadEnd();
 		if (props.onLoadEnd) props.onLoadEnd();
 	}, [props.onLoadEnd, webViewEventHandlers]);

--- a/packages/app-mobile/contentScripts/rendererBundle/contentScript/Renderer.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/contentScript/Renderer.ts
@@ -100,8 +100,8 @@ export default class Renderer {
 				module: scriptModule,
 			};
 		});
-		const evalMs = Date.now() - evalStart;
 		this.recreateMarkupToHtml_();
+		const evalMs = Date.now() - evalStart;
 
 		// If possible, rerenders with the last rendering settings. The goal
 		// of this is to reduce the number of IPC calls between the viewer and

--- a/packages/app-mobile/contentScripts/rendererBundle/contentScript/Renderer.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/contentScript/Renderer.ts
@@ -81,6 +81,7 @@ export default class Renderer {
 	public async setExtraContentScriptsAndRerender(
 		extraContentScripts: ExtraContentScriptSource[],
 	) {
+		const evalStart = Date.now();
 		this.extraContentScripts_ = extraContentScripts.map(script => {
 			const scriptModule = ((0, eval)(script.js))({
 				pluginId: script.pluginId,
@@ -99,14 +100,20 @@ export default class Renderer {
 				module: scriptModule,
 			};
 		});
+		const evalMs = Date.now() - evalStart;
 		this.recreateMarkupToHtml_();
 
 		// If possible, rerenders with the last rendering settings. The goal
 		// of this is to reduce the number of IPC calls between the viewer and
 		// React Native. We want the first render to be as fast as possible.
+		let renderMs = 0;
 		if (this.lastBodyMarkup_) {
+			const renderStart = Date.now();
 			await this.rerenderToBody(this.lastBodyMarkup_, this.lastBodyRenderSettings_);
+			renderMs = Date.now() - renderStart;
 		}
+
+		return { evalMs, renderMs };
 	}
 
 	public async render(markup: MarkupRecord, settings: RenderSettings) {

--- a/packages/app-mobile/contentScripts/rendererBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/useWebViewSetup.ts
@@ -153,7 +153,21 @@ const useWebViewSetup = (props: Props): Result => {
 
 	const contentScripts = useContentScripts(props.pluginStates);
 	useEffect(() => {
-		void messenger.remoteApi.renderer.setExtraContentScriptsAndRerender(contentScripts);
+		const startTime = Date.now();
+		const totalBytes = contentScripts.reduce((sum, s) => sum + s.js.length, 0);
+		logger.info(`[perf] setExtraContentScriptsAndRerender: sending ${contentScripts.length} script(s), ${Math.round(totalBytes / 1024)} KiB`);
+		void (async () => {
+			try {
+				const result = await messenger.remoteApi.renderer.setExtraContentScriptsAndRerender(contentScripts);
+				const totalMs = Date.now() - startTime;
+				const evalMs = result?.evalMs ?? -1;
+				const renderMs = result?.renderMs ?? -1;
+				const bridge = totalMs - evalMs - renderMs;
+				logger.info(`[perf] setExtraContentScriptsAndRerender: round-trip ${totalMs} ms (eval ${evalMs} ms, rerender ${renderMs} ms, bridge ~${bridge} ms)`);
+			} catch (error) {
+				logger.error(`[perf] setExtraContentScriptsAndRerender FAILED after ${Date.now() - startTime} ms:`, error);
+			}
+		})();
 	}, [messenger, contentScripts]);
 
 	const onRerenderRequestRef = useRef(()=>{});


### PR DESCRIPTION
Opening a note (viewer mode) on Android can be very slow whenever a plugin (such as Math) is enabled. This appears to be hard to fix so for now I'm just adding the logging statement to measure this.