### PR TITLE
Mobile: Fixes #12962: Improve side menu gestures to avoid conflicts with OS gesture navigation

### DIFF
--- a/packages/app-mobile/components/SideMenu.tsx
+++ b/packages/app-mobile/components/SideMenu.tsx
@@ -21,9 +21,6 @@ interface Props {
 
 	menu: React.ReactNode;
 	children: React.ReactNode|React.ReactNode[];
-	edgeHitWidth: number;
-	toleranceX: number;
-	toleranceY: number;
 	openMenuOffset: number;
 	menuPosition: SideMenuPosition;
 
@@ -221,17 +218,28 @@ const SideMenuComponent: React.FC<Props> = props => {
 					dx = -gestureState.dx;
 				}
 
-				const motionWithinToleranceY = Math.abs(dy) <= props.toleranceY;
-				let startWithinTolerance, motionWithinToleranceX;
+				// Horizontal swipe gestures can be made anywhere within the middle of the screen, except within the outer edges, to avoid conflicting with OS gesture navigation
+				const toleranceX = 4;
+				const gestureMargin = 35;
+				const minHorizontalSwipe = 35;
+
+				const startWithinTolerance = startX >= gestureMargin && startX <= contentWidth - gestureMargin; // Check the start position is not within the edge margins
+				const horizontalEnough = Math.abs(dx) >= minHorizontalSwipe; // Check that the dead zone has passed before starting the gesture, catering for curved swipes
+				const horizontalDominant = Math.abs(dx) > Math.abs(dy) * 2; // Check the direction is horizontal, allowing diagonal swipes up to a certain angle
+				let motionWithinToleranceX; // Check the correct direction is used in relation to whether swiping open / closed
+
 				if (open) {
-					startWithinTolerance = startX >= menuWidth - props.edgeHitWidth;
-					motionWithinToleranceX = dx <= -props.toleranceX;
+					motionWithinToleranceX = dx <= -toleranceX;
 				} else {
-					startWithinTolerance = startX <= props.edgeHitWidth;
-					motionWithinToleranceX = dx >= props.toleranceX;
+					motionWithinToleranceX = dx >= toleranceX;
 				}
 
-				return startWithinTolerance && motionWithinToleranceX && motionWithinToleranceY;
+				return (
+					startWithinTolerance &&
+					motionWithinToleranceX &&
+					horizontalEnough &&
+					horizontalDominant
+				);
 			},
 			onPanResponderGrant: () => {
 				setIsAnimating(true);
@@ -250,7 +258,7 @@ const SideMenuComponent: React.FC<Props> = props => {
 				}
 			},
 		});
-	}, [isLeftMenu, menuDragOffset, menuWidth, props.toleranceX, props.toleranceY, contentWidth, open, props.disableGestures, props.edgeHitWidth, updateMenuPosition, setIsAnimating]);
+	}, [isLeftMenu, menuDragOffset, contentWidth, open, props.disableGestures, updateMenuPosition, setIsAnimating]);
 
 	const onChangeRef = useRef(props.onChange);
 	onChangeRef.current = props.onChange;

