### PR TITLE
Mobile: Fixes #12962: Improve sidebar swipe gestures and reduce the likelihood of gesture navigation conflicts

### DIFF
--- a/packages/app-mobile/components/SideMenu.tsx
+++ b/packages/app-mobile/components/SideMenu.tsx
@@ -21,11 +21,14 @@ interface Props {
 
 	menu: React.ReactNode;
 	children: React.ReactNode|React.ReactNode[];
+	toleranceX: number;
+	minHorizontalSwipe: number;
 	openMenuOffset: number;
 	menuPosition: SideMenuPosition;
 
 	onChange: OnChangeCallback;
 	disableGestures: boolean;
+	disableOpenGesture: boolean;
 }
 
 interface UseStylesProps {
@@ -198,8 +201,7 @@ const SideMenuComponent: React.FC<Props> = props => {
 					return false;
 				}
 
-				// Opening the right menu requires using the kebab menu on the note viewer / editor, as gestures would interfere with horizontally scrollable content
-				if (!isLeftMenu && !open) {
+				if (props.disableOpenGesture && !open) {
 					return false;
 				}
 
@@ -214,18 +216,15 @@ const SideMenuComponent: React.FC<Props> = props => {
 					dx = -gestureState.dx;
 				}
 
-				// Horizontal swipe gestures can be made anywhere on the screen
-				const toleranceX = 4;
-				const minHorizontalSwipe = 10;
-
-				const horizontalEnough = Math.abs(dx) >= minHorizontalSwipe; // Check that the dead zone has passed before starting the gesture, catering for curved swipes
+				// Allowed horizontal swipe gestures can be made from anywhere on the screen
+				const horizontalEnough = Math.abs(dx) >= props.minHorizontalSwipe; // Check that the dead zone has passed before starting the gesture, catering for curved swipes
 				const horizontalDominant = Math.abs(dx) > Math.abs(dy) * 2; // Check the direction is horizontal, allowing diagonal swipes up to a certain angle
 				let motionWithinToleranceX; // Check the correct direction is used in relation to whether swiping open / closed
 
 				if (open) {
-					motionWithinToleranceX = dx <= -toleranceX;
+					motionWithinToleranceX = dx <= -props.toleranceX;
 				} else {
-					motionWithinToleranceX = dx >= toleranceX;
+					motionWithinToleranceX = dx >= props.toleranceX;
 				}
 
 				return (
@@ -251,7 +250,7 @@ const SideMenuComponent: React.FC<Props> = props => {
 				}
 			},
 		});
-	}, [isLeftMenu, menuDragOffset, open, props.disableGestures, updateMenuPosition, setIsAnimating]);
+	}, [isLeftMenu, menuDragOffset, props.toleranceX, props.minHorizontalSwipe, open, props.disableGestures, props.disableOpenGesture, updateMenuPosition, setIsAnimating]);
 
 	const onChangeRef = useRef(props.onChange);
 	onChangeRef.current = props.onChange;

--- a/packages/app-mobile/components/SideMenu.tsx
+++ b/packages/app-mobile/components/SideMenu.tsx
@@ -174,7 +174,6 @@ const SideMenuComponent: React.FC<Props> = props => {
 	}, [props.isOpen]);
 
 	const [menuWidth, setMenuWidth] = useState(0);
-	const [contentWidth, setContentWidth] = useState(0);
 
 	// In right-to-left layout, swap left and right to be consistent with other parts of
 	// the app's layout.
@@ -185,7 +184,6 @@ const SideMenuComponent: React.FC<Props> = props => {
 		const openMenuOffsetPercentage = props.openMenuOffset / Dimensions.get('window').width;
 		const menuWidth = Math.floor(width * openMenuOffsetPercentage);
 
-		setContentWidth(width);
 		setMenuWidth(menuWidth);
 	}, [props.openMenuOffset]);
 
@@ -200,30 +198,26 @@ const SideMenuComponent: React.FC<Props> = props => {
 					return false;
 				}
 
-				let startX;
+				// Opening the right menu requires using the kebab menu on the note viewer / editor, as gestures would interfere with horizontally scrollable content
+				if (!isLeftMenu && !open) {
+					return false;
+				}
+
 				let dx;
 				const dy = gestureState.dy;
-
-				// Untransformed start position of the gesture -- moveX is the current position of
-				// the pointer. Subtracting dx gives us the original start position.
-				const gestureStartScreenX = gestureState.moveX - gestureState.dx;
 
 				// Transform x, dx such that they are relative to the target screen edge -- this simplifies later
 				// math.
 				if (isLeftMenu) {
-					startX = gestureStartScreenX;
 					dx = gestureState.dx;
 				} else {
-					startX = contentWidth - gestureStartScreenX;
 					dx = -gestureState.dx;
 				}
 
