### PR TITLE
Server: Fixes #15725: Fix LDAP user auto-creation

### DIFF
--- a/packages/server/src/models/UserModel.test.ts
+++ b/packages/server/src/models/UserModel.test.ts
@@ -633,4 +633,26 @@ describe('UserModel', () => {
 		}
 	});
 
+	test('should correctly return whether a user has MFA enabled', async () => {
+		const createTestUser = async (index: number, mfaEnabled: boolean) => {
+			const user = await createUser(index);
+			await models().user().save({
+				id: user.id,
+				totp_secret: mfaEnabled ? '111111' : '',
+			});
+			return await models().user().load(user.id);
+		};
+
+		const user1 = await createTestUser(1, true);
+		expect(await models().user().hasMFAEnabled(user1.email, { requireUserExists: true })).toBe(true);
+		const user2 = await createTestUser(2, false);
+		expect(await models().user().hasMFAEnabled(user2.email, { requireUserExists: true })).toBe(false);
+
+		expect(
+			await models().user().hasMFAEnabled('no-exist@localhost', { requireUserExists: false }),
+		).toBe(false);
+		await expectHttpError(async () => {
+			await models().user().hasMFAEnabled('no-exist@localhost', { requireUserExists: true });
+		}, 403);
+	});
 });

--- a/packages/server/src/models/UserModel.ts
+++ b/packages/server/src/models/UserModel.ts
@@ -52,6 +52,10 @@ interface UserEmailDetails {
 
 export type GetUsersApiResponse = User;
 
+interface HasMfaEnabledOptions {
+	requireUserExists: boolean;
+}
+
 export interface Account {
 	account_type: number;
 	can_share_folder: number;
@@ -887,9 +891,12 @@ export default class UserModel extends BaseModel<User> {
 		}, 'UserModel::saveMulti');
 	}
 
