### PR TITLE
Desktop: Resolves #15824: Use semantic search when there are no full-text or partial-text matches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1811,6 +1811,7 @@ packages/lib/services/rest/utils/readonlyProperties.js
 packages/lib/services/rest/utils/requestFields.js
 packages/lib/services/rest/utils/requestPaginationOptions.js
 packages/lib/services/search/SearchEngine.resources.test.js
+packages/lib/services/search/SearchEngine.semantic.test.js
 packages/lib/services/search/SearchEngine.test.js
 packages/lib/services/search/SearchEngine.js
 packages/lib/services/search/SearchEngineUtils.test.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1837,6 +1837,7 @@ packages/lib/services/rest/utils/readonlyProperties.js
 packages/lib/services/rest/utils/requestFields.js
 packages/lib/services/rest/utils/requestPaginationOptions.js
 packages/lib/services/search/SearchEngine.resources.test.js
+packages/lib/services/search/SearchEngine.semantic.test.js
 packages/lib/services/search/SearchEngine.test.js
 packages/lib/services/search/SearchEngine.js
 packages/lib/services/search/SearchEngineUtils.test.js

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -2326,6 +2326,19 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			isGlobal: true,
 		},
 
+		'featureFlag.enableSemanticSearch': {
+			value: true,
+			type: SettingItemType.Bool,
+			public: true,
+			storage: SettingStorage.File,
+			appTypes: [AppType.Desktop],
+			label: () => 'Use semantic search when the default search finds no results',
+			description: () => 'Allows using semantic search from the search panel',
+			section: 'general',
+			isGlobal: true,
+			advanced: true,
+		},
+
 		// As of December 2025, the voice typing feature doesn't work well on low-resource devices.
 		// There have been requests to allow disabling the voice typing feature at build time. This
 		// feature flag allows doing so, by changing the default `value` from `true` to `false`:

