### PR TITLE
Chore: Server: Store Stripe period start/end in the database

### DIFF
--- a/packages/server/src/migrations/20260713084230_stripe_period.ts
+++ b/packages/server/src/migrations/20260713084230_stripe_period.ts
@@ -1,0 +1,15 @@
+import { DbConnection } from '../db';
+
+export const up = async (db: DbConnection) => {
+	await db.schema.alterTable('subscriptions', (table) => {
+		table.bigInteger('trial_end').defaultTo(0).notNullable();
+		table.bigInteger('current_period_end').defaultTo(0).notNullable();
+	});
+};
+
+export const down = async (db: DbConnection) => {
+	await db.schema.alterTable('subscriptions', (table) => {
+		table.dropColumn('trial_end');
+		table.dropColumn('current_period_end');
+	});
+};

--- a/packages/server/src/models/SubscriptionModel.test.ts
+++ b/packages/server/src/models/SubscriptionModel.test.ts
@@ -1,3 +1,4 @@
+import { mock as stripeMock, stripe, reset as resetStripe } from '../utils/testing/mockStripe';
 import { beforeAllDb, afterAllTests, beforeEachDb, models } from '../utils/testing/testUtils';
 import { AccountType } from './UserModel';
 import { MB } from '../utils/bytes';
@@ -62,4 +63,23 @@ describe('SubscriptionModel', () => {
 		expect(user.enabled).toBe(1);
 	});
 
+	test('should fetch the trial_end/current_period_end from Stripe if not stored in the database', async () => {
+		const periodEnd = new Date('2026-05-06');
+		const trialEnd = new Date('2026-05-05');
+		stripeMock.setMockSubscription('sub_001', { periodEnd, trialEnd });
+		try {
+			const { subscription, user } = await models().subscription().saveUserAndSubscription('user@example.com', 'Test', AccountType.Basic, 'cus_001', 'sub_001');
+			const fetched = await models().subscription().retrievePeriodEnd(stripe, subscription);
+			expect(fetched.currentPeriodEnd).toBe(periodEnd.getTime());
+			expect(fetched.trialEnd).toBe(trialEnd.getTime());
+
+			// Period end and trial end should be saved in the database for future accesses:
+			expect(await models().subscription().byUserId(user.id)).toMatchObject({
+				current_period_end: periodEnd.getTime(),
+				trial_end: trialEnd.getTime(),
+			});
+		} finally {
+			resetStripe();
+		}
+	});
 });

