### PR TITLE
Desktop: AI chat panel: Support multiple windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -660,6 +660,7 @@ packages/app-desktop/utils/initReact.js
 packages/app-desktop/utils/initializeCommandService.js
 packages/app-desktop/utils/isSafeToOpen.test.js
 packages/app-desktop/utils/isSafeToOpen.js
+packages/app-desktop/utils/layout/layoutKeyToLabel.js
 packages/app-desktop/utils/restartInSafeModeFromMain.test.js
 packages/app-desktop/utils/restartInSafeModeFromMain.js
 packages/app-desktop/utils/sourceMapSetup.js

--- a/.gitignore
+++ b/.gitignore
@@ -239,6 +239,7 @@ packages/app-desktop/gui/KeymapConfig/styles/index.js
 packages/app-desktop/gui/KeymapConfig/utils/getLabel.js
 packages/app-desktop/gui/KeymapConfig/utils/useCommandStatus.js
 packages/app-desktop/gui/KeymapConfig/utils/useKeymap.js
+packages/app-desktop/gui/MainLayoutPane.js
 packages/app-desktop/gui/MainScreen.js
 packages/app-desktop/gui/MasterPasswordDialog/Dialog.js
 packages/app-desktop/gui/MenuBar.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -686,6 +686,7 @@ packages/app-desktop/utils/initReact.js
 packages/app-desktop/utils/initializeCommandService.js
 packages/app-desktop/utils/isSafeToOpen.test.js
 packages/app-desktop/utils/isSafeToOpen.js
+packages/app-desktop/utils/layout/layoutKeyToLabel.js
 packages/app-desktop/utils/restartInSafeModeFromMain.test.js
 packages/app-desktop/utils/restartInSafeModeFromMain.js
 packages/app-desktop/utils/sourceMapSetup.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -265,6 +265,7 @@ packages/app-desktop/gui/KeymapConfig/styles/index.js
 packages/app-desktop/gui/KeymapConfig/utils/getLabel.js
 packages/app-desktop/gui/KeymapConfig/utils/useCommandStatus.js
 packages/app-desktop/gui/KeymapConfig/utils/useKeymap.js
+packages/app-desktop/gui/MainLayoutPane.js
 packages/app-desktop/gui/MainScreen.js
 packages/app-desktop/gui/MasterPasswordDialog/Dialog.js
 packages/app-desktop/gui/MenuBar.js

--- a/packages/app-desktop/app.reducer.ts
+++ b/packages/app-desktop/app.reducer.ts
@@ -59,7 +59,7 @@ export interface AppWindowState extends WindowState {
 	// layout container can swap component types and unmount the panel).
 	aiChatMessages: AiChatMessage[];
 	// Layout for secondary windows
-	windowLayout: LayoutItem|null;
+	secondaryWindowLayout: LayoutItem|null;
 }
 
 interface BackgroundWindowStates {
@@ -94,7 +94,7 @@ export const createAppDefaultWindowState = (): AppWindowState => {
 		whiteboardForceMarkdown: {},
 		activeNoteIsWhiteboard: false,
 		aiChatMessages: [],
-		windowLayout: null,
+		secondaryWindowLayout: null,
 	};
 };
 
