### PR TITLE
Desktop: Resolves #15842: Unable to select text within links

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/replaceLinks.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceLinks.test.ts
@@ -36,4 +36,19 @@ describe('replaceLinks', () => {
 		const editor = await createTestEditor(markup, EditorSelection.cursor(0), expectedSyntaxTags, [replaceLinks]);
 		expect(editor.contentDOM.textContent).toBe(expectedText);
 	});
+
+	it('should not move cursor when URL is already visible', async () => {
+		const markup = '[test](https://example.com/)';
+		const initialCursor = markup.indexOf('test');
+		const clickedCursor = markup.indexOf('example');
+		const editor = await createTestEditor(markup, EditorSelection.cursor(initialCursor), ['URL', 'LinkMark', 'Link'], [replaceLinks]);
+
+		expect(editor.contentDOM.textContent).toBe(markup);
+
+		editor.contentDOM.dispatchEvent(new MouseEvent('mousedown', { button: 0, bubbles: true }));
+		editor.dispatch({ selection: EditorSelection.cursor(clickedCursor) });
+		editor.contentDOM.ownerDocument.dispatchEvent(new MouseEvent('mouseup', { button: 0 }));
+
+		expect(editor.state.selection.main.anchor).toBe(clickedCursor);
+	});
 });

--- a/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts
@@ -42,7 +42,7 @@ export const makeInlineReplaceExtension = (extensionSpec: ReplacementExtension) 
 				}
 			});
 
-			const containsHiddenDecoration = (from: number, to: number) => {
+			const hasHiddenDecoration = (from: number, to: number) => {
 				let found = false;
 				this.decorations.between(from, to, (_from, _to, decoration) => {
 					if (!Object.keys(decoration.spec).length) {
@@ -64,9 +64,7 @@ export const makeInlineReplaceExtension = (extensionSpec: ReplacementExtension) 
 					const closingBracket = node.node.getChildren('LinkMark').find(mark => (
 						this.view.state.sliceDoc(mark.from, mark.to) === ']'
 					));
-					if (
-						closingBracket && selection.from >= closingBracket.from && selection.to <= node.to && containsHiddenDecoration(closingBracket.from, node.to)
-					) {
+					if (closingBracket && selection.from >= closingBracket.from && selection.to <= node.to && hasHiddenDecoration(closingBracket.from, node.to)) {
 						selectionUpdate = { anchor: node.to };
 					}
 				},

--- a/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts
@@ -42,6 +42,18 @@ export const makeInlineReplaceExtension = (extensionSpec: ReplacementExtension) 
 				}
 			});
 
+			const containsHiddenDecoration = (from: number, to: number) => {
+				let found = false;
+				this.decorations.between(from, to, (_from, _to, decoration) => {
+					if (!Object.keys(decoration.spec).length) {
+						found = true;
+						return false;
+					}
+					return undefined;
+				});
+				return found;
+			};
+
 			let selectionUpdate = !selection.empty && coveredTo >= selection.to ? { anchor: selection.head } : undefined;
 			const line = this.view.state.doc.lineAt(selection.from);
 			syntaxTree(this.view.state).iterate({
@@ -52,7 +64,9 @@ export const makeInlineReplaceExtension = (extensionSpec: ReplacementExtension) 
 					const closingBracket = node.node.getChildren('LinkMark').find(mark => (
 						this.view.state.sliceDoc(mark.from, mark.to) === ']'
 					));
-					if (closingBracket && selection.from >= closingBracket.from && selection.to <= node.to) {
+					if (
+						closingBracket && selection.from >= closingBracket.from && selection.to <= node.to && containsHiddenDecoration(closingBracket.from, node.to)
+					) {
 						selectionUpdate = { anchor: node.to };
 					}
 				},
@@ -144,7 +158,7 @@ export const makeInlineReplaceExtension = (extensionSpec: ReplacementExtension) 
 			transaction.effects.some(effect => effect.is(updateInlineDecorationsEffect))
 			|| extensionSpec.shouldFullReRender?.(transaction)
 		));
-		if (this.mouseSelectionInProgress && update.selectionSet && update.state.selection.main.empty && !update.docChanged && !forceUpdate) {
+		if (this.mouseSelectionInProgress && !update.docChanged && (update.selectionSet || forceUpdate)) {
 			return;
 		}
 


### PR DESCRIPTION
Resolves #15842 

When URL was already visible, the editor moved cursor to end of link, so user could not select URL text.

Now editor move cursor to link end only when URL is still hidden before mouse up. If URL is already visible before mouse up, editor keep cursor where user click, and user can select URL text.

Before:

https://github.com/user-attachments/assets/126bb2d4-fd3e-4f0b-a9a7-3fa5ce90edc6


After:

https://github.com/user-attachments/assets/739c7eaa-4ac4-43e4-aae0-dbac7d40eefc

