### PR TITLE
Desktop: Fix AI Chat button visible when AI features disabled

### DIFF
--- a/packages/app-desktop/gui/NoteToolbar/NoteToolbar.tsx
+++ b/packages/app-desktop/gui/NoteToolbar/NoteToolbar.tsx
@@ -59,9 +59,11 @@ const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 		'editAlarm',
 		'toggleVisiblePanes',
 		'showNoteProperties',
-		// Always shown — the panel itself surfaces any configuration issue.
-		'toggleAiChat',
 	];
+
+	if (state.settings['ai.enabled']) {
+		commands.push('toggleAiChat');
+	}
 
 	// `toggleEditorPlugin` shows for plugin editors; we extend it to also
 	// toggle the core whiteboard editor on whiteboard notes (see the command's


### PR DESCRIPTION
## Description
The "Toggle AI Chat" button was visible in the toolbar even when AI features were disabled in Settings. Toggling AI features on or off had no effect on the button visibility.

## Changes
- Conditionally include the `toggleAiChat` command in the toolbar based on the `ai.enabled` setting
- The button now only appears when AI features are enabled

## Issue
Fixes #15924

## Testing
1. Open Joplin Desktop
2. Go to Settings > AI and disable AI features
3. Verify the "Toggle AI Chat" button is no longer visible in the toolbar
4. Enable AI features
5. Verify the button reappears