--- a/packages/lib/services/search/SearchEngine.semantic.test.ts
+++ b/packages/lib/services/search/SearchEngine.semantic.test.ts
@@ -1,0 +1,49 @@
+import Note from '../../models/Note';
+import { db, setupDatabaseAndSynchronizer, switchClient } from '../../testing/test-utils';
+import AiService from '../ai/AiService';
+import EmbeddingIndexer from '../ai/EmbeddingIndexer';
+import TestEmbeddingProvider from '../ai/testing/TestEmbeddingProvider';
+import SearchEngine, { SearchType } from './SearchEngine';
+
+describe('SearchEngine.semantic', () => {
+	let engine: SearchEngine = null;
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+
+		engine = new SearchEngine();
+		engine.setDb(db());
+
+		const provider = new TestEmbeddingProvider();
+		AiService.instance().setEmbeddingProvider(provider);
+	});
+
+	afterEach(async () => {
+		AiService.instance().setEmbeddingProvider(null);
+		await EmbeddingIndexer.instance().stopRunInBackground();
+	});
+
+	it('should fall back to semantic search when there are no FTS results', async () => {
+		await Note.save({ title: 'test', body: 'letter letter letter letter' });
+
+		await EmbeddingIndexer.instance().maintenance();
+		await engine.syncTables();
+
+		const ftsRows = await engine.search('letters', { searchType: SearchType.Fts });
+		expect(ftsRows).toHaveLength(0);
+
+		const rows = await engine.search('letters');
+		expect(rows).toHaveLength(1);
+	});
+
+	it('should not use semantic search when the user has specified a field to search in', async () => {
+		await Note.save({ title: 'test', body: 'letter letter letter body:letter' });
+
+		await EmbeddingIndexer.instance().maintenance();
+		await engine.syncTables();
+
+		const rows = await engine.search('body:letters');
+		expect(rows).toHaveLength(0);
+	});
+});

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -681,20 +681,28 @@ export default class SearchEngine {
 
 	public async semanticSearch(query: string, parsedQuery: ParsedQuery) {
 		const rows: ProcessResultsRow[] = [];
-		const results = await SearchService.instance().search({ query: { text: query } });
+		const results = await SearchService.instance().search({
+			query: { text: query }, relevance: 'strict',
+		});
 
-		const seenNotes = new Set<string>();
+		const seenNotes = new Map<string, ProcessResultsRow>();
 		for (const result of results) {
-			if (seenNotes.has(result.noteId)) {
+			let row = seenNotes.get(result.noteId);
+			if (row) {
+				// Move the row's weight slightly closer to 1. Notes with more matches
+				// should be rated higher:
+				row.weight = row.weight * 0.9 + 0.1;
 				continue;
 			}
-			seenNotes.add(result.noteId);
 
 			const item = await Note.load(
 				result.noteId,
 				{ fields: ['id', 'parent_id', 'title', 'user_updated_time', 'user_created_time', 'is_todo', 'todo_completed'] },
 			);
-			rows.push({
+			// Handle the case where the item was deleted after search started
+			if (!item) continue;
+
+			row = {
 				id: item.id,
 				item_id: item.id,
 				parent_id: item.parent_id,
@@ -707,9 +715,13 @@ export default class SearchEngine {
 				is_todo: item.is_todo,
 				todo_completed: item.todo_completed,
 
+				// For now, estimate whether the match is in the title or the body.
+				// For performance, we avoid loading 'body'.
 				fields: item.title.includes(result.chunkText) ? ['title'] : ['body'],
 				offsets: '',
-			});
+			};
+			seenNotes.set(result.noteId, row);
+			rows.push(row);
 		}
 		this.processResults_(rows, parsedQuery, false);
 
@@ -908,9 +920,12 @@ export default class SearchEngine {
 			rows = await this.searchFromItemIds(searchString);
 		}
 
-		if (rows.length < 4
+		if (rows.length === 0
 			&& this.canSemanticSearch_(parsedQuery)
-			&& searchType !== SearchType.Semantic && options.searchType === SearchType.Auto
+			// Don't use semantic search if another search type was explicitly requested
+			&& options.searchType === SearchType.Auto
+			// Avoid doing semantic search twice
+			&& searchType !== SearchType.Semantic
 		) {
 			rows = rows.concat(await this.semanticSearch(searchString, parsedQuery));
 		}

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -19,6 +19,7 @@ const { sprintf } = require('sprintf-js');
 import { pregQuote, scriptType, removeDiacritics } from '../../string-utils';
 import PerformanceLogger from '../../PerformanceLogger';
 import SearchService from '../ai/SearchService';
+import AiService from '../ai/AiService';
 
 const perfLogger = PerformanceLogger.create();
 
@@ -681,9 +682,7 @@ export default class SearchEngine {
 
 	public async semanticSearch(query: string, parsedQuery: ParsedQuery) {
 		const rows: ProcessResultsRow[] = [];
-		const results = await SearchService.instance().search({
-			query: { text: query }, relevance: 'strict',
-		});
+		const results = await SearchService.instance().search({ query: { text: query }, relevance: 'strict' });
 
 		const seenNotes = new Map<string, ProcessResultsRow>();
 		for (const result of results) {
@@ -760,8 +759,13 @@ export default class SearchEngine {
 		return SearchEngine.SEARCH_TYPE_FTS;
 	}
 
-	private canSemanticSearch_(_parsedQuery: ParsedQuery) {
-		return shim.isElectron() && Setting.value('ai.embedding.enabled');
+	private canSemanticSearch_(parsedQuery: ParsedQuery) {
+		// Disable semantic search if the user has explicitly specified a field to search in
+		if (parsedQuery.allTerms.some(term => term.name !== 'text')) {
+			return false;
+		}
+
+		return Setting.value('ai.embedding.enabled') && !!AiService.instance().getActiveEmbeddingProvider();
 	}
 
 	private async searchFromItemIds(searchString: string): Promise<ProcessResultsRow[]> {

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -18,14 +18,16 @@ import { htmlentitiesDecode } from '@joplin/utils/html';
 const { sprintf } = require('sprintf-js');
 import { pregQuote, scriptType, removeDiacritics } from '../../string-utils';
 import PerformanceLogger from '../../PerformanceLogger';
+import SearchService from '../ai/SearchService';
 
 const perfLogger = PerformanceLogger.create();
 
-enum SearchType {
+export enum SearchType {
 	Auto = 'auto',
 	Basic = 'basic',
 	Nonlatin = 'nonlatin',
 	Fts = 'fts',
+	Semantic = 'semantic',
 }
 
 interface SearchOptions {
@@ -471,8 +473,8 @@ export default class SearchEngine {
 			};
 
 			row.fields = Object.keys(matchedFields).filter(key => matchedFields[key]);
-			row.weight = 0;
-			row.fuzziness = 0;
+			row.weight ??= 0;
+			row.fuzziness ??= 0;
 		}
 	}
 
@@ -678,8 +680,8 @@ export default class SearchEngine {
 	}
 
 	private determineSearchType_(query: string, preferredSearchType: SearchType) {
-		if (preferredSearchType === SearchEngine.SEARCH_TYPE_BASIC) return SearchEngine.SEARCH_TYPE_BASIC;
-		if (preferredSearchType === SearchEngine.SEARCH_TYPE_NONLATIN_SCRIPT) return SearchEngine.SEARCH_TYPE_NONLATIN_SCRIPT;
+		if (preferredSearchType === SearchType.Basic) return SearchType.Basic;
+		if (preferredSearchType === SearchType.Nonlatin) return SearchType.Nonlatin;
 
 		// If preferredSearchType is "fts" we auto-detect anyway
 		// because it's not always supported.
@@ -693,6 +695,10 @@ export default class SearchEngine {
 
 		const textQuery = allTerms.filter(x => x.name === 'text' || x.name === 'title' || x.name === 'body').map(x => x.value).join(' ');
 		const st = scriptType(textQuery);
+
+		if (preferredSearchType === SearchType.Semantic && shim.isElectron() && Setting.value('ai.embedding.enabled')) {
+			return SearchType.Semantic;
+		}
 
 		if (!Setting.value('db.ftsEnabled')) {
 			return SearchEngine.SEARCH_TYPE_BASIC;
@@ -763,6 +769,37 @@ export default class SearchEngine {
 		if (searchType === SearchEngine.SEARCH_TYPE_BASIC) {
 			searchString = this.normalizeText_(searchString);
 			rows = (await this.basicSearch(searchString)) as unknown as ProcessResultsRow[];
+			this.processResults_(rows, parsedQuery, true);
+		} else if (searchType === SearchType.Semantic) {
+			const results = await SearchService.instance().search({ query: { text: searchString } });
+
+			const seenNotes = new Map<string, number>();
+			for (const result of results) {
+				if (seenNotes.has(result.noteId)) {
+					rows[seenNotes.get(result.noteId)].offsets += ` ${result.chunkIndex}`;
+					continue;
+				}
+				seenNotes.set(result.noteId, rows.length);
+
+				const item = await Note.load(
+					result.noteId,
+					{ fields: ['id', 'parent_id', 'title', 'user_updated_time', 'user_created_time', 'is_todo', 'todo_completed'] },
+				);
+				rows.push({
+					id: item.id,
+					item_id: item.id,
+					parent_id: item.parent_id,
+					title: item.title,
+					user_updated_time: item.user_updated_time,
+					user_created_time: item.user_created_time,
+					offsets: String(result.chunkIndex),
+					matchinfo: null,
+					item_type: ModelType.Note,
+					weight: result.score,
+					is_todo: item.is_todo,
+					todo_completed: item.todo_completed,
+				});
+			}
 			this.processResults_(rows, parsedQuery, true);
 		} else {
 			// SEARCH_TYPE_FTS

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -687,12 +687,7 @@ export default class SearchEngine {
 		const seenNotes = new Map<string, ProcessResultsRow>();
 		for (const result of results) {
 			let row = seenNotes.get(result.noteId);
-			if (row) {
-				// Move the row's weight slightly closer to 1. Notes with more matches
-				// should be rated higher:
-				row.weight = row.weight * 0.9 + 0.1;
-				continue;
-			}
+			if (row) continue;
 
 			const item = await Note.load(
 				result.noteId,

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -765,7 +765,9 @@ export default class SearchEngine {
 			return false;
 		}
 
-		return Setting.value('ai.embedding.enabled') && !!AiService.instance().getActiveEmbeddingProvider();
+		return Setting.value('featureFlag.enableSemanticSearch')
+			&& Setting.value('ai.embedding.enabled')
+			&& !!AiService.instance().getActiveEmbeddingProvider();
 	}
 
 	private async searchFromItemIds(searchString: string): Promise<ProcessResultsRow[]> {

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -459,7 +459,7 @@ export default class SearchEngine {
 		}
 	}
 
-	private processBasicSearchResults_(rows: ProcessResultsRow[], parsedQuery: ParsedQuery) {
+	private processNonFtsSearchResults_(rows: ProcessResultsRow[], parsedQuery: ParsedQuery) {
 		const valueRegexs = parsedQuery.keys.includes('_') ? parsedQuery.terms['_'].map(term => (typeof term === 'string' ? term : term.valueRegex || term.value)) : [];
 		const isTitleSearch = parsedQuery.keys.includes('title');
 		const isOnlyTitle = parsedQuery.keys.length === 1 && isTitleSearch;
@@ -468,8 +468,8 @@ export default class SearchEngine {
 			const row = rows[i];
 			const testTitle = (regex: string) => new RegExp(regex, 'ig').test(row.title);
 			const matchedFields: Record<string, boolean> = {
-				title: isTitleSearch || valueRegexs.some(testTitle),
-				body: !isOnlyTitle,
+				title: isTitleSearch || valueRegexs.some(testTitle) || row.fields?.includes('title'),
+				body: !isOnlyTitle || row.fields?.includes('body'),
 			};
 
 			row.fields = Object.keys(matchedFields).filter(key => matchedFields[key]);
@@ -478,16 +478,16 @@ export default class SearchEngine {
 		}
 	}
 
-	private processResults_(rows: ProcessResultsRow[], parsedQuery: ParsedQuery, isBasicSearchResults = false) {
-		if (isBasicSearchResults) {
-			this.processBasicSearchResults_(rows, parsedQuery);
-		} else {
+	private processResults_(rows: ProcessResultsRow[], parsedQuery: ParsedQuery, isFtsSearchResults = false) {
+		if (isFtsSearchResults) {
 			this.calculateWeightBM25_(rows);
 			for (let i = 0; i < rows.length; i++) {
 				const row = rows[i];
 				const offsets = row.offsets.split(' ').map(o => Number(o));
 				row.fields = this.fieldNamesFromOffsets_(offsets);
 			}
+		} else {
+			this.processNonFtsSearchResults_(rows, parsedQuery);
 		}
 
 		rows.sort((a, b) => {
@@ -679,9 +679,49 @@ export default class SearchEngine {
 		return Note.previews(null, searchOptions);
 	}
 
-	private determineSearchType_(query: string, preferredSearchType: SearchType) {
+	public async semanticSearch(query: string, parsedQuery: ParsedQuery) {
+		const rows: ProcessResultsRow[] = [];
+		const results = await SearchService.instance().search({ query: { text: query } });
+
+		const seenNotes = new Set<string>();
+		for (const result of results) {
+			if (seenNotes.has(result.noteId)) {
+				continue;
+			}
+			seenNotes.add(result.noteId);
+
+			const item = await Note.load(
+				result.noteId,
+				{ fields: ['id', 'parent_id', 'title', 'user_updated_time', 'user_created_time', 'is_todo', 'todo_completed'] },
+			);
+			rows.push({
+				id: item.id,
+				item_id: item.id,
+				parent_id: item.parent_id,
+				title: item.title,
+				user_updated_time: item.user_updated_time,
+				user_created_time: item.user_created_time,
+				matchinfo: null,
+				item_type: ModelType.Note,
+				weight: result.score,
+				is_todo: item.is_todo,
+				todo_completed: item.todo_completed,
+
+				fields: item.title.includes(result.chunkText) ? ['title'] : ['body'],
+				offsets: '',
+			});
+		}
+		this.processResults_(rows, parsedQuery, false);
+
+		return rows;
+	}
+
+	private determineSearchType_(query: string, parsedQuery: ParsedQuery, preferredSearchType: SearchType) {
 		if (preferredSearchType === SearchType.Basic) return SearchType.Basic;
 		if (preferredSearchType === SearchType.Nonlatin) return SearchType.Nonlatin;
+		if (preferredSearchType === SearchType.Semantic && this.canSemanticSearch_(parsedQuery)) {
+			return SearchType.Semantic;
+		}
 
 		// If preferredSearchType is "fts" we auto-detect anyway
 		// because it's not always supported.
@@ -696,10 +736,6 @@ export default class SearchEngine {
 		const textQuery = allTerms.filter(x => x.name === 'text' || x.name === 'title' || x.name === 'body').map(x => x.value).join(' ');
 		const st = scriptType(textQuery);
 
-		if (preferredSearchType === SearchType.Semantic && shim.isElectron() && Setting.value('ai.embedding.enabled')) {
-			return SearchType.Semantic;
-		}
-
 		if (!Setting.value('db.ftsEnabled')) {
 			return SearchEngine.SEARCH_TYPE_BASIC;
 		}
@@ -710,6 +746,10 @@ export default class SearchEngine {
 		}
 
 		return SearchEngine.SEARCH_TYPE_FTS;
+	}
+
+	private canSemanticSearch_(_parsedQuery: ParsedQuery) {
+		return shim.isElectron() && Setting.value('ai.embedding.enabled');
 	}
 
 	private async searchFromItemIds(searchString: string): Promise<ProcessResultsRow[]> {
@@ -761,46 +801,17 @@ export default class SearchEngine {
 			...options,
 		};
 
-		const searchType = this.determineSearchType_(searchString, options.searchType);
 		const parsedQuery = await this.parseQuery(searchString);
+		const searchType = this.determineSearchType_(searchString, parsedQuery, options.searchType);
 
 		let rows: ProcessResultsRow[] = [];
 
 		if (searchType === SearchEngine.SEARCH_TYPE_BASIC) {
 			searchString = this.normalizeText_(searchString);
 			rows = (await this.basicSearch(searchString)) as unknown as ProcessResultsRow[];
-			this.processResults_(rows, parsedQuery, true);
+			this.processResults_(rows, parsedQuery, false);
 		} else if (searchType === SearchType.Semantic) {
-			const results = await SearchService.instance().search({ query: { text: searchString } });
-
-			const seenNotes = new Map<string, number>();
-			for (const result of results) {
-				if (seenNotes.has(result.noteId)) {
-					rows[seenNotes.get(result.noteId)].offsets += ` ${result.chunkIndex}`;
-					continue;
-				}
-				seenNotes.set(result.noteId, rows.length);
-
-				const item = await Note.load(
-					result.noteId,
-					{ fields: ['id', 'parent_id', 'title', 'user_updated_time', 'user_created_time', 'is_todo', 'todo_completed'] },
-				);
-				rows.push({
-					id: item.id,
-					item_id: item.id,
-					parent_id: item.parent_id,
-					title: item.title,
-					user_updated_time: item.user_updated_time,
-					user_created_time: item.user_created_time,
-					offsets: String(result.chunkIndex),
-					matchinfo: null,
-					item_type: ModelType.Note,
-					weight: result.score,
-					is_todo: item.is_todo,
-					todo_completed: item.todo_completed,
-				});
-			}
-			this.processResults_(rows, parsedQuery, true);
+			rows = await this.semanticSearch(searchString, parsedQuery);
 		} else {
 			// SEARCH_TYPE_FTS
 			// FTS will ignore all special characters, like "-" in the index. So if
@@ -886,7 +897,7 @@ export default class SearchEngine {
 					rows = rows.concat(itemRows);
 				}
 
-				this.processResults_(rows as ProcessResultsRow[], parsedQuery, !useFts);
+				this.processResults_(rows as ProcessResultsRow[], parsedQuery, useFts);
 			} catch (error) {
 				this.logger().warn(`Cannot execute MATCH query: ${searchString}: ${error.message}`);
 				rows = [];
@@ -895,6 +906,13 @@ export default class SearchEngine {
 
 		if (!rows.length) {
 			rows = await this.searchFromItemIds(searchString);
+		}
+
+		if (rows.length < 4
+			&& this.canSemanticSearch_(parsedQuery)
+			&& searchType !== SearchType.Semantic && options.searchType === SearchType.Auto
+		) {
+			rows = rows.concat(await this.semanticSearch(searchString, parsedQuery));
 		}
 
 		return rows;

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -682,7 +682,7 @@ export default class SearchEngine {
 
 	public async semanticSearch(query: string, parsedQuery: ParsedQuery) {
 		const rows: ProcessResultsRow[] = [];
-		const results = await SearchService.instance().search({ query: { text: query }, relevance: 'strict' });
+		const results = await SearchService.instance().search({ query: { text: query } });
 
 		const seenNotes = new Map<string, ProcessResultsRow>();
 		for (const result of results) {

--- a/packages/lib/services/search/SearchEngineUtils.ts
+++ b/packages/lib/services/search/SearchEngineUtils.ts
@@ -18,7 +18,7 @@ export default class SearchEngineUtils {
 			searchEngine = SearchEngine.instance();
 		}
 
-		let searchType = SearchType.Fts;
+		let searchType = SearchType.Auto;
 		if (query.length) {
 			if (query[0] === '/') {
 				searchType = SearchType.Basic;

--- a/packages/lib/services/search/SearchEngineUtils.ts
+++ b/packages/lib/services/search/SearchEngineUtils.ts
@@ -23,11 +23,6 @@ export default class SearchEngineUtils {
 			if (query[0] === '/') {
 				searchType = SearchType.Basic;
 			}
-
-			if (query[0] === '%') {
-				searchType = SearchType.Semantic;
-				query = query.substring(1);
-			}
 		}
 
 		const results = await searchEngine.search(query, {

--- a/packages/lib/services/search/SearchEngineUtils.ts
+++ b/packages/lib/services/search/SearchEngineUtils.ts
@@ -1,4 +1,4 @@
-import SearchEngine from './SearchEngine';
+import SearchEngine, { SearchType } from './SearchEngine';
 import Note, { PreviewsOptions } from '../../models/Note';
 import Setting from '../../models/Setting';
 
@@ -18,9 +18,16 @@ export default class SearchEngineUtils {
 			searchEngine = SearchEngine.instance();
 		}
 
-		let searchType = SearchEngine.SEARCH_TYPE_FTS;
-		if (query.length && query[0] === '/') {
-			searchType = SearchEngine.SEARCH_TYPE_BASIC;
+		let searchType = SearchType.Fts;
+		if (query.length) {
+			if (query[0] === '/') {
+				searchType = SearchType.Basic;
+			}
+
+			if (query[0] === '%') {
+				searchType = SearchType.Semantic;
+				query = query.substring(1);
+			}
 		}
 
 		const results = await searchEngine.search(query, {

--- a/packages/lib/services/search/SearchEngineUtils.ts
+++ b/packages/lib/services/search/SearchEngineUtils.ts
@@ -19,10 +19,8 @@ export default class SearchEngineUtils {
 		}
 
 		let searchType = SearchType.Auto;
-		if (query.length) {
-			if (query[0] === '/') {
-				searchType = SearchType.Basic;
-			}
+		if (query.length && query[0] === '/') {
+			searchType = SearchType.Basic;
 		}
 
 		const results = await searchEngine.search(query, {


### PR DESCRIPTION
# Problem

Joplin now supports semantic search, but it isn't available from the built-in search panels.

# Solution

Use semantic search from go-to-anything and the search sidebar when there are no full-text or partial-text matches. A `featureFlag.enableSemanticSearch` feature flag has been added to -- for now -- allow disabling the new search type.

Resolves #15824.

# Testing

## Screen recording


https://github.com/user-attachments/assets/c835ad9c-0a3d-4b1f-8fa8-820d3ff7ba59



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
