### PR TITLE
Server: Silence Katex warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2009,6 +2009,7 @@ packages/renderer/MdToHtml/rules/frontmatter.js
 packages/renderer/MdToHtml/rules/highlight_keywords.js
 packages/renderer/MdToHtml/rules/html_image.js
 packages/renderer/MdToHtml/rules/image.js
+packages/renderer/MdToHtml/rules/katex.test.js
 packages/renderer/MdToHtml/rules/katex.js
 packages/renderer/MdToHtml/rules/link_close.js
 packages/renderer/MdToHtml/rules/link_open.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -2035,6 +2035,7 @@ packages/renderer/MdToHtml/rules/frontmatter.js
 packages/renderer/MdToHtml/rules/highlight_keywords.js
 packages/renderer/MdToHtml/rules/html_image.js
 packages/renderer/MdToHtml/rules/image.js
+packages/renderer/MdToHtml/rules/katex.test.js
 packages/renderer/MdToHtml/rules/katex.js
 packages/renderer/MdToHtml/rules/link_close.js
 packages/renderer/MdToHtml/rules/link_open.js

--- a/packages/renderer/MdToHtml/rules/katex.test.ts
+++ b/packages/renderer/MdToHtml/rules/katex.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import MarkdownIt = require('markdown-it');
+import katexRule from './katex';
+
+// Non-breaking space (U+00A0) inside math is the canonical trigger — this is
+// what emails, Word, and web pastes typically inject and what KaTeX complains
+// about with strict:'warn'.
+const nbspMath = '$x = 1$';
+
+const createMarkdownIt = (strict?: unknown) => {
+	const md = new MarkdownIt();
+	const context = {
+		userData: {} as Record<string, unknown>,
+		pluginWasUsed: { katex: false } as Record<string, boolean>,
+	};
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- plugin signature uses a narrower MarkdownIt type than the one exposed by markdown-it's own types
+	md.use(katexRule.plugin as any, { context, strict });
+	return md;
+};
+
+describe('katex rule', () => {
+
+	let warnSpy: jest.SpiedFunction<typeof console.warn>;
+
+	beforeEach(() => {
+		warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		warnSpy.mockRestore();
+	});
+
+	test('warns by default on LaTeX-incompatible input', () => {
+		const md = createMarkdownIt();
+		const output = md.render(nbspMath);
+		expect(output).toContain('katex');
+		const warned = warnSpy.mock.calls.some(args => String(args[0]).includes('LaTeX-incompatible'));
+		expect(warned).toBe(true);
+	});
+
+	test('is silent when strict:"ignore" is passed via plugin options', () => {
+		const md = createMarkdownIt('ignore');
+		const output = md.render(nbspMath);
+		expect(output).toContain('katex');
+		const warned = warnSpy.mock.calls.some(args => String(args[0]).includes('LaTeX-incompatible'));
+		expect(warned).toBe(false);
+	});
+});

--- a/packages/renderer/MdToHtml/rules/katex.ts
+++ b/packages/renderer/MdToHtml/rules/katex.ts
@@ -27,10 +27,13 @@ interface KatexTrustContext {
 	protocol?: string;
 }
 
+type KatexStrict = boolean | 'error' | 'warn' | 'ignore' | ((errorCode: string, errorMsg: string)=> 'error' | 'warn' | 'ignore');
+
 interface KatexOptions {
 	macros?: Record<string, string | KatexMacro>;
 	displayMode?: boolean;
 	trust?: boolean | ((context: KatexTrustContext)=> boolean);
+	strict?: KatexStrict;
 }
 
 // KaTeX's `\href` and `\url` commands accept arbitrary URLs when trust is
@@ -352,6 +355,12 @@ export default {
 		const katexOptions: KatexOptions = {};
 		katexOptions.macros = options.context.userData.__katex.macros as KatexOptions['macros'];
 		katexOptions.trust = isTrustedKatexContext;
+		// Callers can pass `plugins: { katex: { strict: 'ignore' } }` via
+		// RenderOptions to silence KaTeX's console warnings for LaTeX-
+		// incompatible input (e.g. U+00A0 pasted from email/Word). Output
+		// is unchanged — only the warning stream is suppressed.
+		const strict = (options as unknown as { strict?: KatexStrict }).strict;
+		if (strict !== undefined) katexOptions.strict = strict;
 
 		// When targeting inline math, the `containerTag` should be a `span` to prevent issues
 		// with converting back to Markdown from the Rich Text Editor:

--- a/packages/server/src/utils/joplinUtils.ts
+++ b/packages/server/src/utils/joplinUtils.ts
@@ -250,6 +250,14 @@ async function renderNote(share: Share, note: NoteEntity, resourceInfos: Resourc
 		checkboxDisabled: true,
 
 		linkRenderingType: 2,
+
+		// KaTeX defaults to strict:'warn' and dumps to console.warn on any
+		// LaTeX-incompatible input (commonly U+00A0 from email/Word pastes).
+		// Shared-note viewers see the same output either way; silence the
+		// server logs.
+		plugins: {
+			katex: { strict: 'ignore' },
+		},
 	};
 
 	try {


### PR DESCRIPTION
Katex can generate a lot of warnings in the server log, when someone view a published note that include invalid Katex. But we cannot act on it since it's user data, so we silence them.