### PR TITLE
Chore: Server: Add Joplin Server Business-related config logic

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -9,6 +9,7 @@ interface PackageJson {
 	version: string;
 	joplinServer: {
 		forkVersion: string;
+		businessServerVersion?: string;
 	};
 }
 
@@ -168,6 +169,15 @@ export const isUsingExternalAuth = (env: EnvVariables) => {
 	return !!env.SAML_ENABLED || !!env.LDAP_1_ENABLED || !!env.LDAP_2_ENABLED;
 };
 
+const determineAppVersion = (isJoplinServerBusiness: boolean) => {
+	const forkVersion = packageJson.joplinServer?.forkVersion;
+	const businessServerVersion = packageJson.joplinServer?.businessServerVersion;
+
+	if (isJoplinServerBusiness) return businessServerVersion;
+	if (forkVersion) return forkVersion;
+	return packageJson.version;
+};
+
 let config_: Config = null;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `Partial<Config>` would be ideal, but `Config` requires `resourceDir: string` which is only set via `overrides` in some test paths — tightening would expose a pre-existing missing-field issue
@@ -178,16 +188,16 @@ export async function initConfig(envType: Env, env: EnvVariables, overrides: any
 	const stripePublicConfig = loadStripeConfig(envType === Env.BuildTypes ? Env.Dev : envType, `${rootDir}/stripeConfig.json`);
 	const appName = env.APP_NAME;
 	const viewDir = `${rootDir}/src/views`;
+	const assetsDir = `${rootDir}/assets`;
 	const appPort = env.APP_PORT;
 	const baseUrl = baseUrlFromEnv(env, appPort);
 	const apiBaseUrl = env.API_BASE_URL ? env.API_BASE_URL : baseUrl;
 	const supportEmail = env.SUPPORT_EMAIL;
-	const forkVersion = packageJson.joplinServer?.forkVersion;
 	const dbConfig = databaseConfigFromEnv(runningInDocker_, env, false);
 
 	config_ = {
 		...env,
-		appVersion: forkVersion ? forkVersion : packageJson.version,
+		appVersion: determineAppVersion(false),
 		joplinServerVersion: packageJson.version,
 		appName,
 		isJoplinCloud: apiBaseUrl.includes('.joplincloud.com') || apiBaseUrl.includes('.joplincloud.local'),
@@ -195,8 +205,10 @@ export async function initConfig(envType: Env, env: EnvVariables, overrides: any
 		env: envType,
 		rootDir: rootDir,
 		viewDir: viewDir,
+		assetsDir: assetsDir,
 		layoutDir: `${viewDir}/layouts`,
 		tempDir: `${rootDir}/temp`,
+		resourceDir: `${rootDir}/resource`,
 		logDir: `${rootDir}/logs`,
 		database: dbConfig,
 		databaseSlave: env.DB_USE_SLAVE ? databaseConfigFromEnv(runningInDocker_, env, true) : dbConfig,

--- a/packages/server/src/utils/types.ts
+++ b/packages/server/src/utils/types.ts
@@ -162,6 +162,7 @@ export interface Config extends EnvVariables {
 	rootDir: string;
 	viewDir: string;
 	layoutDir: string;
+	assetsDir: string;
 	// Note that, for now, nothing is being logged to file. Log is just printed
 	// to stdout, which is then handled by Docker own log mechanism
 	logDir: string;


### PR DESCRIPTION
# Summary

Adds logic to `config.ts` in `packages/server` related to determining the version of Joplin Server, if running as Joplin Server Business.
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
