### PR TITLE
Desktop: AI chat panel: Support cancelling in-progress responses

### DIFF
--- a/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
@@ -84,11 +84,13 @@ const useCancelCallback = () => {
 	// abort instead of landing in a cleared or destroyed conversation.
 	const cancelRequestRef = useRef(cancelRequest);
 	cancelRequestRef.current = cancelRequest;
+	const generationIdRef = useRef(makeId());
 	useEffect(() => () => {
 		cancelRequestRef.current();
+		generationIdRef.current = makeId();
 	}, []);
 
-	return { abortControllerRef, cancelRequest };
+	return { abortControllerRef, cancelRequest, generationIdRef };
 };
 
 // Single-window for v1: mapStateToProps hard-codes defaultWindowId and the
@@ -113,7 +115,7 @@ const ChatPanel: React.FC<Props> = (props) => {
 	noteIdRef.current = props.noteId;
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 
-	const { abortControllerRef, cancelRequest } = useCancelCallback();
+	const { abortControllerRef, cancelRequest, generationIdRef } = useCancelCallback();
 
 	const windowId = useContext(WindowIdContext);
 
@@ -155,6 +157,10 @@ const ChatPanel: React.FC<Props> = (props) => {
 	const requiresDisclosure = props.providerType !== 'joplin-cloud';
 	const showDisclosure = requiresDisclosure && !disclosureShown && messages.length === 0;
 
+	const handleCancel = useCallback(() => {
+		cancelRequest();
+	}, [cancelRequest]);
+
 	const handleSend = useCallback(async () => {
 		const text = input.trim();
 		if (!text || sending) return;
@@ -165,6 +171,9 @@ const ChatPanel: React.FC<Props> = (props) => {
 			return;
 		}
 		const abortController = abortControllerRef.current;
+		const generationId = makeId();
+		generationIdRef.current = generationId;
+		const newChatStarted = () => generationId !== generationIdRef.current;
 
 		const noteIdAtStart = props.noteId;
 		setSending(true);
@@ -273,17 +282,18 @@ const ChatPanel: React.FC<Props> = (props) => {
 			);
 		} catch (error) {
 			logger.warn('Chat failed:', error);
-			if (abortController.signal.aborted) return;
 
-			if (!hadSuccessfulResponse) {
+			if (!hadSuccessfulResponse && !newChatStarted()) {
 				dispatch({ type: 'AI_CHAT_REMOVE', windowId, id: userTurnId });
 				setInput(text);
 			}
-			appendMessage({ id: makeId(), role: 'error', text: error.message || _('Something went wrong.'), raw: [] });
+			if (!abortController.signal.aborted) {
+				appendMessage({ id: makeId(), role: 'error', text: error.message || _('Something went wrong.'), raw: [] });
+			}
 		} finally {
 			setSending(false);
 		}
-	}, [input, sending, props.noteId, conversationTurns, windowId, addToolResult, appendMessage, dispatch, cancelRequest, abortControllerRef]);
+	}, [input, sending, props.noteId, conversationTurns, windowId, addToolResult, appendMessage, dispatch, cancelRequest, abortControllerRef, generationIdRef]);
 
 	const handleAcknowledgeDisclosure = useCallback(() => {
 		Setting.setValue(disclosureSetting, true);
@@ -401,12 +411,12 @@ const ChatPanel: React.FC<Props> = (props) => {
 					<button
 						type='button'
 						className='send'
-						onClick={() => { void handleSend(); }}
-						disabled={sending || !input.trim()}
-						aria-label={sending ? _('Sending') : _('Send')}
-						title={sending ? _('Sending…') : _('Send')}
+						onClick={sending ? handleCancel : handleSend}
+						disabled={!sending && !input.trim()}
+						aria-label={sending ? _('Cancel send') : _('Send')}
+						title={sending ? _('Cancel send') : _('Send')}
 					>
-						<i className={sending ? 'fas fa-spinner' : 'fas fa-paper-plane'} aria-hidden='true' />
+						<i className={sending ? 'fas fa-stop' : 'fas fa-paper-plane'} aria-hidden='true' />
 					</button>
 				</div>
 			</div>

--- a/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
@@ -341,6 +341,8 @@ const ChatPanel: React.FC<Props> = (props) => {
 		);
 	}
 
+	const sendButtonLabel = sending ? _('Stop generating') : _('Send');
+
 	return (
 		<div className='chat-panel'>
 			<div className='header'>
@@ -413,8 +415,8 @@ const ChatPanel: React.FC<Props> = (props) => {
 						className='send'
 						onClick={sending ? handleCancel : handleSend}
 						disabled={!sending && !input.trim()}
-						aria-label={sending ? _('Cancel send') : _('Send')}
-						title={sending ? _('Cancel send') : _('Send')}
+						aria-label={sendButtonLabel}
+						title={sendButtonLabel}
 					>
 						<i className={sending ? 'fas fa-stop' : 'fas fa-paper-plane'} aria-hidden='true' />
 					</button>

--- a/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
@@ -84,13 +84,11 @@ const useCancelCallback = () => {
 	// abort instead of landing in a cleared or destroyed conversation.
 	const cancelRequestRef = useRef(cancelRequest);
 	cancelRequestRef.current = cancelRequest;
-	const generationIdRef = useRef(makeId());
 	useEffect(() => () => {
 		cancelRequestRef.current();
-		generationIdRef.current = makeId();
 	}, []);
 
-	return { abortControllerRef, cancelRequest, generationIdRef };
+	return { abortControllerRef, cancelRequest };
 };
 
 // Single-window for v1: mapStateToProps hard-codes defaultWindowId and the
@@ -115,7 +113,7 @@ const ChatPanel: React.FC<Props> = (props) => {
 	noteIdRef.current = props.noteId;
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 
-	const { abortControllerRef, cancelRequest, generationIdRef } = useCancelCallback();
+	const { abortControllerRef, cancelRequest } = useCancelCallback();
 
 	const windowId = useContext(WindowIdContext);
 
@@ -159,7 +157,8 @@ const ChatPanel: React.FC<Props> = (props) => {
 
 	const handleCancel = useCallback(() => {
 		cancelRequest();
-	}, [cancelRequest]);
+		appendMessage({ id: makeId(), role: 'assistant', text: _('(Cancelled)'), raw: [] });
+	}, [cancelRequest, appendMessage]);
 
 	const handleSend = useCallback(async () => {
 		const text = input.trim();
@@ -171,9 +170,6 @@ const ChatPanel: React.FC<Props> = (props) => {
 			return;
 		}
 		const abortController = abortControllerRef.current;
-		const generationId = makeId();
-		generationIdRef.current = generationId;
-		const newChatStarted = () => generationId !== generationIdRef.current;
 
 		const noteIdAtStart = props.noteId;
 		setSending(true);
@@ -183,7 +179,12 @@ const ChatPanel: React.FC<Props> = (props) => {
 		// send the prior user turn as history alongside the new prompt.
 		const userTurnId = makeId();
 		let hadSuccessfulResponse = false;
-		appendMessage({ id: userTurnId, role: 'user', text, raw: [] });
+		appendMessage({
+			id: userTurnId,
+			role: 'user',
+			text,
+			raw: [{ role: ChatRole.User, content: text }],
+		});
 
 		try {
 			const note = await Note.load(props.noteId);
@@ -282,18 +283,17 @@ const ChatPanel: React.FC<Props> = (props) => {
 			);
 		} catch (error) {
 			logger.warn('Chat failed:', error);
+			if (abortController.signal.aborted) return;
 
-			if (!hadSuccessfulResponse && !newChatStarted()) {
+			if (!hadSuccessfulResponse) {
 				dispatch({ type: 'AI_CHAT_REMOVE', windowId, id: userTurnId });
 				setInput(text);
 			}
-			if (!abortController.signal.aborted) {
-				appendMessage({ id: makeId(), role: 'error', text: error.message || _('Something went wrong.'), raw: [] });
-			}
+			appendMessage({ id: makeId(), role: 'error', text: error.message || _('Something went wrong.'), raw: [] });
 		} finally {
 			setSending(false);
 		}
-	}, [input, sending, props.noteId, conversationTurns, windowId, addToolResult, appendMessage, dispatch, cancelRequest, abortControllerRef, generationIdRef]);
+	}, [input, sending, props.noteId, conversationTurns, windowId, addToolResult, appendMessage, dispatch, cancelRequest, abortControllerRef]);
 
 	const handleAcknowledgeDisclosure = useCallback(() => {
 		Setting.setValue(disclosureSetting, true);


### PR DESCRIPTION
# Problem

It can take a long time for AI providers to respond to user messages, particularly with self-hosted models. It's currently possible to cancel responses by clicking "reset" or closing the AI chat panel, but this is non-obvious.

# Solution

Change the "send" button to a "stop" button while generating a response. When the user clicks "Stop", cancel any ongoing AI requests triggered by the panel.

# Screen recordings

Note: The below recordings use the `gemma4:e2b` Ollama model.

Verifying that cancel/retry works correctly:

https://github.com/user-attachments/assets/207b7635-0917-4b00-9b7e-cd7eb3f19d8b

Verifying that cancelling also cancels generation in Ollama:

https://github.com/user-attachments/assets/81898250-dc84-4624-9052-b99d171ac2a0



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
