### PR TITLE
Desktop, Mobile: Resolves #15828:Provide a clear message on what needs to be done when sync fails due to wrong version

### DIFF
--- a/packages/app-desktop/checkForUpdates.ts
+++ b/packages/app-desktop/checkForUpdates.ts
@@ -36,6 +36,12 @@ async function fetchLatestReleases() {
 	return (await response.json()) as GitHubRelease[];
 }
 
+export async function isReleaseVersion(version: string): Promise<boolean | null> {
+	const releases = await fetchLatestReleases();
+	const release = releases.find(release => release.tag_name === `v${version}`);
+	return release ? !release.prerelease : null;
+}
+
 function truncateText(text: string, length: number) {
 	let truncated = text.substring(0, length);
 	const lastNewLine = truncated.lastIndexOf('\n');

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -439,6 +439,17 @@ class MainScreenComponent extends React.Component<Props, State> {
 			</a>
 		);
 
+		if (!callForAction2 && message.includes(callForAction)) {
+			const actionIndex = message.indexOf(callForAction);
+			return (
+				<span>
+					{message.substring(0, actionIndex)}
+					{cfa}
+					{message.substring(actionIndex + callForAction.length)}
+				</span>
+			);
+		}
+
 		return (
 			<span>
 				{message}{callForAction ? ' ' : ''}
@@ -581,16 +592,26 @@ class MainScreenComponent extends React.Component<Props, State> {
 			if (!this.props.syncTargetAppMinVersion) {
 				msg = this.renderNotificationMessage(this.props.mustUpgradeAppMessage);
 			} else if (this.props.syncTargetAppMinVersion.includes('-') && shim.isLinux()) {
+				const callForAction = _('Download it from GitHub Releases');
 				msg = this.renderNotificationMessage(
-					_('Please upgrade your application to version %s or update it using your package manager:', this.props.syncTargetAppMinVersion),
-					_('Download it from GitHub Releases'),
+					_(
+						'Please upgrade your application to version %s: %s or update it using your package manager',
+						this.props.syncTargetAppMinVersion,
+						callForAction,
+					),
+					callForAction,
 					() => shim.openUrl('https://github.com/laurent22/joplin/releases'),
 				);
 			} else {
 				const isTargetPreRelease = this.props.syncTargetAppMinVersion.includes('-');
+				const callForAction = isTargetPreRelease ? _('Download it from GitHub Releases') : _('Check for updates');
 				msg = this.renderNotificationMessage(
-					_('Please upgrade your application to version %s:', this.props.syncTargetAppMinVersion),
-					isTargetPreRelease ? _('Download it from GitHub Releases') : _('Check for updates'),
+					_(
+						'Please upgrade your application to version %s: %s',
+						this.props.syncTargetAppMinVersion,
+						callForAction,
+					),
+					callForAction,
 					isTargetPreRelease ? () => shim.openUrl('https://github.com/laurent22/joplin/releases') : onCheckForUpdates,
 				);
 			}

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -40,6 +40,7 @@ import PluginNotification from './PluginNotification/PluginNotification';
 import { Toast } from '@joplin/lib/services/plugins/api/types';
 import QuitSyncDialog from './QuitSyncDialog';
 import Logger from '@joplin/utils/Logger';
+import checkForUpdates from '../checkForUpdates';
 
 const logger = Logger.create('MainScreen');
 
@@ -72,6 +73,7 @@ interface Props {
 	lastDeletion: StateLastDeletion;
 	lastDeletionNotificationTime: number;
 	mustUpgradeAppMessage: string;
+	syncTargetAppMinVersion: string;
 	showInvalidJoplinCloudCredential: boolean;
 	toast: Toast;
 	shouldSwitchToAppleSiliconVersion: boolean;
@@ -491,6 +493,14 @@ class MainScreenComponent extends React.Component<Props, State> {
 			shim.openUrl('https://joplinapp.org/download/');
 		};
 
+		const onCheckForUpdates = () => {
+			if (Setting.value('featureFlag.autoUpdaterServiceEnabled')) {
+				ipcRenderer.send('check-for-updates');
+			} else {
+				void checkForUpdates(false, bridge().mainWindow(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') });
+			}
+		};
+
 		const onRestartAndUpgrade = async () => {
 			Setting.setValue('sync.upgradeState', Setting.SYNC_UPGRADE_STATE_MUST_DO);
 			await Setting.saveAll();
@@ -572,7 +582,15 @@ class MainScreenComponent extends React.Component<Props, State> {
 				onViewEncryptionConfigScreen,
 			);
 		} else if (this.props.mustUpgradeAppMessage) {
-			msg = this.renderNotificationMessage(this.props.mustUpgradeAppMessage);
+			if (this.props.syncTargetAppMinVersion && !shim.isLinux()) {
+				msg = this.renderNotificationMessage(
+					_('Please upgrade your application to version %s:', this.props.syncTargetAppMinVersion),
+					Setting.value('autoUpdate.includePreReleases') ? _('Download it from GitHub Releases') : _('Check for updates'),
+					Setting.value('autoUpdate.includePreReleases') ? () => shim.openUrl('https://github.com/laurent22/joplin/releases') : onCheckForUpdates,
+				);
+			} else {
+				msg = this.renderNotificationMessage(this.props.mustUpgradeAppMessage);
+			}
 		} else if (this.props.shouldSwitchToAppleSiliconVersion) {
 			msg = this.renderNotificationMessage(
 				_('You are running the Intel version of Joplin on an Apple Silicon processor. Download the Apple Silicon one for better performance.'),
@@ -747,6 +765,7 @@ const mapStateToProps = (state: AppState) => {
 		lastDeletion: state.lastDeletion,
 		lastDeletionNotificationTime: state.lastDeletionNotificationTime,
 		mustUpgradeAppMessage: state.mustUpgradeAppMessage,
+		syncTargetAppMinVersion: syncInfo.appMinVersion,
 		showInvalidJoplinCloudCredential: state.settings['sync.target'] === 10 && state.mustAuthenticate,
 		toast: state.toast,
 		shouldSwitchToAppleSiliconVersion: shim.isAppleSilicon() && shim.isMac() && process.arch !== 'arm64',

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -494,11 +494,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 		};
 
 		const onCheckForUpdates = () => {
-			if (Setting.value('featureFlag.autoUpdaterServiceEnabled')) {
-				ipcRenderer.send('check-for-updates');
-			} else {
-				void checkForUpdates(false, bridge().mainWindow(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') });
-			}
+			void checkForUpdates(false, bridge().mainWindow(), { includePreReleases: false });
 		};
 
 		const onRestartAndUpgrade = async () => {

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -656,6 +656,8 @@ class MainScreenComponent extends React.Component<Props, State> {
 					callForAction,
 					isTargetPreRelease ? () => shim.openUrl('https://github.com/laurent22/joplin/releases') : onCheckForUpdates,
 				);
+			} else {
+				msg = this.renderNotificationMessage(this.props.mustUpgradeAppMessage);
 			}
 		} else if (this.props.shouldSwitchToAppleSiliconVersion) {
 			msg = this.renderNotificationMessage(

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -584,18 +584,18 @@ class MainScreenComponent extends React.Component<Props, State> {
 		} else if (this.props.mustUpgradeAppMessage) {
 			if (!this.props.syncTargetAppMinVersion) {
 				msg = this.renderNotificationMessage(this.props.mustUpgradeAppMessage);
-			} else if (Setting.value('autoUpdate.includePreReleases') && shim.isLinux()) {
+			} else if (this.props.syncTargetAppMinVersion.includes('-') && shim.isLinux()) {
 				msg = this.renderNotificationMessage(
 					_('Please upgrade your application to version %s or update it using your package manager:', this.props.syncTargetAppMinVersion),
 					_('Download it from GitHub Releases'),
 					() => shim.openUrl('https://github.com/laurent22/joplin/releases'),
 				);
 			} else {
-				const includePreReleases = Setting.value('autoUpdate.includePreReleases');
+				const isTargetPreRelease = this.props.syncTargetAppMinVersion.includes('-');
 				msg = this.renderNotificationMessage(
 					_('Please upgrade your application to version %s:', this.props.syncTargetAppMinVersion),
-					includePreReleases ? _('Download it from GitHub Releases') : _('Check for updates'),
-					includePreReleases ? () => shim.openUrl('https://github.com/laurent22/joplin/releases') : onCheckForUpdates,
+					isTargetPreRelease ? _('Download it from GitHub Releases') : _('Check for updates'),
+					isTargetPreRelease ? () => shim.openUrl('https://github.com/laurent22/joplin/releases') : onCheckForUpdates,
 				);
 			}
 		} else if (this.props.shouldSwitchToAppleSiliconVersion) {

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -582,14 +582,21 @@ class MainScreenComponent extends React.Component<Props, State> {
 				onViewEncryptionConfigScreen,
 			);
 		} else if (this.props.mustUpgradeAppMessage) {
-			if (this.props.syncTargetAppMinVersion && !shim.isLinux()) {
+			if (!this.props.syncTargetAppMinVersion) {
+				msg = this.renderNotificationMessage(this.props.mustUpgradeAppMessage);
+			} else if (Setting.value('autoUpdate.includePreReleases') && shim.isLinux()) {
 				msg = this.renderNotificationMessage(
-					_('Please upgrade your application to version %s:', this.props.syncTargetAppMinVersion),
-					Setting.value('autoUpdate.includePreReleases') ? _('Download it from GitHub Releases') : _('Check for updates'),
-					Setting.value('autoUpdate.includePreReleases') ? () => shim.openUrl('https://github.com/laurent22/joplin/releases') : onCheckForUpdates,
+					_('Please upgrade your application to version %s or update it using your package manager:', this.props.syncTargetAppMinVersion),
+					_('Download it from GitHub Releases'),
+					() => shim.openUrl('https://github.com/laurent22/joplin/releases'),
 				);
 			} else {
-				msg = this.renderNotificationMessage(this.props.mustUpgradeAppMessage);
+				const includePreReleases = Setting.value('autoUpdate.includePreReleases');
+				msg = this.renderNotificationMessage(
+					_('Please upgrade your application to version %s:', this.props.syncTargetAppMinVersion),
+					includePreReleases ? _('Download it from GitHub Releases') : _('Check for updates'),
+					includePreReleases ? () => shim.openUrl('https://github.com/laurent22/joplin/releases') : onCheckForUpdates,
+				);
 			}
 		} else if (this.props.shouldSwitchToAppleSiliconVersion) {
 			msg = this.renderNotificationMessage(

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -629,7 +629,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 			} else if (this.state.didSyncTargetAppMinVersionReleaseLoadFail) {
 				msg = this.renderNotificationMessage(
 					_(
-						'Please upgrade your application to version %s. Joplin could not check update information.',
+						'In order to synchronise, Please upgrade your application to version %s. Joplin could not check update information.',
 						this.props.syncTargetAppMinVersion,
 					),
 				);
@@ -637,7 +637,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 				const callForAction = _('Download it from GitHub Releases');
 				msg = this.renderNotificationMessage(
 					_(
-						'Please upgrade your application to version %s: %s or update it using your package manager',
+						'In order to synchronise, Please upgrade your application to version %s: %s or update it using your package manager',
 						this.props.syncTargetAppMinVersion,
 						callForAction,
 					),
@@ -649,7 +649,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 				const callForAction = isTargetPreRelease ? _('Download it from GitHub Releases') : _('Check for updates');
 				msg = this.renderNotificationMessage(
 					_(
-						'Please upgrade your application to version %s: %s',
+						'In order to synchronise, Please upgrade your application to version %s: %s',
 						this.props.syncTargetAppMinVersion,
 						callForAction,
 					),

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -644,7 +644,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 					callForAction,
 					() => shim.openUrl('https://github.com/laurent22/joplin/releases'),
 				);
-			} else {
+			} else if (this.state.syncTargetAppMinVersionIsRelease !== null) {
 				const isTargetPreRelease = this.state.syncTargetAppMinVersionIsRelease === false;
 				const callForAction = isTargetPreRelease ? _('Download it from GitHub Releases') : _('Check for updates');
 				msg = this.renderNotificationMessage(

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -40,7 +40,7 @@ import PluginNotification from './PluginNotification/PluginNotification';
 import { Toast } from '@joplin/lib/services/plugins/api/types';
 import QuitSyncDialog from './QuitSyncDialog';
 import Logger from '@joplin/utils/Logger';
-import checkForUpdates from '../checkForUpdates';
+import checkForUpdates, { isReleaseVersion } from '../checkForUpdates';
 
 const logger = Logger.create('MainScreen');
 
@@ -90,6 +90,7 @@ interface State {
 	noteContentPropertiesDialogOptions: Record<string, unknown>;
 	shareNoteDialogOptions: Record<string, unknown>;
 	shareFolderDialogOptions: ShareFolderDialogOptions;
+	syncTargetAppMinVersionIsRelease: boolean | null;
 }
 
 const StyledUserWebviewDialogContainer = styled.div`
@@ -132,6 +133,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 				visible: false,
 				folderId: '',
 			},
+			syncTargetAppMinVersionIsRelease: null,
 		};
 
 		this.updateMainLayout(this.buildLayout(props.plugins));
@@ -349,6 +351,13 @@ class MainScreenComponent extends React.Component<Props, State> {
 				value: false,
 			});
 		}
+
+		if (
+			this.props.mustUpgradeAppMessage !== prevProps.mustUpgradeAppMessage ||
+			this.props.syncTargetAppMinVersion !== prevProps.syncTargetAppMinVersion
+		) {
+			void this.loadSyncTargetAppMinVersionIsRelease();
+		}
 	}
 
 	public layoutModeListenerKeyDown(event: KeyboardEvent) {
@@ -359,11 +368,27 @@ class MainScreenComponent extends React.Component<Props, State> {
 
 	public componentDidMount() {
 		window.addEventListener('keydown', this.layoutModeListenerKeyDown);
+		void this.loadSyncTargetAppMinVersionIsRelease();
 	}
 
 	public componentWillUnmount() {
 		window.removeEventListener('resize', this.window_resize);
 		window.removeEventListener('keydown', this.layoutModeListenerKeyDown);
+	}
+
+	private async loadSyncTargetAppMinVersionIsRelease() {
+		const version = this.props.syncTargetAppMinVersion;
+
+		this.setState({ syncTargetAppMinVersionIsRelease: null });
+		if (!this.props.mustUpgradeAppMessage || !version) return;
+
+		try {
+			const syncTargetAppMinVersionIsRelease = await isReleaseVersion(version);
+			if (!this.props.mustUpgradeAppMessage || this.props.syncTargetAppMinVersion !== version) return;
+			this.setState({ syncTargetAppMinVersionIsRelease });
+		} catch (error) {
+			logger.error(error);
+		}
 	}
 
 	public rootLayoutSize() {
@@ -591,7 +616,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 		} else if (this.props.mustUpgradeAppMessage) {
 			if (!this.props.syncTargetAppMinVersion) {
 				msg = this.renderNotificationMessage(this.props.mustUpgradeAppMessage);
-			} else if (this.props.syncTargetAppMinVersion.includes('-') && shim.isLinux()) {
+			} else if (this.state.syncTargetAppMinVersionIsRelease === false && shim.isLinux()) {
 				const callForAction = _('Download it from GitHub Releases');
 				msg = this.renderNotificationMessage(
 					_(
@@ -603,7 +628,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 					() => shim.openUrl('https://github.com/laurent22/joplin/releases'),
 				);
 			} else {
-				const isTargetPreRelease = this.props.syncTargetAppMinVersion.includes('-');
+				const isTargetPreRelease = this.state.syncTargetAppMinVersionIsRelease === false;
 				const callForAction = isTargetPreRelease ? _('Download it from GitHub Releases') : _('Check for updates');
 				msg = this.renderNotificationMessage(
 					_(

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -91,6 +91,7 @@ interface State {
 	shareNoteDialogOptions: Record<string, unknown>;
 	shareFolderDialogOptions: ShareFolderDialogOptions;
 	syncTargetAppMinVersionIsRelease: boolean | null;
+	didSyncTargetAppMinVersionReleaseLoadFail: boolean;
 }
 
 const StyledUserWebviewDialogContainer = styled.div`
@@ -134,6 +135,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 				folderId: '',
 			},
 			syncTargetAppMinVersionIsRelease: null,
+			didSyncTargetAppMinVersionReleaseLoadFail: false,
 		};
 
 		this.updateMainLayout(this.buildLayout(props.plugins));
@@ -379,15 +381,23 @@ class MainScreenComponent extends React.Component<Props, State> {
 	private async loadSyncTargetAppMinVersionIsRelease() {
 		const version = this.props.syncTargetAppMinVersion;
 
-		this.setState({ syncTargetAppMinVersionIsRelease: null });
+		this.setState({
+			syncTargetAppMinVersionIsRelease: null,
+			didSyncTargetAppMinVersionReleaseLoadFail: false,
+		});
 		if (!this.props.mustUpgradeAppMessage || !version) return;
 
 		try {
 			const syncTargetAppMinVersionIsRelease = await isReleaseVersion(version);
 			if (!this.props.mustUpgradeAppMessage || this.props.syncTargetAppMinVersion !== version) return;
-			this.setState({ syncTargetAppMinVersionIsRelease });
+			this.setState({
+				syncTargetAppMinVersionIsRelease,
+				didSyncTargetAppMinVersionReleaseLoadFail: syncTargetAppMinVersionIsRelease === null,
+			});
 		} catch (error) {
 			logger.error(error);
+			if (!this.props.mustUpgradeAppMessage || this.props.syncTargetAppMinVersion !== version) return;
+			this.setState({ didSyncTargetAppMinVersionReleaseLoadFail: true });
 		}
 	}
 
@@ -616,6 +626,13 @@ class MainScreenComponent extends React.Component<Props, State> {
 		} else if (this.props.mustUpgradeAppMessage) {
 			if (!this.props.syncTargetAppMinVersion) {
 				msg = this.renderNotificationMessage(this.props.mustUpgradeAppMessage);
+			} else if (this.state.didSyncTargetAppMinVersionReleaseLoadFail) {
+				msg = this.renderNotificationMessage(
+					_(
+						'Please upgrade your application to version %s. Joplin could not check update information.',
+						this.props.syncTargetAppMinVersion,
+					),
+				);
 			} else if (this.state.syncTargetAppMinVersionIsRelease === false && shim.isLinux()) {
 				const callForAction = _('Download it from GitHub Releases');
 				msg = this.renderNotificationMessage(

--- a/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
@@ -32,6 +32,7 @@ interface Props {
 
 const androidGooglePlayUrl = 'https://play.google.com/store/apps/details?id=net.cozic.joplin';
 const androidPreReleaseUrl = 'https://github.com/laurent22/joplin-android/tags';
+const iosAppStoreUrl = 'https://apps.apple.com/app/id1315599797';
 
 const fetchAndroidVersionIsPreRelease = async (version: string) => {
 	const response = await shim.fetch(`https://api.github.com/repos/laurent22/joplin-android/releases/tags/android-v${version}`);
@@ -91,7 +92,7 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 
 			if (Platform.OS === 'ios') {
 				return renderWarningBox(
-					'UpgradeApp',
+					iosAppStoreUrl,
 					upgradeMessage(_('Update it from the App Store')),
 				);
 			}

--- a/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
@@ -81,7 +81,7 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 				if (isAndroidTargetPreRelease) {
 					return renderWarningBox(
 						'UpgradeApp',
-						upgradeMessage(_('Download it from the Joplin Android tags page')),
+						upgradeMessage(_('Download it from the Joplin Android repository')),
 						androidPreReleaseUrl,
 					);
 				}

--- a/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
@@ -58,11 +58,12 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 		}
 	}, [props.mustUpgradeAppMessage, props.syncTargetAppMinVersion]);
 
-	const renderWarningBox = (screen: string, message: string) => {
+	const renderWarningBox = (screen: string, message: string, url?: string) => {
 		return <WarningBox
 			key={screen}
 			themeId={props.themeId}
 			targetScreen={screen}
+			url={url}
 			message={message}
 			testID='warning-box'
 		/>;
@@ -79,21 +80,24 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 			if (Platform.OS === 'android' && isAndroidTargetPreRelease !== null) {
 				if (isAndroidTargetPreRelease) {
 					return renderWarningBox(
-						androidPreReleaseUrl,
+						'UpgradeApp',
 						upgradeMessage(_('Download it from the Joplin Android tags page')),
+						androidPreReleaseUrl,
 					);
 				}
 
 				return renderWarningBox(
-					androidGooglePlayUrl,
+					'UpgradeApp',
 					upgradeMessage(_('Update it from Google Play')),
+					androidGooglePlayUrl,
 				);
 			}
 
 			if (Platform.OS === 'ios') {
 				return renderWarningBox(
-					iosAppStoreUrl,
+					'UpgradeApp',
 					upgradeMessage(_('Update it from the App Store')),
+					iosAppStoreUrl,
 				);
 			}
 

--- a/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
@@ -26,7 +26,7 @@ interface Props {
 
 const androidGooglePlayUrl = 'https://play.google.com/store/apps/details?id=net.cozic.joplin';
 const androidPreReleaseUrl = 'https://github.com/laurent22/joplin-android/tags';
-const iosAppStoreUrl = 'https://apps.apple.com/us/app/joplin/id1315599797';
+const iosAppStoreUrl = 'https://apps.apple.com/app/id1315599797';
 
 export const WarningBannerComponent: React.FC<Props> = props => {
 	const warningComps = [];

--- a/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
@@ -95,6 +95,8 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 					upgradeMessage(_('Update it from the App Store')),
 				);
 			}
+
+			return renderWarningBox('UpgradeApp', _('Please upgrade your application to version %s', props.syncTargetAppMinVersion));
 		}
 
 		return renderWarningBox('UpgradeApp', props.mustUpgradeAppMessage);

--- a/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
@@ -72,7 +72,7 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 	const renderMustUpgradeAppMessage = () => {
 		if (props.syncTargetAppMinVersion) {
 			const upgradeMessage = (message: string) => _(
-				'Please upgrade your application to version %s: %s',
+				'In order to synchronise, Please upgrade your application to version %s: %s',
 				props.syncTargetAppMinVersion,
 				message,
 			);
@@ -101,7 +101,7 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 				);
 			}
 
-			return renderWarningBox('UpgradeApp', _('Please upgrade your application to version %s', props.syncTargetAppMinVersion));
+			return renderWarningBox('UpgradeApp', _('In order to synchronise, Please upgrade your application to version %s', props.syncTargetAppMinVersion));
 		}
 
 		return renderWarningBox('UpgradeApp', props.mustUpgradeAppMessage);

--- a/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
@@ -24,6 +24,8 @@ interface Props {
 	showInvalidJoplinCloudCredential: boolean;
 }
 
+const androidGooglePlayUrl = 'https://play.google.com/store/apps/details?id=net.cozic.joplin';
+const androidPreReleaseUrl = 'https://github.com/laurent22/joplin-android/tags';
 const iosAppStoreUrl = 'https://apps.apple.com/us/app/joplin/id1315599797';
 
 export const WarningBannerComponent: React.FC<Props> = props => {
@@ -40,19 +42,32 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 	};
 
 	const renderMustUpgradeAppMessage = () => {
-		if (Platform.OS === 'ios' && props.syncTargetAppMinVersion) {
-			const isPreRelease = props.syncTargetAppMinVersion.includes('-');
-			if (isPreRelease) {
+		const syncTargetAppMinVersion = props.syncTargetAppMinVersion;
+		if (syncTargetAppMinVersion) {
+			const isPreRelease = syncTargetAppMinVersion.includes('-');
+
+			if (Platform.OS === 'android') {
 				return renderWarningBox(
-					'UpgradeApp',
-					_('Please upgrade your application to version %s: Update it from TestFlight', props.syncTargetAppMinVersion),
+					isPreRelease ? androidPreReleaseUrl : androidGooglePlayUrl,
+					isPreRelease ?
+						_('Please upgrade your application to version %s: Download it from the Joplin Android tags page', syncTargetAppMinVersion) :
+						_('Please upgrade your application to version %s: Update it from Google Play', syncTargetAppMinVersion),
 				);
 			}
 
-			return renderWarningBox(
-				iosAppStoreUrl,
-				_('Please upgrade your application to version %s: Update it from the App Store', props.syncTargetAppMinVersion),
-			);
+			if (Platform.OS === 'ios') {
+				if (isPreRelease) {
+					return renderWarningBox(
+						'UpgradeApp',
+						_('Please upgrade your application to version %s: Update it from TestFlight', syncTargetAppMinVersion),
+					);
+				}
+
+				return renderWarningBox(
+					iosAppStoreUrl,
+					_('Please upgrade your application to version %s: Update it from the App Store', syncTargetAppMinVersion),
+				);
+			}
 		}
 
 		return renderWarningBox('UpgradeApp', props.mustUpgradeAppMessage);

--- a/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
@@ -92,7 +92,7 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 			if (Platform.OS === 'ios') {
 				return renderWarningBox(
 					'UpgradeApp',
-					upgradeMessage(_('If it is a release, update it from the App Store. If it is a pre-release, check TestFlight')),
+					upgradeMessage(_('Update it from the App Store')),
 				);
 			}
 		}

--- a/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useState } from 'react';
 import { connect } from 'react-redux';
 import { Platform } from 'react-native';
 import { AppState } from '../../utils/types';
@@ -9,6 +10,11 @@ import { localSyncInfoFromState } from '@joplin/lib/services/synchronizer/syncIn
 import Setting from '@joplin/lib/models/Setting';
 import { ShareInvitation, ShareUserStatus } from '@joplin/lib/services/share/reducer';
 import { substrWithEllipsis } from '@joplin/lib/string-utils';
+import useAsyncEffect from '@joplin/lib/hooks/useAsyncEffect';
+import shim from '@joplin/lib/shim';
+import Logger from '@joplin/utils/Logger';
+
+const logger = Logger.create('WarningBanner');
 
 interface Props {
 	themeId: number;
@@ -28,8 +34,29 @@ const androidGooglePlayUrl = 'https://play.google.com/store/apps/details?id=net.
 const androidPreReleaseUrl = 'https://github.com/laurent22/joplin-android/tags';
 const iosAppStoreUrl = 'https://apps.apple.com/app/id1315599797';
 
+const fetchAndroidVersionIsPreRelease = async (version: string) => {
+	const response = await shim.fetch(`https://api.github.com/repos/laurent22/joplin-android/releases/tags/android-v${version}`);
+	if (!response.ok) return null;
+	const release = await response.json();
+	return !!release.prerelease;
+};
+
 export const WarningBannerComponent: React.FC<Props> = props => {
 	const warningComps = [];
+
+	const [isAndroidTargetPreRelease, setIsAndroidTargetPreRelease] = useState<boolean|null>(null);
+
+	useAsyncEffect(async event => {
+		setIsAndroidTargetPreRelease(null);
+		if (Platform.OS !== 'android' || !props.mustUpgradeAppMessage || !props.syncTargetAppMinVersion) return;
+
+		try {
+			const isPreRelease = await fetchAndroidVersionIsPreRelease(props.syncTargetAppMinVersion);
+			if (!event.cancelled) setIsAndroidTargetPreRelease(isPreRelease);
+		} catch (error) {
+			logger.error('Could not load release metadata for version', props.syncTargetAppMinVersion, error);
+		}
+	}, [props.mustUpgradeAppMessage, props.syncTargetAppMinVersion]);
 
 	const renderWarningBox = (screen: string, message: string) => {
 		return <WarningBox
@@ -42,17 +69,15 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 	};
 
 	const renderMustUpgradeAppMessage = () => {
-		const syncTargetAppMinVersion = props.syncTargetAppMinVersion;
-		if (syncTargetAppMinVersion) {
-			const isPreRelease = syncTargetAppMinVersion.includes('-');
+		if (props.syncTargetAppMinVersion) {
 			const upgradeMessage = (message: string) => _(
 				'Please upgrade your application to version %s: %s',
-				syncTargetAppMinVersion,
+				props.syncTargetAppMinVersion,
 				message,
 			);
 
-			if (Platform.OS === 'android') {
-				if (isPreRelease) {
+			if (Platform.OS === 'android' && isAndroidTargetPreRelease !== null) {
+				if (isAndroidTargetPreRelease) {
 					return renderWarningBox(
 						androidPreReleaseUrl,
 						upgradeMessage(_('Download it from the Joplin Android tags page')),
@@ -66,16 +91,9 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 			}
 
 			if (Platform.OS === 'ios') {
-				if (isPreRelease) {
-					return renderWarningBox(
-						'UpgradeApp',
-						upgradeMessage(_('Check TestFlight for an update')),
-					);
-				}
-
 				return renderWarningBox(
 					iosAppStoreUrl,
-					upgradeMessage(_('Update it from the App Store')),
+					upgradeMessage(_('If it is a release, update it from the App Store. If it is a pre-release, check TestFlight')),
 				);
 			}
 		}

--- a/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { Platform } from 'react-native';
 import { AppState } from '../../utils/types';
 import WarningBox from './WarningBox';
 import { _ } from '@joplin/lib/locale';
@@ -17,11 +18,13 @@ interface Props {
 	showShouldUpgradeSyncTargetMessage: boolean|undefined;
 	hasDisabledEncryptionItems: boolean;
 	mustUpgradeAppMessage: string;
+	syncTargetAppMinVersion?: string;
 	shareInvitations: ShareInvitation[];
 	processingShareInvitationResponse: boolean;
 	showInvalidJoplinCloudCredential: boolean;
 }
 
+const iosAppStoreUrl = 'https://apps.apple.com/us/app/joplin/id1315599797';
 
 export const WarningBannerComponent: React.FC<Props> = props => {
 	const warningComps = [];
@@ -36,6 +39,25 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 		/>;
 	};
 
+	const renderMustUpgradeAppMessage = () => {
+		if (Platform.OS === 'ios' && props.syncTargetAppMinVersion) {
+			const isPreRelease = props.syncTargetAppMinVersion.includes('-');
+			if (isPreRelease) {
+				return renderWarningBox(
+					'UpgradeApp',
+					_('Please upgrade your application to version %s: Update it from TestFlight', props.syncTargetAppMinVersion),
+				);
+			}
+
+			return renderWarningBox(
+				iosAppStoreUrl,
+				_('Please upgrade your application to version %s: Update it from the App Store', props.syncTargetAppMinVersion),
+			);
+		}
+
+		return renderWarningBox('UpgradeApp', props.mustUpgradeAppMessage);
+	};
+
 	if (props.showMissingMasterKeyMessage) {
 		warningComps.push(renderWarningBox('EncryptionConfig', _('Press to set the decryption password.')));
 	}
@@ -46,7 +68,7 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 		warningComps.push(renderWarningBox('UpgradeSyncTarget', _('The sync target needs to be upgraded. Press this banner to proceed.')));
 	}
 	if (props.mustUpgradeAppMessage) {
-		warningComps.push(renderWarningBox('UpgradeApp', props.mustUpgradeAppMessage));
+		warningComps.push(renderMustUpgradeAppMessage());
 	}
 	if (props.hasDisabledEncryptionItems) {
 		warningComps.push(renderWarningBox('Status', _('Some items cannot be decrypted.')));
@@ -87,6 +109,7 @@ export default connect((state: AppState) => {
 		hasDisabledSyncItems: state.hasDisabledSyncItems,
 		shouldUpgradeSyncTarget: state.settings['sync.upgradeState'] === Setting.SYNC_UPGRADE_STATE_SHOULD_DO,
 		mustUpgradeAppMessage: state.mustUpgradeAppMessage,
+		syncTargetAppMinVersion: syncInfo.appMinVersion,
 		shareInvitations: state.shareService.shareInvitations,
 		processingShareInvitationResponse: state.shareService.processingShareInvitationResponse,
 		showInvalidJoplinCloudCredential: state.settings['sync.target'] === 10 && state.mustAuthenticate,

--- a/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
@@ -32,7 +32,6 @@ interface Props {
 
 const androidGooglePlayUrl = 'https://play.google.com/store/apps/details?id=net.cozic.joplin';
 const androidPreReleaseUrl = 'https://github.com/laurent22/joplin-android/tags';
-const iosAppStoreUrl = 'https://apps.apple.com/app/id1315599797';
 
 const fetchAndroidVersionIsPreRelease = async (version: string) => {
 	const response = await shim.fetch(`https://api.github.com/repos/laurent22/joplin-android/releases/tags/android-v${version}`);
@@ -92,7 +91,7 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 
 			if (Platform.OS === 'ios') {
 				return renderWarningBox(
-					iosAppStoreUrl,
+					'UpgradeApp',
 					upgradeMessage(_('If it is a release, update it from the App Store. If it is a pre-release, check TestFlight')),
 				);
 			}

--- a/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
@@ -59,7 +59,7 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 				if (isPreRelease) {
 					return renderWarningBox(
 						'UpgradeApp',
-						_('Please upgrade your application to version %s: Update it from TestFlight', syncTargetAppMinVersion),
+						_('Please upgrade your application to version %s: Check TestFlight for an update', syncTargetAppMinVersion),
 					);
 				}
 

--- a/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBanner.tsx
@@ -45,13 +45,23 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 		const syncTargetAppMinVersion = props.syncTargetAppMinVersion;
 		if (syncTargetAppMinVersion) {
 			const isPreRelease = syncTargetAppMinVersion.includes('-');
+			const upgradeMessage = (message: string) => _(
+				'Please upgrade your application to version %s: %s',
+				syncTargetAppMinVersion,
+				message,
+			);
 
 			if (Platform.OS === 'android') {
+				if (isPreRelease) {
+					return renderWarningBox(
+						androidPreReleaseUrl,
+						upgradeMessage(_('Download it from the Joplin Android tags page')),
+					);
+				}
+
 				return renderWarningBox(
-					isPreRelease ? androidPreReleaseUrl : androidGooglePlayUrl,
-					isPreRelease ?
-						_('Please upgrade your application to version %s: Download it from the Joplin Android tags page', syncTargetAppMinVersion) :
-						_('Please upgrade your application to version %s: Update it from Google Play', syncTargetAppMinVersion),
+					androidGooglePlayUrl,
+					upgradeMessage(_('Update it from Google Play')),
 				);
 			}
 
@@ -59,13 +69,13 @@ export const WarningBannerComponent: React.FC<Props> = props => {
 				if (isPreRelease) {
 					return renderWarningBox(
 						'UpgradeApp',
-						_('Please upgrade your application to version %s: Check TestFlight for an update', syncTargetAppMinVersion),
+						upgradeMessage(_('Check TestFlight for an update')),
 					);
 				}
 
 				return renderWarningBox(
 					iosAppStoreUrl,
-					_('Please upgrade your application to version %s: Update it from the App Store', syncTargetAppMinVersion),
+					upgradeMessage(_('Update it from the App Store')),
 				);
 			}
 		}

--- a/packages/app-mobile/components/ScreenHeader/WarningBox.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBox.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useMemo, useCallback } from 'react';
-import { TouchableOpacity, StyleSheet, Text } from 'react-native';
+import { TouchableOpacity, StyleSheet, Text, Linking } from 'react-native';
 import { themeStyle } from '../global-style';
 import NavService from '@joplin/lib/services/NavService';
 
@@ -32,6 +32,11 @@ const WarningBox: React.FC<Props> = props => {
 	const styles = useStyles(props.themeId);
 
 	const onPress = useCallback(() => {
+		if (props.targetScreen.startsWith('http')) {
+			void Linking.openURL(props.targetScreen);
+			return;
+		}
+
 		void NavService.go(props.targetScreen);
 	}, [props.targetScreen]);
 

--- a/packages/app-mobile/components/ScreenHeader/WarningBox.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBox.tsx
@@ -7,6 +7,7 @@ import NavService from '@joplin/lib/services/NavService';
 interface Props {
 	themeId: number;
 	targetScreen: string;
+	url?: string;
 	message: string;
 	testID?: string;
 }
@@ -32,13 +33,13 @@ const WarningBox: React.FC<Props> = props => {
 	const styles = useStyles(props.themeId);
 
 	const onPress = useCallback(() => {
-		if (props.targetScreen.startsWith('http')) {
-			void Linking.openURL(props.targetScreen);
+		if (props.url !== undefined) {
+			void Linking.openURL(props.url);
 			return;
 		}
 
 		void NavService.go(props.targetScreen);
-	}, [props.targetScreen]);
+	}, [props.targetScreen, props.url]);
 
 	return (
 		<TouchableOpacity

--- a/packages/lib/services/synchronizer/syncInfoUtils.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.ts
@@ -43,7 +43,7 @@ export interface SyncInfoValuePublicPrivateKeyPair {
 //
 // `appMinVersion_` should really just be a constant but for testing purposes it can be changed
 // using `setAppMinVersion()`
-let appMinVersion_ = '3.7.0';
+let appMinVersion_ = '90.0.0';
 
 export const setAppMinVersion = (v: string) => {
 	appMinVersion_ = v;

--- a/packages/lib/services/synchronizer/syncInfoUtils.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.ts
@@ -43,7 +43,7 @@ export interface SyncInfoValuePublicPrivateKeyPair {
 //
 // `appMinVersion_` should really just be a constant but for testing purposes it can be changed
 // using `setAppMinVersion()`
-let appMinVersion_ = '90.0.0';
+let appMinVersion_ = '3.7.0';
 
 export const setAppMinVersion = (v: string) => {
 	appMinVersion_ = v;


### PR DESCRIPTION
Resolves #15828 

Android release:
<img width="430" height="786" alt="Screenshot 2026-07-07 at 9 58 09 PM" src="https://github.com/user-attachments/assets/32bca2f8-9da8-42fb-b221-2b029b1b6089" />




Android pre-release:
<img width="430" height="786" alt="Screenshot 2026-07-07 at 6 59 39 PM" src="https://github.com/user-attachments/assets/c33e5cc8-4b59-4de6-bd6e-aa1b47e61f52" />



Desktop release:
<img width="1624" height="998" alt="Screenshot 2026-07-07 at 4 34 17 PM" src="https://github.com/user-attachments/assets/32f9e654-cd07-49a4-80ef-5db33a136951" />




Desktop pre-release:
<img width="1624" height="998" alt="Screenshot 2026-07-07 at 5 23 21 PM" src="https://github.com/user-attachments/assets/19dbd780-1b1e-4f15-a42f-f454d01ec784" />

