### PR TITLE
Chore: Server: Add logic to customize the home screen for external users

### DIFF
--- a/packages/server/src/routes/index/home.ts
+++ b/packages/server/src/routes/index/home.ts
@@ -66,6 +66,7 @@ router.get('home', async (_path: SubPath, ctx: AppContext) => {
 	if (ctx.method === 'GET') {
 		const user = ctx.joplin.owner;
 		const subscription = await ctx.joplin.models.subscription().byUserId(user.id);
+		const isExternal = false;
 
 		const view = defaultView('home', 'Home');
 		view.content = {
@@ -83,33 +84,33 @@ router.get('home', async (_path: SubPath, ctx: AppContext) => {
 				{
 					label: 'Max item size',
 					value: formatMaxItemSize(user),
-					show: true,
+					show: !isExternal,
 				},
 				{
 					label: 'Total size',
 					classes: [totalSizeClass(user)],
 					value: `${formatTotalSize(user)} (${formatTotalSizePercent(user)})`,
-					show: true,
+					show: !isExternal,
 				},
 				{
 					label: 'Max total size',
 					value: formatMaxTotalSize(user),
-					show: true,
+					show: !isExternal,
 				},
 				{
 					label: 'Can publish notes',
 					value: yesOrNo(true),
-					show: true,
+					show: !isExternal,
 				},
 				{
 					label: 'Can share notebooks',
 					value: yesOrNo(getCanShareFolder(user)),
-					show: true,
+					show: !isExternal,
 				},
 				{
 					label: 'Can receive notebooks',
 					value: !!yesOrNo(getCanReceiveFolder(user)),
-					show: true,
+					show: !isExternal,
 				},
 			],
 			showUpgradeProButton: subscription && user.account_type === AccountType.Basic,
@@ -117,6 +118,7 @@ router.get('home', async (_path: SubPath, ctx: AppContext) => {
 			betaExpiredDays: betaUserTrialPeriodDays(user.created_time, 0, 0),
 			betaStartSubUrl: betaStartSubUrl(user.email, user.account_type),
 			setupMessageHtml: setupMessageHtml(),
+			syncTargetName: isExternal ? 'Joplin Server Business' : config().appName,
 			isJoplinCloud: config().isJoplinCloud,
 			socialFeeds: socialFeeds(),
 		};

--- a/packages/server/src/views/index/home.mustache
+++ b/packages/server/src/views/index/home.mustache
@@ -9,9 +9,9 @@
 
 <h2 class="title">Welcome to {{global.appName}}</h2>
 <div class="block readable-block content">
-	<p>To start using {{global.appName}}, make sure to <a href="{{{global.joplinAppBaseUrl}}}/download">download one of the Joplin applications</a>, either for desktop or for your mobile phone.</p>
+	<p>To start using {{syncTargetName}}, make sure to <a href="{{{global.joplinAppBaseUrl}}}/download">download one of the Joplin applications</a>, either for desktop or for your mobile phone.</p>
 	<p>Once the app is installed, open the <strong>Configuration</strong> screen, then the <strong>Synchronisation</strong> section. {{{setupMessageHtml}}}<p>
-	<p>Once it is set up {{global.appName}} allows you to synchronise your devices, to publish notes, or to collaborate on notebooks with other {{global.appName}} users.</p>
+	<p>Once it is set up {{syncTargetName}} allows you to synchronise your devices, to publish notes, or to collaborate on notebooks with other {{syncTargetName}} users.</p>
 </div>
 
 {{#isJoplinCloud}}


### PR DESCRIPTION
# Summary

Adds (currently disabled) logic to:
- Change the sync target name suggested to users.
- Change the items shown in the "Your account" list on the Joplin Server homepage.


# Testing

1. Sign in to the default Joplin Server admin account
2. Verify that the homepage 
   - Lists the sync target name as "Joplin Server".
   - Includes `Can publish notes`, `Can share notebooks`, and `Can receive notebooks` in the "Your account" table. 

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
