### PR TITLE
Desktop: Whiteboard: Place new groups in empty space instead of viewport centre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1890,6 +1890,8 @@ packages/lib/services/trash/permanentlyDeleteOldItems.test.js
 packages/lib/services/trash/permanentlyDeleteOldItems.js
 packages/lib/services/trash/restoreItems.test.js
 packages/lib/services/trash/restoreItems.js
+packages/lib/services/whiteboard/findEmptySpot.test.js
+packages/lib/services/whiteboard/findEmptySpot.js
 packages/lib/services/whiteboard/generateId.js
 packages/lib/services/whiteboard/jsoncanvas.js
 packages/lib/services/whiteboard/parse.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1916,6 +1916,8 @@ packages/lib/services/trash/permanentlyDeleteOldItems.test.js
 packages/lib/services/trash/permanentlyDeleteOldItems.js
 packages/lib/services/trash/restoreItems.test.js
 packages/lib/services/trash/restoreItems.js
+packages/lib/services/whiteboard/findEmptySpot.test.js
+packages/lib/services/whiteboard/findEmptySpot.js
 packages/lib/services/whiteboard/generateId.js
 packages/lib/services/whiteboard/jsoncanvas.js
 packages/lib/services/whiteboard/parse.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/WhiteboardSurface.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/WhiteboardSurface.tsx
@@ -22,6 +22,7 @@ import {
 	useReactFlow,
 } from '@xyflow/react';
 import generateId from '@joplin/lib/services/whiteboard/generateId';
+import findEmptySpot from '@joplin/lib/services/whiteboard/findEmptySpot';
 import { _, _n } from '@joplin/lib/locale';
 import { Canvas, CanvasColor, CanvasEdge, CanvasNode } from '@joplin/lib/services/whiteboard/jsoncanvas';
 import { presetColors, resolveCanvasColor } from '@joplin/lib/services/whiteboard/presetColors';
@@ -198,6 +199,28 @@ const InnerSurface = ({ canvas, onChange }: Props) => {
 		return { x: cx, y: cy };
 	}, [rf]);
 
