### PR TITLE
Desktop: Fixes #15918: Preserve trailing spaces in table editor cells

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/renderTables.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderTables.ts
@@ -222,7 +222,7 @@ class TableWidget extends WidgetType {
 				for (let ci = 0; ci < allCells[ri].length; ci++) {
 					const td = allCells[ri][ci].querySelector('.cm-tw-text') as HTMLElement;
 					if (td !== active) continue;
-					const v = (td.textContent || '').trim().replace(/\n/g, '<br>').replace(/\|/g, '\\|');
+					const v = (td.textContent || '').replace(/\n/g, '<br>').replace(/\|/g, '\\|');
 					const isH = ri === 0;
 					if (isH) table.header.cells[ci].content = v;
 					else if (ri - 1 < table.body.length) table.body[ri - 1].cells[ci].content = v;
@@ -250,7 +250,7 @@ class TableWidget extends WidgetType {
 			// rebuild is triggered by an external event (image paste, toolbar
 			// command, etc.) before the deferred blur handler runs.
 			const pushToModel = () => {
-				const v = (textDiv.textContent || '').trim()
+				const v = (textDiv.textContent || '')
 					.replace(/\n/g, '<br>').replace(/\|/g, '\\|');
 				if (isHdr) table.header.cells[c].content = v;
 				else if (r - 1 < table.body.length) table.body[r - 1].cells[c].content = v;
@@ -389,7 +389,7 @@ class TableWidget extends WidgetType {
 					// context menu action), the old container is detached.
 					// Do nothing — the rebuild already has the latest data.
 					if (!container.isConnected) return;
-					const v = (textDiv.textContent || '').trim();
+					const v = textDiv.textContent || '';
 					const orig = isHdr
 						? table.header.cells[c]?.content
 						: table.body[r - 1]?.cells[c]?.content;


### PR DESCRIPTION
## Problem

Fixes #15918

When editing table cells, trailing spaces typed by the user are stripped on re-render. This causes words to concatenate — e.g., typing "Hello " in one cell and "World" in the next results in "HelloWorld" instead of "Hello World".

## Root Cause

The `renderTables.ts` widget reads cell content via `textContent.trim()`, which strips trailing whitespace. The trimmed value is stored in the in-memory Table model and written back to the markdown source, so the trailing spaces are permanently lost.

## Fix

Remove `.trim()` from three locations in `renderTables.ts` where cell textContent is read:

- `syncDirtyCells` (line 225)
- `pushToModel` (line 253)
- blur handler (line 392)

Cell content is still sanitized (newlines to `<br>`, pipes to `\|`) but trailing spaces are now preserved.

## Testing

1. Create a table with two columns
2. Type "Hello " (with trailing space) in column 1
3. Type "World" in column 2
4. Click outside the table — should see "Hello World" in source
5. Click back into the table — trailing space should still be present
