### PR TITLE
Mobile, Desktop: Fixes #15840: Fixed RTL markdown lists rendered as LTR

### DIFF
--- a/packages/renderer/MdToHtml/rules/checkbox.ts
+++ b/packages/renderer/MdToHtml/rules/checkbox.ts
@@ -25,8 +25,8 @@ function pluginAssets(theme: RendererTheme) {
 				}
 
 				li.md-checkbox input[type=checkbox] {
-					margin-left: -1.71em;
-					margin-right: 0.7em;
+					margin-inline-start: -1.71em;
+					margin-inline-end: 0.7em;
 					position: relative;
 					top: 1px;
 				}
@@ -47,7 +47,7 @@ function pluginAssets(theme: RendererTheme) {
 					cursor: pointer;
 					width: 1em;
 					height: 1em;
-					margin-left: -1.3em;
+					margin-inline-start: -1.3em;
 					position: absolute;
 					color: ${theme.color};
 				}

--- a/packages/renderer/noteStyle.ts
+++ b/packages/renderer/noteStyle.ts
@@ -166,7 +166,7 @@ export default function(theme: RendererTheme, options: Options = null) {
 			padding-top: 0;
 		}
 		
-		p, h1, h2, h3, h4, h5, h6, ul, table {
+		p, h1, h2, h3, h4, h5, h6, ul, ol, table {
 			margin-top: .6em;
 			margin-bottom: 1.35em;
 
@@ -177,7 +177,7 @@ export default function(theme: RendererTheme, options: Options = null) {
 			unicode-bidi: plaintext;
 		}
 
-		h1, h2, h3, h4, h5, h6, ul, table {
+		h1, h2, h3, h4, h5, h6, ul, ol, table {
 			margin-bottom: 0.65em;
 		}
 
@@ -218,10 +218,13 @@ export default function(theme: RendererTheme, options: Options = null) {
 		}
 		ul, ol {
 			padding-left: 0;
-			margin-left: ${theme.listTabSize};
+			padding-inline-start: 0;
+			margin-left: 0;
+			margin-inline-start: ${theme.listTabSize};
 		}
 		li {
 			margin-bottom: .4em;
+			unicode-bidi: plaintext;
 		}
 		li p {
 			margin-top: 0.2em;


### PR DESCRIPTION
## Description
Fixes #15840

This PR resolves an issue where Right-to-Left (RTL) Markdown lists (both bulleted and numbered) were incorrectly forced into a Left-to-Right (LTR) layout in the mobile app. 

**Changes:**
- Added `ol` to the list of elements receiving `unicode-bidi: plaintext` in `noteStyle.ts`.
- Migrated hardcoded `margin-left` and `padding-left` values for `ul` and `ol` to use logical properties (`margin-inline-start` and `padding-inline-start`).
- Added `unicode-bidi: plaintext` directly to `li` elements to ensure WebViews dynamically recalculate and position the list markers (bullets/numbers) correctly on the right side for RTL list items.
- Updated the checkbox list styles (`packages/renderer/MdToHtml/rules/checkbox.ts`) to use `margin-inline-start` and `margin-inline-end` to ensure checkboxes also align correctly in RTL contexts.

## Testing
- Verified that using `unicode-bidi: plaintext` on `li` properly isolates the element and moves markers to the expected side in rendering engines.
- Verified that the migration to `margin-inline-start` defaults safely back to left-margins for LTR layouts, avoiding any breaking changes or regressions to standard LTR lists.


