### PR TITLE
Mobile: Fixes #13901: Fix auto-derived title being cleared after saving a new note

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -535,6 +535,7 @@ describe('screens/Note', () => {
 			currentPosition: () => new Promise(resolve => { resolveGeoloc = resolve; }),
 		};
 
+		let unmount = () => {};
 		try {
 			const noteId = await openNewNote({ title: '', body: '' });
 			store.dispatch({
@@ -543,7 +544,7 @@ describe('screens/Note', () => {
 				provisional: true,
 			});
 
-			const { unmount } = render(<WrappedNoteScreen />);
+			({ unmount } = render(<WrappedNoteScreen />));
 			const editor = await getMarkdownEditorControl();
 
 			await act(async () => {
@@ -562,9 +563,8 @@ describe('screens/Note', () => {
 			});
 
 			expect(screen.getByDisplayValue('Derived from body')).toBeVisible();
-
-			unmount();
 		} finally {
+			unmount();
 			shim.Geolocation = originalGeolocation;
 			Setting.setValue('trackLocation', false);
 		}

--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -521,6 +521,55 @@ describe('screens/Note', () => {
 		unmount();
 	});
 
+	// Regression test: when a provisional note has no title, saving derives the
+	// title from the body. The provisional-note branch of saveNoteButton_press
+	// also kicks off a background geolocation update; that callback used to
+	// close over a stale `state.note` (captured before the title was derived)
+	// and wipe the derived title back to empty when it resolved.
+	it('should not clear the auto-derived title when the background geolocation update resolves', async () => {
+		Setting.setValue('trackLocation', true);
+
+		const originalGeolocation = shim.Geolocation;
+		let resolveGeoloc: (v: unknown)=> void = () => {};
+		shim.Geolocation = {
+			currentPosition: () => new Promise(resolve => { resolveGeoloc = resolve; }),
+		};
+
+		try {
+			const noteId = await openNewNote({ title: '', body: '' });
+			store.dispatch({
+				type: 'NOTE_UPDATE_ONE',
+				note: await Note.load(noteId),
+				provisional: true,
+			});
+
+			const { unmount } = render(<WrappedNoteScreen />);
+			const editor = await getMarkdownEditorControl();
+
+			await act(async () => {
+				editor.insertText('Derived from body');
+			});
+
+			await screen.findByDisplayValue('Derived from body');
+
+			await act(async () => {
+				resolveGeoloc({ timestamp: Date.now(), coords: { latitude: 1, longitude: 2, altitude: 3 } });
+			});
+			await waitForNoteToMatch(noteId, { title: 'Derived from body' });
+			await waitFor(async () => {
+				const loaded = await Note.load(noteId);
+				expect(Number(loaded.latitude)).toBe(1);
+			});
+
+			expect(screen.getByDisplayValue('Derived from body')).toBeVisible();
+
+			unmount();
+		} finally {
+			shim.Geolocation = originalGeolocation;
+			Setting.setValue('trackLocation', false);
+		}
+	});
+
 	it('should set the initial editor cursor location to the specified hash', async () => {
 		await openNewNote({ title: 'To be edited', body: 'a test\n\n# Test\n\n# Test 2\n\n# Test 3' });
 		store.dispatch({ type: 'NAV_GO', noteHash: 'test-2' });

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -198,7 +198,9 @@ shared.saveNoteButton_press = async function(comp: BaseNoteScreenComponent, stat
 		const updateGeoloc = async () => {
 			const geoNote: NoteEntity = await Note.updateGeolocation(note.id);
 
-			const stateNote = state.note;
+			// Read the latest state (not the closure `state`, which was captured
+			// before Note.save and doesn't include the auto-derived title).
+			const stateNote = comp.state.note;
 			if (!stateNote || !geoNote) return;
 			if (stateNote.id !== geoNote.id) return; // Another note has been loaded while geoloc was being retrieved
 
@@ -212,7 +214,7 @@ shared.saveNoteButton_press = async function(comp: BaseNoteScreenComponent, stat
 			};
 
 			const modNote = { ...stateNote, ...geoInfo };
-			const modLastSavedNote = { ...state.lastSavedNote, ...geoInfo };
+			const modLastSavedNote = { ...comp.state.lastSavedNote, ...geoInfo };
 
 			comp.setState({ note: modNote, lastSavedNote: modLastSavedNote });
 		};


### PR DESCRIPTION
When creating a new note (todo or otherwise) on mobile and typing in the body, the title was briefly auto-derived from the body content but then immediately cleared.

The background `updateGeoloc` callback in `saveNoteButton_press` closed over the `state` argument, which was captured *before* `Note.save` derived the title. When `Note.updateGeolocation` resolved, the callback called `setState({ note: { ...stateNote, ... } })` with the stale (pre-derivation) note, wiping the derived title.

Fixed by reading `comp.state.note` and `comp.state.lastSavedNote` at resolve time, matching how the rest of the function handles post-async reads.