@@ -303,15 +303,15 @@ export default function(state: AppState, action: any) {
 
 		case 'WINDOW_LAYOUT_SET':
 		case 'MAIN_LAYOUT_SET':
-			if ((action.windowId ?? defaultWindowId) !== defaultWindowId) {
-				newState = withWindowStateUpdated(
-					state, action.windowId, 'windowLayout', () => action.value,
-				);
-			} else {
+			if ((action.windowId ?? defaultWindowId) === defaultWindowId) {
 				newState = {
 					...state,
 					mainLayout: action.value,
 				};
+			} else {
+				newState = withWindowStateUpdated(
+					state, action.windowId, 'secondaryWindowLayout', () => action.value,
+				);
 			}
 			break;
 
@@ -321,7 +321,7 @@ export default function(state: AppState, action: any) {
 
 			if ((action.windowId ?? defaultWindowId) !== defaultWindowId) {
 				newState = withWindowStateUpdated(
-					state, action.windowId, 'windowLayout', oldLayout => (
+					state, action.windowId, 'secondaryWindowLayout', oldLayout => (
 						setLayoutProp(oldLayout, updateOption)
 					),
 				);

--- a/packages/app-desktop/app.reducer.ts
+++ b/packages/app-desktop/app.reducer.ts
@@ -59,7 +59,7 @@ export interface AppWindowState extends WindowState {
 	// layout container can swap component types and unmount the panel).
 	aiChatMessages: AiChatMessage[];
 	// Layout for secondary windows
-	windowLayout: LayoutItem;
+	windowLayout: LayoutItem|null;
 }
 
 interface BackgroundWindowStates {
@@ -94,10 +94,7 @@ export const createAppDefaultWindowState = (): AppWindowState => {
 		whiteboardForceMarkdown: {},
 		activeNoteIsWhiteboard: false,
 		aiChatMessages: [],
-		windowLayout: { key: 'root', isRoot: true, width: 500, height: 500, children: [
-			{ key: 'editor' },
-			{ key: 'chatPanel', width: 340, visible: false },
-		] },
+		windowLayout: null,
 	};
 };
 

--- a/packages/app-desktop/app.reducer.ts
+++ b/packages/app-desktop/app.reducer.ts
@@ -1,6 +1,6 @@
 import { produce } from 'immer';
 import Setting from '@joplin/lib/models/Setting';
-import { defaultState, defaultWindowState, State, WindowState } from '@joplin/lib/reducer';
+import { defaultState, defaultWindowId, defaultWindowState, State, stateUtils, WindowState } from '@joplin/lib/reducer';
 import iterateItems from './gui/ResizableLayout/utils/iterateItems';
 import { LayoutItem } from './gui/ResizableLayout/utils/types';
 import validateLayout from './gui/ResizableLayout/utils/validateLayout';
@@ -58,6 +58,8 @@ export interface AppWindowState extends WindowState {
 	// In window state so the conversation survives panel hide/show (the
 	// layout container can swap component types and unmount the panel).
 	aiChatMessages: AiChatMessage[];
+	// Layout for secondary windows
+	windowLayout: LayoutItem;
 }
 
 interface BackgroundWindowStates {
@@ -92,6 +94,10 @@ export const createAppDefaultWindowState = (): AppWindowState => {
 		whiteboardForceMarkdown: {},
 		activeNoteIsWhiteboard: false,
 		aiChatMessages: [],
+		windowLayout: { key: 'root', isRoot: true, width: 500, height: 500, children: [
+			{ key: 'editor' },
+			{ key: 'chatPanel', width: 340, visible: false },
+		] },
 	};
 };
 
@@ -126,6 +132,42 @@ const hideBackgroundDialogsWithId = produce((state: AppState, id: string) => {
 		}
 	}
 });
+
+const withWindowStateUpdated = <Key extends keyof AppWindowState> (
+	state: AppState, windowId: string, stateKey: Key, value: (oldValue: AppWindowState[Key])=> AppWindowState[Key],
+) => {
+	return produce((state: AppState) => {
+		const windowState = stateUtils.windowStateById(state, windowId);
+		windowState[stateKey] = value(windowState[stateKey]);
+	})(state);
+};
+
+interface SetLayoutPropOptions {
+	key: string;
+	prop: string;
+	value: string;
+}
+
+const setLayoutProp = (layout: LayoutItem, { key, prop, value }: SetLayoutPropOptions) => {
+	let newLayout = produce(layout, (draftLayout: LayoutItem) => {
+		iterateItems(draftLayout, (_itemIndex: number, item: LayoutItem, _parent: LayoutItem) => {
+			if (!item) {
+				logger.warn('MAIN_LAYOUT_SET_ITEM_PROP: Found an empty item in layout: ', JSON.stringify(layout));
+			} else {
+				if (item.key === key) {
+					(item as unknown as Record<string, unknown>)[prop] = value;
+					return false;
+				}
+			}
+
+			return true;
+		});
+	});
+
+	if (newLayout !== layout) newLayout = validateLayout(newLayout);
+
+	return newLayout;
+};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Redux actions are heterogeneous; typing this would require an action-type union and many narrowing casts inside the switch
 export default function(state: AppState, action: any) {
@@ -245,65 +287,56 @@ export default function(state: AppState, action: any) {
 			break;
 
 		case 'AI_CHAT_APPEND':
-			newState = {
-				...state,
-				aiChatMessages: [...state.aiChatMessages, action.message as AiChatMessage],
-			};
+			newState = withWindowStateUpdated(
+				state, action.windowId, 'aiChatMessages', messages => [...messages, action.message as AiChatMessage],
+			);
 			break;
 
 		case 'AI_CHAT_REMOVE':
-			newState = {
-				...state,
-				aiChatMessages: state.aiChatMessages.filter(m => m.id !== action.id),
-			};
+			newState = withWindowStateUpdated(
+				state, action.windowId, 'aiChatMessages', messages => messages.filter(m => m.id !== action.id),
+			);
 			break;
 
 		case 'AI_CHAT_RESET':
-			newState = {
-				...state,
-				aiChatMessages: [],
-			};
+			newState = withWindowStateUpdated(
+				state, action.windowId, 'aiChatMessages', (): AiChatMessage[] => [],
+			);
 			break;
 
+		case 'WINDOW_LAYOUT_SET':
 		case 'MAIN_LAYOUT_SET':
-
-			newState = {
-				...state,
-				mainLayout: action.value,
-			};
+			if ((action.windowId ?? defaultWindowId) !== defaultWindowId) {
+				newState = withWindowStateUpdated(
+					state, action.windowId, 'windowLayout', () => action.value,
+				);
+			} else {
+				newState = {
+					...state,
+					mainLayout: action.value,
+				};
+			}
 			break;
 
-		case 'MAIN_LAYOUT_SET_ITEM_PROP':
+		case 'WINDOW_LAYOUT_SET_ITEM_PROP':
+		case 'MAIN_LAYOUT_SET_ITEM_PROP': {
+			const updateOption = { key: action.itemKey, prop: action.propName, value: action.propValue };
 
-			{
-				if (!state.mainLayout) {
-					logger.warn('MAIN_LAYOUT_SET_ITEM_PROP: Trying to set an item prop on the layout, but layout is empty: ', JSON.stringify(action));
-				} else {
-					let newLayout = produce(state.mainLayout, (draftLayout: LayoutItem) => {
-						iterateItems(draftLayout, (_itemIndex: number, item: LayoutItem, _parent: LayoutItem) => {
-							if (!item) {
-								logger.warn('MAIN_LAYOUT_SET_ITEM_PROP: Found an empty item in layout: ', JSON.stringify(state.mainLayout));
-							} else {
-								if (item.key === action.itemKey) {
-									(item as unknown as Record<string, unknown>)[action.propName] = action.propValue;
-									return false;
-								}
-							}
-
-							return true;
-						});
-					});
-
-					if (newLayout !== state.mainLayout) newLayout = validateLayout(newLayout);
-
-					newState = {
-						...state,
-						mainLayout: newLayout,
-					};
-				}
+			if ((action.windowId ?? defaultWindowId) !== defaultWindowId) {
+				newState = withWindowStateUpdated(
+					state, action.windowId, 'windowLayout', oldLayout => (
+						setLayoutProp(oldLayout, updateOption)
+					),
+				);
+			} else {
+				newState = {
+					...state,
+					mainLayout: setLayoutProp(state.mainLayout, updateOption),
+				};
 			}
 
 			break;
+		}
 
 		case 'SHOW_MODAL_MESSAGE':
 			newState = { ...newState, modalOverlayMessage: action.message };

--- a/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { _ } from '@joplin/lib/locale';
@@ -7,11 +7,12 @@ import Setting from '@joplin/lib/models/Setting';
 import Note from '@joplin/lib/models/Note';
 import CommandService from '@joplin/lib/services/CommandService';
 import Logger from '@joplin/utils/Logger';
-import { defaultWindowId, stateUtils } from '@joplin/lib/reducer';
+import { stateUtils } from '@joplin/lib/reducer';
 import { AiChatMessage, AppState } from '../../app.reducer';
 import { runNoteChat, ChatTurn } from '@joplin/lib/services/ai/noteChat';
 import { applyAnchorEdits } from '@joplin/lib/services/ai/applyNoteEdits';
 import { chatAvailability } from '@joplin/lib/services/ai/availability';
+import { WindowIdContext } from '../NewWindowOrIFrame';
 
 const logger = Logger.create('ChatPanel');
 
@@ -65,9 +66,11 @@ const ChatPanel: React.FC<Props> = (props) => {
 	const generationRef = useRef(0);
 	useEffect(() => () => { generationRef.current++; }, []);
 
+	const windowId = useContext(WindowIdContext);
+
 	const appendMessage = useCallback((message: AiChatMessage) => {
-		dispatch({ type: 'AI_CHAT_APPEND', message });
-	}, [dispatch]);
+		dispatch({ type: 'AI_CHAT_APPEND', windowId, message });
+	}, [dispatch, windowId]);
 
 	// Drop a separator when the active note changes mid-conversation. Skip
 	// the first ever opened note (no prior context to separate from).
@@ -198,13 +201,13 @@ const ChatPanel: React.FC<Props> = (props) => {
 		} catch (error) {
 			logger.warn('Chat failed:', error);
 			if (generationRef.current !== startGeneration) return;
-			dispatch({ type: 'AI_CHAT_REMOVE', id: userTurnId });
+			dispatch({ type: 'AI_CHAT_REMOVE', windowId, id: userTurnId });
 			setInput(text);
 			appendMessage({ id: makeId(), role: 'error', text: error.message || _('Something went wrong.') });
 		} finally {
 			setSending(false);
 		}
-	}, [input, sending, props.noteId, conversationTurns, appendMessage, dispatch]);
+	}, [input, sending, props.noteId, conversationTurns, windowId, appendMessage, dispatch]);
 
 	const handleAcknowledgeDisclosure = useCallback(() => {
 		Setting.setValue(disclosureSetting, true);
@@ -321,8 +324,12 @@ const ChatPanel: React.FC<Props> = (props) => {
 	);
 };
 
-const mapStateToProps = (state: AppState) => {
-	const windowState = stateUtils.windowStateById(state, defaultWindowId);
+interface OwnProps {
+	windowId: string;
+}
+
+const mapStateToProps = (state: AppState, ownProps: OwnProps) => {
+	const windowState = stateUtils.windowStateById(state, ownProps.windowId);
 	const noteId = stateUtils.selectedNoteId(windowState);
 	const note = noteId ? windowState.notes.find(n => n.id === noteId) : null;
 	const availability = chatAvailability();

--- a/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
@@ -222,8 +222,8 @@ const ChatPanel: React.FC<Props> = (props) => {
 
 	const handleReset = useCallback(() => {
 		generationRef.current++;
-		dispatch({ type: 'AI_CHAT_RESET' });
-	}, [dispatch]);
+		dispatch({ type: 'AI_CHAT_RESET', windowId: windowId });
+	}, [dispatch, windowId]);
 
 	const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
 		// Don't send while an IME composition is in flight — Enter commits

--- a/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
@@ -171,7 +171,10 @@ const ChatPanel: React.FC<Props> = (props) => {
 								editsMissed++;
 								continue;
 							}
-							await CommandService.instance().execute('replaceSelection', edit.text);
+							await CommandService.instance().executeInWindow('replaceSelection', {
+								windowId,
+								args: [edit.text],
+							});
 							editsApplied++;
 						}
 
@@ -182,7 +185,10 @@ const ChatPanel: React.FC<Props> = (props) => {
 							editsMissed += missed;
 							editsApplied += appliedEdits.length - missed;
 							if (newBody !== liveBody) {
-								await CommandService.instance().execute('editor.setText', newBody);
+								await CommandService.instance().executeInWindow('editor.setText', {
+									windowId,
+									args: [newBody],
+								});
 							}
 						}
 					}

--- a/packages/app-desktop/gui/MainLayoutPane.tsx
+++ b/packages/app-desktop/gui/MainLayoutPane.tsx
@@ -1,0 +1,173 @@
+import * as React from 'react';
+import { useContext, useRef } from 'react';
+import NoteListWrapper from './NoteListWrapper/NoteListWrapper';
+import { RenderItemEvent } from './ResizableLayout/ResizableLayout';
+import Sidebar from './Sidebar/Sidebar';
+import { WindowIdContext } from './NewWindowOrIFrame';
+import { NoteListColumns } from '@joplin/lib/services/plugins/api/noteListType';
+import NoteEditor from './NoteEditor/NoteEditor';
+import ChatPanel from './ChatPanel/ChatPanel';
+import { PluginHtmlContents, PluginStates, utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
+import { _ } from '@joplin/lib/locale';
+import UserWebview from '../services/plugins/UserWebview';
+import removeItem from './ResizableLayout/utils/removeItem';
+import { LayoutItem } from './ResizableLayout/utils/types';
+import { AppState } from '../app.reducer';
+import { connect } from 'react-redux';
+import { stateUtils } from '@joplin/lib/reducer';
+import validateColumns from './NoteListHeader/utils/validateColumns';
+
+interface Props {
+	themeId: number;
+	listRendererId: string;
+	startupPluginsLoaded: boolean;
+	notesSortOrderField: string;
+	notesColumns: NoteListColumns;
+	selectedFolderId: string;
+	notesSortOrderReverse: boolean;
+	plugins: PluginStates;
+	pluginHtmlContents: PluginHtmlContents;
+
+	contentKey: string;
+	event: RenderItemEvent;
+	layout: LayoutItem;
+	onNoteTitleChange?: (title: string)=> void;
+	onUpdateLayout: (layout: LayoutItem)=> void;
+}
+
+const MainLayoutPane: React.FC<Props> = (props) => {
+	const { contentKey, event } = props;
+
+
+	const windowId = useContext(WindowIdContext);
+	const cancelLayoutRemoveRef = useRef(0);
+
+	// Key should never be undefined but somehow it can happen, also not
+	// clear how. For now in this case render nothing so that the app
+	// doesn't crash.
+	// https://discourse.joplinapp.org/t/rearranging-the-pannels-crushed-the-app-and-generated-fatal-error/14373?u=laurent
+	if (!contentKey) {
+		console.error('resizableLayout_renderItem: Trying to render an item using an empty key. Full layout is:', props.layout);
+		return null;
+	}
+
+	const eventEmitter = event.eventEmitter;
+
+	// const viewsToRemove:string[] = [];
+
+	const components: Record<string, ()=> React.ReactNode> = {
+		sideBar: () => {
+			return <Sidebar />;
+		},
+
+		noteList: () => {
+			return <NoteListWrapper
+				resizableLayoutEventEmitter={eventEmitter}
+				visible={event.visible}
+				size={event.size}
+				themeId={props.themeId}
+				listRendererId={props.listRendererId}
+				startupPluginsLoaded={props.startupPluginsLoaded}
+				notesSortOrderField={props.notesSortOrderField}
+				notesSortOrderReverse={props.notesSortOrderReverse}
+				columns={props.notesColumns}
+				selectedFolderId={props.selectedFolderId}
+			/>;
+		},
+
+		editor: () => {
+			return <div className='note-editor-wrapper' role='main' aria-label={_('Note')}>
+				<NoteEditor
+					windowId={windowId}
+					onTitleChange={props.onNoteTitleChange}
+					startupPluginsLoaded={props.startupPluginsLoaded}
+				/>
+			</div>;
+		},
+
+		chatPanel: () => {
+			return <ChatPanel windowId={windowId} />;
+		},
+	};
+
+	if (components[contentKey]) return components[contentKey]();
+
+	const viewsToRemove: string[] = [];
+
+	if (contentKey.indexOf('plugin-view') === 0) {
+		const viewInfo = pluginUtils.viewInfoByViewId(props.plugins, event.item.key);
+
+		if (!viewInfo) {
+			// Once all startup plugins have loaded, we know that all the
+			// views are ready so we can remove the orphans ones.
+			//
+			// Before they are loaded, there might be views that don't match
+			// any plugins, but that's only because it hasn't loaded yet.
+			if (props.startupPluginsLoaded) {
+				console.warn(`Could not find plugin associated with view: ${event.item.key}`);
+				viewsToRemove.push(event.item.key);
+			}
+		} else {
+			const { view, plugin } = viewInfo;
+			const html = props.pluginHtmlContents[plugin.id]?.[view.id] ?? '';
+
+			return <UserWebview
+				key={view.id}
+				viewId={view.id}
+				themeId={props.themeId}
+				html={html}
+				scripts={view.scripts}
+				pluginId={plugin.id}
+				borderBottom={true}
+				fitToContent={false}
+			/>;
+		}
+	} else {
+		// The layout may reference a component that no longer exists -
+		// for example a panel from a previous version of the app, or a
+		// feature that has been removed. Rather than crash, log the issue
+		// and queue the item for removal from the layout.
+		console.warn(`Invalid layout component: ${contentKey} - it will be removed from the layout`);
+		viewsToRemove.push(contentKey);
+	}
+
+	if (viewsToRemove.length) {
+		const cancelCounter = cancelLayoutRemoveRef.current + 1;
+		cancelLayoutRemoveRef.current = cancelCounter;
+		window.requestAnimationFrame(() => {
+			if (cancelCounter !== cancelLayoutRemoveRef.current) return;
+
+			let newLayout = props.layout;
+			for (const itemKey of viewsToRemove) {
+				newLayout = removeItem(newLayout, itemKey);
+			}
+
+			if (newLayout !== props.layout) {
+				console.warn('Removed invalid views:', viewsToRemove);
+				props.onUpdateLayout(newLayout);
+			}
+		});
+	}
+
+	return null;
+};
+
+interface OwnProps {
+	windowId: string;
+}
+
+export default connect((state: AppState, ownProps: OwnProps) => {
+	const windowState = stateUtils.windowStateById(state, ownProps.windowId);
+
+	return {
+		themeId: state.settings.theme,
+		plugins: state.pluginService.plugins,
+		pluginHtmlContents: state.pluginService.pluginHtmlContents,
+		startupPluginsLoaded: state.startupPluginsLoaded,
+		listRendererId: state.settings['notes.listRendererId'],
+		selectedFolderId: windowState.selectedFolderId,
+		notesSortOrderField: state.settings['notes.sortOrder.field'],
+		notesSortOrderReverse: state.settings['notes.sortOrder.reverse'],
+		notesColumns: validateColumns(state.settings['notes.columns']),
+	};
+})(MainLayoutPane);

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -45,13 +45,13 @@ import NoteEditor from './NoteEditor/NoteEditor';
 import ChatPanel from './ChatPanel/ChatPanel';
 import PluginNotification from './PluginNotification/PluginNotification';
 import { Toast } from '@joplin/lib/services/plugins/api/types';
-import PluginService from '@joplin/lib/services/plugins/PluginService';
 import QuitSyncDialog from './QuitSyncDialog';
 import Logger from '@joplin/utils/Logger';
 
 const logger = Logger.create('MainScreen');
 
 import { ipcRenderer } from 'electron';
+import layoutKeyToLabel from '../utils/layout/layoutKeyToLabel';
 
 interface Props {
 	plugins: PluginStates;
@@ -122,19 +122,6 @@ const defaultLayout: LayoutItem = {
 		{ key: 'editor' },
 		{ key: 'chatPanel', width: 340, visible: false },
 	],
-};
-
-const layoutKeyToLabel = (key: string, plugins: PluginStates) => {
-	if (key === 'sideBar') return _('Sidebar');
-	if (key === 'noteList') return _('Note list');
-	if (key === 'editor') return _('Editor');
-	if (key === 'chatPanel') return _('AI Chat');
-
-	const viewInfo = pluginUtils.viewInfoByViewId(plugins, key);
-	if (viewInfo) {
-		return PluginService.instance().safePluginNameById(viewInfo.plugin.id);
-	}
-	return key;
 };
 
 class MainScreenComponent extends React.Component<Props, State> {
@@ -689,7 +676,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 			},
 
 			chatPanel: () => {
-				return <ChatPanel key={key} />;
+				return <ChatPanel windowId={defaultWindowId} key={key} />;
 			},
 		};
 

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -34,7 +34,6 @@ import { MasterKeyEntity } from '@joplin/lib/services/e2ee/types';
 import invitationRespond from '@joplin/lib/services/share/invitationRespond';
 import restart from '../services/restart';
 import { connect } from 'react-redux';
-import validateColumns from './NoteListHeader/utils/validateColumns';
 import TrashNotification from './TrashNotification/TrashNotification';
 import UpdateNotification from './UpdateNotification/UpdateNotification';
 import PluginNotification from './PluginNotification/PluginNotification';
@@ -712,7 +711,6 @@ class MainScreenComponent extends React.Component<Props, State> {
 const mapStateToProps = (state: AppState) => {
 	const syncInfo = localSyncInfoFromState(state);
 	const showNeedUpgradingEnabledMasterKeyMessage = !!EncryptionService.instance().masterKeysThatNeedUpgrading(syncInfo.masterKeys.filter((k) => !!k.enabled)).length;
-	const windowState = stateUtils.windowStateById(state, defaultWindowId);
 
 	return {
 		themeId: state.settings.theme,
@@ -728,21 +726,15 @@ const mapStateToProps = (state: AppState) => {
 		hasNotesBeingSaved: stateUtils.hasNotesBeingSaved(state),
 		layoutMoveMode: state.layoutMoveMode,
 		mainLayout: state.mainLayout,
-		startupPluginsLoaded: state.startupPluginsLoaded,
 		shareInvitations: state.shareService.shareInvitations,
 		processingShareInvitationResponse: state.shareService.processingShareInvitationResponse,
 		isSafeMode: state.settings.isSafeMode,
 		enableLegacyMarkdownEditor: state.settings['editor.legacyMarkdown'],
 		needApiAuth: state.needApiAuth,
 		isResettingLayout: state.isResettingLayout,
-		listRendererId: state.settings['notes.listRendererId'],
 		lastDeletion: state.lastDeletion,
 		lastDeletionNotificationTime: state.lastDeletionNotificationTime,
-		selectedFolderId: windowState.selectedFolderId,
 		mustUpgradeAppMessage: state.mustUpgradeAppMessage,
-		notesSortOrderField: state.settings['notes.sortOrder.field'],
-		notesSortOrderReverse: state.settings['notes.sortOrder.reverse'],
-		notesColumns: validateColumns(state.settings['notes.columns']),
 		showInvalidJoplinCloudCredential: state.settings['sync.target'] === 10 && state.mustAuthenticate,
 		toast: state.toast,
 		shouldSwitchToAppleSiliconVersion: shim.isAppleSilicon() && shim.isMac() && process.arch !== 'arm64',

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -7,13 +7,10 @@ import { move } from './ResizableLayout/utils/movements';
 import { LayoutItem } from './ResizableLayout/utils/types';
 import CommandService from '@joplin/lib/services/CommandService';
 import { PluginHtmlContents, PluginStates, utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
-import Sidebar from './Sidebar/Sidebar';
-import UserWebview from '../services/plugins/UserWebview';
 import UserWebviewDialog from '../services/plugins/UserWebviewDialog';
 import { ContainerType } from '@joplin/lib/services/plugins/WebviewController';
 import { defaultWindowId, StateLastDeletion, stateUtils } from '@joplin/lib/reducer';
 import { _ } from '@joplin/lib/locale';
-import NoteListWrapper from './NoteListWrapper/NoteListWrapper';
 import { AppState } from '../app.reducer';
 import { saveLayout, loadLayout } from './ResizableLayout/utils/persist';
 import Setting from '@joplin/lib/models/Setting';
@@ -37,12 +34,9 @@ import { MasterKeyEntity } from '@joplin/lib/services/e2ee/types';
 import invitationRespond from '@joplin/lib/services/share/invitationRespond';
 import restart from '../services/restart';
 import { connect } from 'react-redux';
-import { NoteListColumns } from '@joplin/lib/services/plugins/api/noteListType';
 import validateColumns from './NoteListHeader/utils/validateColumns';
 import TrashNotification from './TrashNotification/TrashNotification';
 import UpdateNotification from './UpdateNotification/UpdateNotification';
-import NoteEditor from './NoteEditor/NoteEditor';
-import ChatPanel from './ChatPanel/ChatPanel';
 import PluginNotification from './PluginNotification/PluginNotification';
 import { Toast } from '@joplin/lib/services/plugins/api/types';
 import QuitSyncDialog from './QuitSyncDialog';
@@ -52,11 +46,11 @@ const logger = Logger.create('MainScreen');
 
 import { ipcRenderer } from 'electron';
 import layoutKeyToLabel from '../utils/layout/layoutKeyToLabel';
+import MainLayoutPane from './MainLayoutPane';
 
 interface Props {
 	plugins: PluginStates;
 	pluginHtmlContents: PluginHtmlContents;
-	pluginsLoaded: boolean;
 	hasNotesBeingSaved: boolean;
 	dispatch: Dispatch;
 	mainLayout: LayoutItem;
@@ -70,21 +64,15 @@ interface Props {
 	showNeedUpgradingMasterKeyMessage: boolean;
 	showShouldReencryptMessage: boolean;
 	themeId: number;
-	startupPluginsLoaded: boolean;
 	shareInvitations: ShareInvitation[];
 	isSafeMode: boolean;
 	enableLegacyMarkdownEditor: boolean;
 	needApiAuth: boolean;
 	processingShareInvitationResponse: boolean;
 	isResettingLayout: boolean;
-	listRendererId: string;
 	lastDeletion: StateLastDeletion;
 	lastDeletionNotificationTime: number;
-	selectedFolderId: string;
 	mustUpgradeAppMessage: string;
-	notesSortOrderField: string;
-	notesSortOrderReverse: boolean;
-	notesColumns: NoteListColumns;
 	showInvalidJoplinCloudCredential: boolean;
 	toast: Toast;
 	shouldSwitchToAppleSiliconVersion: boolean;
@@ -631,111 +619,14 @@ class MainScreenComponent extends React.Component<Props, State> {
 	}
 
 	private resizableLayout_renderItem(key: string, event: RenderItemEvent): React.ReactNode {
-		// Key should never be undefined but somehow it can happen, also not
-		// clear how. For now in this case render nothing so that the app
-		// doesn't crash.
-		// https://discourse.joplinapp.org/t/rearranging-the-pannels-crushed-the-app-and-generated-fatal-error/14373?u=laurent
-		if (!key) {
-			console.error('resizableLayout_renderItem: Trying to render an item using an empty key. Full layout is:', this.props.mainLayout);
-			return null;
-		}
-
-		const eventEmitter = event.eventEmitter;
-
-		// const viewsToRemove:string[] = [];
-
-		const components: Record<string, ()=> React.ReactNode> = {
-			sideBar: () => {
-				return <Sidebar key={key} />;
-			},
-
-			noteList: () => {
-				return <NoteListWrapper
-					key={key}
-					resizableLayoutEventEmitter={eventEmitter}
-					visible={event.visible}
-					size={event.size}
-					themeId={this.props.themeId}
-					listRendererId={this.props.listRendererId}
-					startupPluginsLoaded={this.props.startupPluginsLoaded}
-					notesSortOrderField={this.props.notesSortOrderField}
-					notesSortOrderReverse={this.props.notesSortOrderReverse}
-					columns={this.props.notesColumns}
-					selectedFolderId={this.props.selectedFolderId}
-				/>;
-			},
-
-			editor: () => {
-				return <div className='note-editor-wrapper' role='main' aria-label={_('Note')}>
-					<NoteEditor
-						windowId={defaultWindowId}
-						key={key}
-						startupPluginsLoaded={this.props.startupPluginsLoaded}
-					/>
-				</div>;
-			},
-
-			chatPanel: () => {
-				return <ChatPanel windowId={defaultWindowId} key={key} />;
-			},
-		};
-
-		if (components[key]) return components[key]();
-
-		const viewsToRemove: string[] = [];
-
-		if (key.indexOf('plugin-view') === 0) {
-			const viewInfo = pluginUtils.viewInfoByViewId(this.props.plugins, event.item.key);
-
-			if (!viewInfo) {
-				// Once all startup plugins have loaded, we know that all the
-				// views are ready so we can remove the orphans ones.
-				//
-				// Before they are loaded, there might be views that don't match
-				// any plugins, but that's only because it hasn't loaded yet.
-				if (this.props.startupPluginsLoaded) {
-					console.warn(`Could not find plugin associated with view: ${event.item.key}`);
-					viewsToRemove.push(event.item.key);
-				}
-			} else {
-				const { view, plugin } = viewInfo;
-				const html = this.props.pluginHtmlContents[plugin.id]?.[view.id] ?? '';
-
-				return <UserWebview
-					key={view.id}
-					viewId={view.id}
-					themeId={this.props.themeId}
-					html={html}
-					scripts={view.scripts}
-					pluginId={plugin.id}
-					borderBottom={true}
-					fitToContent={false}
-				/>;
-			}
-		} else {
-			// The layout may reference a component that no longer exists -
-			// for example a panel from a previous version of the app, or a
-			// feature that has been removed. Rather than crash, log the issue
-			// and queue the item for removal from the layout.
-			console.warn(`Invalid layout component: ${key} - it will be removed from the layout`);
-			viewsToRemove.push(key);
-		}
-
-		if (viewsToRemove.length) {
-			window.requestAnimationFrame(() => {
-				let newLayout = this.props.mainLayout;
-				for (const itemKey of viewsToRemove) {
-					newLayout = removeItem(newLayout, itemKey);
-				}
-
-				if (newLayout !== this.props.mainLayout) {
-					console.warn('Removed invalid views:', viewsToRemove);
-					this.updateMainLayout(newLayout);
-				}
-			});
-		}
-
-		return null;
+		return <MainLayoutPane
+			key={key}
+			contentKey={key}
+			event={event}
+			windowId={defaultWindowId}
+			onUpdateLayout={this.updateMainLayout}
+			layout={this.props.mainLayout}
+		/>;
 	}
 
 	public renderPluginDialogs() {

--- a/packages/app-desktop/gui/NewWindowOrIFrame.tsx
+++ b/packages/app-desktop/gui/NewWindowOrIFrame.tsx
@@ -12,6 +12,7 @@ import { SecondaryWindowApi } from '../utils/window/types';
 export const WindowIdContext = createContext(defaultWindowId);
 
 type OnCloseCallback = ()=> void;
+type OnSetWindowCallback = (window: Window)=> void;
 
 export enum WindowMode {
 	Iframe, NewWindow,
@@ -25,6 +26,7 @@ interface Props {
 	mode: WindowMode;
 	windowId: string;
 	onClose: OnCloseCallback;
+	onWindow: OnSetWindowCallback;
 }
 
 const useDocument = (
@@ -146,6 +148,15 @@ const NewWindowOrIFrame: React.FC<Props> = props => {
 			electronWindow.onSetWindowId(props.windowId);
 		}
 	}, [doc, props.windowId]);
+
+	const onWindowRef = useRef(props.onWindow);
+	onWindowRef.current = props.onWindow;
+	useEffect(() => {
+		const win = doc?.defaultView;
+		if (win && onWindowRef.current) {
+			onWindowRef.current(win);
+		}
+	}, [doc]);
 
 	const parentNode = loaded ? doc?.body : null;
 	const wrappedChildren = <WindowIdContext.Provider value={props.windowId}>{props.children}</WindowIdContext.Provider>;

--- a/packages/app-desktop/gui/NoteEditor/EditorWindow.tsx
+++ b/packages/app-desktop/gui/NoteEditor/EditorWindow.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import NoteEditor from './NoteEditor';
 import StyleSheetContainer from '../StyleSheets/StyleSheetContainer';
 import { connect } from 'react-redux';
 import { AppState } from '../../app.reducer';
@@ -13,11 +12,11 @@ import { StyleSheetManager } from 'styled-components';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import { stateUtils } from '@joplin/lib/reducer';
-import ResizableLayout from '../ResizableLayout/ResizableLayout';
+import ResizableLayout, { RenderItemEvent } from '../ResizableLayout/ResizableLayout';
 import { LayoutItem } from '../ResizableLayout/utils/types';
 import { PluginStates } from '@joplin/lib/services/plugins/reducer';
 import layoutKeyToLabel from '../../utils/layout/layoutKeyToLabel';
-import ChatPanel from '../ChatPanel/ChatPanel';
+import MainLayoutPane from '../MainLayoutPane';
 
 interface Props {
 	dispatch: Dispatch;
@@ -27,7 +26,6 @@ interface Props {
 	plugins: PluginStates;
 	newWindow: boolean;
 	windowId: string;
-	startupPluginsLoaded: boolean;
 }
 
 const emptyCallback = () => {};
@@ -44,8 +42,20 @@ const useWindowTitle = (isNewWindow: boolean) => {
 	return { windowTitle: `Joplin - ${title}`, onNoteTitleChange: setTitle };
 };
 
+const defaultLayout = {
+	key: 'root',
+	isRoot: true,
+	width: 500,
+	height: 500,
+	children: [
+		{ key: 'editor' },
+		{ key: 'chatPanel', width: 340, visible: false },
+	],
+};
+
 const useLayout = ({ windowId, layout, plugins, dispatch }: Props) => {
 	const [window, setWindow] = useState<Window|null>(null);
+	layout ??= defaultLayout;
 
 	const onUpdateLayout = useCallback((newLayout: LayoutItem) => {
 		dispatch({
@@ -90,12 +100,16 @@ const useLayout = ({ windowId, layout, plugins, dispatch }: Props) => {
 		};
 	}, [window, onRefreshLayoutSize]);
 
-	return { layout, onWindow: setWindow, onResize, onKeyToLabel };
+	return {
+		layout,
+		onWindow: setWindow,
+		onResize,
+		onUpdate: onUpdateLayout,
+		onKeyToLabel,
+	};
 };
 
 const SecondaryWindow: React.FC<Props> = props => {
-	const containerRef = useRef<HTMLDivElement>(null);
-
 	const { windowTitle, onNoteTitleChange } = useWindowTitle(props.newWindow);
 
 	const newWindow = props.newWindow;
@@ -107,21 +121,17 @@ const SecondaryWindow: React.FC<Props> = props => {
 
 	const layout = useLayout(props);
 
-	const onRenderItem = useCallback((key: string) => {
-		if (key === 'editor') {
-			return <div key={key} className='note-editor-wrapper' ref={containerRef}>
-				<NoteEditor
-					windowId={props.windowId}
-					onTitleChange={onNoteTitleChange}
-					startupPluginsLoaded={props.startupPluginsLoaded}
-				/>
-			</div>;
-		}
-		if (key === 'chatPanel') {
-			return <ChatPanel windowId={props.windowId} key={key} />;
-		}
-		return null;
-	}, [props.windowId, props.startupPluginsLoaded, onNoteTitleChange, containerRef]);
+	const onRenderItem = useCallback((key: string, event: RenderItemEvent) => {
+		return <MainLayoutPane
+			key={key}
+			contentKey={key}
+			windowId={props.windowId}
+			onNoteTitleChange={onNoteTitleChange}
+			event={event}
+			onUpdateLayout={layout.onUpdate}
+			layout={layout.layout}
+		/>;
+	}, [props.windowId, onNoteTitleChange, layout.layout, layout.onUpdate]);
 
 	return <NewWindowOrIFrame
 		onWindow={layout.onWindow}
@@ -186,7 +196,6 @@ export default connect((state: AppState, ownProps: ConnectProps) => {
 		layout: windowState.windowLayout,
 		codeView: windowState?.editorCodeView ?? state.settings['editor.codeView'],
 		legacyMarkdown: state.settings['editor.legacyMarkdown'],
-		startupPluginsLoaded: state.startupPluginsLoaded,
 		plugins: state.pluginService.plugins,
 	};
 })(SecondaryWindow);

--- a/packages/app-desktop/gui/NoteEditor/EditorWindow.tsx
+++ b/packages/app-desktop/gui/NoteEditor/EditorWindow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import NoteEditor from './NoteEditor';
 import StyleSheetContainer from '../StyleSheets/StyleSheetContainer';
 import { connect } from 'react-redux';
@@ -13,11 +13,18 @@ import { StyleSheetManager } from 'styled-components';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import { stateUtils } from '@joplin/lib/reducer';
+import ResizableLayout from '../ResizableLayout/ResizableLayout';
+import { LayoutItem } from '../ResizableLayout/utils/types';
+import { PluginStates } from '@joplin/lib/services/plugins/reducer';
+import layoutKeyToLabel from '../../utils/layout/layoutKeyToLabel';
+import ChatPanel from '../ChatPanel/ChatPanel';
 
 interface Props {
 	dispatch: Dispatch;
 	themeId: number;
 
+	layout: LayoutItem;
+	plugins: PluginStates;
 	newWindow: boolean;
 	windowId: string;
 	startupPluginsLoaded: boolean;
@@ -37,17 +44,59 @@ const useWindowTitle = (isNewWindow: boolean) => {
 	return { windowTitle: `Joplin - ${title}`, onNoteTitleChange: setTitle };
 };
 
+const useLayout = ({ windowId, layout, plugins, dispatch }: Props) => {
+	const [window, setWindow] = useState<Window|null>(null);
+
+	const onUpdateLayout = useCallback((newLayout: LayoutItem) => {
+		dispatch({
+			type: 'WINDOW_LAYOUT_SET',
+			windowId,
+			value: newLayout,
+		});
+	}, [dispatch, windowId]);
+
+	const onResize = useCallback((event: { layout: LayoutItem }) => {
+		onUpdateLayout(event.layout);
+	}, [onUpdateLayout]);
+
+	const onKeyToLabel = useCallback((key: string) => {
+		return layoutKeyToLabel(key, plugins);
+	}, [plugins]);
+
+	const currentLayoutRef = useRef(layout);
+	currentLayoutRef.current = layout;
+
+	const onRefreshLayoutSize = useCallback((window: Window) => {
+		const layout = currentLayoutRef.current;
+		if (layout.width !== window.innerWidth || layout.height !== window.innerHeight) {
+			const newLayout = {
+				...currentLayoutRef.current,
+				width: window.innerWidth,
+				height: window.innerHeight,
+			};
+			onUpdateLayout(newLayout);
+		}
+	}, [onUpdateLayout]);
+
+	useEffect(() => {
+		if (!window) return ()=>{};
+
+		const onWindowResize = () => onRefreshLayoutSize(window);
+		window.addEventListener('resize', onWindowResize);
+		onWindowResize();
+
+		return () => {
+			window.removeEventListener('resize', onWindowResize);
+		};
+	}, [window, onRefreshLayoutSize]);
+
+	return { layout, onWindow: setWindow, onResize, onKeyToLabel };
+};
+
 const SecondaryWindow: React.FC<Props> = props => {
 	const containerRef = useRef<HTMLDivElement>(null);
 
 	const { windowTitle, onNoteTitleChange } = useWindowTitle(props.newWindow);
-	const editor = <div className='note-editor-wrapper' ref={containerRef}>
-		<NoteEditor
-			windowId={props.windowId}
-			onTitleChange={onNoteTitleChange}
-			startupPluginsLoaded={props.startupPluginsLoaded}
-		/>
-	</div>;
 
 	const newWindow = props.newWindow;
 	const onWindowClose = useCallback(() => {
@@ -56,7 +105,26 @@ const SecondaryWindow: React.FC<Props> = props => {
 		}
 	}, [props.dispatch, props.windowId, newWindow]);
 
+	const layout = useLayout(props);
+
+	const onRenderItem = useCallback((key: string) => {
+		if (key === 'editor') {
+			return <div key={key} className='note-editor-wrapper' ref={containerRef}>
+				<NoteEditor
+					windowId={props.windowId}
+					onTitleChange={onNoteTitleChange}
+					startupPluginsLoaded={props.startupPluginsLoaded}
+				/>
+			</div>;
+		}
+		if (key === 'chatPanel') {
+			return <ChatPanel windowId={props.windowId} key={key} />;
+		}
+		return null;
+	}, [props.windowId, props.startupPluginsLoaded, onNoteTitleChange, containerRef]);
+
 	return <NewWindowOrIFrame
+		onWindow={layout.onWindow}
 		mode={newWindow ? WindowMode.NewWindow : WindowMode.Iframe}
 		windowId={props.windowId}
 		onClose={onWindowClose}
@@ -64,7 +132,15 @@ const SecondaryWindow: React.FC<Props> = props => {
 	>
 		<LibraryStyleRoot>
 			<WindowCommandsAndDialogs windowId={props.windowId} />
-			{editor}
+			<ResizableLayout
+				layout={layout.layout}
+				onResize={layout.onResize}
+				onMoveButtonClick={() => {}}
+				renderItem={onRenderItem}
+				layoutKeyToLabel={layout.onKeyToLabel}
+				moveMode={false}
+				moveModeMessage={''}
+			/>
 		</LibraryStyleRoot>
 		<StyleSheetContainer />
 	</NewWindowOrIFrame>;
@@ -107,8 +183,10 @@ export default connect((state: AppState, ownProps: ConnectProps) => {
 	return {
 		themeId: state.settings.theme,
 		isSafeMode: state.settings.isSafeMode,
+		layout: windowState.windowLayout,
 		codeView: windowState?.editorCodeView ?? state.settings['editor.codeView'],
 		legacyMarkdown: state.settings['editor.legacyMarkdown'],
 		startupPluginsLoaded: state.startupPluginsLoaded,
+		plugins: state.pluginService.plugins,
 	};
 })(SecondaryWindow);

--- a/packages/app-desktop/gui/NoteEditor/EditorWindow.tsx
+++ b/packages/app-desktop/gui/NoteEditor/EditorWindow.tsx
@@ -193,7 +193,7 @@ export default connect((state: AppState, ownProps: ConnectProps) => {
 	return {
 		themeId: state.settings.theme,
 		isSafeMode: state.settings.isSafeMode,
-		layout: windowState.windowLayout,
+		layout: windowState.secondaryWindowLayout,
 		codeView: windowState?.editorCodeView ?? state.settings['editor.codeView'],
 		legacyMarkdown: state.settings['editor.legacyMarkdown'],
 		plugins: state.pluginService.plugins,

--- a/packages/app-desktop/gui/NoteEditor/utils/getWindowCommandPriority.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/getWindowCommandPriority.ts
@@ -1,6 +1,9 @@
 import { RefObject } from 'react';
 
-const getWindowCommandPriority = <T extends HTMLElement> (contentContainer: RefObject<T>) => {
+const getWindowCommandPriority = <T extends HTMLElement> (contentContainer: RefObject<T>, inTargetWindow: boolean) => {
+	// If there's an explicit target window, always prefer the runtime
+	if (inTargetWindow) return 3;
+
 	if (!contentContainer.current) return 0;
 	const containerDocument = contentContainer.current.getRootNode() as Document;
 	if (!containerDocument || !containerDocument.hasFocus()) return 0;

--- a/packages/app-desktop/gui/NoteEditor/utils/useWindowCommandHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useWindowCommandHandler.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, RefObject, Dispatch, SetStateAction, useEffect } from 'react';
+import { MutableRefObject, RefObject, Dispatch, SetStateAction, useEffect, useContext } from 'react';
 import { Dispatch as ReduxDispatch } from 'redux';
 import { WindowCommandDependencies, NoteBodyEditorRef, OnChangeEvent, ScrollOptionTypes } from './types';
 import editorCommandDeclarations, { enabledCondition } from '../editorCommandDeclarations';
@@ -6,6 +6,8 @@ import CommandService, { CommandDeclaration, CommandRuntime, CommandContext, Reg
 import { formatMsToLocal } from '@joplin/utils/time';
 import { reg } from '@joplin/lib/registry';
 import getWindowCommandPriority from './getWindowCommandPriority';
+import { State } from '@joplin/lib/reducer';
+import { WindowIdContext } from '../../NewWindowOrIFrame';
 
 const commandsWithDependencies = [
 	require('../commands/showLocalSearch'),
@@ -79,9 +81,12 @@ function editorCommandRuntime(
 
 export default function useWindowCommandHandler(dependencies: HookDependencies) {
 	const { setShowLocalSearch, noteSearchBarRef, editorRef, titleInputRef, onBodyChange, containerRef } = dependencies;
+	const windowId = useContext(WindowIdContext);
 
 	useEffect(() => {
-		const getRuntimePriority = () => getWindowCommandPriority(containerRef);
+		const getRuntimePriority = (_state: State, targetWindowId: string|null) => {
+			return getWindowCommandPriority(containerRef, windowId === targetWindowId);
+		};
 
 		const deregisterCallbacks: RegisteredRuntime[] = [];
 		for (const declaration of editorCommandDeclarations) {
@@ -115,5 +120,5 @@ export default function useWindowCommandHandler(dependencies: HookDependencies) 
 				runtime.deregister();
 			}
 		};
-	}, [editorRef, setShowLocalSearch, noteSearchBarRef, titleInputRef, onBodyChange, containerRef]);
+	}, [editorRef, windowId, setShowLocalSearch, noteSearchBarRef, titleInputRef, onBodyChange, containerRef]);
 }

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleAiChat.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleAiChat.ts
@@ -3,6 +3,7 @@ import { _ } from '@joplin/lib/locale';
 import layoutItemProp from '../../ResizableLayout/utils/layoutItemProp';
 import { AppState } from '../../../app.reducer';
 import { WindowControl } from '../utils/useWindowControl';
+import { defaultWindowId } from '@joplin/lib/reducer';
 
 export const declaration: CommandDeclaration = {
 	name: 'toggleAiChat',
@@ -13,7 +14,8 @@ export const declaration: CommandDeclaration = {
 export const runtime = (control: WindowControl): CommandRuntime => {
 	return {
 		execute: async (context: CommandContext) => {
-			const layout = (context.state as AppState).mainLayout;
+			const state = context.state as AppState;
+			const layout = state.windowId === defaultWindowId ? state.mainLayout : state.windowLayout;
 			if (!layout) return;
 
 			const visible = !layoutItemProp(layout, 'chatPanel', 'visible');
@@ -22,7 +24,8 @@ export const runtime = (control: WindowControl): CommandRuntime => {
 			window.dispatchEvent(new Event('resize'));
 
 			context.dispatch({
-				type: 'MAIN_LAYOUT_SET_ITEM_PROP',
+				type: 'WINDOW_LAYOUT_SET_ITEM_PROP',
+				windowId: context.state.windowId,
 				itemKey: 'chatPanel',
 				propName: 'visible',
 				propValue: visible,

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleAiChat.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleAiChat.ts
@@ -15,7 +15,7 @@ export const runtime = (control: WindowControl): CommandRuntime => {
 	return {
 		execute: async (context: CommandContext) => {
 			const state = context.state as AppState;
-			const layout = state.windowId === defaultWindowId ? state.mainLayout : state.windowLayout;
+			const layout = state.windowId === defaultWindowId ? state.mainLayout : state.secondaryWindowLayout;
 			if (!layout) return;
 
 			const visible = !layoutItemProp(layout, 'chatPanel', 'visible');

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowCommands.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowCommands.ts
@@ -1,11 +1,12 @@
-import { EditorNoteStatuses } from '@joplin/lib/reducer';
-import { RefObject } from 'react';
+import { EditorNoteStatuses, State } from '@joplin/lib/reducer';
+import { RefObject, useContext } from 'react';
 import usePrintToCallback from './usePrintToCallback';
 import useWindowControl, { OnSetDialogState, WindowControl } from './useWindowControl';
 import commands from '../commands';
 import CommandService, { CommandRuntime, ComponentCommandSpec } from '@joplin/lib/services/CommandService';
 import useNowEffect from '@joplin/lib/hooks/useNowEffect';
 import { PluginStates } from '@joplin/lib/services/plugins/reducer';
+import { WindowIdContext } from '../../NewWindowOrIFrame';
 
 interface Props {
 	documentRef: RefObject<Document|null>;
@@ -22,13 +23,15 @@ const useWindowCommands = ({ documentRef, customCss, plugins, editorNoteStatuses
 		plugins: plugins,
 	});
 	const windowControl = useWindowControl(setDialogState, onPrintCallback, documentRef);
+	const windowId = useContext(WindowIdContext);
 
 	// This effect needs to run as soon as possible. Certain components may fail to load if window
 	// commands are not registered on their first render.
 	useNowEffect(() => {
 		const runtimeHandles = commands.map((command: ComponentCommandSpec<WindowControl>) => {
 			const runtime: CommandRuntime = {
-				getPriority: () => {
+				getPriority: (_state: State, targetWindowId: string|null) => {
+					if (targetWindowId === windowId) return 2;
 					return documentRef.current?.hasFocus() ? 1 : 0;
 				},
 				...command.runtime(windowControl),
@@ -45,7 +48,7 @@ const useWindowCommands = ({ documentRef, customCss, plugins, editorNoteStatuses
 				runtimeHandle.deregister();
 			}
 		};
-	}, [windowControl]);
+	}, [windowControl, windowId]);
 };
 
 export default useWindowCommands;

--- a/packages/app-desktop/utils/layout/layoutKeyToLabel.ts
+++ b/packages/app-desktop/utils/layout/layoutKeyToLabel.ts
@@ -1,0 +1,18 @@
+import { _ } from '@joplin/lib/locale';
+import PluginService from '@joplin/lib/services/plugins/PluginService';
+import { PluginStates, utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
+
+const layoutKeyToLabel = (key: string, plugins: PluginStates) => {
+	if (key === 'sideBar') return _('Sidebar');
+	if (key === 'noteList') return _('Note list');
+	if (key === 'editor') return _('Editor');
+	if (key === 'chatPanel') return _('AI Chat');
+
+	const viewInfo = pluginUtils.viewInfoByViewId(plugins, key);
+	if (viewInfo) {
+		return PluginService.instance().safePluginNameById(viewInfo.plugin.id);
+	}
+	return key;
+};
+
+export default layoutKeyToLabel;

--- a/packages/lib/services/CommandService.ts
+++ b/packages/lib/services/CommandService.ts
@@ -28,7 +28,7 @@ export interface CommandRuntime {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- State is lib's State for cli but app-desktop runtimes type this as AppState; narrowing here breaks downstream contravariance
 	mapStateToTitle?(state: any): string;
 	// Used to break ties when commands are registered by different components.
-	getPriority?(state: State): number;
+	getPriority?(state: State, targetWindowId: string): number;
 }
 
 export interface CommandDeclaration {
@@ -105,6 +105,11 @@ export interface SearchResult {
 
 export interface RegisteredRuntime {
 	deregister: ()=> void;
+}
+
+export interface ExecuteInWindowOptions {
+	windowId: string|null; // null -> active window
+	args: unknown[];
 }
 
 export default class CommandService extends BaseService {
@@ -299,14 +304,14 @@ export default class CommandService extends BaseService {
 		};
 	}
 
-	private getRuntime(command: Command) {
+	private getRuntime(command: Command, targetWindowId: string|null = null) {
 		if (!Array.isArray(command.runtime)) return command.runtime;
 		if (!command.runtime.length) return null;
 
 		let bestRuntime = null;
 		let bestRuntimeScore = -1;
 		for (const runtime of command.runtime) {
-			const score = runtime.getPriority?.(this.store_.getState()) ?? 0;
+			const score = runtime.getPriority?.(this.store_.getState(), targetWindowId) ?? 0;
 			if (score >= bestRuntimeScore) {
 				bestRuntime = runtime;
 				bestRuntimeScore = score;
@@ -317,16 +322,20 @@ export default class CommandService extends BaseService {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Args/return shape varies per command, see CommandRuntime.execute
 	public async execute(commandName: string, ...args: any[]): Promise<any | void> {
+		return this.executeInWindow(commandName, { windowId: null, args });
+	}
+
+	public async executeInWindow(commandName: string, options: ExecuteInWindowOptions): Promise<unknown | void> {
 		const command = this.commandByName(commandName);
 		// Some commands such as "showModalMessage" can be executed many
 		// times per seconds, so we should only display this message in
 		// debug mode.
-		if (commandName !== 'showModalMessage') this.logger().debug('CommandService::execute:', commandName, args);
+		if (commandName !== 'showModalMessage') this.logger().debug('CommandService::execute:', commandName, options.args);
 
-		const runtime = this.getRuntime(command);
+		const runtime = this.getRuntime(command, options.windowId);
 		if (!runtime) throw new Error(`Cannot execute a command without a runtime: ${commandName}`);
 
-		return runtime.execute(this.createContext(), ...args);
+		return runtime.execute(this.createContext(), ...options.args);
 	}
 
 	public scheduleExecute(commandName: string, args: unknown) {

--- a/packages/lib/services/CommandService.ts
+++ b/packages/lib/services/CommandService.ts
@@ -28,7 +28,9 @@ export interface CommandRuntime {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- State is lib's State for cli but app-desktop runtimes type this as AppState; narrowing here breaks downstream contravariance
 	mapStateToTitle?(state: any): string;
 	// Used to break ties when commands are registered by different components.
-	getPriority?(state: State, targetWindowId: string): number;
+	// `state` should be the main app state. `targetWindowId` should be the window ID
+	// the command should run in, or `null` for any window.
+	getPriority?(state: State, targetWindowId: string|null): number;
 }
 
 export interface CommandDeclaration {


### PR DESCRIPTION
# Problem

- The new "AI chat" panel only works in the main window.
- Edits are sometimes applied to the wrong window if a secondary window is opened while using the "AI chat" panel.

# Solution

Support the AI chat panel in secondary windows. This is done in a way that should simplify adding other panels to secondary windows in the future (e.g. plugin panels).

# Implementation notes

- `mainLayout` and `secondaryWindowLayout` are currently separate reducer props. This is to limit the scope of the change: Many locations currently refer to `mainLayout` to determine whether a panel is visible (e.g. plugins).
- A new `CommandService.executeInWindow` function was added, to allow the chat panel to apply edits to the correct window (rather than the focused window).

# Testing

1. Set up AI using a local Ollama model ([IBM Granite 4.1 (`granite4.1:8b`)](https://ollama.com/library/granite4.1)).
1. Create two notes. Let the first contain:
    ```
	4 * 2 = ANS_1
	8 + 3 = ANS_2
	2 ** 3 = ANS_3
	```
	Let the second contain:
	```
	1 + 4 = ANS_1
	-3 + 8 = ANS_2
	4 + 4 = ANS_3
	```
2. Open one in one secondary window and one in another.
3. Open the AI chat panels in both windows.
4. Prompt both to "Replace `ANS_#` with the number that makes each equation true. Update the note with the answers."
  - See https://github.com/laurent22/joplin/pull/15801 for screenshots.
5. Move focus back to the main window while processing occurs.
6. Verify that both notes are updated successfully.
7. Open the first note in the main window. Prompt Ollama to "Add a few more equations to the end of the note."
8. Verify that this completes successfully:
   <img width="955" height="590" alt="image" src="https://github.com/user-attachments/assets/42d1a081-72ed-4342-91de-466082d06699" />
9. Select the first block of numbers. Prompt Ollama to "Add one to the selected numbers."
   <img width="956" height="587" alt="image" src="https://github.com/user-attachments/assets/4842dfaf-a21a-4d55-ae37-9cb58517b78a" />



> [!NOTE]
>
> To make failures less likely (they were *very* frequent with the "replace" prompts), I applied the changes from https://github.com/laurent22/joplin/pull/15801 before running the above tests.