### PR TITLE
Chore: Server: Allow specifying an image name during build and fix license specifiers

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -43,7 +43,6 @@ RUN sed --in-place '/onenote-converter/d' ./packages/lib/package.json
 # Joplin Server -- and the Joplin packages, when included with it -- are licensed under their own license.
 RUN sed --in-place 's/"license": "AGPL-3.0-or-later"/"license": "UNLICENSED"/' ./package.json ./packages/*/package.json
 
-
 # For some reason there's both a .yarn/cache and .yarn/berry/cache that are
 # being generated, and both have the same content. Not clear why it does this
 # but we can delete it anyway. We can delete the cache because we use

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -40,6 +40,10 @@ COPY packages/server ./packages/server
 # We don't want to build onenote-converter since it is not used by the server
 RUN sed --in-place '/onenote-converter/d' ./packages/lib/package.json
 
+# Joplin Server -- and the Joplin packages, when included with it -- are licensed under their own license.
+RUN sed --in-place 's/"license": "AGPL-3.0-or-later"/"license": "UNLICENSED"/' ./package.json ./packages/*/package.json
+
+
 # For some reason there's both a .yarn/cache and .yarn/berry/cache that are
 # being generated, and both have the same content. Not clear why it does this
 # but we can delete it anyway. We can delete the cache because we use
@@ -102,8 +106,9 @@ ARG BUILD_DATE
 ARG REVISION
 ARG VERSION
 ARG SOURCE
+ARG IMAGE_NAME="Joplin Server"
 LABEL org.opencontainers.image.created="$BUILD_DATE" \
-      org.opencontainers.image.title="Joplin Server" \
+      org.opencontainers.image.title="$IMAGE_NAME" \
       org.opencontainers.image.description="Docker image for Joplin Server" \
       org.opencontainers.image.url="https://joplinapp.org/" \
       org.opencontainers.image.revision="$REVISION" \

--- a/packages/tools/buildServerDocker.ts
+++ b/packages/tools/buildServerDocker.ts
@@ -6,6 +6,7 @@ interface Argv {
 	dryRun?: boolean;
 	pushImages?: boolean;
 	repository?: string;
+	imageName?: string;
 	tagName?: string;
 	platform?: string;
 	source?: string;
@@ -26,6 +27,11 @@ function parseArgv(): Argv {
 			describe: 'Target image repository. Usually in format `OWNER/NAME`',
 			demandOption: true,
 			type: 'string',
+		})
+		.option('imageName', {
+			describe: 'Name to associate with the image',
+			type: 'string',
+			default: 'Joplin Server',
 		})
 		.option('tagName', {
 			describe: 'Base image tag. Usually should be in format `server-v1.2.3` or `server-v1.2.3-beta`. The latest `server-v*` git tag will be used by default.',
@@ -92,6 +98,7 @@ async function main() {
 	const platform = argv.platform;
 	const source = argv.source;
 	const architecture = argv.platform.split('/')[1];
+	const imageName = argv.imageName;
 
 	const isPreRelease = getIsPreRelease(tagName);
 	const imageVersion = getVersionFromTag(tagName, isPreRelease);
@@ -108,6 +115,7 @@ async function main() {
 	buildArgs.push(`REVISION="${revision}"`);
 	buildArgs.push(`VERSION="${imageVersion}"`);
 	buildArgs.push(`SOURCE="${source}"`);
+	buildArgs.push(`IMAGE_NAME="${imageName}"`);
 
 	const dockerTags: string[] = [];
 	const versionParts = imageVersion.split('.');


### PR DESCRIPTION
# Summary

- Allows specifying the `org.opencontainers.image.title` to be used for the built server instance.
- During build, replaces `"license": "AGPL-3.0-or-later"` for packages in `packages/*/` -- `packages/server` (and thus the built Docker image) [has its own license](https://github.com/laurent22/joplin/blob/dev/packages/server/LICENSE.md).

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
