### PR TITLE
Desktop: AI chat panel: Make model responses more likely to be valid

### DIFF
--- a/packages/lib/services/ai/applyNoteEdits.ts
+++ b/packages/lib/services/ai/applyNoteEdits.ts
@@ -1,8 +1,12 @@
-import { EditOp, replaceFencedBlockSupportedTags } from './noteChat';
+import { EditOp } from './noteChat';
 
 export type ApplyEditStatus = 'applied' | 'anchor-not-found' | 'invalid';
 
-export const structuredBlockTags = new Set<string>([...replaceFencedBlockSupportedTags]);
+// Structured-document fences where the model regenerates the whole block —
+// plain code fences (```js, ```python) are deliberately excluded.
+export const structuredBlockTags = new Set<string>([
+	'jsoncanvas', 'mermaid', 'abc', 'fountain',
+]);
 
 const fencedBlockRegex = (tag: string) =>
 	new RegExp(`\`\`\`${tag}\\s*\\n([\\s\\S]*?)\\n?\`\`\``, 'gi');

--- a/packages/lib/services/ai/applyNoteEdits.ts
+++ b/packages/lib/services/ai/applyNoteEdits.ts
@@ -1,12 +1,8 @@
-import { EditOp } from './noteChat';
+import { EditOp, replaceFencedBlockSupportedTags } from './noteChat';
 
 export type ApplyEditStatus = 'applied' | 'anchor-not-found' | 'invalid';
 
-// Structured-document fences where the model regenerates the whole block —
-// plain code fences (```js, ```python) are deliberately excluded.
-export const structuredBlockTags = new Set<string>([
-	'jsoncanvas', 'mermaid', 'abc', 'fountain',
-]);
+export const structuredBlockTags = new Set<string>([...replaceFencedBlockSupportedTags]);
 
 const fencedBlockRegex = (tag: string) =>
 	new RegExp(`\`\`\`${tag}\\s*\\n([\\s\\S]*?)\\n?\`\`\``, 'gi');

