### PR TITLE
Desktop: AI chat panel: Stop retry loop after several repeated failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1588,6 +1588,7 @@ packages/lib/services/ai/providers/ChatProviderBase.js
 packages/lib/services/ai/providers/JoplinCloud.test.js
 packages/lib/services/ai/providers/JoplinCloud.js
 packages/lib/services/ai/providers/OpenAiCompatible.js
+packages/lib/services/ai/providers/TestProvider.js
 packages/lib/services/ai/testing/TestEmbeddingProvider.test.js
 packages/lib/services/ai/testing/TestEmbeddingProvider.js
 packages/lib/services/ai/types.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1614,6 +1614,7 @@ packages/lib/services/ai/providers/ChatProviderBase.js
 packages/lib/services/ai/providers/JoplinCloud.test.js
 packages/lib/services/ai/providers/JoplinCloud.js
 packages/lib/services/ai/providers/OpenAiCompatible.js
+packages/lib/services/ai/providers/TestProvider.js
 packages/lib/services/ai/testing/TestEmbeddingProvider.test.js
 packages/lib/services/ai/testing/TestEmbeddingProvider.js
 packages/lib/services/ai/types.js

--- a/packages/lib/services/ai/AiService.ts
+++ b/packages/lib/services/ai/AiService.ts
@@ -8,6 +8,7 @@ import ChatProviderBase from './providers/ChatProviderBase';
 import OpenAiCompatibleProvider from './providers/OpenAiCompatible';
 import AnthropicProvider from './providers/Anthropic';
 import JoplinCloudProvider from './providers/JoplinCloud';
+import TestProvider from './providers/TestProvider';
 
 const logger = Logger.create('AiService');
 
@@ -72,6 +73,10 @@ export default class AiService {
 				model: Setting.value('ai.chat.model'),
 				classification: deriveClassification('openai-compatible', baseUrl),
 			}));
+		}
+
+		if (providerType === 'test-provider') {
+			return this.attachRecorder(new TestProvider());
 		}
 
 		throw new JoplinError(`Unknown AI provider type: ${providerType}`, 'aiUnknownProvider');

--- a/packages/lib/services/ai/noteChat.test.ts
+++ b/packages/lib/services/ai/noteChat.test.ts
@@ -1,9 +1,39 @@
-import { _internal, NoteContext } from './noteChat';
+import { _internal, ChatCommands, NoteContext, runNoteChat } from './noteChat';
 import { applyAnchorEdits } from './applyNoteEdits';
 import { ChatRole, ChatToolCall } from './types';
