### PR TITLE
Mobile, Desktop, Cli: Resolves #15887: Rename remote_title/remote_body to resolved_title/resolved_body in conflict_note_states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1610,6 +1610,7 @@ packages/lib/services/database/migrations/50.js
 packages/lib/services/database/migrations/51.js
 packages/lib/services/database/migrations/52.js
 packages/lib/services/database/migrations/53.js
+packages/lib/services/database/migrations/54.js
 packages/lib/services/database/migrations/index.js
 packages/lib/services/database/sqlStringToLines.js
 packages/lib/services/database/types.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1636,6 +1636,7 @@ packages/lib/services/database/migrations/50.js
 packages/lib/services/database/migrations/51.js
 packages/lib/services/database/migrations/52.js
 packages/lib/services/database/migrations/53.js
+packages/lib/services/database/migrations/54.js
 packages/lib/services/database/migrations/index.js
 packages/lib/services/database/sqlStringToLines.js
 packages/lib/services/database/types.js

--- a/packages/lib/models/ConflictNoteState.ts
+++ b/packages/lib/models/ConflictNoteState.ts
@@ -23,13 +23,13 @@ export default class ConflictNoteState extends BaseModel {
 
 	public static async save(state: ConflictNoteStateEntity) {
 		await this.db().exec(
-			'INSERT OR REPLACE INTO conflict_note_states (note_id, base_body, base_title, remote_body, remote_title, remote_updated_time) VALUES (?, ?, ?, ?, ?, ?)',
+			'INSERT OR REPLACE INTO conflict_note_states (note_id, base_body, base_title, resolved_body, resolved_title, remote_updated_time) VALUES (?, ?, ?, ?, ?, ?)',
 			[
 				state.note_id,
 				state.base_body ?? '',
 				state.base_title ?? '',
-				state.remote_body ?? '',
-				state.remote_title ?? '',
+				state.resolved_body ?? '',
+				state.resolved_title ?? '',
 				state.remote_updated_time ?? 0,
 			],
 		);

--- a/packages/lib/services/database/migrations/53.ts
+++ b/packages/lib/services/database/migrations/53.ts
@@ -14,8 +14,8 @@ export default (): (SqlQuery|string)[] => {
 			note_id TEXT NOT NULL UNIQUE,
 			base_body TEXT NOT NULL DEFAULT "",
 			base_title TEXT NOT NULL DEFAULT "",
-			resolved_body TEXT NOT NULL DEFAULT "",
-			resolved_title TEXT NOT NULL DEFAULT "",
+			remote_body TEXT NOT NULL DEFAULT "",
+			remote_title TEXT NOT NULL DEFAULT "",
 			remote_updated_time INT NOT NULL DEFAULT 0
 		)`,
 	];

--- a/packages/lib/services/database/migrations/53.ts
+++ b/packages/lib/services/database/migrations/53.ts
@@ -14,8 +14,8 @@ export default (): (SqlQuery|string)[] => {
 			note_id TEXT NOT NULL UNIQUE,
 			base_body TEXT NOT NULL DEFAULT "",
 			base_title TEXT NOT NULL DEFAULT "",
-			remote_body TEXT NOT NULL DEFAULT "",
-			remote_title TEXT NOT NULL DEFAULT "",
+			resolved_body TEXT NOT NULL DEFAULT "",
+			resolved_title TEXT NOT NULL DEFAULT "",
 			remote_updated_time INT NOT NULL DEFAULT 0
 		)`,
 	];

--- a/packages/lib/services/database/migrations/54.ts
+++ b/packages/lib/services/database/migrations/54.ts
@@ -1,0 +1,14 @@
+import { SqlQuery } from '../types';
+
+// remote_body/remote_title no longer reflect what these columns hold once the
+// conflict UI lets the user edit the note directly rather than picking
+// between two fixed versions, so rename them to resolved_body/resolved_title.
+// Migration 53 already shipped in a beta release, so existing rows need to be
+// kept rather than dropped.
+
+export default (): (SqlQuery|string)[] => {
+	return [
+		'ALTER TABLE conflict_note_states RENAME COLUMN remote_body TO resolved_body',
+		'ALTER TABLE conflict_note_states RENAME COLUMN remote_title TO resolved_title',
+	];
+};

--- a/packages/lib/services/database/migrations/index.ts
+++ b/packages/lib/services/database/migrations/index.ts
@@ -11,6 +11,7 @@ import migration50 from './50';
 import migration51 from './51';
 import migration52 from './52';
 import migration53 from './53';
+import migration54 from './54';
 
 import { Migration } from '../types';
 
@@ -27,6 +28,7 @@ const index: Migration[] = [
 	migration51,
 	migration52,
 	migration53,
+	migration54,
 ];
 
 export default index;

--- a/packages/lib/services/database/types.ts
+++ b/packages/lib/services/database/types.ts
@@ -101,8 +101,8 @@ export interface ConflictNoteStateEntity {
   'base_title'?: string;
   'id'?: number | null;
   'note_id'?: string;
-  'remote_body'?: string;
-  'remote_title'?: string;
+  'resolved_body'?: string;
+  'resolved_title'?: string;
   'remote_updated_time'?: number;
   'type_'?: number;
 }
@@ -722,8 +722,8 @@ export const databaseSchema: DatabaseTables = {
 		base_title: { type: 'string' },
 		id: { type: 'number' },
 		note_id: { type: 'string' },
-		remote_body: { type: 'string' },
-		remote_title: { type: 'string' },
+		resolved_body: { type: 'string' },
+		resolved_title: { type: 'string' },
 		remote_updated_time: { type: 'number' },
 		type_: { type: 'number' },
 	},

--- a/packages/lib/services/synchronizer/Synchronizer.baseFields.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.baseFields.test.ts
@@ -83,7 +83,7 @@ describe('Synchronizer.baseFields', () => {
 
 		expect(state.base_body).toBe('base body');
 		expect(state.base_title).toBe('base title');
-		expect(state.remote_body).toBe('remote body');
+		expect(state.resolved_body).toBe('remote body');
 		expect(state.remote_updated_time).toBeGreaterThan(0);
 	}));
 

