### PR TITLE
Add Swedish short store description

### DIFF
--- a/fastlane/metadata/android/sv/short_description.txt
+++ b/fastlane/metadata/android/sv/short_description.txt
@@ -1,0 +1,1 @@
+Antecknings- och uppgiftsapp med synkronisering mellan enheter


### PR DESCRIPTION
## Summary

Adds a Swedish short description for Joplin's Android store listing.

## Changes

Added:

- `fastlane/metadata/android/sv/short_description.txt`

The description briefly presents Joplin as an application for notes and
to-dos with synchronisation between devices.

## Translation choices

- `note taking` is represented by `antecknings-`
- `to-do` is translated as `att-göra`
- `sync between Linux, macOS, Windows, and mobile` is expressed more concisely
  as `synkronisering mellan enheter`

The shorter wording is more natural in Swedish and avoids an unnecessarily
long list of platforms in the limited store-description field.

## Validation

- The description is 63 characters long.
- It is below the 80-character limit.
- It does not end with a full stop.
- The file contains plain UTF-8 text only.