### PR TITLE
Desktop: Fix secondary windows have visible scrollbars while/after resizing

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/EditorWindow.tsx
+++ b/packages/app-desktop/gui/NoteEditor/EditorWindow.tsx
@@ -140,19 +140,21 @@ const SecondaryWindow: React.FC<Props> = props => {
 		onClose={onWindowClose}
 		title={windowTitle}
 	>
-		<LibraryStyleRoot>
-			<WindowCommandsAndDialogs windowId={props.windowId} />
-			<ResizableLayout
-				layout={layout.layout}
-				onResize={layout.onResize}
-				onMoveButtonClick={() => {}}
-				renderItem={onRenderItem}
-				layoutKeyToLabel={layout.onKeyToLabel}
-				moveMode={false}
-				moveModeMessage={''}
-			/>
-		</LibraryStyleRoot>
-		<StyleSheetContainer />
+		<div id='react-root' className='secondary-window-root'>
+			<LibraryStyleRoot>
+				<WindowCommandsAndDialogs windowId={props.windowId} />
+				<ResizableLayout
+					layout={layout.layout}
+					onResize={layout.onResize}
+					onMoveButtonClick={() => {}}
+					renderItem={onRenderItem}
+					layoutKeyToLabel={layout.onKeyToLabel}
+					moveMode={false}
+					moveModeMessage={''}
+				/>
+			</LibraryStyleRoot>
+			<StyleSheetContainer />
+		</div>
 	</NewWindowOrIFrame>;
 };
 


### PR DESCRIPTION
# Problem

Scrollbars are sometimes observed while and after resizing secondary windows:
<img height="500" alt="screenshot: Dark mode, larger window shows scrollbars" src="https://github.com/user-attachments/assets/1f68700b-eea2-47c8-8efc-2f6c782fd86e" />
<img height="250" alt="screenshot: Light mode, smaller window shows MacOS-style scrollbars" src="https://github.com/user-attachments/assets/2b8bd72b-1a6f-4452-ba4c-50d95e911862" />

This is most likely a regression related to #15803, which added support for resizable panels in secondary windows.

# Solution

Mark the root element in secondary windows with `id="react-root"`. This applies Joplin's [default root styles](https://github.com/laurent22/joplin/blob/f7f7ba10e2a55bd8a7c9cd09dc439650a07d84e3/packages/app-desktop/main.scss#L11) (including `overflow: hidden`) to secondary windows.

# Testing plan

MacOS:
1. Open a secondary window.
2. Resize the secondary window to a small size.
3. Verify that no scrollbars for the full window content are visible.
4. Verify that the entire editor remains visible.

Screen recording:

https://github.com/user-attachments/assets/4c0177fe-dc30-4769-a141-2c8a3f0f356a


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
