### PR TITLE
Mobile: Fixes #15663: Prevent data loss when toggling the checkbox on a todo immediately after changing note data

### DIFF
--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -171,7 +171,7 @@ shared.saveNoteButton_press = async function(comp: BaseNoteScreenComponent, stat
 	note = { ...note, ...savedNote };
 
 	if (stateNote.id === note.id) {
-		// But we preserve the current title and body because
+		// But we preserve the current title, body and todo_completed because
 		// the user might have changed them between the time
 		// saveNoteButton_press was called and the note was
 		// saved (it's done asynchronously).
@@ -180,6 +180,7 @@ shared.saveNoteButton_press = async function(comp: BaseNoteScreenComponent, stat
 		// it from the state because it will be empty there.
 		if (!hasAutoTitle) note.title = stateNote.title;
 		note.body = stateNote.body;
+		note.todo_completed = stateNote.todo_completed;
 	}
 
 	const newState: Partial<BaseState> = {
@@ -235,7 +236,7 @@ shared.saveOneProperty = async function(comp: BaseNoteScreenComponent, name: str
 	(note as Record<string, unknown>)[name] = saved[name];
 
 	comp.setState({
-		lastSavedNote: { ...note },
+		lastSavedNote: { ...note, ...saved },
 		note: note,
 	});
 };


### PR DESCRIPTION
Due to a race condition, it is possible for the checkbox state to revert and lose the last change to note title / body data when toggling the completed state of a todo on mobile too quickly after finishing typing. This PR addresses these issues by ensuring the latest todo_completed field is restored from the state upon completing a note save (alongside the title and body which is already restored from there) and in saveOneProperty ensuring the lastSavedNote property is updated to include the latest changes from the saved note upon finishing save (to match the behaviour for saveNoteButton_press, where I previously made the same change to address another race condition in PR https://github.com/laurent22/joplin/pull/11334)

This fixes https://github.com/laurent22/joplin/issues/15663

### Testing

Tested on both Android emulator and web, and the results are consistent. Also verified desktop behaves correctly. See videos testing on web:

**Before:**

https://github.com/user-attachments/assets/0885f0a6-9e8e-4b03-9c36-f08605f2d9c1

**After:**

https://github.com/user-attachments/assets/640aac35-093c-47a6-9a08-a0376bd95c36

