### PR TITLE
Desktop: Add joplin.ai.getIndexStatus() plugin API

### DIFF
--- a/packages/lib/services/ai/EmbeddingIndexer.test.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.test.ts
@@ -5,7 +5,8 @@ import Note from '../../models/Note';
 import ItemChange from '../../models/ItemChange';
 import NoteEmbedding from '../../models/NoteEmbedding';
 import AiService from './AiService';
-import EmbeddingIndexer from './EmbeddingIndexer';
+import EmbeddingIndexer, { coarseStateFrom } from './EmbeddingIndexer';
+import { IndexStatus } from './types';
 import TestEmbeddingProvider from './testing/TestEmbeddingProvider';
 
 // Note.save() and Note.delete() record ItemChange rows fire-and-forget
@@ -369,6 +370,67 @@ describe('EmbeddingIndexer', () => {
 			Setting.setValue('ai.enabled', false);
 			await EmbeddingIndexer.instance().stopRunInBackground();
 		}
+	});
+
+	test.each([
+		{ name: 'unavailable wins over disabled',
+			status: { indexerState: 'vector-search-unavailable', modelDownloadStatus: 'unavailable', notesIndexed: 0, totalNotes: 0 },
+			expected: 'unavailable' },
+		{ name: 'ai-disabled → disabled',
+			status: { indexerState: 'ai-disabled', modelDownloadStatus: 'downloaded', notesIndexed: 0, totalNotes: 0 },
+			expected: 'disabled' },
+		{ name: 'index-disabled → disabled',
+			status: { indexerState: 'index-disabled', modelDownloadStatus: 'downloaded', notesIndexed: 0, totalNotes: 0 },
+			expected: 'disabled' },
+		{ name: 'no provider but enabled → preparing',
+			status: { indexerState: 'idle', modelDownloadStatus: 'unavailable', notesIndexed: 0, totalNotes: 0 },
+			expected: 'preparing' },
+		{ name: 'model downloading → preparing',
+			status: { indexerState: 'idle', modelDownloadStatus: 'downloading', notesIndexed: 0, totalNotes: 0 },
+			expected: 'preparing' },
+		{ name: 'model not-started → preparing',
+			status: { indexerState: 'idle', modelDownloadStatus: 'not-started', notesIndexed: 0, totalNotes: 0 },
+			expected: 'preparing' },
+		{ name: 'running with model ready → indexing',
+			status: { indexerState: 'running', modelDownloadStatus: 'downloaded', notesIndexed: 1, totalNotes: 5 },
+			expected: 'indexing' },
+		{ name: 'idle with model ready → ready',
+			status: { indexerState: 'idle', modelDownloadStatus: 'downloaded', notesIndexed: 3, totalNotes: 3 },
+			expected: 'ready' },
+	] as { name: string; status: IndexStatus; expected: string }[])('coarseStateFrom: $name', ({ status, expected }) => {
+		expect(coarseStateFrom(status)).toBe(expected);
+	});
+
+	it('getPluginStatus: ready is false until at least one note is indexed', async () => {
+		if (skipIfNoVec()) return;
+		Setting.setValue('ai.enabled', true);
+		// note_embeddings isn't reset by test-utils — start clean.
+		await NoteEmbedding.clearAll();
+		try {
+			const before = await EmbeddingIndexer.instance().getPluginStatus();
+			expect(before.state).toBe('ready');
+			expect(before.ready).toBe(false);
+			expect(before.modelId).toBe(provider.modelId);
+
+			const folder = await Folder.save({ title: 'f' });
+			await Note.save({ title: 't', body: 'something', parent_id: folder.id });
+			await waitForChangesSince(0, 1);
+			await EmbeddingIndexer.instance().maintenance();
+
+			const after = await EmbeddingIndexer.instance().getPluginStatus();
+			expect(after.state).toBe('ready');
+			expect(after.ready).toBe(true);
+			expect(after.notesIndexed).toBe(1);
+		} finally {
+			Setting.setValue('ai.enabled', false);
+		}
+	});
+
+	it('getPluginStatus: modelId is null when no provider is active', async () => {
+		AiService.instance().setEmbeddingProvider(null);
+		const status = await EmbeddingIndexer.instance().getPluginStatus();
+		expect(status.modelId).toBeNull();
+		expect(status.ready).toBe(false);
 	});
 
 	it('getStatus counts indexed vs total notes and excludes trashed ones', async () => {

--- a/packages/lib/services/ai/EmbeddingIndexer.test.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.test.ts
@@ -427,10 +427,15 @@ describe('EmbeddingIndexer', () => {
 	});
 
 	it('getPluginStatus: modelId is null when no provider is active', async () => {
+		const original = AiService.instance().getActiveEmbeddingProvider();
 		AiService.instance().setEmbeddingProvider(null);
-		const status = await EmbeddingIndexer.instance().getPluginStatus();
-		expect(status.modelId).toBeNull();
-		expect(status.ready).toBe(false);
+		try {
+			const status = await EmbeddingIndexer.instance().getPluginStatus();
+			expect(status.modelId).toBeNull();
+			expect(status.ready).toBe(false);
+		} finally {
+			AiService.instance().setEmbeddingProvider(original);
+		}
 	});
 
 	it('getStatus counts indexed vs total notes and excludes trashed ones', async () => {

--- a/packages/lib/services/ai/EmbeddingIndexer.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.ts
@@ -99,8 +99,30 @@ export default class EmbeddingIndexer {
 	// Snapshot of indexer + model state for the settings UI. Cheap enough to
 	// poll on a UI tick (two COUNTs + a provider probe).
 	public async getStatus(): Promise<IndexStatus> {
-		const provider = AiService.instance().getActiveEmbeddingProvider();
+		return this.statusFor(AiService.instance().getActiveEmbeddingProvider());
+	}
 
+	// Plugin-facing snapshot. Coarsens the internal state so the public API
+	// isn't pinned to current internals.
+	public async getPluginStatus(): Promise<AiIndexStatus> {
+		// Capture once so modelId in the response matches the provider the
+		// rest of the snapshot was computed from.
+		const provider = AiService.instance().getActiveEmbeddingProvider();
+		const internal = await this.statusFor(provider);
+
+		const state = coarseStateFrom(internal);
+		const ready = state === 'ready' && internal.notesIndexed > 0;
+
+		return {
+			ready,
+			state,
+			modelId: provider?.modelId ?? null,
+			notesIndexed: internal.notesIndexed,
+			totalNotes: internal.totalNotes,
+		};
+	}
+
+	private async statusFor(provider: EmbeddingProvider | null): Promise<IndexStatus> {
 		let modelDownloadStatus: IndexStatus['modelDownloadStatus'] = 'unavailable';
 		if (provider) {
 			// Providers without a downloadable artefact (remote, test stub)
@@ -129,24 +151,6 @@ export default class EmbeddingIndexer {
 		const totalNotes = await Note.indexableCount();
 
 		return { modelDownloadStatus, indexerState, notesIndexed, totalNotes };
-	}
-
-	// Plugin-facing snapshot. Coarsens the internal state so the public API
-	// isn't pinned to current internals.
-	public async getPluginStatus(): Promise<AiIndexStatus> {
-		const internal = await this.getStatus();
-		const provider = AiService.instance().getActiveEmbeddingProvider();
-
-		const state = coarseStateFrom(internal);
-		const ready = state === 'ready' && internal.notesIndexed > 0;
-
-		return {
-			ready,
-			state,
-			modelId: provider?.modelId ?? null,
-			notesIndexed: internal.notesIndexed,
-			totalNotes: internal.totalNotes,
-		};
 	}
 
 	// Single maintenance tick. Public so tests can drive it without waiting

--- a/packages/lib/services/ai/EmbeddingIndexer.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.ts
@@ -10,6 +10,7 @@ import NoteEmbedding from '../../models/NoteEmbedding';
 import AiService from './AiService';
 import { chunkText } from './chunker';
 import { EmbeddingProvider, IndexStatus } from './types';
+import { AiIndexState, AiIndexStatus } from '../plugins/api/types';
 
 const logger = Logger.create('EmbeddingIndexer');
 
@@ -128,6 +129,24 @@ export default class EmbeddingIndexer {
 		const totalNotes = await Note.indexableCount();
 
 		return { modelDownloadStatus, indexerState, notesIndexed, totalNotes };
+	}
+
+	// Plugin-facing snapshot. Coarsens the internal state so the public API
+	// isn't pinned to current internals.
+	public async getPluginStatus(): Promise<AiIndexStatus> {
+		const internal = await this.getStatus();
+		const provider = AiService.instance().getActiveEmbeddingProvider();
+
+		const state = coarseStateFrom(internal);
+		const ready = state === 'ready' && internal.notesIndexed > 0;
+
+		return {
+			ready,
+			state,
+			modelId: provider?.modelId ?? null,
+			notesIndexed: internal.notesIndexed,
+			totalNotes: internal.totalNotes,
+		};
 	}
 
 	// Single maintenance tick. Public so tests can drive it without waiting
@@ -282,3 +301,13 @@ export default class EmbeddingIndexer {
 		await NoteEmbedding.saveChunks(noteId, provider.modelId, payload);
 	}
 }
+
+// Exported so the mapping is unit-testable without spinning up the indexer.
+export const coarseStateFrom = (status: IndexStatus): AiIndexState => {
+	if (status.indexerState === 'vector-search-unavailable') return 'unavailable';
+	if (status.indexerState === 'ai-disabled' || status.indexerState === 'index-disabled') return 'disabled';
+	if (status.modelDownloadStatus === 'unavailable' || status.modelDownloadStatus === 'not-started') return 'preparing';
+	if (status.modelDownloadStatus === 'downloading') return 'preparing';
+	if (status.indexerState === 'running') return 'indexing';
+	return 'ready';
+};

--- a/packages/lib/services/plugins/api/JoplinAi.ts
+++ b/packages/lib/services/plugins/api/JoplinAi.ts
@@ -1,8 +1,9 @@
 /* eslint-disable multiline-comment-style */
 
 import AiService from '../../ai/AiService';
+import EmbeddingIndexer from '../../ai/EmbeddingIndexer';
 import SearchService from '../../ai/SearchService';
-import { ChatMessage, ChatOptions, SearchOptions, SearchResult } from './types';
+import { AiIndexStatus, ChatMessage, ChatOptions, SearchOptions, SearchResult } from './types';
 
 /**
  * Provides access to AI models configured by the user. The active provider
@@ -88,6 +89,25 @@ export default class JoplinAi {
 	 */
 	public async search(options: SearchOptions): Promise<SearchResult[]> {
 		return SearchService.instance().search(options);
+	}
+
+	/**
+	 * Returns the current state of the on-device embedding index. Useful for
+	 * hybrid pipelines that prefer {@link search} when ready and fall back
+	 * otherwise. Cheap enough to call on a UI tick.
+	 *
+	 * @example
+	 * ```typescript
+	 * const status = await joplin.ai.getIndexStatus();
+	 * if (status.ready) {
+	 *     await runOnJoplinAi();
+	 * } else {
+	 *     await runOnLocalFallback();
+	 * }
+	 * ```
+	 */
+	public async getIndexStatus(): Promise<AiIndexStatus> {
+		return EmbeddingIndexer.instance().getPluginStatus();
 	}
 
 }

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -1047,3 +1047,33 @@ export interface SearchResult {
 	score: number;
 }
 
+/**
+ * State of the on-device embedding indexer.
+ *
+ * - `unavailable`: vector search isn't supported on this platform (won't change this session).
+ * - `disabled`: AI or the embedding index is turned off in settings.
+ * - `preparing`: the embedding model is downloading or loading.
+ * - `indexing`: the background scan is embedding notes; search works but results are incomplete.
+ * - `ready`: the index is idle and at least one note is embedded.
+ */
+export type AiIndexState = 'unavailable' | 'disabled' | 'preparing' | 'indexing' | 'ready';
+
+/**
+ * Returned by {@link JoplinAi.getIndexStatus}. Lets plugins decide whether to
+ * use Joplin's native AI or fall back to their own implementation.
+ */
+export interface AiIndexStatus {
+	/** `true` when `state === 'ready'` and at least one note is indexed. */
+	ready: boolean;
+	state: AiIndexState;
+	/**
+	 * Identifier of the model producing the current vectors, e.g.
+	 * `'multilingual-e5-small'`. `null` when no provider is active. Plugins
+	 * that cache derived data should key it by `modelId`.
+	 */
+	modelId: string | null;
+	notesIndexed: number;
+	/** Indexable notes in the vault (excludes trashed, conflict, locked). */
+	totalNotes: number;
+}
+

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -1054,7 +1054,8 @@ export interface SearchResult {
  * - `disabled`: AI or the embedding index is turned off in settings.
  * - `preparing`: the embedding model is downloading or loading.
  * - `indexing`: the background scan is embedding notes; search works but results are incomplete.
- * - `ready`: the index is idle and at least one note is embedded.
+ * - `ready`: the index is idle and the model is loaded. Indexed-note count
+ *   may still be 0 (e.g. empty vault) — see the separate `ready` boolean.
  */
 export type AiIndexState = 'unavailable' | 'disabled' | 'preparing' | 'indexing' | 'ready';
 


### PR DESCRIPTION
Exposes the on-device embedding indexer's state to plugins, so they can decide whether to use Joplin's native AI features or fall back to their own implementation.

API:

    joplin.ai.getIndexStatus()
      → { ready, state, modelId, notesIndexed, totalNotes }

- `ready` is `true` when the indexer is idle and at least one note is indexed — the common case for "should I use Joplin's AI or my fallback?"
- `state` is a coarse 5-value enum ('unavailable' | 'disabled' | 'preparing' | 'indexing' | 'ready') translated from the richer internal state machine, so the public API isn't pinned to current internals
- `modelId` pairs with vector-producing APIs so plugins can invalidate cached data on model swaps
