### PR TITLE
Doc: Resolves #15823: Docker compose template: Don't expose PostgreSQL container port

### DIFF
--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -31,7 +31,8 @@ services:
         networks:
             - app-network
         ports:
-            - "5432:5432"
+            # (Optional): Allow accessing the database using an external tool (e.g. `psql`) from the host:
+            - "127.0.0.1:5432:5432"
         restart: unless-stopped
         environment:
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -31,8 +31,8 @@ services:
         networks:
             - app-network
         ports:
-            # (Optional): Allow accessing the database using an external tool (e.g. `psql`) from the host:
-            # - "127.0.0.1:5432:5432"
+            # Allow accessing the database using an external tool (e.g. `psql`) from the host:
+            - "127.0.0.1:5432:5432"
         restart: unless-stopped
         environment:
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -30,9 +30,8 @@ services:
             - ./data/postgres:/var/lib/postgresql/data
         networks:
             - app-network
-        ports:
-            # Allow accessing the database using an external tool (e.g. `psql`) from the host:
-            - "127.0.0.1:5432:5432"
+        # (Optional): Allow accessing the database using an external tool (e.g. `psql`) from the host:
+        # ports: [ "127.0.0.1:5432:5432" ]
         restart: unless-stopped
         environment:
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -32,7 +32,7 @@ services:
             - app-network
         ports:
             # (Optional): Allow accessing the database using an external tool (e.g. `psql`) from the host:
-            - "127.0.0.1:5432:5432"
+            # - "127.0.0.1:5432:5432"
         restart: unless-stopped
         environment:
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}


### PR DESCRIPTION
# Problem

In the sample Docker Compose file, the PostgreSQL port isn't restricted to a specific host/interface. Docker [exposes ports on all interfaces by default](https://docs.docker.com/get-started/docker-concepts/running-containers/publishing-ports/#publishing-ports).

# Solution

- Don't expose port `5432` by default. The `app` container already has access to `db`, since it and `db` are both on `app-network`.
- Add a comment showing how to expose port `5432` on `127.0.0.1` to allow accessing the database from an external tool like `psql`.

Resolves #15823.

# Testing

1. Create a `.env` file similar to:
    ```env
    TRANSCRIBE_ENABLED=0
    TRANSCRIBE_API_KEY=
    POSTGRES_PORT=5432
    POSTGRES_USER=pg
    POSTGRES_DATABASE=joplin
    POSTGRES_PASSWORD=some-postgres-password-here
    POSTGRES_USER=joplin
    APP_BASE_URL=http://localhost:22300/
    HTR_CLI_IMAGES_FOLDER=/tmp/htr-cli-images
    HTR_CLI_MODELS_FOLDER=/tmp/htr-cli-models
    ```
2. Comment out `app`'s `transcribe` dependency
   - Note: This seems to be required to run the `server` profile. Without this, Joplin Server fails to start with `service "app" depends on undefined service "transcribe": invalid compose project`.
3. Start Joplin Server with `docker compose --profile server -f ./docker-compose.server.yml up`.
4. Start the sync fuzzer with `yarn syncFuzzer start --use-running-server`.
5. Connect to the database, using
   ```
   bash$ docker compose --profile server -f ./docker-compose.server.yml exec db psql -U joplin
   ```
6. Verify that the sync fuzzer successfully created users (run `SELECT email FROM users;`).
7. From the host, attempt to connect to the PostgreSQL database using `psql -h 127.0.0.1 -p 5432 -U joplin`. Verify that this fails.
8. Uncomment `ports: [ "127.0.0.1:5432:5432" ]` in the Docker compose file and recreate the container.
9. Attempt to connect to the PostgreSQL database using `psql -h 127.0.0.1 -p 5432 -U joplin`. Sign in using the PostgreSQL password set in step 1. Verify that `SELECT email FROM users;` lists emails.
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
