### PR TITLE
Desktop: Add joplin.ai.getEmbeddings() plugin API for raw vector access

### DIFF
--- a/packages/lib/models/NoteEmbedding.ts
+++ b/packages/lib/models/NoteEmbedding.ts
@@ -239,6 +239,60 @@ export default class NoteEmbedding extends BaseModel {
 		return results;
 	}
 
+	// Page through stored chunks (with raw vectors) ordered by rowid. rowid is
+	// monotonic on insert so a cursor positioned at rowid=N is guaranteed to
+	// never miss a chunk with rowid<N inserted later — the only chunks the
+	// caller can miss are those added ahead of an in-flight cursor, which is
+	// the documented snapshot tradeoff for the plugin API.
+	//
+	// noteIds is an optional filter; afterRowid is the cursor (exclusive).
+	// Returns rows in rowid order so the last row's id is the next cursor.
+	public static async chunksPage(options: {
+		noteIds?: string[];
+		afterRowid?: number;
+		limit: number;
+	}): Promise<{ rowid: number; noteId: string; chunkIndex: number; chunkText: string; vector: number[] }[]> {
+		this.requireVec();
+		if (!await this.vecTableExists()) return [];
+		if (options.noteIds && options.noteIds.length === 0) return [];
+
+		const whereParts: string[] = [];
+		const params: (string | number)[] = [];
+		if (options.afterRowid !== undefined) {
+			whereParts.push('m.id > ?');
+			params.push(options.afterRowid);
+		}
+		if (options.noteIds && options.noteIds.length) {
+			whereParts.push(`m.note_id IN (${options.noteIds.map(() => '?').join(',')})`);
+			params.push(...options.noteIds);
+		}
+		const where = whereParts.length ? `WHERE ${whereParts.join(' AND ')}` : '';
+
+		const rows = await this.db().selectAll<{
+			id: number;
+			note_id: string;
+			chunk_index: number;
+			chunk_text: string;
+			embedding: string;
+		}>(
+			`SELECT m.id, m.note_id, m.chunk_index, m.chunk_text, vec_to_json(v.embedding) AS embedding
+			 FROM note_embeddings_meta m
+			 JOIN note_embeddings_vec v ON v.rowid = m.id
+			 ${where}
+			 ORDER BY m.id ASC
+			 LIMIT ?`,
+			[...params, options.limit],
+		);
+
+		return rows.map(r => ({
+			rowid: r.id,
+			noteId: r.note_id,
+			chunkIndex: r.chunk_index,
+			chunkText: r.chunk_text,
+			vector: JSON.parse(r.embedding) as number[],
+		}));
+	}
+
 	// Loads the stored vectors for a note's chunks in chunk-index order.
 	// Lets noteId-based searches reuse indexed vectors instead of re-embedding.
 	public static async vectorsByNoteId(noteId: string): Promise<number[][]> {

--- a/packages/lib/models/NoteEmbedding.ts
+++ b/packages/lib/models/NoteEmbedding.ts
@@ -251,7 +251,7 @@ export default class NoteEmbedding extends BaseModel {
 		noteIds?: string[];
 		afterRowid?: number;
 		limit: number;
-	}): Promise<{ rowid: number; noteId: string; chunkIndex: number; chunkText: string; vector: number[] }[]> {
+	}): Promise<{ rowid: number; noteId: string; modelId: string; chunkIndex: number; chunkText: string; vector: number[] }[]> {
 		this.requireVec();
 		if (!await this.vecTableExists()) return [];
 		if (options.noteIds && options.noteIds.length === 0) return [];
@@ -271,11 +271,12 @@ export default class NoteEmbedding extends BaseModel {
 		const rows = await this.db().selectAll<{
 			id: number;
 			note_id: string;
+			model_id: string;
 			chunk_index: number;
 			chunk_text: string;
 			embedding: string;
 		}>(
-			`SELECT m.id, m.note_id, m.chunk_index, m.chunk_text, vec_to_json(v.embedding) AS embedding
+			`SELECT m.id, m.note_id, m.model_id, m.chunk_index, m.chunk_text, vec_to_json(v.embedding) AS embedding
 			 FROM note_embeddings_meta m
 			 JOIN note_embeddings_vec v ON v.rowid = m.id
 			 ${where}
@@ -287,6 +288,7 @@ export default class NoteEmbedding extends BaseModel {
 		return rows.map(r => ({
 			rowid: r.id,
 			noteId: r.note_id,
+			modelId: r.model_id,
 			chunkIndex: r.chunk_index,
 			chunkText: r.chunk_text,
 			vector: JSON.parse(r.embedding) as number[],

--- a/packages/lib/services/ai/SearchService.test.ts
+++ b/packages/lib/services/ai/SearchService.test.ts
@@ -249,10 +249,23 @@ describe('SearchService', () => {
 		} while (cursor);
 
 		// Three seeded notes, one chunk each (titles + short bodies fit in a
-		// single chunk). One row per page → at least 3 pages, then a short
-		// final page closes the stream.
+		// single chunk). With look-ahead, the final page that contains the
+		// third chunk must omit nextCursor — so we expect exactly 3 pages,
+		// not 4 (which would mean a wasted empty-page round-trip).
 		expect(collected).toHaveLength(3);
 		expect(new Set(collected).size).toBe(3);
+		expect(pageCount).toBe(3);
+	});
+
+	it('getEmbeddings: does not emit nextCursor when the page fills exactly to limit', async () => {
+		if (skipIfNoVec()) return;
+		// Three indexed chunks total; requesting a limit that exactly matches
+		// the row count would, without look-ahead, return a cursor pointing at
+		// an empty next page.
+		await seed();
+		const page = await SearchService.instance().getEmbeddings({ limit: 3 });
+		expect(page.chunks).toHaveLength(3);
+		expect(page.nextCursor).toBeUndefined();
 	});
 
 	it('getEmbeddings: rejects a malformed cursor', async () => {

--- a/packages/lib/services/ai/SearchService.test.ts
+++ b/packages/lib/services/ai/SearchService.test.ts
@@ -261,6 +261,24 @@ describe('SearchService', () => {
 			.rejects.toThrow(/Invalid embeddings cursor/);
 	});
 
+	it.each([NaN, Infinity, -1, 0, 1.5])('getEmbeddings: rejects invalid limit %p', async (limit) => {
+		await expect(SearchService.instance().getEmbeddings({ limit }))
+			.rejects.toThrow(/Invalid embeddings limit/);
+	});
+
+	it('getEmbeddings: reads modelId from rows so a mid-flight provider swap cannot mislabel them', async () => {
+		if (skipIfNoVec()) return;
+		const { catNote } = await seed();
+		// Swap the active provider *after* indexing. Rows in the table still
+		// carry the original modelId; the page envelope must reflect that, not
+		// the live provider.
+		AiService.instance().setEmbeddingProvider(new TestEmbeddingProvider({ dimension: 64, modelId: 'different-model' }));
+
+		const page = await SearchService.instance().getEmbeddings({ noteIds: [catNote.id] });
+		expect(page.chunks.length).toBeGreaterThan(0);
+		expect(page.modelId).toBe('test-model-v1');
+	});
+
 	it('uses embedQuery when the provider exposes it', async () => {
 		if (skipIfNoVec()) return;
 		const { catNote } = await seed();

--- a/packages/lib/services/ai/SearchService.test.ts
+++ b/packages/lib/services/ai/SearchService.test.ts
@@ -198,6 +198,69 @@ describe('SearchService', () => {
 		expect(strict.length).toBeLessThanOrEqual(loose.length);
 	});
 
+	it('getEmbeddings: throws when no embedding provider is active', async () => {
+		AiService.instance().setEmbeddingProvider(null);
+		await expect(SearchService.instance().getEmbeddings())
+			.rejects.toThrow(/No embedding provider/);
+	});
+
+	it('getEmbeddings: returns chunks with raw vectors and model metadata', async () => {
+		if (skipIfNoVec()) return;
+		const { catNote, dogNote, carNote } = await seed();
+
+		const page = await SearchService.instance().getEmbeddings();
+
+		expect(page.modelId).toBe(provider.modelId);
+		expect(page.dimension).toBe(64);
+		expect(page.chunks.length).toBeGreaterThanOrEqual(3);
+		for (const chunk of page.chunks) {
+			expect(chunk.vector).toHaveLength(64);
+			expect(typeof chunk.chunkText).toBe('string');
+		}
+		const seenNotes = new Set(page.chunks.map(c => c.noteId));
+		expect(seenNotes).toEqual(new Set([catNote.id, dogNote.id, carNote.id]));
+	});
+
+	it('getEmbeddings: filters by noteIds and silently skips unindexed ids', async () => {
+		if (skipIfNoVec()) return;
+		const { catNote } = await seed();
+
+		const page = await SearchService.instance().getEmbeddings({
+			noteIds: [catNote.id, 'doesnotexist'],
+		});
+
+		const noteIds = new Set(page.chunks.map(c => c.noteId));
+		expect(noteIds).toEqual(new Set([catNote.id]));
+	});
+
+	it('getEmbeddings: paginates with a cursor and signals end-of-stream by omitting nextCursor', async () => {
+		if (skipIfNoVec()) return;
+		await seed();
+
+		const collected: string[] = [];
+		let cursor: string | undefined;
+		let pageCount = 0;
+		do {
+			const page = await SearchService.instance().getEmbeddings({ cursor, limit: 1 });
+			pageCount++;
+			for (const c of page.chunks) collected.push(`${c.noteId}:${c.chunkIndex}`);
+			cursor = page.nextCursor;
+			if (pageCount > 50) throw new Error('Pagination did not terminate');
+		} while (cursor);
+
+		// Three seeded notes, one chunk each (titles + short bodies fit in a
+		// single chunk). One row per page → at least 3 pages, then a short
+		// final page closes the stream.
+		expect(collected).toHaveLength(3);
+		expect(new Set(collected).size).toBe(3);
+	});
+
+	it('getEmbeddings: rejects a malformed cursor', async () => {
+		if (skipIfNoVec()) return;
+		await expect(SearchService.instance().getEmbeddings({ cursor: 'garbage' }))
+			.rejects.toThrow(/Invalid embeddings cursor/);
+	});
+
 	it('uses embedQuery when the provider exposes it', async () => {
 		if (skipIfNoVec()) return;
 		const { catNote } = await seed();

--- a/packages/lib/services/ai/SearchService.ts
+++ b/packages/lib/services/ai/SearchService.ts
@@ -4,9 +4,9 @@ import Note from '../../models/Note';
 import Tag from '../../models/Tag';
 import AiService from './AiService';
 import { EmbeddingProvider } from './types';
-import { SearchOptions, SearchQuery, SearchRelevance, SearchResult, SearchScope } from '../plugins/api/types';
+import { EmbeddingsPage, GetEmbeddingsOptions, SearchOptions, SearchQuery, SearchRelevance, SearchResult, SearchScope } from '../plugins/api/types';
 
-export type { SearchOptions, SearchQuery, SearchRelevance, SearchResult, SearchScope };
+export type { EmbeddingsPage, GetEmbeddingsOptions, SearchOptions, SearchQuery, SearchRelevance, SearchResult, SearchScope };
 
 const logger = Logger.create('SearchService');
 
@@ -26,6 +26,20 @@ const RELEVANCE_DEFAULTS: Record<SearchRelevance, RelevanceTuning> = {
 	loose: { k: 20, minScore: 0.25 },
 };
 
+const DEFAULT_EMBEDDINGS_PAGE_SIZE = 500;
+const MAX_EMBEDDINGS_PAGE_SIZE = 5000;
+
+// Opaque to plugins: the cursor format is an implementation detail and may
+// change. The `v1:` prefix lets a future format coexist via a version bump.
+const encodeEmbeddingsCursor = (rowid: number): string => `v1:${rowid}`;
+
+const decodeEmbeddingsCursor = (cursor: string | undefined): number | undefined => {
+	if (!cursor) return undefined;
+	const match = /^v1:(\d+)$/.exec(cursor);
+	if (!match) throw new Error(`Invalid embeddings cursor: ${cursor}`);
+	return Number(match[1]);
+};
+
 // vec0 returns L2 distance. Our vectors are L2-normalised, so cosine
 // similarity = 1 − d²/2 exactly. Clamp to handle float drift on self-matches
 // and opposite-vector edges.
@@ -43,6 +57,42 @@ export default class SearchService {
 	public static instance(): SearchService {
 		if (!this.instance_) this.instance_ = new SearchService();
 		return this.instance_;
+	}
+
+	public async getEmbeddings(options: GetEmbeddingsOptions = {}): Promise<EmbeddingsPage> {
+		const provider = AiService.instance().getActiveEmbeddingProvider();
+		if (!provider) {
+			throw new Error('No embedding provider is active. Enable AI features in Settings → AI.');
+		}
+
+		const limit = Math.min(Math.max(1, options.limit ?? DEFAULT_EMBEDDINGS_PAGE_SIZE), MAX_EMBEDDINGS_PAGE_SIZE);
+		const afterRowid = decodeEmbeddingsCursor(options.cursor);
+
+		const rows = await NoteEmbedding.chunksPage({
+			noteIds: options.noteIds,
+			afterRowid,
+			limit,
+		});
+
+		const chunks = rows.map(r => ({
+			noteId: r.noteId,
+			chunkIndex: r.chunkIndex,
+			chunkText: r.chunkText,
+			vector: r.vector,
+		}));
+
+		// Only emit a cursor when we filled the page. A short page is the
+		// natural end-of-stream signal — saves the plugin one empty round-trip.
+		const nextCursor = rows.length === limit
+			? encodeEmbeddingsCursor(rows[rows.length - 1].rowid)
+			: undefined;
+
+		return {
+			modelId: provider.modelId,
+			dimension: provider.dimension,
+			chunks,
+			nextCursor,
+		};
 	}
 
 	public async search(options: SearchOptions): Promise<SearchResult[]> {

--- a/packages/lib/services/ai/SearchService.ts
+++ b/packages/lib/services/ai/SearchService.ts
@@ -31,19 +31,27 @@ const MAX_EMBEDDINGS_PAGE_SIZE = 5000;
 
 // Opaque to plugins: the cursor format is an implementation detail and may
 // change. The `v1:` prefix lets a future format coexist via a version bump.
-const encodeEmbeddingsCursor = (rowid: number): string => `v1:${rowid}`;
+const encodeEmbeddingsCursor = (rowid: number) => `v1:${rowid}`;
 
-const decodeEmbeddingsCursor = (cursor: string | undefined): number | undefined => {
+const decodeEmbeddingsCursor = (cursor: string | undefined) => {
 	if (!cursor) return undefined;
 	const match = /^v1:(\d+)$/.exec(cursor);
-	if (!match) throw new Error(`Invalid embeddings cursor: ${cursor}`);
+	if (!match) throw new Error(`Invalid embeddings cursor: ${JSON.stringify(cursor)}`);
 	return Number(match[1]);
+};
+
+const resolveEmbeddingsLimit = (raw: number | undefined) => {
+	if (raw === undefined) return DEFAULT_EMBEDDINGS_PAGE_SIZE;
+	if (!Number.isInteger(raw) || raw < 1) {
+		throw new Error(`Invalid embeddings limit: ${raw}`);
+	}
+	return Math.min(raw, MAX_EMBEDDINGS_PAGE_SIZE);
 };
 
 // vec0 returns L2 distance. Our vectors are L2-normalised, so cosine
 // similarity = 1 − d²/2 exactly. Clamp to handle float drift on self-matches
 // and opposite-vector edges.
-const cosineFromDistance = (distance: number): number => {
+const cosineFromDistance = (distance: number) => {
 	const score = 1 - (distance * distance) / 2;
 	if (score < 0) return 0;
 	if (score > 1) return 1;
@@ -65,7 +73,7 @@ export default class SearchService {
 			throw new Error('No embedding provider is active. Enable AI features in Settings → AI.');
 		}
 
-		const limit = Math.min(Math.max(1, options.limit ?? DEFAULT_EMBEDDINGS_PAGE_SIZE), MAX_EMBEDDINGS_PAGE_SIZE);
+		const limit = resolveEmbeddingsLimit(options.limit);
 		const afterRowid = decodeEmbeddingsCursor(options.cursor);
 
 		const rows = await NoteEmbedding.chunksPage({
@@ -74,6 +82,26 @@ export default class SearchService {
 			limit,
 		});
 
+		// Take the page's modelId from the rows themselves rather than the
+		// live provider: a model swap during the await could leave rows from
+		// the old model in flight while provider.modelId already reports the
+		// new one. Empty pages have no rows to read from, so fall back to the
+		// provider (no rows = no mismatch to expose).
+		let modelId: string;
+		let dimension: number;
+		if (rows.length === 0) {
+			modelId = provider.modelId;
+			dimension = provider.dimension;
+		} else {
+			modelId = rows[0].modelId;
+			dimension = rows[0].vector.length;
+			for (const r of rows) {
+				if (r.modelId !== modelId) {
+					throw new Error(`Embeddings page spans multiple models (${modelId} and ${r.modelId}). The index is being rebuilt — retry shortly.`);
+				}
+			}
+		}
+
 		const chunks = rows.map(r => ({
 			noteId: r.noteId,
 			chunkIndex: r.chunkIndex,
@@ -81,15 +109,14 @@ export default class SearchService {
 			vector: r.vector,
 		}));
 
-		// Only emit a cursor when we filled the page. A short page is the
-		// natural end-of-stream signal — saves the plugin one empty round-trip.
+		// Short page = end-of-stream. Saves the plugin one empty round-trip.
 		const nextCursor = rows.length === limit
 			? encodeEmbeddingsCursor(rows[rows.length - 1].rowid)
 			: undefined;
 
 		return {
-			modelId: provider.modelId,
-			dimension: provider.dimension,
+			modelId,
+			dimension,
 			chunks,
 			nextCursor,
 		};

--- a/packages/lib/services/ai/SearchService.ts
+++ b/packages/lib/services/ai/SearchService.ts
@@ -76,11 +76,16 @@ export default class SearchService {
 		const limit = resolveEmbeddingsLimit(options.limit);
 		const afterRowid = decodeEmbeddingsCursor(options.cursor);
 
-		const rows = await NoteEmbedding.chunksPage({
+		// Fetch one extra row to detect end-of-stream without an extra round-
+		// trip: if the DB returns limit+1, there's at least one more page; if
+		// it returns ≤limit, we know this is the last page.
+		const fetched = await NoteEmbedding.chunksPage({
 			noteIds: options.noteIds,
 			afterRowid,
-			limit,
+			limit: limit + 1,
 		});
+		const hasMore = fetched.length > limit;
+		const rows = hasMore ? fetched.slice(0, limit) : fetched;
 
 		// Take the page's modelId from the rows themselves rather than the
 		// live provider: a model swap during the await could leave rows from
@@ -109,8 +114,7 @@ export default class SearchService {
 			vector: r.vector,
 		}));
 
-		// Short page = end-of-stream. Saves the plugin one empty round-trip.
-		const nextCursor = rows.length === limit
+		const nextCursor = hasMore
 			? encodeEmbeddingsCursor(rows[rows.length - 1].rowid)
 			: undefined;
 

--- a/packages/lib/services/plugins/api/JoplinAi.ts
+++ b/packages/lib/services/plugins/api/JoplinAi.ts
@@ -2,7 +2,7 @@
 
 import AiService from '../../ai/AiService';
 import SearchService from '../../ai/SearchService';
-import { ChatMessage, ChatOptions, SearchOptions, SearchResult } from './types';
+import { ChatMessage, ChatOptions, EmbeddingsPage, GetEmbeddingsOptions, SearchOptions, SearchResult } from './types';
 
 /**
  * Provides access to AI models configured by the user. The active provider
@@ -88,6 +88,47 @@ export default class JoplinAi {
 	 */
 	public async search(options: SearchOptions): Promise<SearchResult[]> {
 		return SearchService.instance().search(options);
+	}
+
+	/**
+	 * Returns raw embedding vectors for indexed note chunks, paginated.
+	 *
+	 * Unlike {@link search}, this exposes the underlying vectors rather than
+	 * similarity scores — intended for plugins that need to run their own
+	 * clustering, dimensionality reduction, or distance computations over the
+	 * full set.
+	 *
+	 * Vectors are model-specific: the response includes the `modelId` that
+	 * produced them. Plugins that cache vectors must invalidate on `modelId`
+	 * change. If the model swaps mid-pagination, the cursor stops returning
+	 * rows; the plugin should restart with no cursor and the new `modelId`.
+	 *
+	 * Pagination uses an opaque cursor. Pass `nextCursor` from one call back
+	 * as `cursor` on the next. A missing `nextCursor` signals end-of-stream.
+	 *
+	 * The cursor is stable under concurrent writes: chunks inserted behind
+	 * the cursor are guaranteed to have been returned; chunks inserted ahead
+	 * of the cursor will be returned in a later page.
+	 *
+	 * Throws when AI features are disabled or no embedding provider is
+	 * active.
+	 *
+	 * @example
+	 * ```typescript
+	 * let cursor: string | undefined;
+	 * const all: EmbeddingChunk[] = [];
+	 * let modelId: string | null = null;
+	 * do {
+	 *     const page = await joplin.ai.getEmbeddings({ cursor, limit: 1000 });
+	 *     if (modelId && page.modelId !== modelId) throw new Error('model changed mid-fetch');
+	 *     modelId = page.modelId;
+	 *     all.push(...page.chunks);
+	 *     cursor = page.nextCursor;
+	 * } while (cursor);
+	 * ```
+	 */
+	public async getEmbeddings(options?: GetEmbeddingsOptions): Promise<EmbeddingsPage> {
+		return SearchService.instance().getEmbeddings(options);
 	}
 
 }

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -1047,3 +1047,66 @@ export interface SearchResult {
 	score: number;
 }
 
+/**
+ * Parameters for {@link JoplinAi.getEmbeddings}.
+ */
+export interface GetEmbeddingsOptions {
+	/**
+	 * Restrict the result to these notes. Omit to page through every indexed
+	 * chunk in the vault. Requesting a note that isn't indexed yet (e.g. still
+	 * in the initial backfill) is not an error — it's silently skipped.
+	 */
+	noteIds?: string[];
+	/**
+	 * Opaque pagination cursor returned by a previous call. Treat as a black
+	 * box: pass it back unchanged to get the next page. Omit on the first
+	 * call.
+	 */
+	cursor?: string;
+	/**
+	 * Maximum chunks to return in this page. Defaults to 500. Hard-capped at
+	 * 5000 to keep payload size bounded.
+	 */
+	limit?: number;
+}
+
+/**
+ * One chunk's raw embedding vector and the text it was computed from.
+ */
+export interface EmbeddingChunk {
+	noteId: string;
+	chunkIndex: number;
+	chunkText: string;
+	/**
+	 * Unit-norm vector of length {@link EmbeddingsPage.dimension}. Only
+	 * comparable to vectors with the same {@link EmbeddingsPage.modelId}.
+	 */
+	vector: number[];
+}
+
+/**
+ * Returned by {@link JoplinAi.getEmbeddings}.
+ *
+ * The vectors are produced by a specific model: comparing vectors across
+ * different `modelId` values (or persisting vectors across model changes) is
+ * meaningless. Plugins that cache vectors must key the cache by `modelId` and
+ * invalidate when it changes between calls.
+ */
+export interface EmbeddingsPage {
+	/** Identifier of the model that produced these vectors, e.g. `'multilingual-e5-small'`. */
+	modelId: string;
+	/** Length of each `vector` array. */
+	dimension: number;
+	chunks: EmbeddingChunk[];
+	/**
+	 * Pass this back as `cursor` on the next call to get the following page.
+	 * `undefined` means there are no more results in the current snapshot.
+	 *
+	 * If the index is wiped between pages (e.g. the user changes the embedding
+	 * model), pagination ends silently — the next call with this cursor
+	 * returns an empty `chunks` array. Plugins should watch for a `modelId`
+	 * change between pages and discard partial results if it differs.
+	 */
+	nextCursor?: string;
+}
+

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -332,3 +332,4 @@ tiebreak
 heic
 heif
 logits
+tradeoff


### PR DESCRIPTION
Exposes the raw embedding vectors stored in the on-device index to plugins, so they can run their own clustering, dimensionality reduction, or distance computations without making O(N) similarity queries to reconstruct the data.

API:

    joplin.ai.getEmbeddings({ noteIds?, cursor?, limit? })
      → { modelId, dimension, chunks, nextCursor? }

- Chunk-level granularity, matching how vectors are stored
- Opaque cursor over monotonic rowids — chunks inserted behind the cursor are guaranteed to have been returned
- modelId on every page so plugins can detect a mid-iteration model swap and discard partial results
- Unindexed noteIds are silently skipped; throws when AI is disabled