### PR TITLE
Chore: Server: Add logic for displaying Joplin Server Business status

### DIFF
--- a/packages/server/src/middleware/notificationHandler.ts
+++ b/packages/server/src/middleware/notificationHandler.ts
@@ -2,14 +2,15 @@ import { AppContext, KoaNext, NotificationView } from '../utils/types';
 import { isApiRequest } from '../utils/requestUtils';
 import { NotificationLevel } from '../services/database/types';
 import { defaultAdminEmail } from '../db';
-import { _ } from '@joplin/lib/locale';
+import { _, _n } from '@joplin/lib/locale';
 import Logger from '@joplin/utils/Logger';
 import { NotificationKey } from '../models/NotificationModel';
-import { helpUrl, profileUrl } from '../utils/urlUtils';
+import { adminUsersUrl, helpUrl, profileUrl } from '../utils/urlUtils';
 import { userFlagToString } from '../models/UserFlagModel';
 import renderMarkdown from '../utils/renderMarkdown';
 import config from '../config';
 import { unique } from '../utils/array';
+import { formatDurationToDays } from '../utils/time';
 
 const logger = Logger.create('notificationHandler');
 
@@ -52,6 +53,76 @@ async function handleChangeAdminPasswordNotification(ctx: AppContext) {
 		await notificationModel.setRead(ctx.joplin.owner.id, NotificationKey.ChangeAdminPassword);
 	}
 }
+
+const handleLicenseStatusNotification = async (ctx: AppContext): Promise<NotificationView|null> => {
+	const licenseStatus = { gracePeriod: false, expired: false, maximumUserCount: -1, licenceRemainingTime: -1 };
+	const isOverUserCapacity = () => Promise.resolve(false);
+
+	const licenseDashboardUrl = () => '';
+	const getUpdateLicenseKeyCallToAction = () => _('Please update the license key from the [admin dashboard](%s).', licenseDashboardUrl());
+
+	if (licenseStatus.gracePeriod && ctx.joplin.owner?.is_admin) {
+		return {
+			id: 'licenseExpiring',
+			messageHtml: renderMarkdown([
+				_('The license key for this Joplin Server Business instance has expired and needs to be renewed.'),
+				_('Item upload will be disabled in %s.', formatDurationToDays(licenseStatus.licenceRemainingTime)),
+				'',
+				getUpdateLicenseKeyCallToAction(),
+			].join('\n')),
+			levelClassName: levelClassName(NotificationLevel.Important),
+			closeUrl: '',
+		};
+	} else if (licenseStatus.expired) {
+		return {
+			id: 'licenseExpiring',
+			messageHtml: renderMarkdown([
+				_('The license key for this Joplin Server Business instance has expired or is invalid. Uploading items has been disabled until the license is renewed.'),
+				'',
+				getUpdateLicenseKeyCallToAction(),
+			].join('\n')),
+			levelClassName: levelClassName(NotificationLevel.Important),
+			closeUrl: '',
+		};
+	} else if (await isOverUserCapacity() && ctx.joplin.owner?.is_admin) {
+		return {
+			id: 'licenseCapacityExceeded',
+			messageHtml: renderMarkdown([
+				_('Item upload has been disabled.'),
+				_n(
+					'This Joplin Server Business instance is only licensed for %d user.',
+					'This Joplin Server Business instance is only licensed for %d users.',
+					licenseStatus.maximumUserCount,
+					licenseStatus.maximumUserCount,
+				),
+				'\n\n',
+				_('Please disable users from the [admin dashboard](%s) to bring this server under the limit.', adminUsersUrl()),
+			].join(' ')),
+			levelClassName: levelClassName(NotificationLevel.Important),
+			closeUrl: '',
+		};
+	}
+
+	if (ctx.joplin.owner?.is_admin) {
+		const licenseRefreshError = '';
+
+		if (licenseRefreshError) {
+			return {
+				id: 'licenseRefreshError',
+				messageHtml: renderMarkdown([
+					_('The license for this server failed to refresh.'),
+					_('Error: %s', licenseRefreshError),
+					'\n\n',
+					_('Manage this server\'s license from the [admin dashboard](%s).', licenseDashboardUrl()),
+				].join(' ')),
+				levelClassName: levelClassName(NotificationLevel.Important),
+				closeUrl: '',
+			};
+		}
+	}
+
+	return null;
+};
 
 // Special notification that cannot be dismissed.
 async function handleUserFlags(ctx: AppContext): Promise<NotificationView> {
@@ -150,6 +221,7 @@ export default async function(ctx: AppContext, next: KoaNext): Promise<void> {
 
 		const nonDismisableViews = [
 			await handleUserFlags(ctx),
+			await handleLicenseStatusNotification(ctx),
 			await handleConfirmEmailNotification(ctx),
 		];
 

--- a/packages/server/src/utils/time.test.ts
+++ b/packages/server/src/utils/time.test.ts
@@ -1,5 +1,5 @@
 import { expectThrow } from './testing/testUtils';
-import { Day, durationToMilliseconds, Month, Second } from './time';
+import { Day, durationToMilliseconds, formatDurationToDays, Hour, Month, Second } from './time';
 
 describe('time', () => {
 
@@ -13,6 +13,12 @@ describe('time', () => {
 		const d = durationToMilliseconds('PT10S');
 		expect(d).toBe(10000);
 		await expectThrow(() => durationToMilliseconds('notaduration'));
+	});
+
+	it('should format millisecond durations to days', () => {
+		expect(formatDurationToDays(Day)).toBe('1 day');
+		expect(formatDurationToDays(Day + 12 * Hour)).toBe('1 day');
+		expect(formatDurationToDays(Day + 26 * Hour)).toBe('2 days');
 	});
 
 });

--- a/packages/server/src/utils/time.ts
+++ b/packages/server/src/utils/time.ts
@@ -3,6 +3,7 @@ import dayJsUtc = require('dayjs/plugin/utc');
 import dayJsDuration = require('dayjs/plugin/duration');
 import dayJsTimezone = require('dayjs/plugin/timezone');
 import { LoggerWrapper } from '@joplin/utils/Logger';
+import { _n } from '@joplin/lib/locale';
 
 function defaultTimezone() {
 	return dayjs.tz.guess();
@@ -49,6 +50,11 @@ export function formatDate(ms: number | Date): string {
 	ms = ms instanceof Date ? ms.getTime() : ms;
 	return `${dayjs(ms).format('D MMM YYYY')}`;
 }
+
+export const formatDurationToDays = (ms: number) => {
+	const days = Math.floor(ms / Day);
+	return _n('1 day', '%d days', days, days);
+};
 
 export const durationToMilliseconds = (durationIso8601: string) => {
 	const d = dayjs.duration(durationIso8601).asMilliseconds();


### PR DESCRIPTION
# Summary

Adds (disabled) logic for showing Joplin Server Business status notifications.

# Test plan

1. Start Joplin Server and sign in using the default admin credentials.
2. Verify that the admin password notification is still shown.
3. Verify that no other notifications are shown.
4. Change the admin password. Verify that this dismisses the admin password notification.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