-import { expectThrow } from '../../testing/test-utils';
+import { expectThrow, setupDatabase, switchClient } from '../../testing/test-utils';
+import Setting from '../../models/Setting';
+
+const makeTestContext = () => {
+	let body = 'Body';
+	const initialContext: NoteContext = {
+		title: 'Test',
+		body,
+		selection: null,
+	};
+
+	const commands: ChatCommands = {
+		replaceSelection: jest.fn(),
+		updateNoteBody: (newBody) => {
+			body = newBody;
+			return Promise.resolve();
+		},
+		displayError: jest.fn(),
+	};
+
+	return {
+		onContext: () => Promise.resolve({ ...initialContext, body }),
+		commands,
+	};
+};
 
 describe('noteChat', () => {
+	beforeAll(async () => {
+		await setupDatabase(0);
+		await switchClient(0);
+		Setting.setValue('ai.chat.providerType', 'test-provider');
+		Setting.setValue('ai.enabled', true);
+	});
 
 	test('systemPrompt includes selection when present and omits full body', () => {
 		const prompt = _internal.systemPrompt({
@@ -248,29 +278,18 @@ describe('noteChat', () => {
 			{ toolName: 'appendToNote', callId: 'call-1', arguments: { text: 'Test.' } },
 			{ toolName: 'replaceRange', callId: 'call-2', arguments: { anchor: 'Body', text: 'Updated' } },
 		];
-		let body = 'Body';
-		const initialContext: NoteContext = {
-			title: 'Test',
-			body,
-			selection: null,
-		};
+
+		const { onContext, commands } = makeTestContext();
 
 		const result = await _internal.runTools(
 			{ text: 'Test...', toolCalls, usage: { inputTokens: 10, outputTokens: 300 } },
-			initialContext,
-			() => Promise.resolve({ ...initialContext, body }),
-			{
-				replaceSelection: jest.fn(),
-				updateNoteBody: (newBody) => {
-					body = newBody;
-					return Promise.resolve();
-				},
-				displayError: jest.fn(),
-			},
+			await onContext(),
+			onContext,
+			commands,
 			new AbortController().signal,
 		);
 
-		expect(body).toBe('Updated\n\nTest.');
+		expect((await onContext()).body).toBe('Updated\n\nTest.');
 		expect(result).toMatchObject([
 			{
 				role: ChatRole.Tool,
@@ -286,6 +305,45 @@ describe('noteChat', () => {
 				isError: false,
 				userDescription: 'Removed 1 word\nAdded 1 word',
 			},
+		]);
+	});
+
+	test('noteChat should stop retry loop if several responses in a row include tool failures', async () => {
+		const { onContext, commands } = makeTestContext();
+		const failingAndSucceedingToolCall = (repeat: number) => [
+			`/repeat ${repeat}`,
+			// one failing tool
+			`/tool replaceRange ${JSON.stringify({ anchor: 'does not exist', text: 'replaced' })}`,
+			// and one tool call that should succeed
+			'/tool appendToNote { "text": "test" }',
+		].join('\n');
+
+		const userMessage = failingAndSucceedingToolCall(32);
+		const result = await runNoteChat(
+			onContext,
+			[],
+			userMessage,
+			commands,
+			() => {},
+			new AbortController().signal,
+		);
+
+		const failedAttempts = [];
+		for (let i = 0; i < 5; i++) {
+			failedAttempts.push(
+				{ role: ChatRole.Assistant },
+				{ role: ChatRole.Tool, isError: true, toolName: 'replaceRange' },
+				{ role: ChatRole.Tool, isError: false, toolName: 'appendToNote' },
+			);
+		}
+
+		expect(result).toMatchObject([
+			{ role: ChatRole.System },
+			{ role: ChatRole.User, content: userMessage },
+
+			...failedAttempts,
+
+			{ role: ChatRole.Assistant, content: 'tool not found: replaceRange\ntool not found: appendToNote' },
 		]);
 	});
 });

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -283,8 +283,12 @@ const stepNoteChat = async ({
 	});
 	onHistoryChanged([...messages]);
 
-	const toolResults = await runTools(chatResult, note, context, commands, signal);
+	let toolResults: ChatToolMessage[] = [];
+	if (allowTools) {
+		toolResults = await runTools(chatResult, note, context, commands, signal);
+	}
 	messages.push(...toolResults);
+
 	onHistoryChanged([...messages]);
 
 	return { messages, failedToolCount: toolResults.filter(t => t.isError).length };

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -1,5 +1,5 @@
 import AiService from './AiService';
-import { ChatMessage, ChatResult, ChatRole, ChatToolCall, ToolSpec } from './types';
+import { ChatMessage, ChatResult, ChatRole, ChatToolCall, ChatToolMessage, ToolSpec } from './types';
 import JoplinError from '../../JoplinError';
 import Logger from '@joplin/utils/Logger';
 import findFencedBlock from './utils/findFencedBlock';
@@ -201,7 +201,7 @@ const toolDefinitions = (note: NoteContext) => {
 
 const estimateTokens = (text: string) => Math.ceil(text.length / charsPerToken);
 
-interface Commands {
+export interface ChatCommands {
 	replaceSelection: (text: string, originalText: string)=> Promise<void>;
 	updateNoteBody: (body: string, originalBody: string)=> Promise<void>;
 	displayError: (message: string)=> void;
@@ -214,7 +214,7 @@ export const runNoteChat = async (
 	context: OnContext,
 	history: ChatMessage[],
 	userMessage: string,
-	commands: Commands,
+	commands: ChatCommands,
 	onHistoryChanged: OnHistoryChanged,
 	signal: AbortSignal,
 ) => {
@@ -229,32 +229,49 @@ export const runNoteChat = async (
 	onHistoryChanged([...history]);
 
 	const hasUndeliveredToolResults = () => history[history.length - 1]?.role === ChatRole.Tool;
+	let runsWithFailedTools = 0;
 	do {
-		history = await stepNoteChat(
+		// If the model fails to successfully use tools more than 4 times in a row, disallow tool use
+		// to avoid an infinite loop:
+		const allowTools = runsWithFailedTools < 5;
+		const { messages, failedToolCount } = await stepNoteChat({
 			context,
-			history,
+			messages: history,
 			commands,
 			onHistoryChanged,
 			signal,
-		);
+			allowTools,
+		});
+
+		history = messages;
+		if (failedToolCount > 0) {
+			runsWithFailedTools ++;
+		} else {
+			runsWithFailedTools = 0;
+		}
 	}
 	while (!signal.aborted && hasUndeliveredToolResults());
 
 	return history;
 };
 
-const stepNoteChat = async (
-	context: OnContext,
-	messages: ChatMessage[],
-	commands: Commands,
-	onHistoryChanged: OnHistoryChanged,
-	signal: AbortSignal,
-) => {
+interface StepNoteChatOptions {
+	context: OnContext;
+	messages: ChatMessage[];
+	commands: ChatCommands;
+	onHistoryChanged: OnHistoryChanged;
+	signal: AbortSignal;
+	allowTools: boolean;
+}
+
+const stepNoteChat = async ({
+	context, messages, commands, onHistoryChanged, signal, allowTools,
+}: StepNoteChatOptions) => {
 	const note = await context();
 
 	assertWithinTokenBudget(messages, noteBodyTokenBudget);
 	const chatResult = await AiService.instance().chat(
-		messages, { tools: toolDefinitions(note), signal },
+		messages, { tools: allowTools ? toolDefinitions(note) : [], signal },
 	);
 
 	// Chat results can contain sensitive information -- only log in dev mode
@@ -262,16 +279,15 @@ const stepNoteChat = async (
 	messages.push({
 		role: ChatRole.Assistant,
 		content: chatResult.text ?? '',
-		toolCalls: chatResult.toolCalls,
+		toolCalls: allowTools ? chatResult.toolCalls : [],
 	});
 	onHistoryChanged([...messages]);
 
-	messages.push(
-		...await runTools(chatResult, note, context, commands, signal),
-	);
+	const toolResults = await runTools(chatResult, note, context, commands, signal);
+	messages.push(...toolResults);
 	onHistoryChanged([...messages]);
 
-	return messages;
+	return { messages, failedToolCount: toolResults.filter(t => t.isError).length };
 };
 
 const removeSystemPrompt = (history: ChatMessage[]) => {
@@ -317,10 +333,10 @@ const assertNotCancelled = (signal: AbortSignal) => {
 	}
 };
 
-const runTools = async (chat: ChatResult, initialContext: NoteContext, context: OnContext, commands: Commands, signal: AbortSignal) => {
+const runTools = async (chat: ChatResult, initialContext: NoteContext, context: OnContext, commands: ChatCommands, signal: AbortSignal) => {
 	assertNotCancelled(signal);
 
-	let chatResponses: ChatMessage[] = [];
+	let chatResponses: ChatToolMessage[] = [];
 
 	const respondSuccess = (action: ChatToolCall, message: string) => {
 		chatResponses.push({

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -283,15 +283,16 @@ const stepNoteChat = async ({
 	});
 	onHistoryChanged([...messages]);
 
-	let toolResults: ChatToolMessage[] = [];
+	let failedToolCount = 0;
 	if (allowTools) {
-		toolResults = await runTools(chatResult, note, context, commands, signal);
+		const toolResults = await runTools(chatResult, note, context, commands, signal);
+		messages.push(...toolResults);
+		onHistoryChanged([...messages]);
+
+		failedToolCount = toolResults.filter(t => t.isError).length;
 	}
-	messages.push(...toolResults);
 
-	onHistoryChanged([...messages]);
-
-	return { messages, failedToolCount: toolResults.filter(t => t.isError).length };
+	return { messages, failedToolCount };
 };
 
 const removeSystemPrompt = (history: ChatMessage[]) => {

--- a/packages/lib/services/ai/providers/TestProvider.ts
+++ b/packages/lib/services/ai/providers/TestProvider.ts
@@ -1,0 +1,80 @@
+import { ChatMessage, ChatOptions, ChatResult, ChatRole, ChatToolCall, ProviderClassification, ToolSpec } from '../types';
+import ChatProviderBase from './ChatProviderBase';
+
+const parseUserCommand = (message: ChatMessage, availableTools: ToolSpec[]) => {
+	const toolCalls: ChatToolCall[] = [];
+	const reply = [];
+	let repeat = 0;
+	for (const line of message.content.split('\n')) {
+		const command = line.match(/^\/(tool|reply-with|repeat) (.*)$/);
+		if (!command) continue;
+
+		if (command[1] === 'tool') {
+			const args = command[2].split(' ');
+			const toolName = args[0];
+			if (!availableTools.some(tool => tool.name === toolName)) {
+				reply.push(`tool not found: ${toolName}`);
+			} else {
+				toolCalls.push({
+					callId: `tool-call-${toolCalls.length}`,
+					toolName: args[0],
+					arguments: JSON.parse(args.slice(1).join(' ')),
+				});
+			}
+		} else if (command[1] === 'reply-with') {
+			reply.push(command[2]);
+		} else if (command[1] === 'repeat') {
+			repeat = Number(command[2]);
+		}
+	}
+
+	return { toolCalls, reply: reply.join('\n'), repeat };
+};
+
+
+export default class TestProvider extends ChatProviderBase {
+
+	public id = 'test-provider';
+	public classification: ProviderClassification = 'local';
+
+	public constructor() {
+		super();
+	}
+
+	protected async doChat(messages: ChatMessage[], { tools = [] }: ChatOptions): Promise<ChatResult> {
+		const lastMessage = messages[messages.length - 1];
+
+		const toolCalls: ChatToolCall[] = [];
+		const content = [];
+		if (lastMessage.role === ChatRole.User) {
+			const command = parseUserCommand(lastMessage, tools);
+			toolCalls.push(...command.toolCalls);
+			content.push(command.reply);
+		} else if (lastMessage.role === ChatRole.Tool) {
+			let lastUserMessage;
+			let replyCount = 0;
+			for (let i = messages.length - 1; i >= 0; i--) {
+				if (messages[i].role === ChatRole.User) {
+					lastUserMessage = messages[i];
+					break;
+				}
+				if (messages[i].role === ChatRole.Assistant) {
+					replyCount ++;
+				}
+			}
+
+			if (lastUserMessage) {
+				const command = parseUserCommand(lastUserMessage, tools);
+				if (command.repeat >= replyCount) {
+					toolCalls.push(...command.toolCalls);
+				}
+				content.push(command.reply);
+			}
+		}
+
+		const output = content.join(' ');
+		const inputTokens = lastMessage.content.length;
+		const outputTokens = output.length + toolCalls.length;
+		return { text: output, toolCalls, usage: { inputTokens, outputTokens } };
+	}
+}

--- a/packages/lib/services/ai/providers/TestProvider.ts
+++ b/packages/lib/services/ai/providers/TestProvider.ts
@@ -41,7 +41,7 @@ export default class TestProvider extends ChatProviderBase {
 		super();
 	}
 
-	protected async doChat(messages: ChatMessage[], { tools = [] }: ChatOptions): Promise<ChatResult> {
+	protected async doChat(messages: ChatMessage[], { tools = [] }: ChatOptions = {}): Promise<ChatResult> {
 		const lastMessage = messages[messages.length - 1];
 
 		const toolCalls: ChatToolCall[] = [];


### PR DESCRIPTION
# Problem

The desktop app's AI chat panel allows models to retry tool call failures. Currently, a model can retry a failing tool indefinitely (until the chat panel is closed or reset by a user).

# Solution

- Continue allowing the AI chat panel to respond to tool calls.
- If there are more than 5 failed tool calls in a row, stop the AI chat loop.
  - This is done by exposing no tools, which gives the LLM a chance to respond to the user's request, but stops the tool call loop. 

# Testing
## Manual regression testing

1. Set up Joplin's chat panel (provider: Joplin Cloud)
2. Request a repeated edit operation.
   <details><summary>Example prompt</summary>
   
    ```
    Repeat 10 times:
    1. In parallel:
      1. Add a test message (e.g. "this is a test") to the end of the note.
      2. Replace "does not exist" with "testing"
    2. Wait for a response.
    
    Guidance:
    - Step 1 should execute only two tools: `appendToNote` and `replaceRange`.
    - Step 2 should block future tool calls.
    - If, for steps 1-2, `appendToNote` and `replaceRange` are both no longer available, reply with "N/A".
    ```
    
    Note: The model has trouble following this prompt exactly.
    </details>
4. Verify that the does multiple edit operations in a row. Verify that the model does no more than 5 operations in a row with failed edits.
5. Clear the note and reset the chat.
6. Repeat steps 1-4 for a total of 3 trials.

<details><summary>Screenshots</summary>

| Trial | Screenshot |
|-------|---------|
| 1 | <img width="1576" height="1700" alt="screenshot: Model stops after 5 failed edits" src="https://github.com/user-attachments/assets/f05fde86-eb67-4f43-9767-8ca9e8e0f6bd" /> |
| 2 | <img width="1576" height="1700" alt="screenshot: Model stops after 3 failed edits" src="https://github.com/user-attachments/assets/f008f7bf-fcd2-4ec4-9b7b-9ad49fa49f2f" /> |
| 3 | <img width="1576" height="1700" alt="screenshot: Model stops after 3 failed edits and 1 successful edit" src="https://github.com/user-attachments/assets/5cdb313f-fdae-4eca-a9fd-7ef2faa30201" /> |


</details>



## Automated testing

This pull request adds an automated test for `runNoteChat`. This test verifies that after 5 sequential responses that have failing tool calls, no tools are exposed to the model.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
