### PR TITLE
Chore: Server: Add a utility function for determining the number of enabled non-admin users

### DIFF
--- a/packages/server/src/models/UserModel.test.ts
+++ b/packages/server/src/models/UserModel.test.ts
@@ -657,4 +657,26 @@ describe('UserModel', () => {
 			await models().user().hasMFAEnabled('no-exist@localhost', { requireUserExists: true });
 		}, 403);
 	});
+
+	test('should return the number of enabled non-admin users from enabledUserCount', async () => {
+		const user1 = await createUser(1);
+		const user2 = await createUser(2);
+		await createUser(3, true);
+
+		expect(await models().user().enabledUserCount({ excludeMainAdmin: true })).toBe(2);
+		expect(await models().user().enabledUserCount({ excludeMainAdmin: false })).toBe(3);
+
+		await models().user().save({
+			id: user2.id,
+			enabled: 0,
+		});
+		expect(await models().user().enabledUserCount({ excludeMainAdmin: true })).toBe(1);
+		expect(await models().user().enabledUserCount({ excludeMainAdmin: false })).toBe(2);
+
+		await models().user().save({
+			id: user1.id,
+			enabled: 0,
+		});
+		expect(await models().user().enabledUserCount({ excludeMainAdmin: true })).toBe(0);
+	});
 });

--- a/packages/server/src/models/UserModel.ts
+++ b/packages/server/src/models/UserModel.ts
@@ -65,6 +65,10 @@ export interface Account {
 	max_total_item_size: number;
 }
 
+interface EnabledUserCountOptions {
+	excludeMainAdmin: boolean;
+}
+
 const accountMetadata: Record<AccountType, Account> = {
 	// The "default" account is the account that would be used on a self-hosted
 	// Joplin Server, or a user that can be created from the admin UI (or API).
@@ -928,4 +932,21 @@ export default class UserModel extends BaseModel<User> {
 		await this.models().notification().add(userId, NotificationKey.Any, NotificationLevel.Important, 'Multi-factor authentication has been enabled for your account. Please remember to copy and save your recovery codes');
 	}
 
+	public async enabledUserCount({ excludeMainAdmin }: EnabledUserCountOptions) {
+		const result = await this.db('users')
+			.where('enabled', '=', 1)
+			.count('*', { as: 'count' });
+		let count = Number(result[0].count);
+
+		if (excludeMainAdmin) {
+			const hasAdminUser = !!await this.db('users')
+				.select({ 'id': 'id' })
+				.where('is_admin', '=', 1)
+				.where('enabled', '=', 1)
+				.first();
+			count -= (hasAdminUser ? 1 : 0);
+		}
+
+		return count;
+	}
 }


### PR DESCRIPTION
# Summary

Adds an `enabledUserCount` method on `UserModel`, which can be used to determine the number of enabled non-admin accounts on a server instance.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
