### PR TITLE
Desktop, Mobile, Cli: Fixes #15811: Add safeguard to prevent revision chains being broken by revision cleaning, where old revisions still exist unexpectedly

### DIFF
--- a/packages/lib/models/Revision.test.ts
+++ b/packages/lib/models/Revision.test.ts
@@ -24,6 +24,7 @@ const createChangeAndRevision = async (note: NoteEntity, parentRevId: string = n
 		item_type: BaseModel.TYPE_NOTE,
 		item_id: note.id,
 		item_updated_time: note.updated_time,
+		encryption_applied: 0,
 	};
 
 	if (!parentRev) {
@@ -373,6 +374,38 @@ describe('models/Revision', () => {
 
 		const remainingRevs = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
 		expect(remainingRevs.length).toBe(3);
+	}));
+
+	test('mergeDiffs should stop traversal when parent_id is not set', (async () => {
+		const note = await Note.save({ title: 'test', body: testBody });
+
+		// Prove a broken revision state causes duplication in the evaluated revision, if a middle revision is rebased, but the parent_id
+		// still matches an existing revision
+		const rev1 = await createChangeAndRevision(note); // testa
+		const rev2 = await createChangeAndRevision(note); // testaa
+		const rev3 = await createChangeAndRevision(note); // testaaa
+
+		const mergedRev2 = await Revision.mergeDiffs(rev2, [rev1, rev2]);
+		expect(mergedRev2.title).toBe('testaa');
+
+		// Do not save - update in memory only for the assertion
+		rev2.title_diff = Revision.createTextPatch('', mergedRev2.title);
+		rev2.body_diff = Revision.createTextPatch('', mergedRev2.body);
+
+		const mergedRev3 = await Revision.mergeDiffs(rev3, [rev1, rev2, rev3]);
+		expect(mergedRev3.title).toBe('testaatestaa');
+
+		// Merge the middle revision using the real revision cleaning logic, but verify the end revision is not broken when evaluated, if the
+		// older revision is still available when merging the revision chain
+		const ttl = (1 * oneDayMs) + halfDayMs; // Delete rev 1
+		await Revision.deleteOldRevisions(ttl);
+		const newRev2 = await Revision.load(rev2.id);
+		const newMergedRev3 = await Revision.mergeDiffs(rev3, [rev1, newRev2, rev3]);
+
+		expect(newMergedRev3.title).toBe('testaaa');
+		expect(newRev2.title_diff).toBe(rev2.title_diff);
+		expect(newRev2.body_diff).toBe(rev2.body_diff);
+		expect(newRev2.parent_id).toBe('');
 	}));
 
 });

--- a/packages/lib/models/Revision.test.ts
+++ b/packages/lib/models/Revision.test.ts
@@ -376,6 +376,7 @@ describe('models/Revision', () => {
 		expect(remainingRevs.length).toBe(3);
 	}));
 
+	// cSpell:disable
 	test('mergeDiffs should stop traversal when parent_id is not set', (async () => {
 		const note = await Note.save({ title: 'test', body: testBody });
 
@@ -407,5 +408,6 @@ describe('models/Revision', () => {
 		expect(newRev2.body_diff).toBe(rev2.body_diff);
 		expect(newRev2.parent_id).toBe('');
 	}));
+	// cSpell:enable
 
 });

--- a/packages/lib/models/Revision.ts
+++ b/packages/lib/models/Revision.ts
@@ -365,8 +365,8 @@ export default class Revision extends BaseItem {
 					const bodyDiff = this.createTextPatch('', merged.body);
 					const metadataDiff = this.createObjectPatch({}, merged.metadata);
 					queries.push({
-						sql: `UPDATE revisions SET title_diff = ?, body_diff = ?, metadata_diff = ?, updated_time = ?, parent_id = '' WHERE id = ?`,
-						params: [titleDiff, bodyDiff, metadataDiff, time.unixMs(), keptRev.id],
+						sql: 'UPDATE revisions SET title_diff = ?, body_diff = ?, metadata_diff = ?, updated_time = ?, parent_id = ? WHERE id = ?',
+						params: [titleDiff, bodyDiff, metadataDiff, time.unixMs(), '', keptRev.id],
 					});
 				}
 			}

--- a/packages/lib/models/Revision.ts
+++ b/packages/lib/models/Revision.ts
@@ -365,7 +365,7 @@ export default class Revision extends BaseItem {
 					const bodyDiff = this.createTextPatch('', merged.body);
 					const metadataDiff = this.createObjectPatch({}, merged.metadata);
 					queries.push({
-						sql: 'UPDATE revisions SET title_diff = ?, body_diff = ?, metadata_diff = ?, updated_time = ? WHERE id = ?',
+						sql: `UPDATE revisions SET title_diff = ?, body_diff = ?, metadata_diff = ?, updated_time = ?, parent_id = '' WHERE id = ?`,
 						params: [titleDiff, bodyDiff, metadataDiff, time.unixMs(), keptRev.id],
 					});
 				}


### PR DESCRIPTION
It is possible for revisions to become increasingly large and garbled, if revisions exist which are in an invalid state. A user posted a sync item for a revision which was almost 100mb in size, which was causing their Android app to crash. When inspecting the contents, this contained the note title and body repeated over 3000 times within a single merged diff for each field.

This can happen when a revision in the middle of a revision chain is merged, but for some reason the parent and its ancestors do not get deleted, or they are somehow restored after deletion. This will cause content duplication when merging the kept revision, because the parent_id of the revision does not get cleared. For full details of my hypothesis about how the revisions can get in this problematic state, see https://github.com/laurent22/joplin/issues/15811.

This PR prevents future possibilities of having faulty revision merges which cause content duplications, by clearing the parent_id of a kept revision when it is merged, to stop further traversal to older revisions during the merge.

This fixes https://github.com/laurent22/joplin/issues/15811

### Testing

I have implemented a unit test which verifies merge behaviour is correct when removing the parent_id on a merged revision, and included a check in the test which demonstrates how the duplicate content scenario can occur for a revision