### PR TITLE
Chore: Fix CI

### DIFF
--- a/packages/lib/services/ai/providers/TestProvider.ts
+++ b/packages/lib/services/ai/providers/TestProvider.ts
@@ -19,6 +19,7 @@ const parseUserCommand = (message: ChatMessage, availableTools: ToolSpec[]) => {
 					callId: `tool-call-${toolCalls.length}`,
 					toolName: args[0],
 					arguments: JSON.parse(args.slice(1).join(' ')),
+					parseError: null,
 				});
 			}
 		} else if (command[1] === 'reply-with') {


### PR DESCRIPTION
# Problem

A merge issue is causing `tsc` errors in CI: #15886 added a new required `parseError` property to tool call result objects. Another PR (#15944) added logic that creates a new tool call result. Since #15944 based on dev before #15886 was merged, the tool call declaration is missing this new property. 

# Solution

Add the missing property.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