--- a/packages/server/src/models/SubscriptionModel.test.ts
+++ b/packages/server/src/models/SubscriptionModel.test.ts
@@ -16,6 +16,7 @@ describe('SubscriptionModel', () => {
 
 	beforeEach(async () => {
 		await beforeEachDb();
+		resetStripe();
 	});
 
 	test('should create a user and subscription', async () => {
@@ -67,19 +68,16 @@ describe('SubscriptionModel', () => {
 		const periodEnd = new Date('2026-05-06');
 		const trialEnd = new Date('2026-05-05');
 		stripeMock.setMockSubscription('sub_001', { periodEnd, trialEnd });
-		try {
-			const { subscription, user } = await models().subscription().saveUserAndSubscription('user@example.com', 'Test', AccountType.Basic, 'cus_001', 'sub_001');
-			const fetched = await models().subscription().retrievePeriodEnd(stripe, subscription);
-			expect(fetched.currentPeriodEnd).toBe(periodEnd.getTime());
-			expect(fetched.trialEnd).toBe(trialEnd.getTime());
 
-			// Period end and trial end should be saved in the database for future accesses:
-			expect(await models().subscription().byUserId(user.id)).toMatchObject({
-				current_period_end: periodEnd.getTime(),
-				trial_end: trialEnd.getTime(),
-			});
-		} finally {
-			resetStripe();
-		}
+		const { subscription, user } = await models().subscription().saveUserAndSubscription('user@example.com', 'Test', AccountType.Basic, 'cus_001', 'sub_001');
+		const fetched = await models().subscription().retrievePeriodEnd(stripe, subscription);
+		expect(fetched.currentPeriodEnd).toBe(periodEnd.getTime());
+		expect(fetched.trialEnd).toBe(trialEnd.getTime());
+
+		// Period end and trial end should be saved in the database for future accesses:
+		expect(await models().subscription().byUserId(user.id)).toMatchObject({
+			current_period_end: periodEnd.getTime(),
+			trial_end: trialEnd.getTime(),
+		});
 	});
 });

--- a/packages/server/src/models/SubscriptionModel.ts
+++ b/packages/server/src/models/SubscriptionModel.ts
@@ -176,6 +176,7 @@ export default class SubscriptionModel extends BaseModel<Subscription> {
 		if (!subscription.id) {
 			subscription = await this.byUserId(subscription.user_id);
 		}
+		if (!subscription) throw new ErrorNotFound('Failed to update subscription from Stripe: Unable to load full subscription');
 
 		// Depending on the source of the stripeSubscription and the API version, current_period_end is stored in different locations:
 		const periodEndSeconds = stripeSubscription.current_period_end
@@ -200,7 +201,7 @@ export default class SubscriptionModel extends BaseModel<Subscription> {
 	}
 
 	public async retrievePeriodEnd(stripe: Stripe, subscription: Subscription) {
-		const assertHasSubscription = () => {
+		const assertSubscriptionExists = (subscription: Subscription|null) => {
 			// Handles the case where the subscription is disabled/deleted while retrieving its period end
 			if (!subscription) {
 				throw new ErrorNotFound('Failed to reload subscription: Subscription not found');
@@ -208,7 +209,7 @@ export default class SubscriptionModel extends BaseModel<Subscription> {
 		};
 
 		subscription = subscription.id ? await this.load(subscription.id) : await this.byUserId(subscription.user_id);
-		assertHasSubscription();
+		assertSubscriptionExists(subscription);
 
 		// Older subscriptions might not have a trial_end or current_period_end
 		const isUninitialized = subscription.trial_end === 0 && subscription.current_period_end === 0;
@@ -216,7 +217,7 @@ export default class SubscriptionModel extends BaseModel<Subscription> {
 			const stripeSubscription = await stripe.subscriptions.retrieve(subscription.stripe_subscription_id);
 			await this.updateFromStripe(subscription, stripeSubscription);
 			subscription = await this.load(subscription.id);
-			assertHasSubscription();
+			assertSubscriptionExists(subscription);
 		}
 
 		return {

--- a/packages/server/src/models/SubscriptionModel.ts
+++ b/packages/server/src/models/SubscriptionModel.ts
@@ -187,8 +187,8 @@ export default class SubscriptionModel extends BaseModel<Subscription> {
 			throw new ErrorBadRequest('Failed to update subscription from Stripe -- missing both trial_end and current_period_end');
 		}
 
-		const stripePeriodEnd = periodEndSeconds * Second;
-		const stripeTrialEnd = trialEndSeconds * Second;
+		const stripePeriodEnd = (periodEndSeconds ?? 0) * Second;
+		const stripeTrialEnd = (trialEndSeconds ?? 0) * Second;
 
 		if (subscription.current_period_end !== stripePeriodEnd || subscription.trial_end !== stripeTrialEnd) {
 			await this.save({

--- a/packages/server/src/models/SubscriptionModel.ts
+++ b/packages/server/src/models/SubscriptionModel.ts
@@ -1,11 +1,13 @@
 import { Knex } from 'knex';
 import { EmailSender, Subscription, User, UserFlagType, Uuid } from '../services/database/types';
-import { ErrorNotFound } from '../utils/errors';
+import { ErrorBadRequest, ErrorNotFound } from '../utils/errors';
 import { Day } from '../utils/time';
 import { uuidgen } from '../utils/uuid';
 import paymentFailedTemplate from '../views/emails/paymentFailedTemplate';
 import BaseModel from './BaseModel';
 import { AccountType } from './UserModel';
+import { Second } from '@joplin/utils/time';
+import type Stripe from 'stripe';
 
 export const failedPaymentWarningInterval = 7 * Day;
 export const failedPaymentFinalAccount = 14 * Day;
@@ -23,6 +25,11 @@ enum PaymentAttemptStatus {
 interface PaymentAttempt {
 	status: PaymentAttemptStatus;
 	time: number;
+}
+
+export interface StripeSubscriptionSlice {
+	current_period_end: number|null;
+	trial_end: number|null;
 }
 
 export default class SubscriptionModel extends BaseModel<Subscription> {
@@ -156,4 +163,43 @@ export default class SubscriptionModel extends BaseModel<Subscription> {
 		await this.save({ id, is_deleted: isDeleted ? 1 : 0 });
 	}
 
+	public async updateFromStripe(subscription: Subscription, stripeSubscription: StripeSubscriptionSlice) {
+		if (!subscription.id) {
+			subscription = await this.byUserId(subscription.user_id);
+		}
+
+		if ((stripeSubscription.current_period_end ?? null) === null && (stripeSubscription.trial_end ?? null) === null) {
+			throw new ErrorBadRequest('Failed to update subscription from Stripe -- missing both trial_end and current_period_end');
+		}
+
+		// Stripe subscriptions date/time properties are in seconds. Handling undefined is important, since
+		// current_period_end can be undefined when creating a new trial subscription:
+		const stripePeriodEnd = (stripeSubscription.current_period_end ?? 0) * Second;
+		const stripeTrialEnd = (stripeSubscription.trial_end ?? 0) * Second;
+
+		if (subscription.current_period_end !== stripePeriodEnd || subscription.trial_end !== stripeTrialEnd) {
+			await this.save({
+				id: subscription.id,
+				current_period_end: stripePeriodEnd,
+				trial_end: stripeTrialEnd,
+			});
+		}
+	}
+
+	public async retrievePeriodEnd(stripe: Stripe, subscription: Subscription) {
+		subscription = subscription.id ? await this.load(subscription.id) : await this.byUserId(subscription.user_id);
+
+		// Older subscriptions might not have a trial_end or current_period_end
+		const isUninitialized = subscription.trial_end === 0 && subscription.current_period_end === 0;
+		if (isUninitialized) {
+			const stripeSubscription = await stripe.subscriptions.retrieve(subscription.stripe_subscription_id);
+			await this.updateFromStripe(subscription, stripeSubscription);
+			subscription = await this.load(subscription.id);
+		}
+
+		return {
+			trialEnd: subscription.trial_end,
+			currentPeriodEnd: subscription.current_period_end,
+		};
+	}
 }

--- a/packages/server/src/models/SubscriptionModel.ts
+++ b/packages/server/src/models/SubscriptionModel.ts
@@ -200,8 +200,15 @@ export default class SubscriptionModel extends BaseModel<Subscription> {
 	}
 
 	public async retrievePeriodEnd(stripe: Stripe, subscription: Subscription) {
+		const assertHasSubscription = () => {
+			// Handles the case where the subscription is disabled/deleted while retrieving its period end
+			if (!subscription) {
+				throw new ErrorNotFound('Failed to reload subscription: Subscription not found');
+			}
+		};
+
 		subscription = subscription.id ? await this.load(subscription.id) : await this.byUserId(subscription.user_id);
-		if (!subscription) throw new ErrorNotFound(`No subscription found with ID ${subscription.id}`);
+		assertHasSubscription();
 
 		// Older subscriptions might not have a trial_end or current_period_end
 		const isUninitialized = subscription.trial_end === 0 && subscription.current_period_end === 0;
@@ -209,6 +216,7 @@ export default class SubscriptionModel extends BaseModel<Subscription> {
 			const stripeSubscription = await stripe.subscriptions.retrieve(subscription.stripe_subscription_id);
 			await this.updateFromStripe(subscription, stripeSubscription);
 			subscription = await this.load(subscription.id);
+			assertHasSubscription();
 		}
 
 		return {

--- a/packages/server/src/models/SubscriptionModel.ts
+++ b/packages/server/src/models/SubscriptionModel.ts
@@ -27,9 +27,18 @@ interface PaymentAttempt {
 	time: number;
 }
 
+interface StripeSubscriptionItemSlice {
+	current_period_end?: number;
+	quantity?: number;
+}
+
 export interface StripeSubscriptionSlice {
-	current_period_end: number|null;
-	trial_end: number|null;
+	trial_end: number|undefined;
+
+	// When retrieved from the webhook with newer API versions, current_period_end is stored in `items.data`.
+	// With older API versions and when retrieved directly, current_period_end is present directly on the subscription.
+	current_period_end: number|undefined;
+	items?: { data: StripeSubscriptionItemSlice[] };
 }
 
 export default class SubscriptionModel extends BaseModel<Subscription> {
@@ -168,14 +177,18 @@ export default class SubscriptionModel extends BaseModel<Subscription> {
 			subscription = await this.byUserId(subscription.user_id);
 		}
 
-		if ((stripeSubscription.current_period_end ?? null) === null && (stripeSubscription.trial_end ?? null) === null) {
+		// Depending on the source of the stripeSubscription and the API version, current_period_end is stored in different locations:
+		const periodEndSeconds = stripeSubscription.current_period_end
+			?? stripeSubscription.items?.data?.[0]?.current_period_end
+			?? null;
+		const trialEndSeconds = stripeSubscription.trial_end ?? null;
+
+		if (periodEndSeconds === null && trialEndSeconds === null) {
 			throw new ErrorBadRequest('Failed to update subscription from Stripe -- missing both trial_end and current_period_end');
 		}
 
-		// Stripe subscriptions date/time properties are in seconds. Handling undefined is important, since
-		// current_period_end can be undefined when creating a new trial subscription:
-		const stripePeriodEnd = (stripeSubscription.current_period_end ?? 0) * Second;
-		const stripeTrialEnd = (stripeSubscription.trial_end ?? 0) * Second;
+		const stripePeriodEnd = periodEndSeconds * Second;
+		const stripeTrialEnd = trialEndSeconds * Second;
 
 		if (subscription.current_period_end !== stripePeriodEnd || subscription.trial_end !== stripeTrialEnd) {
 			await this.save({

--- a/packages/server/src/models/SubscriptionModel.ts
+++ b/packages/server/src/models/SubscriptionModel.ts
@@ -188,6 +188,7 @@ export default class SubscriptionModel extends BaseModel<Subscription> {
 
 	public async retrievePeriodEnd(stripe: Stripe, subscription: Subscription) {
 		subscription = subscription.id ? await this.load(subscription.id) : await this.byUserId(subscription.user_id);
+		if (!subscription) throw new ErrorNotFound(`No subscription found with ID ${subscription.id}`);
 
 		// Older subscriptions might not have a trial_end or current_period_end
 		const isUninitialized = subscription.trial_end === 0 && subscription.current_period_end === 0;

--- a/packages/server/src/routes/index/stripe.test.ts
+++ b/packages/server/src/routes/index/stripe.test.ts
@@ -8,6 +8,7 @@ import { uuidgen } from '@joplin/lib/uuid';
 import { postHandlers } from './stripe';
 import Stripe from 'stripe';
 import { SubPath } from '../../utils/routeUtils';
+import { Hour, Month, Second } from '@joplin/utils/time';
 
 interface StripeOptions {
 	userEmail?: string;
@@ -53,6 +54,7 @@ interface WebhookOptions {
 	stripe?: ReturnType<typeof mockStripe>;
 	eventId?: string;
 	subscriptionId?: string;
+	currentPeriodEndSeconds?: number;
 	customerId?: string;
 	sessionId?: string;
 	userEmail?: string;
@@ -93,6 +95,7 @@ async function createUserViaSubscription(ctx: AppContext, options: WebhookOption
 	await simulateWebhook(ctx, 'customer.subscription.created', {
 		id: options.subscriptionId,
 		customer: options.customerId,
+		current_period_end: options.currentPeriodEndSeconds ?? Math.floor((Date.now() + Month) / Second),
 		items: {
 			data: [
 				{
@@ -291,6 +294,7 @@ describe('index/stripe', () => {
 		await simulateWebhook(ctx, 'customer.subscription.created', {
 			id: 'sub_new',
 			customer: 'cus_toto',
+			current_period_end: Date.now() + Month,
 			items: { data: [{ price: { id: stripePrice.id } }] },
 		}, { stripe });
 
@@ -332,6 +336,8 @@ describe('index/stripe', () => {
 		await simulateWebhook(ctx, 'customer.subscription.created', {
 			id: 'sub_1',
 			customer: 'cus_toto',
+			current_period_end: Date.now() + Month,
+			trial_end: Date.now() + Month,
 			items: { data: [{ price: { id: stripePrice.id } }] },
 		}, { stripe });
 
@@ -339,4 +345,31 @@ describe('index/stripe', () => {
 		expect(stripe.subscriptions.cancel).toHaveBeenCalledTimes(0);
 	});
 
+	test('should update subscription period end/trial end dates in the database when updated in Stripe', async () => {
+		const stripe = mockStripe({ userEmail: 'toto@example.com' });
+		const ctx = await koaAppContext();
+
+		const stripePrice = findPrice(stripeConfig(), { accountType: AccountType.Basic, period: PricePeriod.Monthly });
+		const sendWebhookEvent = (eventType: 'created'|'updated', currentPeriodEndSeconds: number) => {
+			return simulateWebhook(ctx, `customer.subscription.${eventType}`, {
+				id: 'sub_1',
+				customer: 'cus_toto',
+				current_period_end: currentPeriodEndSeconds,
+				items: { data: [{ price: { id: stripePrice.id } }] },
+			}, { stripe });
+		};
+
+		// Should update the subscription on created events
+		let periodEndSeconds = Math.floor((Date.now() + Hour) / Second);
+		await sendWebhookEvent('created', periodEndSeconds);
+
+		const subscription = () => models().subscription().byStripeSubscriptionId('sub_1');
+		expect(await subscription()).toMatchObject({ current_period_end: periodEndSeconds * Second });
+
+		periodEndSeconds += 300;
+
+		// Should update the subscription on updated events
+		await sendWebhookEvent('updated', periodEndSeconds);
+		expect(await subscription()).toMatchObject({ current_period_end: periodEndSeconds * Second });
+	});
 });

--- a/packages/server/src/routes/index/stripe.test.ts
+++ b/packages/server/src/routes/index/stripe.test.ts
@@ -336,8 +336,8 @@ describe('index/stripe', () => {
 		await simulateWebhook(ctx, 'customer.subscription.created', {
 			id: 'sub_1',
 			customer: 'cus_toto',
-			current_period_end: Date.now() + Month,
-			trial_end: Date.now() + Month,
+			current_period_end: Math.floor((Date.now() + Month) / Second),
+			trial_end: Math.floor((Date.now() + Month) / Second),
 			items: { data: [{ price: { id: stripePrice.id } }] },
 		}, { stripe });
 

--- a/packages/server/src/routes/index/stripe.test.ts
+++ b/packages/server/src/routes/index/stripe.test.ts
@@ -294,7 +294,7 @@ describe('index/stripe', () => {
 		await simulateWebhook(ctx, 'customer.subscription.created', {
 			id: 'sub_new',
 			customer: 'cus_toto',
-			current_period_end: Date.now() + Month,
+			current_period_end: Math.floor((Date.now() + Month) / Second),
 			items: { data: [{ price: { id: stripePrice.id } }] },
 		}, { stripe });
 

--- a/packages/server/src/routes/index/stripe.ts
+++ b/packages/server/src/routes/index/stripe.ts
@@ -310,6 +310,11 @@ export const postHandlers: PostHandlers = {
 					stripeUserId,
 					stripeSubscriptionId,
 				);
+
+				const subscription = await models.subscription().byStripeSubscriptionId(stripeSubscriptionId);
+				if (subscription) {
+					await models.subscription().updateFromStripe(subscription, stripeSub);
+				}
 			},
 
 			'invoice.paid': async () => {
@@ -357,6 +362,8 @@ export const postHandlers: PostHandlers = {
 				const newAccountType = priceIdToAccountType(stripeSub.items.data[0].price.id);
 				const user = await models.user().load(sub.user_id, { fields: ['id'] });
 				if (!user) throw new Error(`No such user: ${sub.user_id}`);
+
+				await models.subscription().updateFromStripe(sub, stripeSub);
 
 				logger.info(`Updating subscription of user ${user.id} to ${newAccountType}`);
 				await models.user().save({ id: user.id, account_type: newAccountType });

--- a/packages/server/src/routes/index/stripe.ts
+++ b/packages/server/src/routes/index/stripe.ts
@@ -363,10 +363,10 @@ export const postHandlers: PostHandlers = {
 				const user = await models.user().load(sub.user_id, { fields: ['id'] });
 				if (!user) throw new Error(`No such user: ${sub.user_id}`);
 
-				await models.subscription().updateFromStripe(sub, stripeSub);
-
 				logger.info(`Updating subscription of user ${user.id} to ${newAccountType}`);
 				await models.user().save({ id: user.id, account_type: newAccountType });
+
+				await models.subscription().updateFromStripe(sub, stripeSub);
 			},
 
 		};

--- a/packages/server/src/services/database/types.ts
+++ b/packages/server/src/services/database/types.ts
@@ -248,6 +248,8 @@ export interface Subscription {
 	updated_time?: string;
 	created_time?: string;
 	is_deleted?: number;
+	trial_end?: number;
+	current_period_end?: number;
 }
 
 export interface UserFlag extends WithDates {
@@ -497,6 +499,8 @@ export const databaseSchema: DatabaseTables = {
 		updated_time: { type: 'string', defaultValue: null },
 		created_time: { type: 'string', defaultValue: null },
 		is_deleted: { type: 'number', defaultValue: 0 },
+		trial_end: { type: 'string', defaultValue: 0 },
+		current_period_end: { type: 'string', defaultValue: 0 },
 	},
 	user_flags: {
 		id: { type: 'number', defaultValue: null },

--- a/packages/server/src/tools/generateTypes.ts
+++ b/packages/server/src/tools/generateTypes.ts
@@ -65,6 +65,8 @@ const propertyTypes: Record<string, string> = {
 	'shares.type': 'ShareType',
 	'subscriptions.last_payment_failed_time': 'number',
 	'subscriptions.last_payment_time': 'number',
+	'subscriptions.trial_end': 'number',
+	'subscriptions.current_period_end': 'number',
 	'task_states.task_id': 'TaskId',
 	'user_deletions.end_time': 'number',
 	'user_deletions.scheduled_time': 'number',

--- a/packages/server/src/utils/stripe.test.ts
+++ b/packages/server/src/utils/stripe.test.ts
@@ -1,0 +1,38 @@
+import { AccountType } from '../models/UserModel';
+import { stripe, mock as stripeMock, reset as resetStripe } from '../utils/testing/mockStripe';
+import { recheckPaymentStatus } from './stripe';
+import { afterAllTests, beforeAllDb, models } from './testing/testUtils';
+
+describe('utils/stripe', () => {
+	beforeAll(async () => {
+		await beforeAllDb('utils/stripe');
+	});
+
+	afterAll(async () => {
+		await afterAllTests();
+	});
+
+	beforeEach(() => {
+		resetStripe();
+	});
+
+	test('recheckPaymentStatus should recheck the billing period', async () => {
+		const periodEnd1 = new Date('2026-07-13');
+		const periodEnd2 = new Date('2026-07-15');
+		stripeMock.setMockSubscription('sub_001', { periodEnd: periodEnd1 });
+
+		const { user } = await models().subscription().saveUserAndSubscription('test@example.com', 'Testing', AccountType.Basic, 'cus_001', 'sub_001');
+
+		await recheckPaymentStatus(stripe, models(), user.id);
+		expect(await models().subscription().byUserId(user.id)).toMatchObject({
+			current_period_end: periodEnd1.getTime(),
+		});
+
+		stripeMock.setMockSubscription('sub_001', { periodEnd: periodEnd2 });
+
+		await recheckPaymentStatus(stripe, models(), user.id);
+		expect(await models().subscription().byUserId(user.id)).toMatchObject({
+			current_period_end: periodEnd2.getTime(),
+		});
+	});
+});

--- a/packages/server/src/utils/stripe.test.ts
+++ b/packages/server/src/utils/stripe.test.ts
@@ -1,7 +1,7 @@
 import { AccountType } from '../models/UserModel';
 import { stripe, mock as stripeMock, reset as resetStripe } from '../utils/testing/mockStripe';
 import { recheckPaymentStatus } from './stripe';
-import { afterAllTests, beforeAllDb, models } from './testing/testUtils';
+import { afterAllTests, beforeAllDb, beforeEachDb, models } from './testing/testUtils';
 
 describe('utils/stripe', () => {
 	beforeAll(async () => {
@@ -12,7 +12,8 @@ describe('utils/stripe', () => {
 		await afterAllTests();
 	});
 
-	beforeEach(() => {
+	beforeEach(async () => {
+		await beforeEachDb();
 		resetStripe();
 	});
 

--- a/packages/server/src/utils/stripe.ts
+++ b/packages/server/src/utils/stripe.ts
@@ -187,7 +187,17 @@ export const getLastInvoiceStatus = async (stripe: Stripe, subscriptionId: strin
 // manually check the invoice status and update the related flags.
 export const recheckPaymentStatus = async (stripe: Stripe, models: Models, userId: Uuid) => {
 	const subInfo = await subscriptionInfoByUserId(stripe, models, userId);
-	const status = await getLastInvoiceStatus(stripe, subInfo.sub.stripe_subscription_id);
-	if (status === InvoiceStatus.None) return;
-	await models.subscription().handlePayment(subInfo.sub.stripe_subscription_id, status === InvoiceStatus.Paid);
+
+	const recheckBillingPeriod = async () => {
+		await models.subscription().updateFromStripe(subInfo.sub, subInfo.stripeSub);
+	};
+
+	const recheckInvoice = async () => {
+		const status = await getLastInvoiceStatus(stripe, subInfo.sub.stripe_subscription_id);
+		if (status === InvoiceStatus.None) return;
+		await models.subscription().handlePayment(subInfo.sub.stripe_subscription_id, status === InvoiceStatus.Paid);
+	};
+
+	await recheckBillingPeriod();
+	await recheckInvoice();
 };

--- a/packages/server/src/utils/testing/mockStripe.ts
+++ b/packages/server/src/utils/testing/mockStripe.ts
@@ -66,7 +66,11 @@ jest.mock('stripe', () => {
 	return () => mock;
 });
 
-export const mock: StripeMock = require('stripe')();
+const mockedStripe = require('stripe')();
+// Export mockedStripe as both Stripe and StripeMock to limit the number of casts
+// needed in testing logic
+export const stripe: Stripe = mockedStripe;
+export const mock: StripeMock = mockedStripe;
 
 export const reset = () => {
 	mock.resetMock();

--- a/packages/server/src/utils/testing/testUtils.ts
+++ b/packages/server/src/utils/testing/testUtils.ts
@@ -1,5 +1,5 @@
 import { DbConnection, connectDb, disconnectDb, truncateTables } from '../../db';
-import { User, Session, Item, Uuid } from '../../services/database/types';
+import { User, Session, Item, Uuid, Subscription } from '../../services/database/types';
 import { createDb, CreateDbOptions } from '../../tools/dbTools';
 import modelFactory from '../../models/factory';
 import { AppContext, DatabaseConfigClient, Env } from '../types';
@@ -361,12 +361,13 @@ export const createUserAndSession = async function(index = 1, isAdmin = false, o
 	};
 };
 
-export const createSubscription = async (user: User, stripeUserId: string, stripeSubscriptionId: string) => {
+export const createSubscription = async (user: User, stripeUserId: string, stripeSubscriptionId: string, options: Partial<Subscription> = {}) => {
 	return await models().subscription().save({
 		user_id: user.id,
 		stripe_user_id: stripeUserId,
 		stripe_subscription_id: stripeSubscriptionId,
 		last_payment_time: Date.now(),
+		...options,
 	});
 };
 


### PR DESCRIPTION
# Summary

Creates a mirror of Stripe's `current_period_end` and `trial_end` in the `subscriptions` table.

# Testing plan

1. Configure the Stripe sandbox by following the instructions in `stripe.md`. Patch `index/stripe.ts` to disable `alipay` (which doesn't work with the dev sandbox).
2. Verify that it's possible to create a new Stripe subscription from the `stripe/checkoutTest` route.
3. Inspect the database. Verify that `trail_end` and `current_period_end` have been stored successfully.
4. End the trial early.
5. Inspect the database. Verify that `trail_end` and `current_period_end` have been updated, `trial_end` to a smaller number and `current_period_end` to a larger number.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