+	// Viewport bounds in canvas coordinates.
+	const viewportBounds = useCallback((): { x: number; y: number; width: number; height: number } | null => {
+		const view = rf.getViewport();
+		const rect = containerRef.current?.getBoundingClientRect();
+		if (!rect) return null;
+		return {
+			x: -view.x / view.zoom,
+			y: -view.y / view.zoom,
+			width: rect.width / view.zoom,
+			height: rect.height / view.zoom,
+		};
+	}, [rf]);
+
+	const existingRects = useCallback(() => {
+		return flowNodes.map(n => ({
+			x: n.position.x,
+			y: n.position.y,
+			width: (typeof n.width === 'number' ? n.width : (typeof n.style?.width === 'number' ? n.style.width : 0)) ?? 0,
+			height: (typeof n.height === 'number' ? n.height : (typeof n.style?.height === 'number' ? n.style.height : 0)) ?? 0,
+		}));
+	}, [flowNodes]);
+
 	const onAddText = useCallback(() => {
 		const { x: cx, y: cy } = viewportCentre();
 		addCanvasNode({
@@ -212,17 +235,23 @@ const InnerSurface = ({ canvas, onChange }: Props) => {
 	}, [viewportCentre, addCanvasNode]);
 
 	const onAddGroup = useCallback(() => {
-		const { x: cx, y: cy } = viewportCentre();
+		const { x, y, width, height } = findEmptySpot({
+			existing: existingRects(),
+			viewport: viewportBounds(),
+			centre: viewportCentre(),
+			preferred: { width: 320, height: 240 },
+			min: { width: 100, height: 100 },
+		});
 		addCanvasNode({
 			id: generateId(),
 			type: 'group',
-			x: cx - 240,
-			y: cy - 200,
-			width: 480,
-			height: 400,
+			x,
+			y,
+			width,
+			height,
 			label: _('New group'),
 		});
-	}, [viewportCentre, addCanvasNode]);
+	}, [existingRects, viewportBounds, viewportCentre, addCanvasNode]);
 
 	const selectedEdges = useMemo(() => flowEdges.filter(e => e.selected), [flowEdges]);
 	const selectedNodes = useMemo(() => flowNodes.filter(n => n.selected), [flowNodes]);

--- a/packages/lib/services/whiteboard/findEmptySpot.test.ts
+++ b/packages/lib/services/whiteboard/findEmptySpot.test.ts
@@ -1,4 +1,4 @@
-import findEmptySpot, { Rect } from './findEmptySpot';
+import findEmptySpot, { buildSizes, Rect } from './findEmptySpot';
 
 const viewport: Rect = { x: 0, y: 0, width: 1000, height: 800 };
 const centre = { x: 500, y: 400 };
@@ -70,6 +70,19 @@ describe('findEmptySpot', () => {
 	test('returns centre-based rect when viewport is null', () => {
 		const result = findEmptySpot({ existing: [], viewport: null, centre, preferred, min });
 		expect(result).toEqual({ x: 340, y: 280, width: 320, height: 240 });
+	});
+
+	test('buildSizes keeps shrinking width when height clamps first (non-square)', () => {
+		// Preferred 320x80, min 100x50, step 40. Height decrement is round(40 *
+		// 0.25) = 10. Height reaches min (50) at width=200, and the old
+		// implementation stopped there — skipping intermediate widths like 160
+		// and 120. The fix must keep shrinking width while clamping height.
+		const sizes = buildSizes({ width: 320, height: 80 }, { width: 100, height: 50 }, 40);
+		const widths = sizes.map(s => s.width);
+		expect(widths).toContain(120);
+		expect(widths).toContain(160);
+		for (const s of sizes) expect(s.height).toBeGreaterThanOrEqual(50);
+		expect(sizes[sizes.length - 1]).toEqual({ width: 100, height: 50 });
 	});
 
 	test('spiral finds an empty cell adjacent to a centred blocker', () => {

--- a/packages/lib/services/whiteboard/findEmptySpot.test.ts
+++ b/packages/lib/services/whiteboard/findEmptySpot.test.ts
@@ -1,0 +1,85 @@
+import findEmptySpot, { Rect } from './findEmptySpot';
+
+const viewport: Rect = { x: 0, y: 0, width: 1000, height: 800 };
+const centre = { x: 500, y: 400 };
+const preferred = { width: 320, height: 240 };
+const min = { width: 100, height: 100 };
+
+const rectsOverlap = (a: Rect, b: Rect) => a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
+const rectInside = (r: Rect, container: Rect) => r.x >= container.x && r.y >= container.y && r.x + r.width <= container.x + container.width && r.y + r.height <= container.y + container.height;
+
+describe('findEmptySpot', () => {
+	test('places at viewport centre on empty canvas', () => {
+		const result = findEmptySpot({ existing: [], viewport, centre, preferred, min });
+		expect(result).toEqual({ x: 340, y: 280, width: 320, height: 240 });
+	});
+
+	test('avoids overlap with an existing node near the centre', () => {
+		const blocker: Rect = { x: 400, y: 350, width: 200, height: 150 };
+		const result = findEmptySpot({ existing: [blocker], viewport, centre, preferred, min });
+		expect(rectsOverlap(result, blocker)).toBe(false);
+		expect(rectInside(result, viewport)).toBe(true);
+	});
+
+	test('shrinks toward min size when preferred does not fit', () => {
+		// Leave a narrow horizontal strip on the right (width ~110px) where only
+		// a shrunken node can fit; the rest of the viewport is fully blocked.
+		const existing: Rect[] = [
+			{ x: 0, y: 0, width: 890, height: 800 },
+		];
+		const result = findEmptySpot({ existing, viewport, centre, preferred, min });
+		expect(rectsOverlap(result, existing[0])).toBe(false);
+		expect(rectInside(result, viewport)).toBe(true);
+		expect(result.width).toBeLessThan(preferred.width);
+		expect(result.width).toBeGreaterThanOrEqual(min.width);
+	});
+
+	test('falls back offscreen adjacent to content AABB when nothing fits in view', () => {
+		const existing: Rect[] = [
+			{ x: 0, y: 0, width: viewport.width, height: viewport.height },
+		];
+		const result = findEmptySpot({ existing, viewport, centre, preferred, min });
+		expect(rectsOverlap(result, existing[0])).toBe(false);
+		// Should sit adjacent to the AABB with the configured gap. Since the
+		// AABB fills the viewport, the closest side to viewport bounds is a tie
+		// — any side is acceptable, but it must NOT be far from the AABB.
+		const nearRight = result.x === existing[0].x + existing[0].width + 40;
+		const nearBottom = result.y === existing[0].y + existing[0].height + 40;
+		const nearLeft = result.x === existing[0].x - 40 - preferred.width;
+		const nearTop = result.y === existing[0].y - 40 - preferred.height;
+		expect(nearRight || nearBottom || nearLeft || nearTop).toBe(true);
+		// Falls back to preferred size in the offscreen path.
+		expect(result.width).toBe(preferred.width);
+		expect(result.height).toBe(preferred.height);
+	});
+
+	test('offscreen fallback picks the side closest to the viewport', () => {
+		// Block the entire viewport plus have far-away content on the right.
+		// Combined AABB: x [0..2500], y [0..300]. Distances from viewport
+		// (0,0,300,300) with gap=40: right=2240, bottom=40, left=360, top=280.
+		// Bottom wins → y = maxCY + gap = 340.
+		const existing: Rect[] = [
+			{ x: 0, y: 0, width: 300, height: 300 },
+			{ x: 2000, y: 0, width: 500, height: 300 },
+		];
+		const shrunkViewport: Rect = { x: 0, y: 0, width: 300, height: 300 };
+		const result = findEmptySpot({ existing, viewport: shrunkViewport, centre: { x: 150, y: 150 }, preferred, min });
+		expect(result.y).toBe(340);
+	});
+
+	test('returns centre-based rect when viewport is null', () => {
+		const result = findEmptySpot({ existing: [], viewport: null, centre, preferred, min });
+		expect(result).toEqual({ x: 340, y: 280, width: 320, height: 240 });
+	});
+
+	test('spiral finds an empty cell adjacent to a centred blocker', () => {
+		// A blocker covering the centre but small enough that the preferred
+		// 320×240 still fits somewhere in the 1000×800 viewport — the spiral
+		// must find that clear position.
+		const blocker: Rect = { x: 400, y: 300, width: 200, height: 200 };
+		const result = findEmptySpot({ existing: [blocker], viewport, centre, preferred, min });
+		expect(rectsOverlap(result, blocker)).toBe(false);
+		expect(rectInside(result, viewport)).toBe(true);
+		expect(result.width).toBe(preferred.width);
+	});
+});

--- a/packages/lib/services/whiteboard/findEmptySpot.ts
+++ b/packages/lib/services/whiteboard/findEmptySpot.ts
@@ -1,0 +1,130 @@
+export interface Rect {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+export interface Size {
+	width: number;
+	height: number;
+}
+
+export interface FindEmptySpotOptions {
+	// Existing node rectangles the new node must not overlap.
+	existing: Rect[];
+	// Visible viewport in canvas coordinates. If null, the function returns
+	// the preferred-size rect centred on `centre` (used when the viewport
+	// hasn't been measured yet).
+	viewport: Rect | null;
+	// Point around which the search spirals — typically the viewport centre.
+	centre: { x: number; y: number };
+	preferred: Size;
+	// Minimum acceptable size. The search shrinks from preferred toward min
+	// (preserving aspect ratio) and only falls back to offscreen placement
+	// if even the min size doesn't fit anywhere in view.
+	min: Size;
+	// Spiral step in canvas coordinates.
+	step?: number;
+	// Shrink increment (applied to width; height shrinks proportionally).
+	shrinkStep?: number;
+	// Gap between the new node and the AABB of existing nodes when placed
+	// adjacent to it in the offscreen-fallback path.
+	gap?: number;
+}
+
+const rectsOverlap = (a: Rect, b: Rect): boolean => {
+	return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
+};
+
+const overlapsAny = (candidate: Rect, existing: Rect[]): boolean => {
+	for (const e of existing) {
+		if (rectsOverlap(candidate, e)) return true;
+	}
+	return false;
+};
+
+const buildSizes = (preferred: Size, min: Size, shrinkStep: number): Size[] => {
+	const sizes: Size[] = [];
+	const ratio = preferred.height / preferred.width;
+	for (let w = preferred.width, h = preferred.height; w >= min.width && h >= min.height; w -= shrinkStep, h -= Math.round(shrinkStep * ratio)) {
+		sizes.push({ width: Math.max(w, min.width), height: Math.max(h, min.height) });
+		if (w === min.width && h === min.height) break;
+	}
+	const last = sizes[sizes.length - 1];
+	if (!last || last.width !== min.width || last.height !== min.height) sizes.push({ width: min.width, height: min.height });
+	return sizes;
+};
+
+// Finds an empty spot for a new rectangular node. Tries the preferred size
+// first, spiralling out from `centre` inside `viewport`; if nothing fits, it
+// shrinks toward `min` and tries again. If even the min size doesn't fit
+// anywhere in view, falls back to placing a preferred-size rect adjacent to
+// the AABB of existing nodes (with a gap) on whichever side is closest to the
+// viewport, so the new node stays partially visible.
+const findEmptySpot = (options: FindEmptySpotOptions): Rect => {
+	const { existing, viewport, centre, preferred, min } = options;
+	const step = options.step ?? 40;
+	const shrinkStep = options.shrinkStep ?? 40;
+	const gap = options.gap ?? 40;
+
+	if (!viewport) {
+		return { x: centre.x - preferred.width / 2, y: centre.y - preferred.height / 2, ...preferred };
+	}
+
+	const sizes = buildSizes(preferred, min, shrinkStep);
+
+	for (const size of sizes) {
+		const cornerX = centre.x - size.width / 2;
+		const cornerY = centre.y - size.height / 2;
+		const maxX = viewport.x + viewport.width - size.width;
+		const maxY = viewport.y + viewport.height - size.height;
+		if (maxX < viewport.x || maxY < viewport.y) continue;
+
+		const centred: Rect = { x: cornerX, y: cornerY, ...size };
+		if (viewport.x <= cornerX && cornerX <= maxX && viewport.y <= cornerY && cornerY <= maxY && !overlapsAny(centred, existing)) {
+			return centred;
+		}
+
+		const maxRings = Math.ceil(Math.max(viewport.width, viewport.height) / step);
+		for (let ring = 1; ring <= maxRings; ring++) {
+			for (let dy = -ring; dy <= ring; dy++) {
+				for (let dx = -ring; dx <= ring; dx++) {
+					if (Math.max(Math.abs(dx), Math.abs(dy)) !== ring) continue;
+					const x = cornerX + dx * step;
+					const y = cornerY + dy * step;
+					if (x < viewport.x || x > maxX || y < viewport.y || y > maxY) continue;
+					const candidate: Rect = { x, y, ...size };
+					if (!overlapsAny(candidate, existing)) return candidate;
+				}
+			}
+		}
+	}
+
+	if (!existing.length) {
+		return { x: centre.x - preferred.width / 2, y: centre.y - preferred.height / 2, ...preferred };
+	}
+
+	let minCX = Infinity, minCY = Infinity, maxCX = -Infinity, maxCY = -Infinity;
+	for (const e of existing) {
+		minCX = Math.min(minCX, e.x);
+		minCY = Math.min(minCY, e.y);
+		maxCX = Math.max(maxCX, e.x + e.width);
+		maxCY = Math.max(maxCY, e.y + e.height);
+	}
+
+	const viewR = viewport.x + viewport.width;
+	const viewB = viewport.y + viewport.height;
+	const cyMid = Math.max(viewport.y, Math.min(viewB - preferred.height, (minCY + maxCY) / 2 - preferred.height / 2));
+	const cxMid = Math.max(viewport.x, Math.min(viewR - preferred.width, (minCX + maxCX) / 2 - preferred.width / 2));
+	const candidates = [
+		{ x: maxCX + gap, y: cyMid, dist: Math.max(0, maxCX + gap - viewR) },
+		{ x: cxMid, y: maxCY + gap, dist: Math.max(0, maxCY + gap - viewB) },
+		{ x: minCX - gap - preferred.width, y: cyMid, dist: Math.max(0, viewport.x - (minCX - gap - preferred.width)) },
+		{ x: cxMid, y: minCY - gap - preferred.height, dist: Math.max(0, viewport.y - (minCY - gap - preferred.height)) },
+	];
+	candidates.sort((a, b) => a.dist - b.dist);
+	return { x: candidates[0].x, y: candidates[0].y, ...preferred };
+};
+
+export default findEmptySpot;

--- a/packages/lib/services/whiteboard/findEmptySpot.ts
+++ b/packages/lib/services/whiteboard/findEmptySpot.ts
@@ -44,12 +44,19 @@ const overlapsAny = (candidate: Rect, existing: Rect[]): boolean => {
 	return false;
 };
 
-const buildSizes = (preferred: Size, min: Size, shrinkStep: number): Size[] => {
+export const buildSizes = (preferred: Size, min: Size, shrinkStep: number): Size[] => {
 	const sizes: Size[] = [];
 	const ratio = preferred.height / preferred.width;
-	for (let w = preferred.width, h = preferred.height; w >= min.width && h >= min.height; w -= shrinkStep, h -= Math.round(shrinkStep * ratio)) {
+	// Keep shrinking while EITHER dimension is still above its minimum, so the
+	// other one can be clamped instead of terminating the search early. This
+	// matters for non-square preferred/min pairs where one axis reaches its
+	// minimum well before the other.
+	let w = preferred.width;
+	let h = preferred.height;
+	while (w > min.width || h > min.height) {
 		sizes.push({ width: Math.max(w, min.width), height: Math.max(h, min.height) });
-		if (w === min.width && h === min.height) break;
+		w -= shrinkStep;
+		h -= Math.round(shrinkStep * ratio);
 	}
 	const last = sizes[sizes.length - 1];
 	if (!last || last.width !== min.width || last.height !== min.height) sizes.push({ width: min.width, height: min.height });

--- a/packages/lib/services/whiteboard/whiteboard.test.ts
+++ b/packages/lib/services/whiteboard/whiteboard.test.ts
@@ -17,7 +17,7 @@ const sampleCanvas: Canvas = {
 	],
 };
 
-describe('whiteboard format module', () => {
+describe('whiteboard', () => {
 	test('parses a body with a jsoncanvas fence and preserves surrounding text', () => {
 		const before = '# My note\n\nSome intro text.\n\n';
 		const after = '\nA closing paragraph.\n';

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -336,3 +336,4 @@ tradeoff
 Reconnectable
 doleocent1
 Socialboom
+AABB


### PR DESCRIPTION
New groups used to spawn dead-centre at a fixed 480×400, often on top of existing nodes — which then became captives of the group and had to be dragged out before the group could be moved.

Now the placement searches for an empty spot near the viewport centre, spiralling outward and shrinking from a preferred 320×240 down to a 100×100 minimum. If nothing fits in view, the group is placed adjacent to the existing-nodes bounding box (with a gap) on whichever side is closest to the viewport, so it stays partially visible.

Logic is extracted to packages/lib/services/whiteboard/findEmptySpot.ts with unit tests.