### PR TITLE
Chore: Server package refactoring

### DIFF
--- a/packages/server/src/db.initialState.test.ts
+++ b/packages/server/src/db.initialState.test.ts
@@ -1,4 +1,4 @@
-import { afterAllTests, beforeAllDb, models } from './utils/testing/testUtils';
+import { afterAllTests, beforeAllDb, koaAppContext, models } from './utils/testing/testUtils';
 
 describe('db.initialState', () => {
 
@@ -14,8 +14,9 @@ describe('db.initialState', () => {
 				DEFAULT_ADMIN_PASSWORD: 'test-default',
 			},
 			test: async () => {
-				expect(await models().user().login('admin@localhost', 'admin')).toBeNull();
-				expect(await models().user().login('admin@localhost', 'test-default')).toBeTruthy();
+				const ctx = await koaAppContext();
+				expect(await models().user().login('admin@localhost', 'admin', ctx.joplin.services)).toBeNull();
+				expect(await models().user().login('admin@localhost', 'test-default', ctx.joplin.services)).toBeTruthy();
 			},
 		},
 		{
@@ -24,8 +25,9 @@ describe('db.initialState', () => {
 				DEFAULT_ADMIN_PASSWORD: undefined,
 			},
 			test: async () => {
-				expect(await models().user().login('admin@localhost', 'admin')).toBeTruthy();
-				expect(await models().user().login('admin@localhost', 'test-default')).toBeNull();
+				const ctx = await koaAppContext();
+				expect(await models().user().login('admin@localhost', 'admin', ctx.joplin.services)).toBeTruthy();
+				expect(await models().user().login('admin@localhost', 'test-default', ctx.joplin.services)).toBeNull();
 			},
 		},
 	])('$label', async ({ envValues, test }) => {

--- a/packages/server/src/middleware/notificationHandler.ts
+++ b/packages/server/src/middleware/notificationHandler.ts
@@ -21,7 +21,7 @@ async function handleChangeAdminPasswordNotification(ctx: AppContext) {
 		// is only applied on first startup:
 		const dangerousPasswords = unique([config().defaultAdminPassword, 'admin']);
 		for (const password of dangerousPasswords) {
-			const admin = await ctx.joplin.models.user().login(defaultAdminEmail, password);
+			const admin = await ctx.joplin.models.user().login(defaultAdminEmail, password, ctx.joplin.services);
 			if (admin) {
 				return password;
 			}

--- a/packages/server/src/models/SessionModel.test.ts
+++ b/packages/server/src/models/SessionModel.test.ts
@@ -1,4 +1,4 @@
-import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models } from '../utils/testing/testUtils';
+import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models, koaAppContext } from '../utils/testing/testUtils';
 import { defaultSessionTtl } from './SessionModel';
 
 describe('SessionModel', () => {
@@ -24,11 +24,14 @@ describe('SessionModel', () => {
 		const mfaCode = '';
 
 		const { user, password } = await createUserAndSession(1);
-		await models().session().authenticate(user.email, password, mfaCode);
+		const ctx = await koaAppContext();
+		const services = ctx.joplin.services;
+
+		await models().session().authenticate(user.email, password, services, mfaCode);
 
 		jest.setSystemTime(new Date(t0 + defaultSessionTtl + 10));
 
-		const lastSession = await models().session().authenticate(user.email, password, mfaCode);
+		const lastSession = await models().session().authenticate(user.email, password, services, mfaCode);
 
 		expect(await models().session().count()).toBe(3);
 
@@ -37,7 +40,7 @@ describe('SessionModel', () => {
 		expect(await models().session().count()).toBe(1);
 		expect((await models().session().all())[0].id).toBe(lastSession.id);
 
-		await models().session().authenticate(user.email, password, mfaCode);
+		await models().session().authenticate(user.email, password, services, mfaCode);
 		await models().session().deleteExpiredSessions();
 
 		expect(await models().session().count()).toBe(2);

--- a/packages/server/src/models/SessionModel.ts
+++ b/packages/server/src/models/SessionModel.ts
@@ -5,6 +5,7 @@ import { ErrorForbidden } from '../utils/errors';
 import { Hour } from '../utils/time';
 import { isValidMFACode } from '../utils/crypto';
 import { getIsMFAEnabled } from './utils/user';
+import { Services } from '../services/types';
 
 export const defaultSessionTtl = 12 * Hour;
 
@@ -36,16 +37,16 @@ export default class SessionModel extends BaseModel<Session> {
 		}, { isNew: true });
 	}
 
-	public async authenticate(emailOrApplicationId: string, password: string, mfaCode?: string, recoveryCode?: string) {
+	public async authenticate(emailOrApplicationId: string, password: string, services: Services, mfaCode?: string, recoveryCode?: string) {
 		if (this.models().application().isApplicationId(emailOrApplicationId)) {
 			return this.authenticateApplication(emailOrApplicationId, password);
 		} else {
-			return this.authenticateUser(emailOrApplicationId, password, mfaCode, recoveryCode);
+			return this.authenticateUser(emailOrApplicationId, password, services, mfaCode, recoveryCode);
 		}
 	}
 
-	private async authenticateUser(email: string, password: string, mfaCode?: string, recoveryCode?: string) {
-		const user = await this.models().user().login(email, password);
+	private async authenticateUser(email: string, password: string, services: Services, mfaCode?: string, recoveryCode?: string) {
+		const user = await this.models().user().login(email, password, services);
 		if (!user) throw new ErrorForbidden('Invalid email or password', { details: { email } });
 
 		if (getIsMFAEnabled(user)) {

--- a/packages/server/src/models/UserModel.test.ts
+++ b/packages/server/src/models/UserModel.test.ts
@@ -1,4 +1,4 @@
-import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models, checkThrowAsync, expectThrow, expectHttpError, createUser } from '../utils/testing/testUtils';
+import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models, checkThrowAsync, expectThrow, expectHttpError, createUser, koaAppContext } from '../utils/testing/testUtils';
 import { EmailSender, UserFlagType } from '../services/database/types';
 import { ErrorBadRequest, ErrorUnprocessableEntity } from '../utils/errors';
 import { betaUserDateRange, stripeConfig } from '../utils/stripe';
@@ -556,8 +556,9 @@ describe('UserModel', () => {
 		config().LOCAL_AUTH_ENABLED = false;
 
 		const user = await createUser();
+		const ctx = await koaAppContext();
 
-		expect(await models().user().login(user.email, '123456')).toBe(null);
+		expect(await models().user().login(user.email, '123456', ctx.joplin.services)).toBe(null);
 	});
 
 	test('should not change user properties managed by SAML', async () => {
@@ -599,7 +600,8 @@ describe('UserModel', () => {
 		config().SAML_ENABLED = true;
 
 		try {
-			const result = await models().user().ssoLogin(localUser.email, 'Attacker Controlled Name');
+			const ctx = await koaAppContext();
+			const result = await models().user().ssoLogin(localUser.email, 'Attacker Controlled Name', ctx.joplin.services);
 			expect(result).toBeNull();
 
 			const reloaded = await models().user().load(localUser.id);

--- a/packages/server/src/models/UserModel.ts
+++ b/packages/server/src/models/UserModel.ts
@@ -39,6 +39,7 @@ import config, { isUsingExternalAuth } from '../config';
 import { randomInt } from 'node:crypto';
 import { samlOwnedUserProperties } from '../utils/saml';
 import { AccountType, PlanName } from '@joplin/lib/utils/joplinCloud';
+import { Services } from '../services/types';
 export { AccountType };
 
 const logger = Logger.create('UserModel');
@@ -210,7 +211,7 @@ export default class UserModel extends BaseModel<User> {
 		return this.db<User>(this.tableName).where(user).first();
 	}
 
-	public async login(email: string, password: string): Promise<User> {
+	public async login(email: string, password: string, _services: Services): Promise<User> {
 		if (!config().LOCAL_AUTH_ENABLED) {
 			return null;
 		}
@@ -235,7 +236,7 @@ export default class UserModel extends BaseModel<User> {
 		return user;
 	}
 
-	public async ssoLogin(email: string, displayName: string) {
+	public async ssoLogin(email: string, displayName: string, _services: Services) {
 		if (!email || !displayName) {
 			return null;
 		}

--- a/packages/server/src/routes/admin/users.test.ts
+++ b/packages/server/src/routes/admin/users.test.ts
@@ -119,7 +119,8 @@ describe('admin/users', () => {
 
 		const password = uuidgen();
 		await postUser(session.id, email, password);
-		const loggedInUser = await models().user().login(email, password);
+		const ctx = await koaAppContext();
+		const loggedInUser = await models().user().login(email, password, ctx.joplin.services);
 		expect(!!loggedInUser).toBe(true);
 		expect(loggedInUser.email).toBe('ilikeuppercaseandspaces@example.com');
 	});
@@ -164,8 +165,10 @@ describe('admin/users', () => {
 			'STRIPE_SUB_ID',
 		);
 		const { user } = await createUserAndSession(1, false);
+		const ctx = await koaAppContext();
+
 		await models().user().save({ id: admin.id, password, is_admin: 1 });
-		const session = await models().session().authenticate(admin.email, password, '');
+		const session = await models().session().authenticate(admin.email, password, ctx.joplin.services, '');
 		const result = await execRequest(session.id, 'GET', 'admin/users', null, {
 			query: {
 				query: 'STRIPE_SUB_ID',
@@ -198,12 +201,13 @@ describe('admin/users', () => {
 
 	test('should delete sessions when changing password', async () => {
 		const { user, session, password } = await createUserAndSession(1);
+		const ctx = await koaAppContext({ sessionId: session.id });
 
 		const mfaCode = '';
 
-		await models().session().authenticate(user.email, password, mfaCode);
-		await models().session().authenticate(user.email, password, mfaCode);
-		await models().session().authenticate(user.email, password, mfaCode);
+		await models().session().authenticate(user.email, password, ctx.joplin.services, mfaCode);
+		await models().session().authenticate(user.email, password, ctx.joplin.services, mfaCode);
+		await models().session().authenticate(user.email, password, ctx.joplin.services, mfaCode);
 
 		expect(await models().session().count()).toBe(4);
 
@@ -269,9 +273,9 @@ describe('admin/users', () => {
 		const admin = await createUserAndSession(2, true);
 
 		const originalPrice = findPrice(stripeConfig(), { accountType: fromType, period: PricePeriod.Monthly });
-		stripeMock.addMockSubscription(
+		stripeMock.setMockSubscription(
 			'stripe-subscription-id',
-			[originalPrice],
+			{ items: [originalPrice] },
 		);
 
 		await patchUser(admin.session.id, {

--- a/packages/server/src/routes/admin/users.ts
+++ b/packages/server/src/routes/admin/users.ts
@@ -24,6 +24,7 @@ import { userFlagToString } from '../../models/UserFlagModel';
 import { _ } from '@joplin/lib/locale';
 import { makeTablePagination, makeTableView, Row, Table } from '../../utils/views/table';
 import { PaginationOrderDir } from '../../models/utils/pagination';
+import checkCanCreateUser from '../utils/checkCanCreateUser';
 
 export interface CheckRepeatPasswordInput {
 	password: string;
@@ -347,12 +348,15 @@ router.post('admin/users', async (path: SubPath, ctx: AppContext) => {
 
 		if (fields.post_button) {
 			const userToSave: User = models.user().fromApiInput(user);
-			await models.user().checkIfAllowed(owner, isNew ? AclAction.Create : AclAction.Update, userToSave);
 
 			if (isNew) {
+				await checkCanCreateUser(ctx.joplin.services, ctx.joplin.models, ctx.joplin.owner);
+
 				const savedUser = await models.user().save(userToSave);
 				userId = savedUser.id;
 			} else {
+				await models.user().checkIfAllowed(owner, AclAction.Update, userToSave);
+
 				await models.user().save(userToSave, { isNew: false });
 
 				// When changing the password, we also clear all session IDs for

--- a/packages/server/src/routes/api/login.ts
+++ b/packages/server/src/routes/api/login.ts
@@ -43,7 +43,7 @@ router.post('api/saml', async (_path: SubPath, ctx: AppContext) => {
 	if (typeof displayName !== 'string') throw new ErrorBadRequest('displayName must be a string');
 
 	// Load the user
-	const user = await ctx.joplin.models.user().ssoLogin(email, displayName);
+	const user = await ctx.joplin.models.user().ssoLogin(email, displayName, ctx.joplin.services);
 	if (!user) throw new ErrorForbidden(`Could not login using email "${email}" and displayName "${displayName}"`);
 
 	if (fields.RelayState) {

--- a/packages/server/src/routes/api/sessions.ts
+++ b/packages/server/src/routes/api/sessions.ts
@@ -28,7 +28,7 @@ router.post('api/sessions', async (_path: SubPath, ctx: AppContext) => {
 	};
 
 	// we pass null on mfaCode because the user shouldn't be able to make 2FA login over the API
-	const session = await ctx.joplin.models.session().authenticate(fields.email, fields.password, null);
+	const session = await ctx.joplin.models.session().authenticate(fields.email, fields.password, ctx.joplin.services, null);
 
 	await ctx.joplin.models.application().updateOnNewLogin(fields.email, clientInfo);
 

--- a/packages/server/src/routes/api/users.ts
+++ b/packages/server/src/routes/api/users.ts
@@ -7,6 +7,7 @@ import { AppContext } from '../../utils/types';
 import { ErrorNotFound } from '../../utils/errors';
 import { AclAction } from '../../models/BaseModel';
 import { uuidgen } from '../../utils/uuid';
+import checkCanCreateUser from '../utils/checkCanCreateUser';
 
 const router = new Router(RouteType.Api);
 
@@ -43,7 +44,7 @@ router.get('api/users/:id/public_key', async (path: SubPath, ctx: AppContext) =>
 });
 
 router.post('api/users', async (_path: SubPath, ctx: AppContext) => {
-	await ctx.joplin.models.user().checkIfAllowed(ctx.joplin.owner, AclAction.Create);
+	await checkCanCreateUser(ctx.joplin.services, ctx.joplin.models, ctx.joplin.owner);
 	const user = await postedUserFromContext(ctx);
 
 	// We set a random password because it's required, but user will have to

--- a/packages/server/src/routes/index/login.ts
+++ b/packages/server/src/routes/index/login.ts
@@ -118,7 +118,7 @@ router.post('login', async (path: SubPath, ctx: AppContext) => {
 		}
 
 		const session = await ctx.joplin.models.session().authenticate(
-			body.fields.email, body.fields.password, body.fields.mfaCode, body.fields.recoveryCode,
+			body.fields.email, body.fields.password, ctx.joplin.services, body.fields.mfaCode, body.fields.recoveryCode,
 		);
 		cookieSet(ctx, 'sessionId', session.id);
 		const owner = await ctx.joplin.models.user().load(session.user_id, { fields: ['id', 'is_admin'] });

--- a/packages/server/src/routes/index/password.test.ts
+++ b/packages/server/src/routes/index/password.test.ts
@@ -1,4 +1,4 @@
-import { beforeAllDb, afterAllTests, beforeEachDb, createUserAndSession, models, expectHttpError } from '../../utils/testing/testUtils';
+import { beforeAllDb, afterAllTests, beforeEachDb, createUserAndSession, models, expectHttpError, koaAppContext } from '../../utils/testing/testUtils';
 import { execRequest } from '../../utils/testing/apiUtils';
 import { uuidgen } from '@joplin/lib/uuid';
 import { ErrorNotFound } from '../../utils/errors';
@@ -18,14 +18,16 @@ describe('index/password', () => {
 	});
 
 	test('should queue an email to reset password', async () => {
-		const { user, password } = await createUserAndSession(1);
+		const { user, session, password } = await createUserAndSession(1);
+		const context = await koaAppContext({ sessionId: session.id });
 		const mfaCode = '';
 
 		// Create a few sessions, to verify that they are all deleted when the
 		// password is changed.
-		await models().session().authenticate(user.email, password, mfaCode);
-		await models().session().authenticate(user.email, password, mfaCode);
-		await models().session().authenticate(user.email, password, mfaCode);
+		const services = context.joplin.services;
+		await models().session().authenticate(user.email, password, services, mfaCode);
+		await models().session().authenticate(user.email, password, services, mfaCode);
+		await models().session().authenticate(user.email, password, services, mfaCode);
 		expect(await models().session().count()).toBe(4);
 
 		await models().email().deleteAll();
@@ -41,7 +43,7 @@ describe('index/password', () => {
 			password2: newPassword,
 		}, { query: { token: match[2] } });
 
-		const loggedInUser = await models().user().login(user.email, newPassword);
+		const loggedInUser = await models().user().login(user.email, newPassword, context.joplin.services);
 		expect(loggedInUser.id).toBe(user.id);
 
 		// Check that all sessions have been deleted
@@ -56,7 +58,8 @@ describe('index/password', () => {
 	});
 
 	test('should not reset the password if the token is invalid', async () => {
-		const { user } = await createUserAndSession(1);
+		const { user, session } = await createUserAndSession(1);
+		const context = await koaAppContext({ sessionId: session.id });
 		await models().email().deleteAll();
 
 		const newPassword = uuidgen();
@@ -68,7 +71,7 @@ describe('index/password', () => {
 			}, { query: { token: 'stilltryingtohack' } });
 		}, ErrorNotFound.httpCode);
 
-		const loggedInUser = await models().user().login(user.email, newPassword);
+		const loggedInUser = await models().user().login(user.email, newPassword, context.joplin.services);
 		expect(loggedInUser).toBeFalsy();
 	});
 

--- a/packages/server/src/routes/index/users.test.ts
+++ b/packages/server/src/routes/index/users.test.ts
@@ -80,10 +80,11 @@ describe('index/users', () => {
 
 	test('new user should be able to login', async () => {
 		const { session } = await createUserAndSession(1, true);
+		const context = await koaAppContext({ sessionId: session.id });
 
 		const password = uuidgen();
 		await postUser(session.id, 'test@example.com', password);
-		const loggedInUser = await models().user().login('test@example.com', password);
+		const loggedInUser = await models().user().login('test@example.com', password, context.joplin.services);
 		expect(!!loggedInUser).toBe(true);
 		expect(loggedInUser.email).toBe('test@example.com');
 	});
@@ -100,12 +101,13 @@ describe('index/users', () => {
 
 	test('should change the password', async () => {
 		const { user, session } = await createUserAndSession(1, true);
+		const context = await koaAppContext({ sessionId: session.id });
 
 		const userModel = models().user();
 
 		const password = uuidgen();
 		await patchUser(session.id, { id: user.id, password: password, password2: password });
-		const modUser = await userModel.login('user1@localhost', password);
+		const modUser = await userModel.login('user1@localhost', password, context.joplin.services);
 		expect(!!modUser).toBe(true);
 		expect(modUser.id).toBe(user.id);
 	});
@@ -185,7 +187,7 @@ describe('index/users', () => {
 		expect(session.user_id).toBe(user1.id);
 
 		// Check that the password has been set
-		const loggedInUser = await models().user().login(user1.email, newPassword);
+		const loggedInUser = await models().user().login(user1.email, newPassword, context.joplin.services);
 		expect(loggedInUser.id).toBe(user1.id);
 
 		// Check that the email has been verified
@@ -317,9 +319,10 @@ describe('index/users', () => {
 
 	test('should delete all sessions when changing the password but the current one', async () => {
 		const { user, session, password } = await createUserAndSession(1, true);
+		const ctx = await koaAppContext();
 
-		await models().session().authenticate(user.email, password, '');
-		await models().session().authenticate(user.email, password, '');
+		await models().session().authenticate(user.email, password, ctx.joplin.services, '');
+		await models().session().authenticate(user.email, password, ctx.joplin.services, '');
 
 		expect(await models().session().count()).toBe(3);
 

--- a/packages/server/src/routes/utils/checkCanCreateUser.ts
+++ b/packages/server/src/routes/utils/checkCanCreateUser.ts
@@ -1,0 +1,14 @@
+import { AclAction } from '../../models/BaseModel';
+import { Models } from '../../models/factory';
+import { User } from '../../services/database/types';
+import { Services } from '../../services/types';
+
+const checkCanCreateUser = async (
+	_services: Services,
+	models: Models,
+	currentUser: User,
+) => {
+	await models.user().checkIfAllowed(currentUser, AclAction.Create);
+};
+
+export default checkCanCreateUser;

--- a/packages/server/src/utils/request/bruteForceLimiter.ts
+++ b/packages/server/src/utils/request/bruteForceLimiter.ts
@@ -1,0 +1,21 @@
+import { RateLimiterMemory, RateLimiterRes } from 'rate-limiter-flexible';
+import { ErrorTooManyRequests } from '../errors';
+
+export default (maxRequestsPerMinute: number, errorMessage: string) => {
+	const limiter = new RateLimiterMemory({
+		points: maxRequestsPerMinute,
+		duration: 60, // Per 60 seconds
+	});
+
+	return async (ip: string) => {
+		// Tests need to make many requests quickly so we disable it in this case.
+		if (process.env.JOPLIN_IS_TESTING === '1') return;
+
+		try {
+			await limiter.consume(ip);
+		} catch (error) {
+			const result = error as RateLimiterRes;
+			throw new ErrorTooManyRequests(`${errorMessage}. Please try again in ${Math.ceil(result.msBeforeNext / 1000)} seconds.`, result.msBeforeNext);
+		}
+	};
+};

--- a/packages/server/src/utils/request/limiterLoginBruteForce.ts
+++ b/packages/server/src/utils/request/limiterLoginBruteForce.ts
@@ -1,19 +1,6 @@
-import { RateLimiterMemory, RateLimiterRes } from 'rate-limiter-flexible';
-import { ErrorTooManyRequests } from '../errors';
+import bruteForceLimiter from './bruteForceLimiter';
 
-const limiterSlowBruteByIP = new RateLimiterMemory({
-	points: 10, // Up to 10 requests per IP
-	duration: 60, // Per 60 seconds
-});
-
-export default async function(ip: string) {
-	// Tests need to make many requests quickly so we disable it in this case.
-	if (process.env.JOPLIN_IS_TESTING === '1') return;
-
-	try {
-		await limiterSlowBruteByIP.consume(ip);
-	} catch (error) {
-		const result = error as RateLimiterRes;
-		throw new ErrorTooManyRequests(`Too many login attempts. Please try again in ${Math.ceil(result.msBeforeNext / 1000)} seconds.`, result.msBeforeNext);
-	}
-}
+export default bruteForceLimiter(
+	10, // Up to 10 requests per minute per IP
+	'Too many login attempts',
+);

--- a/packages/server/src/utils/testing/mockStripe.ts
+++ b/packages/server/src/utils/testing/mockStripe.ts
@@ -9,6 +9,12 @@ type UpdateSubscription = (subId: string, options: unknown)=> Promise<void>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- using any as an upper bound
 type Mocked<T extends (...args: any)=> any> = jest.Mock<ReturnType<T>, Parameters<T>>;
 
+interface MockSubscriptionOptions {
+	periodEnd?: Date;
+	trialEnd?: Date|null;
+	items?: StripePublicConfigPrice[];
+}
+
 interface StripeMock {
 	subscriptions: {
 		update: Mocked<UpdateSubscription>;
@@ -16,10 +22,12 @@ interface StripeMock {
 	};
 
 	resetMock(): void;
-	addMockSubscription(id: string, items: StripePublicConfigPrice[]): void;
+	setMockSubscription(id: string, options: MockSubscriptionOptions): MockedSubscription;
 }
 
 jest.mock('stripe', () => {
+	const { Day, Second } = require('@joplin/utils/time');
+
 	const subscriptions = new Map<string, MockedSubscription>();
 	const mock: StripeMock = {
 		subscriptions: {
@@ -35,15 +43,24 @@ jest.mock('stripe', () => {
 			subscriptions.clear();
 		},
 
-		addMockSubscription: (id, items) => {
-			subscriptions.set(id, {
+		setMockSubscription: (id, {
+			items = [],
+			periodEnd = new Date(Date.now() + Day),
+			trialEnd,
+		}) => {
+			const subscription = {
 				id,
+				trial_end: trialEnd ? trialEnd.getTime() / Second : null,
+				current_period_end: periodEnd.getTime() / Second,
 				items: {
 					data: items.map(item => ({
 						price: { id: item.id },
 					})),
 				},
-			});
+			};
+			subscriptions.set(id, subscription);
+
+			return subscription;
 		},
 	};
 	return () => mock;

--- a/packages/server/src/utils/testing/testUtils.ts
+++ b/packages/server/src/utils/testing/testUtils.ts
@@ -350,7 +350,9 @@ export const createUserAndSession = async function(index = 1, isAdmin = false, o
 	if (options.account_type) user.account_type = options.account_type;
 
 	user = await models().user().save(user, { skipValidation: true });
-	const session = await models().session().authenticate(options.email, options.password, '');
+
+	const ctx = await koaAppContext();
+	const session = await models().session().authenticate(options.email, options.password, ctx.joplin.services, '');
 
 	return {
 		user: await models().user().load(user.id),


### PR DESCRIPTION
# Summary

- Allows accessing an instance of `services` from certain login-related routes.
- Makes the Stripe test mock utility slightly more powerful.
- Refactors the IP address-based request limiter.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