-				// Horizontal swipe gestures can be made anywhere within the middle of the screen, except within the outer edges, to avoid conflicting with OS gesture navigation
+				// Horizontal swipe gestures can be made anywhere on the screen
 				const toleranceX = 4;
-				const gestureMargin = 35;
-				const minHorizontalSwipe = isLeftMenu ? 10 : 35; // Use a smaller dead zone for the left menu, as the notebook list uses FlatList, which greedily locks vertical scroll
+				const minHorizontalSwipe = 10;
 
-				const startWithinTolerance = startX >= gestureMargin && startX <= contentWidth - gestureMargin; // Check the start position is not within the edge margins
 				const horizontalEnough = Math.abs(dx) >= minHorizontalSwipe; // Check that the dead zone has passed before starting the gesture, catering for curved swipes
 				const horizontalDominant = Math.abs(dx) > Math.abs(dy) * 2; // Check the direction is horizontal, allowing diagonal swipes up to a certain angle
 				let motionWithinToleranceX; // Check the correct direction is used in relation to whether swiping open / closed
@@ -235,7 +229,6 @@ const SideMenuComponent: React.FC<Props> = props => {
 				}
 
 				return (
-					startWithinTolerance &&
 					motionWithinToleranceX &&
 					horizontalEnough &&
 					horizontalDominant
@@ -258,7 +251,7 @@ const SideMenuComponent: React.FC<Props> = props => {
 				}
 			},
 		});
-	}, [isLeftMenu, menuDragOffset, contentWidth, open, props.disableGestures, updateMenuPosition, setIsAnimating]);
+	}, [isLeftMenu, menuDragOffset, open, props.disableGestures, updateMenuPosition, setIsAnimating]);
 
 	const onChangeRef = useRef(props.onChange);
 	onChangeRef.current = props.onChange;

--- a/packages/app-mobile/components/SideMenu.tsx
+++ b/packages/app-mobile/components/SideMenu.tsx
@@ -21,9 +21,6 @@ interface Props {
 
 	menu: React.ReactNode;
 	children: React.ReactNode|React.ReactNode[];
-	edgeHitWidth: number;
-	toleranceX: number;
-	toleranceY: number;
 	openMenuOffset: number;
 	menuPosition: SideMenuPosition;
 
@@ -221,17 +218,28 @@ const SideMenuComponent: React.FC<Props> = props => {
 					dx = -gestureState.dx;
 				}
 
-				const motionWithinToleranceY = Math.abs(dy) <= props.toleranceY;
-				let startWithinTolerance, motionWithinToleranceX;
+				// Horizontal swipe gestures can be made anywhere within the middle of the screen, except within the outer edges, to avoid conflicting with OS gesture navigation
+				const toleranceX = 4;
+				const gestureMargin = 35;
+				const minHorizontalSwipe = 35;
+
+				const startWithinTolerance = startX >= gestureMargin && startX <= contentWidth - gestureMargin; // Check the start position is not within the edge margins
+				const horizontalEnough = Math.abs(dx) >= minHorizontalSwipe; // Check that the dead zone has passed before starting the gesture, catering for curved swipes
+				const horizontalDominant = Math.abs(dx) > Math.abs(dy) * 2; // Check the direction is horizontal, allowing diagonal swipes up to a certain angle
+				let motionWithinToleranceX; // Check the correct direction is used in relation to whether swiping open / closed
+
 				if (open) {
-					startWithinTolerance = startX >= menuWidth - props.edgeHitWidth;
-					motionWithinToleranceX = dx <= -props.toleranceX;
+					motionWithinToleranceX = dx <= -toleranceX;
 				} else {
-					startWithinTolerance = startX <= props.edgeHitWidth;
-					motionWithinToleranceX = dx >= props.toleranceX;
+					motionWithinToleranceX = dx >= toleranceX;
 				}
 
-				return startWithinTolerance && motionWithinToleranceX && motionWithinToleranceY;
+				return (
+					startWithinTolerance &&
+					motionWithinToleranceX &&
+					horizontalEnough &&
+					horizontalDominant
+				);
 			},
 			onPanResponderGrant: () => {
 				setIsAnimating(true);
@@ -250,7 +258,7 @@ const SideMenuComponent: React.FC<Props> = props => {
 				}
 			},
 		});
-	}, [isLeftMenu, menuDragOffset, menuWidth, props.toleranceX, props.toleranceY, contentWidth, open, props.disableGestures, props.edgeHitWidth, updateMenuPosition, setIsAnimating]);
+	}, [isLeftMenu, menuDragOffset, contentWidth, open, props.disableGestures, updateMenuPosition, setIsAnimating]);
 
 	const onChangeRef = useRef(props.onChange);
 	onChangeRef.current = props.onChange;

