### PR TITLE
Desktop: Fixes #15934: Restore vertical panel divider inside a column

### DIFF
--- a/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
@@ -130,18 +130,20 @@ function ResizableLayout(props: Props) {
 		};
 
 		const onResize: ResizeCallback = (_event, direction, _refToElement, delta) => {
-			// The absorber (width/height-less side) is skipped so the layout
-			// system keeps it flexible.
+			// A sized panel is skipped only if the other side is fixed; when
+			// both panels are absorbers, we write to the dragged one so the
+			// divider actually moves (the next sibling then absorbs the rest).
 			const isHorizontal = direction !== 'bottom';
 			const minSize = isHorizontal ? itemMinWidth : itemMinHeight;
 			const rawDelta = isHorizontal ? delta.width : delta.height;
 
 			const itemIsAbsorber = isHorizontal ? resizedItem.itemAbsorbsAlongAxis.width : resizedItem.itemAbsorbsAlongAxis.height;
 			const nextIsAbsorber = isHorizontal ? resizedItem.nextAbsorbsAlongAxis.width : resizedItem.nextAbsorbsAlongAxis.height;
+			const bothAbsorb = itemIsAbsorber && nextIsAbsorber;
 
 			let newLayout = props.layout;
 
-			if (!itemIsAbsorber) {
+			if (!itemIsAbsorber || bothAbsorb) {
 				const initial = isHorizontal ? resizedItem.initialWidth : resizedItem.initialHeight;
 				const newSize = Math.max(minSize, initial + rawDelta);
 				newLayout = setLayoutItemProps(newLayout, resizedItem.key, isHorizontal ? { width: newSize } : { height: newSize });


### PR DESCRIPTION
## Summary

Fixes #15934. When two panels are stacked vertically in a column (e.g. sidebar moved below the notebook list via View → Change application layout), dragging the divider between them stopped moving it — the whole panel was translated instead of resizing.

The root cause was in `onResize`: both stacked panels lacked an explicit height, so each was treated as an "absorber" of the container's remaining space and skipped by the delta write. Now when both sides are absorbers, the dragged panel receives the delta so the divider actually moves; the next sibling stays flexible and absorbs the inverse via the normal space-distribution path.

## Test plan

- [ ] Enter View → Change application layout.
- [ ] Move the note list left so it stacks under the notebook list (or any similar two-panel column).
- [ ] Exit change-layout mode.
- [ ] Drag the horizontal divider between the two stacked panels — the top panel shrinks/grows and the bottom panel takes the rest.
- [ ] Verify pre-existing dividers still resize as before.
