### PR TITLE
Server: Fixes #15857: Fixed LDAP connection leak when login exits early

### DIFF
--- a/packages/server/src/utils/ldapLogin.ts
+++ b/packages/server/src/utils/ldapLogin.ts
@@ -42,38 +42,40 @@ export default async function ldapLogin(email: string, password: string, user: U
 			tlsOptions: tlsOptions,
 		});
 
-		if (bindDN.length !== 0) {
+		try {
+			if (bindDN.length !== 0) {
+				try {
+					await client.bind(bindDN, bindPW);
+				} catch (error) {
+					error.message = `Could not bind to the ldap server ${host}: ${error.message}`;
+					throw error;
+				}
+			}
+
 			try {
-				await client.bind(bindDN, bindPW);
+				searchResults = await client.search(baseDN, {
+					filter: new EqualityFilter({ attribute: mailAttribute, value: email }),
+					attributes: ['dn', fullNameAttribute],
+				});
+
+				if (searchResults.searchEntries.length === 0) return null;
+
 			} catch (error) {
-				error.message = `Could not bind to the ldap server ${host}: ${error.message}`;
+				error.message = `Could not search the ldap server ${host}: ${error.message}`;
 				throw error;
 			}
-		}
 
-		try {
-			searchResults = await client.search(baseDN, {
-				filter: new EqualityFilter({ attribute: mailAttribute, value: email }),
-				attributes: ['dn', fullNameAttribute],
-			});
+			if (bindDN.length !== 0) {
+				await client.unbind();
+			}
 
-			if (searchResults.searchEntries.length === 0) return null;
-
-		} catch (error) {
-			error.message = `Could not search the ldap server ${host}: ${error.message}`;
-			throw error;
-		}
-
-		if (bindDN.length !== 0) {
-			await client.unbind();
-		}
-
-		try {
-			await client.bind(searchResults.searchEntries[0].dn, password);
-		} catch (error) {
-			if (error.code === 49) return null;
-			error.message = `Could not login ${host}: ${error.message}`;
-			throw error;
+			try {
+				await client.bind(searchResults.searchEntries[0].dn, password);
+			} catch (error) {
+				if (error.code === 49) return null;
+				error.message = `Could not login ${host}: ${error.message}`;
+				throw error;
+			}
 		} finally {
 			await client.unbind();
 		}


### PR DESCRIPTION
Hi! While running Joplin Server 3.7.1 with LDAP enabled I noticed the server
slowly accumulating open connections to my LDAP server — a few hundred per
day — until slapd hit its file descriptor limit and stopped answering
(which also took down everything else using that LDAP server).

The cause is in `ldapLogin()`: the client is only unbound on the successful
path. Three early exits leak the connection:

1. The search returns no entries (`return null`) — this is the common one:
   every login attempt by an account that exists in Joplin but not in LDAP
   leaks one connection.
2. The initial service bind throws.
3. The search throws.

This PR wraps the bind/search/login sequence in a `try`/`finally` so the
client is always unbound, whichever way the function exits. `ldapts`'s
`unbind()` returns early when there is no open connection, so the `finally`
is safe on every path, including when the mid-flow unbind (before the user
bind) has already run.

Reproduced on 3.7.1 and the leak paths are unchanged on current `dev`.
Easy to see with `LDAP_1_ENABLED` pointing at any server: repeatedly log in
with a non-LDAP account and watch the ESTABLISHED connection count on the
LDAP side grow by one per attempt; with this patch it stays flat.

Thanks for Joplin — and for the recent LDAP improvements in 3.7!