--- a/packages/app-mobile/components/SideMenu.tsx
+++ b/packages/app-mobile/components/SideMenu.tsx
@@ -221,7 +221,7 @@ const SideMenuComponent: React.FC<Props> = props => {
 				// Horizontal swipe gestures can be made anywhere within the middle of the screen, except within the outer edges, to avoid conflicting with OS gesture navigation
 				const toleranceX = 4;
 				const gestureMargin = 35;
-				const minHorizontalSwipe = 35;
+				const minHorizontalSwipe = isLeftMenu ? 10 : 35; // Use a smaller dead zone for the left menu, as the notebook list uses FlatList, which greedily locks vertical scroll
 
 				const startWithinTolerance = startX >= gestureMargin && startX <= contentWidth - gestureMargin; // Check the start position is not within the edge margins
 				const horizontalEnough = Math.abs(dx) >= minHorizontalSwipe; // Check that the dead zone has passed before starting the gesture, catering for curved swipes

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -773,22 +773,12 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 		logger.info('root.biometrics: shouldShowMainContent', shouldShowMainContent);
 		logger.info('root.biometrics: this.state.sensorInfo', this.state.sensorInfo);
 
-		// The right sidemenu can be difficult to close due to a bug in the sidemenu
-		// library (right sidemenus can't be swiped closed).
-		//
-		// Additionally, it can interfere with scrolling in the note viewer, so we use
-		// a smaller edge hit width.
-		const menuEdgeHitWidth = menuPosition === 'right' ? 20 : 30;
-
 		const mainContent = (
 			<View style={{ flex: 1, backgroundColor: theme.backgroundColor }}>
 				<View style={{ flexGrow: 1, flexShrink: 1, flexBasis: '100%' }}>
 					<SafeAreaView style={{ flex: 1 }} titleBarUnderlayColor={theme.backgroundColor2}>
 						<SideMenu
 							menu={sideMenuContent}
-							edgeHitWidth={menuEdgeHitWidth}
-							toleranceX={4}
-							toleranceY={20}
 							openMenuOffset={this.state.sideMenuWidth}
 							menuPosition={menuPosition}
 							onChange={this.sideMenu_change}


### PR DESCRIPTION
On mobile, the left 'notebook' side menu on the note home screen, and the right 'properties' side menu on the notes screen, both can be opened using horizontal edge swipe gestures. This however is problematic when used on phones which use gesture navigation, because the edge swipe requirement conflicts with the OS gestures.

This PR replaces the edge swipe gestures with 'swipe from anywhere' style gestures, similar to what is use on the Discord app, as well as other popular apps. In order to avoid still conflicting with the gesture navigation, the starting swipe point of the gesture can be anywhere _except_ a fixed margin on the outer edges of the screen, leaving no possibility of the gesture navigation being blocked.

In addition to directly avoiding conflicts with the gesture navigation, I have given a generous margin before the side menu gesture starts, in order to avoid overly sensitive gestures which interfere with the vertical gestures for scrolling. I have also catered for steep diagonal swipes and curved swipes, to make it very hard to accidentally trigger the horizontal gestures when intending to scroll. For this reason, I feel there is no need to add a new setting to make any of the new behaviour toggle-able.

Please note, when on the notebook list and the notebook has enough notes to make the list scrollable, the horizontal swipe gesture will be ignored unless any vertical scrolling has completely stopped. This is because the note list uses a FlatList which greedily locks the vertical scroll with very little vertical movement. This means that there is less tolerance for diagonal scrolling on this screen, unless using either the top or the bottom of the list as an anchor for a diagonal line - but this is a limitation with the existing edge swipe gesture as well. On the other hand, scrolling the note viewer / editor does not lock the scroll when you start scrolling vertically, so a generous margin is needed before starting the horizontal gesture in that case.

This fixes https://github.com/laurent22/joplin/issues/12962

### Testing

**Areas tested:**
1. The following types of gestures were tested, and all were able to open / close the sidebars within an acceptable tolerance: straight across, diagonal, curved (starting horizontal), scrolling slowly. In addition to testing on Android emulator with a mouse, I also tested on a real device using touch, and the tolerances felt comfortable
2. I verified the horizontal gestures do not interfere with scrolling in both the notebook list / note list and in the note viewer / editor
3. The menus can now be swiped closed when dragging from within the menu now, fixing a limitation which was mentioned in an old comment
4. I verified that simply tapping outside of the side menu when opened dismisses it, as before
5. I briefly tested the change in landscape mode, and verified it behaves in the same way
6. Verified the editor toolbar in the note editor can still be scrolled when it is scrollable

**See video:**

https://github.com/user-attachments/assets/7e0aff9b-93b0-4869-a7ef-54159c2f19cc

Please note, there is a flicker sometimes when opening the properties side menu on the note viewer / editor via swiping. This is an existing issue which can be seen when testing the latest 3.7.2 Android pre-release as well.