--- a/packages/lib/services/synchronizer/utils/handleConflictAction.ts
+++ b/packages/lib/services/synchronizer/utils/handleConflictAction.ts
@@ -73,8 +73,8 @@ export default async (action: SyncAction, ItemClass: typeof BaseItem, remoteExis
 				note_id: conflictNote.id,
 				base_body: base ? base.base_body : '',
 				base_title: base ? base.base_title : '',
-				remote_body: remoteNote ? remoteNote.body : '',
-				remote_title: remoteNote ? remoteNote.title : '',
+				resolved_body: remoteNote ? remoteNote.body : '',
+				resolved_title: remoteNote ? remoteNote.title : '',
 				remote_updated_time: remoteNote ? remoteNote.updated_time : 0,
 			});
 		}


### PR DESCRIPTION
Fixes #15887 
### PR Summary:

This PR renames the remote_body and remote_title columns in conflict_note_states to resolved_body and resolved_title

As described in the issue #15887 with the new conflict resolution UI, there's no fixed remote version anymore. The user works on a single note that starts from the remote content and edits it directly through the diff view and editor, so what these columns actually  keep is the resolved note, not a static copy of the remote. The old names no longer matched that functionality, so this updates them along with all the code that reads and writes them [ used in base population ]

- Since the migration 53 already in a beta release, the columns are renamed through a new migration (54) using ALTER TABLE RENAME COLUMN 
- I also renamed these columns everywhere they were used in the sync base population PR (#15669), including the ConflictNoteState model, database types, and the conflict handling logic

### Testing

Open a new profile and the app opens without any crash and the sync working well

https://github.com/user-attachments/assets/ad1910ee-87c2-45e9-ab6b-2f0dcce60f04

### AI disclosure
Used AI for the command to verify that the testing profile uses migration 54