--- a/packages/app-mobile/components/SideMenu.tsx
+++ b/packages/app-mobile/components/SideMenu.tsx
@@ -221,7 +221,7 @@ const SideMenuComponent: React.FC<Props> = props => {
 				// Horizontal swipe gestures can be made anywhere within the middle of the screen, except within the outer edges, to avoid conflicting with OS gesture navigation
 				const toleranceX = 4;
 				const gestureMargin = 35;
-				const minHorizontalSwipe = 35;
+				const minHorizontalSwipe = isLeftMenu ? 10 : 35; // Use a smaller dead zone for the left menu, as the notebook list uses FlatList, which greedily locks vertical scroll
 
 				const startWithinTolerance = startX >= gestureMargin && startX <= contentWidth - gestureMargin; // Check the start position is not within the edge margins
 				const horizontalEnough = Math.abs(dx) >= minHorizontalSwipe; // Check that the dead zone has passed before starting the gesture, catering for curved swipes

--- a/packages/app-mobile/components/SideMenu.tsx
+++ b/packages/app-mobile/components/SideMenu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { AccessibilityInfo, Animated, Dimensions, Easing, I18nManager, LayoutChangeEvent, PanResponder, Pressable, StyleSheet, useWindowDimensions, View } from 'react-native';
+import { AccessibilityInfo, Animated, Dimensions, Easing, I18nManager, LayoutChangeEvent, PanResponder, PanResponderGestureState, Pressable, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { State } from '@joplin/lib/reducer';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import AccessibleView from './accessibility/AccessibleView';
@@ -194,6 +194,16 @@ const SideMenuComponent: React.FC<Props> = props => {
 		isLeftMenu, menuWidth, open,
 	});
 
+	const onGestureEnd = useCallback((gestureState: PanResponderGestureState) => {
+		const newOpen = (gestureState.dx > 0) === isLeftMenu;
+
+		if (newOpen === open) {
+			updateMenuPosition();
+		} else {
+			setIsOpen(newOpen);
+		}
+	}, [isLeftMenu, open, updateMenuPosition]);
+
 	const panResponder = useMemo(() => {
 		return PanResponder.create({
 			onMoveShouldSetPanResponderCapture: (_event, gestureState) => {
@@ -242,15 +252,14 @@ const SideMenuComponent: React.FC<Props> = props => {
 				{ dx: menuDragOffset },
 			], { useNativeDriver: false }),
 			onPanResponderEnd: (_event, gestureState) => {
-				const newOpen = (gestureState.dx > 0) === isLeftMenu;
-				if (newOpen === open) {
-					updateMenuPosition();
-				} else {
-					setIsOpen(newOpen);
-				}
+				onGestureEnd(gestureState);
+			},
+			onPanResponderTerminate: (_event, gestureState) => {
+				// This prevents the gesture from leaving the menu partially open on web
+				onGestureEnd(gestureState);
 			},
 		});
-	}, [isLeftMenu, menuDragOffset, props.toleranceX, props.minHorizontalSwipe, open, props.disableGestures, props.disableOpenGesture, updateMenuPosition, setIsAnimating]);
+	}, [isLeftMenu, menuDragOffset, props.toleranceX, props.minHorizontalSwipe, open, props.disableGestures, props.disableOpenGesture, onGestureEnd, setIsAnimating]);
 
 	const onChangeRef = useRef(props.onChange);
 	onChangeRef.current = props.onChange;

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -727,11 +727,14 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 		let sideMenuContent: ReactNode = null;
 		let menuPosition = SideMenuPosition.Left;
 		let disableSideMenuGestures = true;
