### PR TITLE
Desktop: Markdown editor: Fix certain types of note edits can't be undone with ctrl-z

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useSyncEditorValue.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useSyncEditorValue.ts
@@ -26,15 +26,17 @@ const useSyncEditorValue = ({ content, visiblePanes, onMessage, editorRef, noteI
 		// to the current note ID.
 		const updateProps = { noteId: noteId };
 		if (editorRef.current?.updateBody(content, updateProps)) {
-			editorRef.current?.clearHistory();
-
-			// Only reset the cursor location when switching notes. If, for example,
-			// the note is updated from a secondary window, the cursor location shouldn't
-			// reset.
 			const noteChanged = lastNoteIdRef.current !== noteId;
 			if (noteChanged) {
+				// Only reset the cursor location when switching notes. If, for example,
+				// the note is updated from a secondary window, the cursor location shouldn't
+				// reset.
 				const cursorLocation = initialCursorLocationRef.current;
 				editorRef.current?.select(cursorLocation, cursorLocation);
+
+				// Only reset history when switching notes to allow, e.g., undoing changes made from another
+				// window.
+				editorRef.current?.clearHistory();
 			}
 			lastNoteIdRef.current = noteId;
 


### PR DESCRIPTION
# Problem

- Edits made from the "AI chat" panel can't be undone. (Unless the edit applied to a selection).
- Editing a note from a secondary window clears the note's undo history in the main window.
- Plugins that change note content with `editor.setText` also clear the note's undo history.

# Solution

Don't clear the Markdown editor's undo history when reloading the note, unless switching notes.

# Testing

Linux (Ubuntu 26.04):
1. Verify that switching notes still clears the undo history:
  - Open one note.
  - From the sidebar, open another note.
  - Press <kbd>ctrl</kbd>-<kbd>z</kbd>. Verify that the editor's content isn't set to the content of the first note.
2. Open the current note in a new window and make a change. Verify that the change made from the secondary window can be undone from the first window.
3. Open the "AI chat" panel and request a change to the note. Verify that the change can be undone with <kbd>ctrl</kbd>-<kbd>z</kbd>.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