-	public async hasMFAEnabled(email: string) {
+	public async hasMFAEnabled(email: string, { requireUserExists }: HasMfaEnabledOptions) {
 		const user = await this.loadByEmail(email, { fields: ['totp_secret'] });
-		if (!user) throw new ErrorForbidden('Invalid email or password', { details: { email } });
+		if (!user) {
+			if (requireUserExists) throw new ErrorForbidden('Invalid email or password', { details: { email } });
+			return false;
+		}
 		return getIsMFAEnabled(user);
 	}
 

--- a/packages/server/src/routes/index/login.ts
+++ b/packages/server/src/routes/index/login.ts
@@ -107,7 +107,7 @@ router.post('login', async (path: SubPath, ctx: AppContext) => {
 	const body = await formParse(ctx.req);
 
 	try {
-		const hasMFAEnabled = await ctx.joplin.models.user().hasMFAEnabled(body.fields.email);
+		const hasMFAEnabled = !!config().MFA_ENABLED && await ctx.joplin.models.user().hasMFAEnabled(body.fields.email);
 
 		if (hasMFAEnabled && (!body.fields.mfaCode && !body.fields.recoveryCode)) {
 			return internalRedirect(path, ctx, router, 'login', body.fields, { showMfaCodeInput: true });

--- a/packages/server/src/routes/index/login.ts
+++ b/packages/server/src/routes/index/login.ts
@@ -82,14 +82,6 @@ router.get('login', async (_path: SubPath, ctx: AppContext, fields: LoginInputFi
 	return makeView(null, fields, viewContentOptions);
 });
 
-router.post('login', async (_path: SubPath, _ctx: AppContext) => {
-	if (!config().LOCAL_AUTH_ENABLED) {
-		return await generateRedirectHtml('web-login');
-	}
-
-	return makeView();
-});
-
 // Log in using external authentication.
 router.get('login/:id', async (path: SubPath, ctx: AppContext) => {
 	if (!config().saml.enabled) throw new ErrorForbidden('SAML not enabled');
@@ -107,6 +99,10 @@ router.get('login/:id', async (path: SubPath, ctx: AppContext) => {
 
 router.post('login', async (path: SubPath, ctx: AppContext) => {
 	await limiterLoginBruteForce(userIp(ctx));
+
+	if (!config().LOCAL_AUTH_ENABLED) {
+		return await generateRedirectHtml('web-login');
+	}
 
 	const body = await formParse(ctx.req);
 

--- a/packages/server/src/routes/index/login.ts
+++ b/packages/server/src/routes/index/login.ts
@@ -68,14 +68,6 @@ const getRedirectUrl = (isAdmin: number, applicationAuthId?: string) => {
 	return homeUrl();
 };
 
-router.post('login', async (_path: SubPath, _ctx: AppContext) => {
-	if (!config().LOCAL_AUTH_ENABLED) {
-		return await generateRedirectHtml('web-login');
-	}
-
-	return makeView();
-});
-
 router.get('login', async (_path: SubPath, ctx: AppContext, fields: LoginInputFields = {}, options: LoginViewContentOptions) => {
 	const viewContentOptions = {
 		showMfaCodeInput: !!options?.showMfaCodeInput,
@@ -88,6 +80,14 @@ router.get('login', async (_path: SubPath, ctx: AppContext, fields: LoginInputFi
 	}
 
 	return makeView(null, fields, viewContentOptions);
+});
+
+router.post('login', async (_path: SubPath, _ctx: AppContext) => {
+	if (!config().LOCAL_AUTH_ENABLED) {
+		return await generateRedirectHtml('web-login');
+	}
+
+	return makeView();
 });
 
 // Log in using external authentication.

--- a/packages/server/src/routes/index/login.ts
+++ b/packages/server/src/routes/index/login.ts
@@ -107,7 +107,11 @@ router.post('login', async (path: SubPath, ctx: AppContext) => {
 	const body = await formParse(ctx.req);
 
 	try {
-		const hasMFAEnabled = !!config().MFA_ENABLED && await ctx.joplin.models.user().hasMFAEnabled(body.fields.email);
+		// Non-existent users may be created by session().authenticate in some setups -- we need to allow
+		// non-existent users here.
+		const hasMFAEnabled = await ctx.joplin.models.user().hasMFAEnabled(
+			body.fields.email, { requireUserExists: false },
+		);
 
 		if (hasMFAEnabled && (!body.fields.mfaCode && !body.fields.recoveryCode)) {
 			return internalRedirect(path, ctx, router, 'login', body.fields, { showMfaCodeInput: true });

--- a/packages/server/src/routes/index/login.ts
+++ b/packages/server/src/routes/index/login.ts
@@ -68,6 +68,14 @@ const getRedirectUrl = (isAdmin: number, applicationAuthId?: string) => {
 	return homeUrl();
 };
 
+router.post('login', async (_path: SubPath, _ctx: AppContext) => {
+	if (!config().LOCAL_AUTH_ENABLED) {
+		return await generateRedirectHtml('web-login');
+	}
+
+	return makeView();
+});
+
 router.get('login', async (_path: SubPath, ctx: AppContext, fields: LoginInputFields = {}, options: LoginViewContentOptions) => {
 	const viewContentOptions = {
 		showMfaCodeInput: !!options?.showMfaCodeInput,
@@ -99,10 +107,6 @@ router.get('login/:id', async (path: SubPath, ctx: AppContext) => {
 
 router.post('login', async (path: SubPath, ctx: AppContext) => {
 	await limiterLoginBruteForce(userIp(ctx));
-
-	if (!config().LOCAL_AUTH_ENABLED) {
-		return await generateRedirectHtml('web-login');
-	}
 
 	const body = await formParse(ctx.req);
 

--- a/packages/server/src/utils/ldapLogin.ts
+++ b/packages/server/src/utils/ldapLogin.ts
@@ -83,6 +83,7 @@ export default async function ldapLogin(email: string, password: string, user: U
 			ldapUser.email = email;
 			ldapUser.password = password;
 			ldapUser.email_confirmed = 1;
+			ldapUser.totp_secret = '';
 			ldapUser.full_name = searchResults.searchEntries[0][fullNameAttribute].toString();
 			return ldapUser;
 		}


### PR DESCRIPTION
# Problem

The MFA-related changes in https://github.com/laurent22/joplin/commit/a3bf0cfdebf1dd97d8d520571d4a3cbe6fd9acc6 broke LDAP user auto-creation.

# Solution

- When deciding whether to redirect to the MFA-enabled login page, don't require that the user exists.
- Add an empty `totp_secret` property (matching the default value) to created LDAP users to fix a "missing totp_secret" error shown just after user creation.

Fixes #15725.

# Testing

## Manual testing

1. Set up LDAP authentication:
   1. Set up [LLDAP](https://github.com/lldap/lldap) via Docker. Use a Docker compose entry similar to:
      ```yml
      networks:
        app-network:
      
      services:
        app:
          # Replace joplin/server:arm64-0.0.11 with the custom image name and version (see step 2)
          image: joplin/server:arm64-0.0.11
          command: node dist/app.js --env dev
          depends_on:
            - ldap
          networks:
            - app-network
          volumes:
            - ./data/app/:/var/lib/joplin/data
          ports:
            - "127.0.0.1:22302:22302"
          restart: unless-stopped
          environment:
            - APP_PORT=22302
            - APP_BASE_URL=${APP_BASE_URL}
            - LDAP_1_ENABLED=1
            - LDAP_1_HOST=ldap://ldap:3890
            - LDAP_1_BASE_DN=${LDAP_BASE_DN}
            - LDAP_1_BIND_DN=${LDAP_BIND_DN}
            - LDAP_1_BIND_PW=${LDAP_BIND_PW}
        ldap:
          image: lldap/lldap:stable
          networks:
            - app-network
          ports:
            - "127.0.0.1:17170:17170"
          volumes:
            - ./data/lldap:/data
          environment:
            - LLDAP_JWT_SECRET=${LDAP_JWT_SECRET}
            - LLDAP_KEY_SEED=${LDAP_KEY_SEED}
            - LLDAP_LDAP_BASE_DN=${LDAP_BASE_DN}
            - LLDAP_LDAP_USER_PASS=${LDAP_USER_PASS}
        ```
      With `LDAP_BASE_DN=dc=example,dc=com`, `LDAP_BIND_DN=uid=binduser,ou=people,dc=example,dc=com`, and `LDAP_JWT_SECRET`/`LDAP_KEY_SEED`/`LDAP_USER_PASS`/`LDAP_BIND_PW` set to secure random values.
   2. Open the LLDAP web UI at `127.0.0.1:17170` and log in as `admin`, with password `LDAP_USER_PASS`.
   3. Create two users from the LLDAP web UI:
      1. `binduser` with password matching the value stored in `LDAP_BIND_PW` as part of step 1. Add this user to the `lldap_strict_readonly` group.
      2. `test` (email: `test@localhost`). Make a note of the password (which will be used later).
2. Build a test Docker image with the patch from this PR:
   ```
   bash$ yarn buildServerDocker --docker-file Dockerfile.server --platform linux/arm64 --tag-name server-v0.0.11 --repository joplin/server
   ```
   The `tag-name` and `repository` should match those used in the Docker compose file from step 3. Open `http://localhost:22302/`.
3. Start the Docker containers with `docker compose up`.
4. Log in as `test@localhost`, using the password defined for this account in step 1.
5. Verify that login works.

Screen recording:

https://github.com/user-attachments/assets/4fa3db74-5aca-4c82-9fae-a5cd3315009d


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