+		let disableSideMenuOpenGesture = false;
 
 		if (this.props.routeName === 'Note') {
 			sideMenuContent = <SideMenuContentNote options={this.props.noteSideMenuOptions}/>;
 			menuPosition = SideMenuPosition.Right;
 			disableSideMenuGestures = this.props.disableSideMenuGestures;
+			// Opening the properties menu requires using the kebab menu, as open gestures would interfere with horizontally scrollable content in notes
+			disableSideMenuOpenGesture = true;
 		} else if (this.props.routeName === 'Notes') {
 			sideMenuContent = <SideMenuContent/>;
 			disableSideMenuGestures = false;
@@ -779,11 +782,14 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 					<SafeAreaView style={{ flex: 1 }} titleBarUnderlayColor={theme.backgroundColor2}>
 						<SideMenu
 							menu={sideMenuContent}
+							toleranceX={4}
+							minHorizontalSwipe={10}
 							openMenuOffset={this.state.sideMenuWidth}
 							menuPosition={menuPosition}
 							onChange={this.sideMenu_change}
 							isOpen={this.props.showSideMenu}
 							disableGestures={disableSideMenuGestures}
+							disableOpenGesture={disableSideMenuOpenGesture}
 						>
 							<View style={{ flex: 1, backgroundColor: theme.backgroundColor }}>
 								{ shouldShowMainContent && <AppNav screens={appNavInit} dispatch={this.props.dispatch} /> }

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -773,22 +773,12 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 		logger.info('root.biometrics: shouldShowMainContent', shouldShowMainContent);
 		logger.info('root.biometrics: this.state.sensorInfo', this.state.sensorInfo);
 
-		// The right sidemenu can be difficult to close due to a bug in the sidemenu
-		// library (right sidemenus can't be swiped closed).
-		//
-		// Additionally, it can interfere with scrolling in the note viewer, so we use
-		// a smaller edge hit width.
-		const menuEdgeHitWidth = menuPosition === 'right' ? 20 : 30;
-
 		const mainContent = (
 			<View style={{ flex: 1, backgroundColor: theme.backgroundColor }}>
 				<View style={{ flexGrow: 1, flexShrink: 1, flexBasis: '100%' }}>
 					<SafeAreaView style={{ flex: 1 }} titleBarUnderlayColor={theme.backgroundColor2}>
 						<SideMenu
 							menu={sideMenuContent}
-							edgeHitWidth={menuEdgeHitWidth}
-							toleranceX={4}
-							toleranceY={20}
 							openMenuOffset={this.state.sideMenuWidth}
 							menuPosition={menuPosition}
 							onChange={this.sideMenu_change}


### PR DESCRIPTION
### Background

I attempted to implement the sidebar using swipe from anywhere gestures for both the notebook (left) sidebar and the properties (right) sidebar in https://github.com/laurent22/joplin/pull/15869. However, although the implementation seemed to work well on the notebook sidebar on the note list, this approach is problematic to use for the properties sidebar in the note viewer / editor, because note content may be horizontally scrollable as well as vertically scrollable.

Looking at other apps, I was surprised to find the Gmail Android app has an edge only swipe gesture to open the folder list, and individual emails have separate swipe gestures of their own. When using gesture navigation, it's technically possible, but very hard to open the sidebar with a swipe gesture. The gesture navigation wins pretty much every time. So with gesture navigation enabled, you're essentially forced to use the hamburger button to open the sidebar. We have a similar situation with the Joplin Android app currently, except it's somewhat easier to accidentally open the sidebar when you intend to use the gesture navigation, if your swipe is diagonal or curved.

Alternatively, I see that the Notesnook app uses the swipe from anywhere approach in the note list to open a left sidebar, but the note editor does not have any swipe gestures. It does also have a similar properties panel, but you have to open it from the menu.

### Changes

In this PR, I have followed a similar approach to Notesnook, as it seems like a good compromise to allow swiping from anywhere on the note list to open the notebook sidebar, and disabling the swipe gesture to open the properties sidebar (so it must be opened from the kebab menu) on the note viewer / editor, but still using a swipe gesture (from anywhere) to close it. In order to deal with the gesture navigation conflicts, I have tweaked with the gesture logic in a way that makes it both difficult to accidentally scroll horizontally when intending to scroll vertically, and also in a way that makes the OS gesture navigation win pretty much every time, even when the swipe is at an angle or is curved (providing the swipe starts at the very edge of the screen).

This fixes https://github.com/laurent22/joplin/issues/12962

### Testing

1. On 2 real devices (Android 10 and 16) and Android emulator with gesture navigation enabled, I tested that the gesture behaviour was comfortable and did not interfere with vertical scrolling or noticeably conflict with the gesture navigation. I also did some brief testing in the web app in Chrome on Windows. With the tweaks to the gesture logic, it is noticeably difficult to produce an accidental open of the side menu with diagonal or curved swipes, which was easily producible with the existing app behaviour. For a reasonably straight swipe from the edge of the screen, it's very unlikely to accidentally open the sidebar instead of triggering the back gesture
2. The following types of gestures were tested, and all were able to open / close the sidebars within an acceptable tolerance: straight across, diagonal, curved (starting horizontal), scrolling slowly
3. I verified the horizontal gestures do not noticeably interfere with scrolling in both the notebook list and note list
4. The menus can now be swiped closed when dragging from within the menu now, fixing a limitation which was mentioned in an old comment
5. I verified that simply tapping outside of the side menu when opened dismisses it, as before
6. I briefly tested the change in landscape mode, and verified it behaves in the same way

**See video:**

https://github.com/user-attachments/assets/586edaf5-2845-46dc-bf3b-591012ef2945