--- a/packages/lib/services/ai/noteChat.test.ts
+++ b/packages/lib/services/ai/noteChat.test.ts
@@ -76,9 +76,12 @@ describe('noteChat', () => {
 		const schema = _internal.responseSchema(note).json_schema.schema;
 
 		// Schema's operations list should be correct
-		const editSchema = schema.properties.edits;
-		const operationSchema = editSchema.items.properties.op;
-		expect([...operationSchema.enum].sort()).toEqual([...expectedOperations].sort());
+		const editSchemaItems = schema.properties.edits.items;
+		const allowedSchemaOperations = [
+			...(editSchemaItems.properties?.op?.enum ?? []),
+			...(editSchemaItems.oneOf?.map(item => item.properties.op.enum)?.flat() ?? []),
+		].sort();
+		expect(allowedSchemaOperations).toEqual([...expectedOperations].sort());
 
 		// Prompt's operations list should be correct
 		for (const operation of expectedOperations) {

--- a/packages/lib/services/ai/noteChat.test.ts
+++ b/packages/lib/services/ai/noteChat.test.ts
@@ -1,5 +1,10 @@
-import { _internal } from './noteChat';
+import { _internal, NoteContext } from './noteChat';
 import { applyAnchorEdits } from './applyNoteEdits';
+
+const getEditOperationSchema = (note: NoteContext) => {
+	const schema = _internal.responseSchema(note).json_schema.schema;
+	return schema.properties.edits.items;
+};
 
 describe('noteChat', () => {
 
@@ -41,6 +46,26 @@ describe('noteChat', () => {
 	});
 
 	test.each([
+		true, false,
+	])('responseSchema should require "op" and disallow additional properties (has selection: %b)', (selection) => {
+		const schema = getEditOperationSchema({
+			title: 'Note',
+			body: 'some body',
+			selection: selection ? 'body' : null,
+		});
+
+		const operations = [
+			...(schema.type === 'object' ? [schema] : []),
+			...(schema.anyOf ?? []),
+		];
+
+		for (const operation of operations) {
+			expect(operation.required).toContain('op');
+			expect(operation.additionalProperties).toBe(false);
+		}
+	});
+
+	test.each([
 		{
 			label: 'restricts ops to replaceSelection when selection present',
 			note: {
@@ -73,13 +98,12 @@ describe('noteChat', () => {
 		}
 
 		const prompt = _internal.systemPrompt(note);
-		const schema = _internal.responseSchema(note).json_schema.schema;
+		const editSchemaItems = getEditOperationSchema(note);
 
 		// Schema's operations list should be correct
-		const editSchemaItems = schema.properties.edits.items;
 		const allowedSchemaOperations = [
 			...(editSchemaItems.properties?.op?.enum ?? []),
-			...(editSchemaItems.oneOf?.map(item => item.properties.op.enum)?.flat() ?? []),
+			...(editSchemaItems.anyOf?.map(item => item.properties.op.enum)?.flat() ?? []),
 		].sort();
 		expect(allowedSchemaOperations).toEqual([...expectedOperations].sort());
 

--- a/packages/lib/services/ai/noteChat.test.ts
+++ b/packages/lib/services/ai/noteChat.test.ts
@@ -15,32 +15,6 @@ describe('noteChat', () => {
 		expect(prompt).not.toContain('long body text');
 	});
 
-	test('systemPrompt restricts ops to replaceSelection when selection present', () => {
-		const prompt = _internal.systemPrompt({
-			title: 'n',
-			body: 'b',
-			selection: 'sel',
-		});
-		expect(prompt).toContain('replaceSelection');
-		expect(prompt).not.toContain('insertBefore');
-		expect(prompt).not.toContain('insertAfter');
-		expect(prompt).not.toContain('appendToNote');
-		expect(prompt).not.toContain('replaceRange');
-		expect(prompt).not.toContain('replaceFencedBlock');
-	});
-
-	test('systemPrompt offers anchor ops when no selection', () => {
-		const prompt = _internal.systemPrompt({
-			title: 'n',
-			body: 'b',
-			selection: null,
-		});
-		expect(prompt).toContain('insertBefore');
-		expect(prompt).toContain('insertAfter');
-		expect(prompt).toContain('appendToNote');
-		expect(prompt).toContain('replaceRange');
-	});
-
 	test('systemPrompt advertises Joplin-specific Markdown features', () => {
 		const prompt = _internal.systemPrompt({ title: 'n', body: 'b', selection: null });
 		// The fence tags are the load-bearing strings — the model knows the
@@ -64,6 +38,55 @@ describe('noteChat', () => {
 		});
 		expect(prompt).toContain('the whole body');
 		expect(prompt).toContain('BEGIN NOTE');
+	});
+
+	test.each([
+		{
+			label: 'restricts ops to replaceSelection when selection present',
+			note: {
+				title: 'My note',
+				body: 'long body text',
+				selection: 'just this bit',
+			},
+			expectedOperations: ['replaceSelection'],
+		},
+		{
+			label: 'offers anchor operations when no selection present',
+			note: {
+				title: 'n',
+				body: 'b',
+				selection: null,
+			},
+			expectedOperations: ['insertBefore', 'insertAfter', 'appendToNote', 'replaceRange', 'replaceFencedBlock'],
+		},
+	])('responseSchema is consistent with systemPrompt (case $label)', ({ note, expectedOperations }) => {
+		const allOperations = new Set([
+			'insertBefore',
+			'insertAfter',
+			'appendToNote',
+			'replaceRange',
+			'replaceFencedBlock',
+		]);
+		const expectedMissingOperations = new Set(allOperations);
+		for (const operation of expectedOperations) {
+			expectedMissingOperations.delete(operation);
+		}
+
+		const prompt = _internal.systemPrompt(note);
+		const schema = _internal.responseSchema(note).json_schema.schema;
+
+		// Schema's operations list should be correct
+		const editSchema = schema.properties.edits;
+		const operationSchema = editSchema.items.properties.op;
+		expect([...operationSchema.enum].sort()).toEqual([...expectedOperations].sort());
+
+		// Prompt's operations list should be correct
+		for (const operation of expectedOperations) {
+			expect(prompt).toContain(operation);
+		}
+		for (const operation of expectedMissingOperations) {
+			expect(prompt).not.toContain(operation);
+		}
 	});
 
 	test.each([

--- a/packages/lib/services/ai/noteChat.test.ts
+++ b/packages/lib/services/ai/noteChat.test.ts
@@ -100,7 +100,6 @@ describe('noteChat', () => {
 		const prompt = _internal.systemPrompt(note);
 		const editSchemaItems = getEditOperationSchema(note);
 
-		// Schema's operations list should be correct
 		const allowedSchemaOperations = [
 			...(editSchemaItems.properties?.op?.enum ?? []),
 			...(editSchemaItems.anyOf?.map(item => item.properties.op.enum)?.flat() ?? []),

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -217,6 +217,7 @@ export const runNoteChat = async (
 	}
 
 	const result = await AiService.instance().chat(messages, { responseFormat: responseSchema(note) });
+	logger.debug('Got response', result);
 	return enforceSelectionScope(tryParseReply(result.text), note.selection);
 };
 

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -113,9 +113,31 @@ const systemPrompt = (note: NoteContext) => {
 	return lines.join('\n');
 };
 
-const responseSchema = (note: NoteContext) => ({
-	type: 'json_schema' as const,
-	json_schema: {
+const responseSchema = (note: NoteContext) => {
+	const editOperationSchema = {
+		type: 'object',
+		properties: note.selection ? {
+			op: {
+				type: 'string',
+				enum: ['replaceSelection'],
+			},
+			text: { type: 'string' },
+		} : {
+			op: {
+				type: 'string',
+				enum: [
+					'insertBefore', 'insertAfter', 'appendToNote',
+					'replaceRange', 'replaceFencedBlock',
+				],
+			},
+			anchor: { type: 'string' },
+			tag: { type: 'string' },
+			text: { type: 'string' },
+		},
+		required: ['op', 'text'],
+	};
+
+	const schema = {
 		name: 'NoteChatResponse',
 		strict: true,
 		schema: {
@@ -124,35 +146,19 @@ const responseSchema = (note: NoteContext) => ({
 				reply: { type: 'string' },
 				edits: {
 					type: 'array',
-					items: {
-						type: 'object',
-						properties: note.selection ? {
-							op: {
-								type: 'string',
-								enum: ['replaceSelection'],
-							},
-							text: { type: 'string' },
-						} : {
-							op: {
-								type: 'string',
-								enum: [
-									'insertBefore', 'insertAfter', 'appendToNote',
-									'replaceRange', 'replaceFencedBlock',
-								],
-							},
-							anchor: { type: 'string' },
-							tag: { type: 'string' },
-							text: { type: 'string' },
-						},
-						required: ['op', 'text'],
-					},
+					items: editOperationSchema,
 				},
 			},
 			required: ['reply', 'edits'],
 			additionalProperties: false,
 		},
-	},
-});
+	};
+
+	return {
+		type: 'json_schema' as const,
+		json_schema: schema,
+	};
+};
 
 const estimateTokens = (text: string) => Math.ceil(text.length / charsPerToken);
 

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -114,27 +114,48 @@ const systemPrompt = (note: NoteContext) => {
 };
 
 const responseSchema = (note: NoteContext) => {
-	const editOperationSchema = {
+	const editOperationSchema = note.selection ? {
 		type: 'object',
-		properties: note.selection ? {
+		properties: {
 			op: {
 				type: 'string',
 				enum: ['replaceSelection'],
 			},
 			text: { type: 'string' },
-		} : {
-			op: {
-				type: 'string',
-				enum: [
-					'appendToNote', 'insertBefore', 'insertAfter',
-					'replaceRange', 'replaceFencedBlock',
-				],
-			},
-			anchor: { type: 'string' },
-			tag: { type: 'string' },
-			text: { type: 'string' },
+			additionalProperties: false,
 		},
-		required: ['op', 'text'],
+	} : {
+		oneOf: [
+			{
+				type: 'object',
+				properties: {
+					op: { type: 'string', enum: ['insertBefore', 'insertAfter', 'replaceRange'] },
+					anchor: { type: 'string' },
+					text: { type: 'string' },
+				},
+				required: ['op', 'anchor', 'text'],
+				additionalProperties: false,
+			},
+			{
+				type: 'object',
+				properties: {
+					op: { type: 'string', enum: ['appendToNote'] },
+					text: { type: 'string' },
+				},
+				required: ['op', 'text'],
+				additionalProperties: false,
+			},
+			{
+				type: 'object',
+				properties: {
+					op: { type: 'string', enum: ['replaceFencedBlock'] },
+					tag: { type: 'string' },
+					text: { type: 'string' },
+				},
+				required: ['op', 'tag', 'text'],
+				additionalProperties: false,
+			},
+		],
 	};
 
 	const schema = {

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -122,10 +122,11 @@ const responseSchema = (note: NoteContext) => {
 				enum: ['replaceSelection'],
 			},
 			text: { type: 'string' },
-			additionalProperties: false,
 		},
+		required: ['op', 'text'],
+		additionalProperties: false,
 	} : {
-		oneOf: [
+		anyOf: [
 			{
 				type: 'object',
 				properties: {

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -24,6 +24,10 @@ const knownOps = new Set<EditOp['op']>([
 	'replaceSelection', 'insertBefore', 'insertAfter', 'appendToNote', 'replaceRange', 'replaceFencedBlock',
 ]);
 
+// Structured-document fences where the model regenerates the whole block —
+// plain code fences (```js, ```python) are deliberately excluded.
+export const replaceFencedBlockSupportedTags = ['jsoncanvas', 'mermaid', 'abc', 'fountain'];
+
 export interface ChatTurn {
 	role: 'user' | 'assistant';
 	content: string;
@@ -101,7 +105,7 @@ const systemPrompt = (note: NoteContext) => {
 		lines.push('  { "op": "insertAfter", "anchor": "...", "text": "..." } — inserts text immediately after the first occurrence of "anchor".');
 		lines.push('  { "op": "appendToNote", "text": "..." } — appends text at the end of the note.');
 		lines.push('  { "op": "replaceRange", "anchor": "...", "text": "..." } — replaces the first occurrence of "anchor" with "text".');
-		lines.push('  { "op": "replaceFencedBlock", "tag": "...", "text": "..." } — replaces the inner content of the first ```<tag>``` fenced block. "text" is the new content inside the fence (no fence markers). Supported tags: jsoncanvas, mermaid, abc, fountain.');
+		lines.push(`  { "op": "replaceFencedBlock", "tag": "...", "text": "..." } — replaces the inner content of the first \`\`\`<tag>\`\`\` fenced block. "text" is the new content inside the fence (no fence markers). Supported tags: ${replaceFencedBlockSupportedTags.join(', ')}.`);
 		lines.push('');
 		lines.push('Anchors must be exact substrings of the current note body. Keep them short but unique.');
 		lines.push('');
@@ -150,7 +154,7 @@ const responseSchema = (note: NoteContext) => {
 				type: 'object',
 				properties: {
 					op: { type: 'string', enum: ['replaceFencedBlock'] },
-					tag: { type: 'string' },
+					tag: { type: 'string', enum: [...replaceFencedBlockSupportedTags] },
 					text: { type: 'string' },
 				},
 				required: ['op', 'tag', 'text'],

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -113,6 +113,47 @@ const systemPrompt = (note: NoteContext) => {
 	return lines.join('\n');
 };
 
+const responseSchema = (note: NoteContext) => ({
+	type: 'json_schema' as const,
+	json_schema: {
+		name: 'NoteChatResponse',
+		strict: true,
+		schema: {
+			type: 'object',
+			properties: {
+				reply: { type: 'string' },
+				edits: {
+					type: 'array',
+					items: {
+						type: 'object',
+						properties: note.selection ? {
+							op: {
+								type: 'string',
+								enum: ['replaceSelection'],
+							},
+							text: { type: 'string' },
+						} : {
+							op: {
+								type: 'string',
+								enum: [
+									'insertBefore', 'insertAfter', 'appendToNote',
+									'replaceRange', 'replaceFencedBlock',
+								],
+							},
+							anchor: { type: 'string' },
+							tag: { type: 'string' },
+							text: { type: 'string' },
+						},
+						required: ['op', 'text'],
+					},
+				},
+			},
+			required: ['reply', 'edits'],
+			additionalProperties: false,
+		},
+	},
+});
+
 const estimateTokens = (text: string) => Math.ceil(text.length / charsPerToken);
 
 // First-pass filter. Per-op field validation lives in applyNoteEdits.
@@ -175,7 +216,7 @@ export const runNoteChat = async (
 		);
 	}
 
-	const result = await AiService.instance().chat(messages);
+	const result = await AiService.instance().chat(messages, { responseFormat: responseSchema(note) });
 	return enforceSelectionScope(tryParseReply(result.text), note.selection);
 };
 
@@ -188,4 +229,4 @@ const enforceSelectionScope = (reply: ChatReply, selection: string | null): Chat
 };
 
 // Exported for tests.
-export const _internal = { systemPrompt, tryParseReply, estimateTokens, sanitizeEdits, enforceSelectionScope, noteBodyTokenBudget };
+export const _internal = { systemPrompt, responseSchema, tryParseReply, estimateTokens, sanitizeEdits, enforceSelectionScope, noteBodyTokenBudget };

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -223,7 +223,6 @@ export const runNoteChat = async (
 	}
 
 	const result = await AiService.instance().chat(messages, { responseFormat: responseSchema(note) });
-	logger.debug('Got response', result);
 	return enforceSelectionScope(tryParseReply(result.text), note.selection);
 };
 

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -126,7 +126,7 @@ const responseSchema = (note: NoteContext) => {
 			op: {
 				type: 'string',
 				enum: [
-					'insertBefore', 'insertAfter', 'appendToNote',
+					'appendToNote', 'insertBefore', 'insertAfter',
 					'replaceRange', 'replaceFencedBlock',
 				],
 			},

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -24,10 +24,6 @@ const knownOps = new Set<EditOp['op']>([
 	'replaceSelection', 'insertBefore', 'insertAfter', 'appendToNote', 'replaceRange', 'replaceFencedBlock',
 ]);
 
-// Structured-document fences where the model regenerates the whole block —
-// plain code fences (```js, ```python) are deliberately excluded.
-export const replaceFencedBlockSupportedTags = ['jsoncanvas', 'mermaid', 'abc', 'fountain'];
-
 export interface ChatTurn {
 	role: 'user' | 'assistant';
 	content: string;
@@ -105,7 +101,7 @@ const systemPrompt = (note: NoteContext) => {
 		lines.push('  { "op": "insertAfter", "anchor": "...", "text": "..." } — inserts text immediately after the first occurrence of "anchor".');
 		lines.push('  { "op": "appendToNote", "text": "..." } — appends text at the end of the note.');
 		lines.push('  { "op": "replaceRange", "anchor": "...", "text": "..." } — replaces the first occurrence of "anchor" with "text".');
-		lines.push(`  { "op": "replaceFencedBlock", "tag": "...", "text": "..." } — replaces the inner content of the first \`\`\`<tag>\`\`\` fenced block. "text" is the new content inside the fence (no fence markers). Supported tags: ${replaceFencedBlockSupportedTags.join(', ')}.`);
+		lines.push('  { "op": "replaceFencedBlock", "tag": "...", "text": "..." } — replaces the inner content of the first ```<tag>``` fenced block. "text" is the new content inside the fence (no fence markers). Supported tags: jsoncanvas, mermaid, abc, fountain.');
 		lines.push('');
 		lines.push('Anchors must be exact substrings of the current note body. Keep them short but unique.');
 		lines.push('');
@@ -154,7 +150,7 @@ const responseSchema = (note: NoteContext) => {
 				type: 'object',
 				properties: {
 					op: { type: 'string', enum: ['replaceFencedBlock'] },
-					tag: { type: 'string', enum: [...replaceFencedBlockSupportedTags] },
+					tag: { type: 'string' },
 					text: { type: 'string' },
 				},
 				required: ['op', 'tag', 'text'],

--- a/packages/lib/services/ai/providers/Anthropic.ts
+++ b/packages/lib/services/ai/providers/Anthropic.ts
@@ -57,6 +57,16 @@ export default class AnthropicProvider extends ChatProviderBase {
 		};
 		if (systemMessages.length) body.system = systemMessages.join('\n\n');
 		if (options?.temperature !== undefined) body.temperature = options.temperature;
+		if (options?.responseFormat?.type === 'json_schema') {
+			// Anthropic's API accepts the schema property directly:
+			const schema = options.responseFormat.json_schema.schema;
+			body.output_config = {
+				format: {
+					type: options.responseFormat.type,
+					schema,
+				},
+			};
+		}
 
 		const response = await shim.fetch('https://api.anthropic.com/v1/messages', {
 			method: 'POST',

--- a/packages/lib/services/ai/providers/Anthropic.ts
+++ b/packages/lib/services/ai/providers/Anthropic.ts
@@ -68,17 +68,26 @@ export default class AnthropicProvider extends ChatProviderBase {
 			};
 		}
 
-		const response = await shim.fetch('https://api.anthropic.com/v1/messages', {
-			method: 'POST',
-			headers: {
-				'x-api-key': this.apiKey_,
-				'anthropic-version': '2023-06-01',
-				'Content-Type': 'application/json',
-			},
-			body: JSON.stringify(body),
-		});
+		const doRequest = async () => {
+			const response = await shim.fetch('https://api.anthropic.com/v1/messages', {
+				method: 'POST',
+				headers: {
+					'x-api-key': this.apiKey_,
+					'anthropic-version': '2023-06-01',
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify(body),
+			});
+			return { response, text: await response.text() };
+		};
 
-		const text = await response.text();
+		// Older Anthropic models may not support the "output_config" property:
+		let { response, text } = await doRequest();
+		if (response.status === 400 && body.output_config && /output_config|json_schema/.test(text)) {
+			delete body.output_config;
+			({ response, text } = await doRequest());
+		}
+
 		let json: AnthropicResponse;
 		try {
 			json = JSON.parse(text) as AnthropicResponse;

--- a/packages/lib/services/ai/providers/JoplinCloud.ts
+++ b/packages/lib/services/ai/providers/JoplinCloud.ts
@@ -66,6 +66,7 @@ export default class JoplinCloudProvider extends ChatProviderBase {
 		};
 		if (options?.maxTokens !== undefined) body.max_tokens = options.maxTokens;
 		if (options?.temperature !== undefined) body.temperature = options.temperature;
+		if (options?.responseFormat !== undefined) body.response_format = options.responseFormat;
 
 		// JoplinServerApi.exec() returns the parsed JSON object directly when
 		// the response format is JSON (the default). No need to JSON.parse.

--- a/packages/lib/services/ai/providers/OpenAiCompatible.ts
+++ b/packages/lib/services/ai/providers/OpenAiCompatible.ts
@@ -80,9 +80,17 @@ export default class OpenAiCompatibleProvider extends ChatProviderBase {
 		// `max_completion_tokens`. Older models and many OpenAI-compatible
 		// servers only know `max_tokens`. Retry once with the new name when the
 		// server tells us so.
-		if (response.status === 400 && 'max_tokens' in body && /max_completion_tokens/i.test(json?.error?.message ?? '')) {
+		const errorMessage = json?.error?.message ?? '';
+		if (response.status === 400 && 'max_tokens' in body && /max_completion_tokens/i.test(errorMessage)) {
 			body.max_completion_tokens = body.max_tokens;
 			delete body.max_tokens;
+			({ response, json } = await doFetch());
+		}
+
+		// Older OpenAI models might reject `response_format` json_schema (see https://stackoverflow.com/q/79039544).
+		// For compatibility, retry without response_format on failure:
+		if (response.status === 400 && 'response_format' in body && /json_schema|response_format/.test(errorMessage)) {
+			delete body.response_format;
 			({ response, json } = await doFetch());
 		}
 

--- a/packages/lib/services/ai/providers/OpenAiCompatible.ts
+++ b/packages/lib/services/ai/providers/OpenAiCompatible.ts
@@ -53,6 +53,7 @@ export default class OpenAiCompatibleProvider extends ChatProviderBase {
 		};
 		if (options?.temperature !== undefined) body.temperature = options.temperature;
 		if (options?.maxTokens !== undefined) body.max_tokens = options.maxTokens;
+		if (options?.responseFormat !== undefined) body.response_format = options.responseFormat;
 
 		const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 		if (this.apiKey_) headers['Authorization'] = `Bearer ${this.apiKey_}`;

--- a/packages/lib/services/ai/providers/OpenAiCompatible.ts
+++ b/packages/lib/services/ai/providers/OpenAiCompatible.ts
@@ -80,8 +80,8 @@ export default class OpenAiCompatibleProvider extends ChatProviderBase {
 		// `max_completion_tokens`. Older models and many OpenAI-compatible
 		// servers only know `max_tokens`. Retry once with the new name when the
 		// server tells us so.
-		const errorMessage = json?.error?.message ?? '';
-		if (response.status === 400 && 'max_tokens' in body && /max_completion_tokens/i.test(errorMessage)) {
+		const errorMessage = () => json?.error?.message ?? '';
+		if (response.status === 400 && 'max_tokens' in body && /max_completion_tokens/i.test(errorMessage())) {
 			body.max_completion_tokens = body.max_tokens;
 			delete body.max_tokens;
 			({ response, json } = await doFetch());
@@ -89,7 +89,7 @@ export default class OpenAiCompatibleProvider extends ChatProviderBase {
 
 		// Older OpenAI models might reject `response_format` json_schema (see https://stackoverflow.com/q/79039544).
 		// For compatibility, retry without response_format on failure:
-		if (response.status === 400 && 'response_format' in body && /json_schema|response_format/.test(errorMessage)) {
+		if (response.status === 400 && 'response_format' in body && /json_schema|response_format/i.test(errorMessage())) {
 			delete body.response_format;
 			({ response, json } = await doFetch());
 		}

--- a/packages/lib/services/ai/types.ts
+++ b/packages/lib/services/ai/types.ts
@@ -5,8 +5,14 @@ export interface ChatMessage {
 	content: string;
 }
 
+export interface ResponseFormat {
+	type: 'json_schema';
+	json_schema: unknown;
+}
+
 export interface ChatOptions {
 	temperature?: number;
+	responseFormat?: ResponseFormat;
 	maxTokens?: number;
 }
 

--- a/packages/lib/services/ai/types.ts
+++ b/packages/lib/services/ai/types.ts
@@ -7,7 +7,11 @@ export interface ChatMessage {
 
 export interface ResponseFormat {
 	type: 'json_schema';
-	json_schema: unknown;
+	json_schema: {
+		name: string;
+		strict: boolean;
+		schema: unknown;
+	};
 }
 
 export interface ChatOptions {


### PR DESCRIPTION
# Problem

Joplin's AI chat panel expects output to match a specific format. However, small, self-hosted models often don't produce output in this format.

# Solution

Enforce [structured JSON output](https://developers.openai.com/api/docs/guides/structured-outputs) for Joplin Cloud and OpenAI-API-compatible (e.g. self-hosted Ollama) models. Compared with before, output is more likely to be valid JSON. However, the model may still attempt to use invalid operations (e.g. `insertAfter` with `--- NOTE END ---`).

**Goal**: Prevent edits from failing because of improperly formatted JSON. (Edits might still fail for other reasons).

# Testing

## Testing with just this PR

<details><summary>Original testing (just this PR)</summary>

**Steps**:
1. Set up the [IBM Granite 4.1 (`granite4.1:3b`)](https://ollama.com/library/granite4.1) model with Ollama.
2. Connect Joplin to the Ollama model from settings.
3. Open a new, empty note.
4. Ask Ollama to do something that involves modifying the note.
   - Prompt: "Derive Euler's formula. Please add the derivation to the currently open note."

**Before/after comparison**:
- **Before**:
  - Trial 1:
    <img width="2002" height="1396" alt="screenshot: Response added to chat, not note (JSON contains extra newlines)" src="https://github.com/user-attachments/assets/ddc5a2bf-8edc-40db-ae24-ddd341f2993a" />
    - Failed: Failed to parse.
  - Trial 2:
    <img width="2002" height="1396" alt="screenshot" src="https://github.com/user-attachments/assets/7089e34c-e76d-419d-a033-d68a2f3f2a26" />
    - Failed: Failed to parse.
  - Trial 3:
    <img width="2002" height="1396" alt="screenshot" src="https://github.com/user-attachments/assets/427dc8a4-b650-4fd3-82b4-9f08bc55c834" />
    - Partial success: Inserted content.

- **After**:
  - Trial 1:
    <img width="2002" height="1396" alt="screenshot" src="https://github.com/user-attachments/assets/6cbc89c3-31bb-46eb-99ba-a5e8979ad05a" />
    - Partial success: Inserted content, some issues with escaping (e.g. `\t` -> tab).
  - Trial 2:
    <img width="2002" height="1396" alt="image" src="https://github.com/user-attachments/assets/51df4880-349a-4342-bff8-6eb71959518e" />
    - Partial success: Inserted content.
  - Trial 3:
    <img width="2002" height="1396" alt="image" src="https://github.com/user-attachments/assets/54521c22-1790-4854-bcc6-6cd6d3487cad" />
    - Failed: The model attempted to use `---` as `anchor` with `insertAfter`. `---` is not part of the note body.

</details>

Joplin Cloud as the AI provider:
1. Create a new note.
2. In the AI chat, request that a new Mermaid diagram be added to the end of the note. Verify that this succeeds.
3. Request that the Mermaid diagram be changed somehow. Verify that this succeeds (and uses the `replaceFencedBlock` command).


## Before/after comparison

> [!NOTE]
>
> The below tests were done with the multi-window support for AI chat changes applied. See the above `<details>` block for tests done with **only** the changes from this pull request.

### Procedure
1. Merge changes that add support for using the AI chat panel in multiple windows.
5. Set up the [IBM Granite 4.1 (`granite4.1:8b`)](https://ollama.com/library/granite4.1) model with Ollama.
6. Connect Joplin to the Ollama model from settings.
7. Create two notes. Let the first contain:
  ```
  4 * 2 = ANS_1
  8 + 3 = ANS_2
  2 ** 3 = ANS_3
  ```
  Let the second contain:
  ```
  1 + 4 = ANS_1
  -3 + 8 = ANS_2
  4 + 4 = ANS_3
  ```
8. Open one in one secondary window and one in another.
9. Open the AI chat panels in both windows.
10. Prompt both to "Replace `ANS_#` with the number that makes each equation true. Update the note with the answers."
11. Move focus back to the main window while processing occurs.
12. Verify that both notes are updated successfully.
13. Revert the edits and repeat steps 4-9 two more times.

### Without the changes from this PR applied

**(Before)** 0/6 trials applied edits successfully

<img width="1920" height="758" alt="image" src="https://github.com/user-attachments/assets/136f23ee-e936-4fda-a57e-5934696dcff7" />
<img width="1920" height="706" alt="image" src="https://github.com/user-attachments/assets/f0961658-ae59-467e-9b6b-9c22e6e64da7" />
<img width="1920" height="706" alt="image" src="https://github.com/user-attachments/assets/029b8c4e-ef98-443f-86b3-08f3f77c4f47" />

### With the changes from this PR applied

**(After)** 5/6 trials applied edits successfully
<img width="1920" height="705" alt="image" src="https://github.com/user-attachments/assets/8ecae728-c083-4ba4-b0d0-a2da5f479f76" />
<img width="1920" height="701" alt="image" src="https://github.com/user-attachments/assets/6d82325a-3d39-4d2b-a660-2b1c6c34ed96" />
<img width="1920" height="702" alt="image" src="https://github.com/user-attachments/assets/d22027a6-f1fa-4013-a9b7-e90c55f75a71" />

The one failure was caused by an attempt to use `replaceFencedBlock` to set the note body.

<!-- With the prompt "Append arbitrary content to the current note.", even the smaller model is successful:
5. Ask Ollama to append content to the end of the note ("Append arbitrary content to the current note.")

**Before/after comparison**:
- **Before:**
  - Trial 1:
    <img width="1034" height="854" alt="image" src="https://github.com/user-attachments/assets/60cdb15f-2b7c-4d4e-817c-762edabd464e" />
  - Trial 2-3: Similarly successful
- **After:**
  - Trial 1:
    <img width="1030" height="854" alt="image" src="https://github.com/user-attachments/assets/d7bc9090-ba4f-4caf-9335-8246685d7bf1" />
  - Trial 2:
    <img width="1033" height="853" alt="image" src="https://github.com/user-attachments/assets/f27dcfdf-1110-43c9-b0be-01feb845e55d" />
  - Trial 3:
    <img width="1033" height="851" alt="image" src="https://github.com/user-attachments/assets/c5c52435-b609-464c-adc8-d7a15b71521e" />


