### PR TITLE
Server: Fixes #15802: Allow SVG resources to be served inline

### DIFF
--- a/packages/server/src/routes/index/items.test.ts
+++ b/packages/server/src/routes/index/items.test.ts
@@ -82,9 +82,9 @@ describe('index_items', () => {
 
 		const resource = await createResource(session.id, {
 			id: '000000000000000000000000000000E1',
-		}, '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>');
+		}, '<script>alert(1)</script>');
 
-		await models().item().saveForUser(user.id, { id: resource.id, mime_type: 'image/svg+xml' });
+		await models().item().saveForUser(user.id, { id: resource.id, mime_type: 'text/html' });
 
 		const dangerous = await execRequestC(session.id, 'GET', `items/${resource.id}/content`);
 		expect(dangerous.response.get('Content-Type')).toBe('application/octet-stream');

--- a/packages/server/src/routes/index/shares.link.test.ts
+++ b/packages/server/src/routes/index/shares.link.test.ts
@@ -250,8 +250,8 @@ describe('shares.link', () => {
 	});
 
 	// A shared SVG resource with an empty title must not be served inline with image/svg+xml,
-	// otherwise its embedded script would run in the Joplin Server origin.
-	test('should not serve attacker-controlled resource content inline', async () => {
+	// SVG is served inline but the strict CSP + sandbox blocks the embedded script.
+	test('should serve SVG inline under a strict CSP that blocks scripts', async () => {
 		const { session } = await createUserAndSession();
 
 		const svgPayload = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>';
@@ -274,8 +274,8 @@ describe('shares.link', () => {
 		});
 
 		const context = await getShareResponse(share.id, { resource_id: '000000000000000000000000000000E1' });
-		expect(context.response.get('Content-Type')).toBe('application/octet-stream');
-		expect(context.response.get('Content-Disposition').startsWith('attachment;')).toBe(true);
+		expect(context.response.get('Content-Type')).toBe('image/svg+xml');
+		expect(context.response.get('Content-Disposition').startsWith('inline;')).toBe(true);
 		expect(context.response.get('X-Content-Type-Options')).toBe('nosniff');
 		const csp = context.response.get('Content-Security-Policy');
 		expect(csp).toContain('default-src \'none\'');

--- a/packages/server/src/routes/index/shares.link.test.ts
+++ b/packages/server/src/routes/index/shares.link.test.ts
@@ -249,7 +249,6 @@ describe('shares.link', () => {
 		}
 	});
 
-	// A shared SVG resource with an empty title must not be served inline with image/svg+xml,
 	// SVG is served inline but the strict CSP + sandbox blocks the embedded script.
 	test('should serve SVG inline under a strict CSP that blocks scripts', async () => {
 		const { session } = await createUserAndSession();

--- a/packages/server/src/utils/safeUserContentResponse.ts
+++ b/packages/server/src/utils/safeUserContentResponse.ts
@@ -1,8 +1,10 @@
 import { friendlySafeFilename } from '@joplin/lib/path-utils';
 
-// Anything not in this allow-list (notably image/svg+xml and text/html) is
-// served as application/octet-stream with attachment disposition, to prevent
-// script execution from user-uploaded resources.
+// Anything not in this allow-list (notably text/html) is served as
+// application/octet-stream with attachment disposition. SVG is inline because
+// the strict CSP + sandbox below blocks script execution inside the document.
+// This assumes user content is served from a separate origin (configured via
+// USER_CONTENT_BASE_URL).
 const safeInlineMimeTypes = new Set<string>([
 	'image/png',
 	'image/jpeg',
@@ -15,6 +17,7 @@ const safeInlineMimeTypes = new Set<string>([
 	'image/avif',
 	'image/heic',
 	'image/heif',
+	'image/svg+xml',
 	'audio/mpeg',
 	'audio/mp4',
 	'audio/ogg',


### PR DESCRIPTION
Relates to https://github.com/laurent22/joplin/pull/15787

SVG resources were forced to attachment download as part of the previous XSS hardening, which broke inline SVG previews in published notes.

Since the strict `default-src 'none'; … sandbox` CSP set by `safeUserContentResponse` already blocks script execution inside the SVG document, and user content is expected to be served from its own origin (configured via `USER_CONTENT_BASE_URL`), it is safe to serve SVG inline. Adds `image/svg+xml` to the inline allow-list and updates the regression tests accordingly.