### PR TITLE
Mobile, Desktop: Fixes #15663: Stop stale state snapshot from overwriting newer edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1374,6 +1374,7 @@ packages/lib/components/shared/config/plugins/useOnInstallHandler.js
 packages/lib/components/shared/config/shouldShowMissingPasswordWarning.test.js
 packages/lib/components/shared/config/shouldShowMissingPasswordWarning.js
 packages/lib/components/shared/dropbox-login-shared.js
+packages/lib/components/shared/note-screen-shared.test.js
 packages/lib/components/shared/note-screen-shared.js
 packages/lib/components/shared/reduxSharedMiddleware.js
 packages/lib/components/shared/side-menu-shared.test.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1400,6 +1400,7 @@ packages/lib/components/shared/config/plugins/useOnInstallHandler.js
 packages/lib/components/shared/config/shouldShowMissingPasswordWarning.test.js
 packages/lib/components/shared/config/shouldShowMissingPasswordWarning.js
 packages/lib/components/shared/dropbox-login-shared.js
+packages/lib/components/shared/note-screen-shared.test.js
 packages/lib/components/shared/note-screen-shared.js
 packages/lib/components/shared/reduxSharedMiddleware.js
 packages/lib/components/shared/side-menu-shared.test.js

--- a/packages/lib/components/shared/note-screen-shared.test.ts
+++ b/packages/lib/components/shared/note-screen-shared.test.ts
@@ -1,0 +1,85 @@
+import Note from '../../models/Note';
+import Folder from '../../models/Folder';
+import { setupDatabaseAndSynchronizer, switchClient, createNTestFolders } from '../../testing/test-utils';
+import shared, { BaseNoteScreenComponent, BaseState } from './note-screen-shared';
+import { NoteEntity } from '../../services/database/types';
+
+// Builds a minimal fake note screen component whose setState() behaves like
+// React's shallow-merge setState, so tests can inspect comp.state afterwards.
+function makeComp(initialState: BaseState): BaseNoteScreenComponent {
+	const comp: BaseNoteScreenComponent = {
+		props: { provisionalNoteIds: [], noteId: initialState.note.id, folders: [], sharedData: undefined, noteVisiblePanes: [] },
+		state: initialState,
+		setState: (partial: Partial<BaseState>) => {
+			comp.state = { ...comp.state, ...partial };
+		},
+		scheduleSave: jest.fn(),
+		scheduleFocusUpdate: jest.fn(),
+		attachFile: jest.fn(),
+	};
+	return comp;
+}
+
+function baseState(note: NoteEntity, folder: Folder): BaseState {
+	return {
+		note,
+		lastSavedNote: { ...note },
+		newAndNoTitleChangeNoteId: false,
+		mode: 'edit',
+		folder: folder as unknown as BaseState['folder'],
+		isLoading: false,
+		fromShare: false,
+		noteResources: {},
+		readOnly: false,
+		noteLastLoadTime: Date.now(),
+	};
+}
+
+describe('components/shared/note-screen-shared', () => {
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+	});
+
+	// b0 and b1 are coupled: noteComponent_change must hand scheduleSave a
+	// *complete* state snapshot (b1), and saveNoteButton_press must let the
+	// live comp.state win over that (possibly stale) snapshot when it merges
+	// (b0). Fixing only one still lets a change get dropped, so both must be
+	// exercised together, matching how a real scheduled save fires against a
+	// snapshot captured earlier: user types -> a save is scheduled with a
+	// snapshot -> user immediately toggles a checkbox -> the scheduled save
+	// finally runs against the now-stale snapshot.
+	it('does not drop a checkbox toggle made after typing, when the earlier scheduled save finally runs', async () => {
+		const [folder] = await createNTestFolders(1);
+		const savedNote = await Note.save({ title: 'note', parent_id: folder.id, body: 'hello', is_todo: 1, todo_completed: 0 });
+
+		const comp = makeComp(baseState(savedNote, folder));
+
+		// User types more text: this schedules a save and captures a snapshot
+		// of comp.state at this point in time.
+		shared.noteComponent_change(comp, 'body', 'hello world');
+		expect(comp.scheduleSave).toHaveBeenCalledTimes(1);
+		const scheduledSnapshot = (comp.scheduleSave as jest.Mock).mock.calls[0][0] as BaseState;
+
+		// The snapshot handed to scheduleSave must be a complete BaseState,
+		// not just the changed 'note' field (b1).
+		expect(scheduledSnapshot.lastSavedNote).toEqual(comp.state.lastSavedNote);
+		expect(scheduledSnapshot.mode).toBe(comp.state.mode);
+
+		// User immediately checks the to-do box: another change goes through
+		// the same code path, updating comp.state and scheduling its own
+		// (still-pending) save.
+		shared.noteComponent_change(comp, 'todo_completed', 123456);
+		expect(comp.state.note.body).toBe('hello world');
+		expect(comp.state.note.todo_completed).toBe(123456);
+
+		// The earlier scheduled save now runs, using the snapshot captured
+		// before the checkbox toggle. It must not clobber the newer
+		// comp.state with the stale snapshot (b0).
+		await shared.saveNoteButton_press(comp, scheduledSnapshot, null, null);
+
+		const reloaded = await Note.load(savedNote.id);
+		expect(reloaded.body).toBe('hello world');
+		expect(reloaded.todo_completed).toBe(123456);
+	});
+});

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -127,7 +127,10 @@ shared.handleNoteDeletedWhileEditing_ = async (note: NoteEntity) => {
 
 shared.saveNoteButton_press = async function(comp: BaseNoteScreenComponent, state: BaseState, folderId: string = null, options: SaveNoteOptions = null) {
 	options = { autoTitle: true, ...options };
-	state = { ...comp.state, ...state };
+	// comp.state always reflects every change made up to and including the
+	// change that triggered this save (setState is called synchronously
+	// before scheduleSave), so it must win over a possibly-stale snapshot.
+	state = { ...state, ...comp.state };
 
 	const releaseMutex = await saveNoteMutex_.acquire();
 
@@ -248,7 +251,9 @@ shared.noteComponent_change = function(comp: BaseNoteScreenComponent, propName: 
 	newState.note = note;
 
 	comp.setState(newState);
-	comp.scheduleSave(newState as BaseState);
+	// scheduleSave requires a complete state snapshot, so merge the change
+	// into the full current state rather than passing the partial newState.
+	comp.scheduleSave({ ...comp.state, ...newState });
 };
 
 let resourceCache_: AttachedResources = {};


### PR DESCRIPTION
## Root cause

`saveNoteButton_press()` in `packages/lib/components/shared/note-screen-shared.ts` merged state as:

```ts
state = { ...comp.state, ...state };
```

This lets the `state` argument — a snapshot captured at some earlier point — win over `comp.state`, even though `comp.state` always reflects every change applied up to and including the change that triggered the save (`setState` runs synchronously before `scheduleSave`). When a newer `comp.state` update raced against an older `state` snapshot already queued for save, the older snapshot silently clobbered the newer fields.

**Concrete repro:** in the note editor, type "hello", then type " world", then toggle the read-only checkbox. The first scheduled save silently drops " world" and the checkbox toggle — data loss with no error, no warning.

A related type-contract violation was also present in `noteComponent_change()`:

```ts
comp.scheduleSave(newState as BaseState);
```

`newState` is only a `Partial<BaseState>`, forcibly cast to the full `BaseState` type via `as`. This bypasses the type system to paper over a shape mismatch, and any code inside `scheduleSave` that trusted a "complete" `BaseState` could read `undefined` fields that TypeScript claimed were present.

## Fix

- `saveNoteButton_press()`: flipped the merge order to `{ ...state, ...comp.state }`, so `comp.state` (the freshest, most complete state) always wins over the possibly-stale `state` snapshot.
- `noteComponent_change()`: replaced the `as BaseState` cast with `comp.scheduleSave({ ...comp.state, ...newState })`, merging the partial change into the actual current state so `scheduleSave` receives a real, complete `BaseState` instead of a partial object mislabeled as one.

## Before / after

- **Before:** rapid sequential edits (or a toggle immediately after typing) could have the last-in-flight save overwrite the current in-memory state with an older snapshot, dropping user edits with no indication anything went wrong.
- **After:** `comp.state` — which is always at least as fresh as any `state` argument passed into `saveNoteButton_press` — takes priority in the merge, so no edit gets silently dropped.

## Tests

Added `packages/lib/components/shared/note-screen-shared.test.ts`, which exercises the merge-order regression directly (asserting that a save triggered with a stale `state` argument does not clobber newer fields already present on `comp.state`).

Note: `.gitignore` / `.ignore.eslint` were regenerated via `yarn updateIgnored` (repo convention, required by the pre-commit hook) to register the new test file's compiled output — no behavioral change.

## Status

Found via an automated graph-driven review pass (code-review-graph + adversarial verification) targeting `note-screen-shared.ts`. Final gate is clean: TypeScript typecheck passes across all packages, and `note-screen-shared.test.js` (compiled from the new `.test.ts`) passes.

Opening as a draft for review — happy to adjust naming/structure to match maintainer preference.