### PR TITLE
Desktop: Fix layout divider behaviour in nested layouts and move mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -438,6 +438,8 @@ packages/app-desktop/gui/ResizableLayout/utils/persist.test.js
 packages/app-desktop/gui/ResizableLayout/utils/persist.js
 packages/app-desktop/gui/ResizableLayout/utils/removeItem.js
 packages/app-desktop/gui/ResizableLayout/utils/removeKeylessItems.js
+packages/app-desktop/gui/ResizableLayout/utils/resizeLogic.test.js
+packages/app-desktop/gui/ResizableLayout/utils/resizeLogic.js
 packages/app-desktop/gui/ResizableLayout/utils/setLayoutItemProps.js
 packages/app-desktop/gui/ResizableLayout/utils/style.js
 packages/app-desktop/gui/ResizableLayout/utils/types.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -464,6 +464,8 @@ packages/app-desktop/gui/ResizableLayout/utils/persist.test.js
 packages/app-desktop/gui/ResizableLayout/utils/persist.js
 packages/app-desktop/gui/ResizableLayout/utils/removeItem.js
 packages/app-desktop/gui/ResizableLayout/utils/removeKeylessItems.js
+packages/app-desktop/gui/ResizableLayout/utils/resizeLogic.test.js
+packages/app-desktop/gui/ResizableLayout/utils/resizeLogic.js
 packages/app-desktop/gui/ResizableLayout/utils/setLayoutItemProps.js
 packages/app-desktop/gui/ResizableLayout/utils/style.js
 packages/app-desktop/gui/ResizableLayout/utils/types.js

--- a/packages/app-desktop/gui/ResizableLayout/LayoutItemContainer.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/LayoutItemContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Resizable, ResizeCallback, ResizeStartCallback, Size } from 're-resizable';
-import { LayoutItem } from './utils/types';
-import { itemMinHeight, itemMinWidth, itemSize, LayoutItemSizes } from './utils/useLayoutItemSizes';
+import { LayoutItem, LayoutItemDirection } from './utils/types';
+import { EdgeFlags, itemMinHeight, itemMinWidth, itemSize, LayoutItemSizes } from './utils/useLayoutItemSizes';
 
 interface Props {
 	item: LayoutItem;
@@ -14,24 +14,31 @@ interface Props {
 	children: React.ReactNode;
 	isLastChild: boolean;
 	visible: boolean;
+	edges: EdgeFlags;
 }
 
 const LayoutItemContainer: React.FC<Props> = ({
-	item, visible, parent, sizes, resizedItemMaxSize, onResize, onResizeStart, onResizeStop, children, isLastChild,
+	item, visible, parent, sizes, resizedItemMaxSize, onResize, onResizeStart, onResizeStop, children, isLastChild, edges,
 }) => {
 	const style: React.CSSProperties = {
 		display: visible ? 'flex' : 'none',
 		flexDirection: item.direction,
 	};
 
-	const size: Size = itemSize(item, parent, sizes, true);
+	const size: Size = itemSize(item, parent, sizes, true, edges);
+
+	// Drag rules follow the runtime "last visible in render" flag so hidden
+	// panels shown by moveMode still get proper dividers.
+	const parentDir = parent?.direction;
+	const canResizeRight = parentDir === LayoutItemDirection.Row && !isLastChild;
+	const canResizeBottom = parentDir === LayoutItemDirection.Column && !isLastChild;
 
 	const className = `resizableLayoutItem rli-${item.key}`;
-	if (item.resizableRight || item.resizableBottom) {
+	if (canResizeRight || canResizeBottom) {
 		const enable = {
 			top: false,
-			right: !!item.resizableRight && !isLastChild,
-			bottom: !!item.resizableBottom && !isLastChild,
+			right: canResizeRight,
+			bottom: canResizeBottom,
 			left: false,
 			topRight: false,
 			bottomRight: false,

--- a/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useRef, useState, useEffect, useCallback } from 'react';
 import useWindowResizeEvent from './utils/useWindowResizeEvent';
 import setLayoutItemProps from './utils/setLayoutItemProps';
-import useLayoutItemSizes, { LayoutItemSizes, itemSize, calculateMaxSizeAvailableForItem, itemMinWidth, itemMinHeight } from './utils/useLayoutItemSizes';
+import useLayoutItemSizes, { EdgeFlags, LayoutItemSizes, itemSize, calculateMaxSizeAvailableForItem, itemMinWidth, itemMinHeight } from './utils/useLayoutItemSizes';
 import validateLayout from './utils/validateLayout';
 import { Size, LayoutItem } from './utils/types';
 import { canMove, MoveDirection } from './utils/movements';
@@ -95,24 +95,53 @@ function ResizableLayout(props: Props) {
 	}
 
 	function renderLayoutItem(
-		item: LayoutItem, parent: LayoutItem | null, sizes: LayoutItemSizes, isVisible: boolean, isLastChild: boolean, onlyMoveControls: boolean,
+		item: LayoutItem, parent: LayoutItem | null, sizes: LayoutItemSizes, isVisible: boolean, isLastChild: boolean, onlyMoveControls: boolean, parentEdges: EdgeFlags = { ownRight: false, ownBottom: false, parentRight: false, parentBottom: false },
 	): React.ReactNode {
+		const parentDir = parent?.direction;
+		const ownRight = parentDir === 'row' && !isLastChild;
+		const ownBottom = parentDir === 'column' && !isLastChild;
+		// A child inherits the parent's trailing gap when its own trailing
+		// edge coincides with the parent's. In a column the right edge is
+		// shared by every child; in a row the bottom edge is shared. And the
+		// last child of any direction inherits the parent's own trailing gap.
+		const parentRight = parentDir === 'column'
+			? parentEdges.ownRight || parentEdges.parentRight
+			: (isLastChild && parentEdges.parentRight);
+		const parentBottom = parentDir === 'row'
+			? parentEdges.ownBottom || parentEdges.parentBottom
+			: (isLastChild && parentEdges.parentBottom);
+		const edges: EdgeFlags = { ownRight, ownBottom, parentRight, parentBottom };
+
 		const onResizeStart: ResizeStartCallback = () => {
+			// A panel counts as the container's absorber only when it (or its
+			// subtree) is flagged flexible. A width-less panel that isn't
+			// flagged (e.g. chatPanel being shown in moveMode without a
+			// persisted width) should still receive drag deltas, so we don't
+			// treat it as the absorber here.
+			const isSubtreeFlexible = (i: LayoutItem) => {
+				if (i.flexible) return true;
+				if (!i.children) return false;
+				for (const c of i.children) if (isSubtreeFlexible(c)) return true;
+				return false;
+			};
+
 			let nextSiblingKey: string | null = null;
 			const nextAbsorbsAlongAxis = { width: false, height: false };
 			if (parent) {
 				const siblings = parent.children;
 				const idx = siblings.findIndex(c => c.key === item.key);
 				for (let i = idx + 1; i < siblings.length; i++) {
-					if (siblings[i].visible !== false) {
+					if (itemVisible(siblings[i], props.moveMode)) {
 						nextSiblingKey = siblings[i].key;
-						nextAbsorbsAlongAxis.width = !('width' in siblings[i]);
-						nextAbsorbsAlongAxis.height = !('height' in siblings[i]);
+						const flex = isSubtreeFlexible(siblings[i]);
+						nextAbsorbsAlongAxis.width = flex && !('width' in siblings[i]);
+						nextAbsorbsAlongAxis.height = flex && !('height' in siblings[i]);
 						break;
 					}
 				}
 			}
 
+			const itemFlex = isSubtreeFlexible(item);
 			setResizedItem({
 				key: item.key,
 				initialWidth: sizes[item.key].width,
@@ -122,26 +151,28 @@ function ResizableLayout(props: Props) {
 				nextSiblingInitialWidth: nextSiblingKey ? sizes[nextSiblingKey].width : 0,
 				nextSiblingInitialHeight: nextSiblingKey ? sizes[nextSiblingKey].height : 0,
 				itemAbsorbsAlongAxis: {
-					width: !('width' in item),
-					height: !('height' in item),
+					width: itemFlex && !('width' in item),
+					height: itemFlex && !('height' in item),
 				},
 				nextAbsorbsAlongAxis,
 			});
 		};
 
 		const onResize: ResizeCallback = (_event, direction, _refToElement, delta) => {
-			// The absorber (width/height-less side) is skipped so the layout
-			// system keeps it flexible.
+			// A sized panel is skipped only if the other side is fixed; when
+			// both panels are absorbers, we write to the dragged one so the
+			// divider actually moves (the next sibling then absorbs the rest).
 			const isHorizontal = direction !== 'bottom';
 			const minSize = isHorizontal ? itemMinWidth : itemMinHeight;
 			const rawDelta = isHorizontal ? delta.width : delta.height;
 
 			const itemIsAbsorber = isHorizontal ? resizedItem.itemAbsorbsAlongAxis.width : resizedItem.itemAbsorbsAlongAxis.height;
 			const nextIsAbsorber = isHorizontal ? resizedItem.nextAbsorbsAlongAxis.width : resizedItem.nextAbsorbsAlongAxis.height;
+			const bothAbsorb = itemIsAbsorber && nextIsAbsorber;
 
 			let newLayout = props.layout;
 
-			if (!itemIsAbsorber) {
+			if (!itemIsAbsorber || bothAbsorb) {
 				const initial = isHorizontal ? resizedItem.initialWidth : resizedItem.initialHeight;
 				const newSize = Math.max(minSize, initial + rawDelta);
 				newLayout = setLayoutItemProps(newLayout, resizedItem.key, isHorizontal ? { width: newSize } : { height: newSize });
@@ -165,10 +196,10 @@ function ResizableLayout(props: Props) {
 		const resizedItemMaxSize = resizedItem && item.key === resizedItem.key ? resizedItem.maxSize : null;
 		const visible = itemVisible(item, props.moveMode);
 		const itemContainerProps = {
-			key: item.key, item, parent, sizes, resizedItemMaxSize, onResizeStart, onResizeStop, onResize, isLastChild, visible,
+			key: item.key, item, parent, sizes, resizedItemMaxSize, onResizeStart, onResizeStop, onResize, isLastChild, visible, edges,
 		};
 		if (!item.children) {
-			const size = itemSize(item, parent, sizes, false);
+			const size = itemSize(item, parent, sizes, false, edges);
 
 			const comp = props.renderItem(item.key, {
 				item: item,
@@ -182,11 +213,20 @@ function ResizableLayout(props: Props) {
 				{wrapper}
 			</LayoutItemContainer>;
 		} else {
+			// Compute the index of the last visible-in-render child so each
+			// child knows whether it has any visible sibling after it. In
+			// moveMode, itemVisible treats hidden panels as visible, so their
+			// dividers stay usable while the layout is being rearranged.
+			let lastVisibleIdx = -1;
+			for (let i = item.children.length - 1; i >= 0; i--) {
+				if (itemVisible(item.children[i], props.moveMode)) { lastVisibleIdx = i; break; }
+			}
+
 			const childrenComponents = [];
 			for (let i = 0; i < item.children.length; i++) {
 				const child = item.children[i];
 				childrenComponents.push(
-					renderLayoutItem(child, item, sizes, isVisible && itemVisible(child, props.moveMode), i === item.children.length - 1, onlyMoveControls),
+					renderLayoutItem(child, item, sizes, isVisible && itemVisible(child, props.moveMode), i === lastVisibleIdx, onlyMoveControls, edges),
 				);
 			}
 

--- a/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import { useRef, useState, useEffect, useCallback } from 'react';
 import useWindowResizeEvent from './utils/useWindowResizeEvent';
 import setLayoutItemProps from './utils/setLayoutItemProps';
-import useLayoutItemSizes, { EdgeFlags, LayoutItemSizes, itemSize, calculateMaxSizeAvailableForItem, itemMinWidth, itemMinHeight } from './utils/useLayoutItemSizes';
+import useLayoutItemSizes, { EdgeFlags, LayoutItemSizes, itemSize, calculateMaxSizeAvailableForItem } from './utils/useLayoutItemSizes';
 import validateLayout from './utils/validateLayout';
 import { Size, LayoutItem } from './utils/types';
 import { canMove, MoveDirection } from './utils/movements';
+import { buildResizeSnapshot, computeEdges, isItemVisibleInRender, lastVisibleChildIndex, planResize, ResizeStartSnapshot } from './utils/resizeLogic';
 import MoveButtons, { MoveButtonClickEvent } from './MoveButtons';
 import { StyledWrapperRoot, StyledMoveOverlay, MoveModeRootMessage } from './utils/style';
 import type { ResizeCallback, ResizeStartCallback } from 're-resizable';
@@ -17,18 +18,8 @@ interface OnResizeEvent {
 	layout: LayoutItem;
 }
 
-interface ResizedItem {
-	key: string;
-	initialWidth: number;
-	initialHeight: number;
+interface ResizedItem extends ResizeStartSnapshot {
 	maxSize: Size;
-	// A divider drag updates the dragged item and its next visible sibling,
-	// so the delta stays between the two panels on either side of it.
-	nextSiblingKey: string | null;
-	nextSiblingInitialWidth: number;
-	nextSiblingInitialHeight: number;
-	itemAbsorbsAlongAxis: { width: boolean; height: boolean };
-	nextAbsorbsAlongAxis: { width: boolean; height: boolean };
 }
 
 export interface RenderItemEvent {
@@ -50,11 +41,7 @@ interface Props {
 	moveModeMessage: string;
 }
 
-function itemVisible(item: LayoutItem, moveMode: boolean) {
-	if (moveMode) return true;
-	if (item.children && !item.children.length) return false;
-	return item.visible !== false;
-}
+const itemVisible = isItemVisibleInRender;
 
 function ResizableLayout(props: Props) {
 	const eventEmitter = useRef(new EventEmitter());
@@ -97,93 +84,20 @@ function ResizableLayout(props: Props) {
 	function renderLayoutItem(
 		item: LayoutItem, parent: LayoutItem | null, sizes: LayoutItemSizes, isVisible: boolean, isLastChild: boolean, onlyMoveControls: boolean, parentEdges: EdgeFlags = { ownRight: false, ownBottom: false, parentRight: false, parentBottom: false },
 	): React.ReactNode {
-		const parentDir = parent?.direction;
-		const ownRight = parentDir === 'row' && !isLastChild;
-		const ownBottom = parentDir === 'column' && !isLastChild;
-		// A child inherits the parent's trailing gap when its own trailing
-		// edge coincides with the parent's. In a column the right edge is
-		// shared by every child; in a row the bottom edge is shared. And the
-		// last child of any direction inherits the parent's own trailing gap.
-		const parentRight = parentDir === 'column'
-			? parentEdges.ownRight || parentEdges.parentRight
-			: (isLastChild && (parentEdges.ownRight || parentEdges.parentRight));
-		const parentBottom = parentDir === 'row'
-			? parentEdges.ownBottom || parentEdges.parentBottom
-			: (isLastChild && (parentEdges.ownBottom || parentEdges.parentBottom));
-		const edges: EdgeFlags = { ownRight, ownBottom, parentRight, parentBottom };
+		const edges = computeEdges(parent, isLastChild, parentEdges);
 
 		const onResizeStart: ResizeStartCallback = () => {
-			// A panel counts as the container's absorber only when it (or its
-			// subtree) is flagged flexible. A width-less panel that isn't
-			// flagged (e.g. chatPanel being shown in moveMode without a
-			// persisted width) should still receive drag deltas, so we don't
-			// treat it as the absorber here.
-			const isSubtreeFlexible = (i: LayoutItem) => {
-				if (i.flexible) return true;
-				if (!i.children) return false;
-				for (const c of i.children) if (isSubtreeFlexible(c)) return true;
-				return false;
-			};
-
-			let nextSiblingKey: string | null = null;
-			const nextAbsorbsAlongAxis = { width: false, height: false };
-			if (parent) {
-				const siblings = parent.children;
-				const idx = siblings.findIndex(c => c.key === item.key);
-				for (let i = idx + 1; i < siblings.length; i++) {
-					if (itemVisible(siblings[i], props.moveMode)) {
-						nextSiblingKey = siblings[i].key;
-						const flex = isSubtreeFlexible(siblings[i]);
-						nextAbsorbsAlongAxis.width = flex && !('width' in siblings[i]);
-						nextAbsorbsAlongAxis.height = flex && !('height' in siblings[i]);
-						break;
-					}
-				}
-			}
-
-			const itemFlex = isSubtreeFlexible(item);
 			setResizedItem({
-				key: item.key,
-				initialWidth: sizes[item.key].width,
-				initialHeight: sizes[item.key].height,
+				...buildResizeSnapshot(item, parent, props.moveMode, sizes),
 				maxSize: calculateMaxSizeAvailableForItem(item, parent, sizes),
-				nextSiblingKey,
-				nextSiblingInitialWidth: nextSiblingKey ? sizes[nextSiblingKey].width : 0,
-				nextSiblingInitialHeight: nextSiblingKey ? sizes[nextSiblingKey].height : 0,
-				itemAbsorbsAlongAxis: {
-					width: itemFlex && !('width' in item),
-					height: itemFlex && !('height' in item),
-				},
-				nextAbsorbsAlongAxis,
 			});
 		};
 
 		const onResize: ResizeCallback = (_event, direction, _refToElement, delta) => {
-			// A sized panel is skipped only if the other side is fixed; when
-			// both panels are absorbers, we write to the dragged one so the
-			// divider actually moves (the next sibling then absorbs the rest).
-			const isHorizontal = direction !== 'bottom';
-			const minSize = isHorizontal ? itemMinWidth : itemMinHeight;
-			const rawDelta = isHorizontal ? delta.width : delta.height;
-
-			const itemIsAbsorber = isHorizontal ? resizedItem.itemAbsorbsAlongAxis.width : resizedItem.itemAbsorbsAlongAxis.height;
-			const nextIsAbsorber = isHorizontal ? resizedItem.nextAbsorbsAlongAxis.width : resizedItem.nextAbsorbsAlongAxis.height;
-			const bothAbsorb = itemIsAbsorber && nextIsAbsorber;
-
 			let newLayout = props.layout;
-
-			if (!itemIsAbsorber || bothAbsorb) {
-				const initial = isHorizontal ? resizedItem.initialWidth : resizedItem.initialHeight;
-				const newSize = Math.max(minSize, initial + rawDelta);
-				newLayout = setLayoutItemProps(newLayout, resizedItem.key, isHorizontal ? { width: newSize } : { height: newSize });
+			for (const update of planResize(resizedItem, direction, delta)) {
+				newLayout = setLayoutItemProps(newLayout, update.key, update.props);
 			}
-
-			if (!nextIsAbsorber && resizedItem.nextSiblingKey) {
-				const initial = isHorizontal ? resizedItem.nextSiblingInitialWidth : resizedItem.nextSiblingInitialHeight;
-				const newSize = Math.max(minSize, initial - rawDelta);
-				newLayout = setLayoutItemProps(newLayout, resizedItem.nextSiblingKey, isHorizontal ? { width: newSize } : { height: newSize });
-			}
-
 			props.onResize({ layout: newLayout });
 			eventEmitter.current.emit('resize');
 		};
@@ -213,15 +127,7 @@ function ResizableLayout(props: Props) {
 				{wrapper}
 			</LayoutItemContainer>;
 		} else {
-			// Compute the index of the last visible-in-render child so each
-			// child knows whether it has any visible sibling after it. In
-			// moveMode, itemVisible treats hidden panels as visible, so their
-			// dividers stay usable while the layout is being rearranged.
-			let lastVisibleIdx = -1;
-			for (let i = item.children.length - 1; i >= 0; i--) {
-				if (itemVisible(item.children[i], props.moveMode)) { lastVisibleIdx = i; break; }
-			}
-
+			const lastVisibleIdx = lastVisibleChildIndex(item, props.moveMode);
 			const childrenComponents = [];
 			for (let i = 0; i < item.children.length; i++) {
 				const child = item.children[i];

--- a/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
@@ -106,10 +106,10 @@ function ResizableLayout(props: Props) {
 		// last child of any direction inherits the parent's own trailing gap.
 		const parentRight = parentDir === 'column'
 			? parentEdges.ownRight || parentEdges.parentRight
-			: (isLastChild && parentEdges.parentRight);
+			: (isLastChild && (parentEdges.ownRight || parentEdges.parentRight));
 		const parentBottom = parentDir === 'row'
 			? parentEdges.ownBottom || parentEdges.parentBottom
-			: (isLastChild && parentEdges.parentBottom);
+			: (isLastChild && (parentEdges.ownBottom || parentEdges.parentBottom));
 		const edges: EdgeFlags = { ownRight, ownBottom, parentRight, parentBottom };
 
 		const onResizeStart: ResizeStartCallback = () => {

--- a/packages/app-desktop/gui/ResizableLayout/utils/resizeLogic.test.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/resizeLogic.test.ts
@@ -172,12 +172,26 @@ describe('resizeLogic', () => {
 		]);
 	});
 
-	test('planResize: clamps the dragged panel to itemMinWidth (40) when the delta would shrink it below', () => {
-		// Only the individual write is clamped; the reciprocal update on the
-		// next sibling isn't rebalanced. The layout system's downstream
-		// distribution handles the resulting overflow.
-		const updates = planResize(baseSnap(), 'right', { width: -500, height: 0 });
+	test('planResize: clamps a shared delta so both sides respect min and the combined size is preserved', () => {
+		const snap = baseSnap();
+		const originalSum = snap.initialWidth + snap.nextSiblingInitialWidth;
+		const updates = planResize(snap, 'right', { width: -500, height: 0 });
+		// itemMinWidth is 40; dragged clamps to 40, next grows by the same
+		// amount so the two sizes sum to the original combined width.
 		expect(updates[0].props.width).toBe(40);
+		expect(updates[1].props.width).toBe(originalSum - 40);
+		expect(updates[0].props.width + updates[1].props.width).toBe(originalSum);
+	});
+
+	test('planResize: preserves the combined size when the delta would push the next sibling below min', () => {
+		const snap = baseSnap();
+		const originalSum = snap.initialWidth + snap.nextSiblingInitialWidth;
+		const updates = planResize(snap, 'right', { width: 500, height: 0 });
+		// The next sibling clamps to itemMinWidth (40); the dragged panel
+		// grows by exactly the same amount so the sum is preserved.
+		expect(updates[1].props.width).toBe(40);
+		expect(updates[0].props.width).toBe(originalSum - 40);
+		expect(updates[0].props.width + updates[1].props.width).toBe(originalSum);
 	});
 
 });

--- a/packages/app-desktop/gui/ResizableLayout/utils/resizeLogic.test.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/resizeLogic.test.ts
@@ -1,0 +1,183 @@
+import { LayoutItem, LayoutItemDirection } from './types';
+import {
+	buildResizeSnapshot,
+	computeEdges,
+	isSubtreeFlexible,
+	lastVisibleChildIndex,
+	nextVisibleSibling,
+	planResize,
+	ResizeStartSnapshot,
+} from './resizeLogic';
+
+describe('resizeLogic', () => {
+
+	const sampleSizes = {
+		sideBar: { width: 250, height: 800 },
+		noteList: { width: 400, height: 800 },
+		editor: { width: 300, height: 800 },
+		chatPanel: { width: 340, height: 800 },
+	};
+
+	test.each([
+		['flag directly on item', { key: 'a', flexible: true } as LayoutItem, true],
+		['flag on nested descendant', { key: 'a', children: [{ key: 'b', children: [{ key: 'c', flexible: true }] }] } as LayoutItem, true],
+		['no flag anywhere in subtree', { key: 'a', children: [{ key: 'b' }] } as LayoutItem, false],
+		['leaf without flag', { key: 'a' } as LayoutItem, false],
+	])('isSubtreeFlexible: %s', (_label, item, expected) => {
+		expect(isSubtreeFlexible(item)).toBe(expected);
+	});
+
+	test('nextVisibleSibling skips hidden siblings in normal mode', () => {
+		const parent: LayoutItem = {
+			key: 'root',
+			children: [
+				{ key: 'a' },
+				{ key: 'b', visible: false },
+				{ key: 'c' },
+			],
+		};
+		expect(nextVisibleSibling(parent.children[0], parent, false)?.key).toBe('c');
+	});
+
+	test('nextVisibleSibling includes hidden siblings in moveMode', () => {
+		const parent: LayoutItem = {
+			key: 'root',
+			children: [
+				{ key: 'a' },
+				{ key: 'b', visible: false },
+				{ key: 'c' },
+			],
+		};
+		expect(nextVisibleSibling(parent.children[0], parent, true)?.key).toBe('b');
+	});
+
+	test('lastVisibleChildIndex is moveMode-aware', () => {
+		const item: LayoutItem = {
+			key: 'root',
+			children: [{ key: 'a' }, { key: 'b' }, { key: 'c', visible: false }],
+		};
+		expect(lastVisibleChildIndex(item, false)).toBe(1);
+		expect(lastVisibleChildIndex(item, true)).toBe(2);
+	});
+
+	test('computeEdges: middle row child gets an own right edge only', () => {
+		const parent: LayoutItem = { key: 'root', direction: LayoutItemDirection.Row };
+		expect(computeEdges(parent, false)).toEqual({ ownRight: true, ownBottom: false, parentRight: false, parentBottom: false });
+	});
+
+	test('computeEdges: last row child inherits parent right', () => {
+		const parent: LayoutItem = { key: 'root', direction: LayoutItemDirection.Row };
+		const parentEdges = { ownRight: false, ownBottom: false, parentRight: true, parentBottom: false };
+		expect(computeEdges(parent, true, parentEdges)).toEqual({ ownRight: false, ownBottom: false, parentRight: true, parentBottom: false });
+	});
+
+	test('computeEdges: every column child sits at the column right edge, so parentRight propagates through', () => {
+		const parent: LayoutItem = { key: 'col', direction: LayoutItemDirection.Column };
+		const parentEdges = { ownRight: true, ownBottom: false, parentRight: false, parentBottom: false };
+		expect(computeEdges(parent, false, parentEdges).parentRight).toBe(true);
+	});
+
+	test('computeEdges: same-axis nesting propagates outer own-right to a last row-in-row child', () => {
+		// Unusual but valid nesting: the inner container's right edge
+		// coincides with the outer's, so the outer's own right divider gap
+		// must flow to the inner's descendants.
+		const parent: LayoutItem = { key: 'inner', direction: LayoutItemDirection.Row };
+		const parentEdges = { ownRight: true, ownBottom: false, parentRight: false, parentBottom: false };
+		expect(computeEdges(parent, true, parentEdges).parentRight).toBe(true);
+	});
+
+	test('buildResizeSnapshot: only truly-flexible subtrees are flagged as absorbers', () => {
+		const parent: LayoutItem = { key: 'root', direction: LayoutItemDirection.Row, children: [
+			{ key: 'sideBar', width: 250 },
+			{ key: 'editor', flexible: true },
+		] };
+		const snap = buildResizeSnapshot(parent.children[0], parent, false, sampleSizes);
+		expect(snap.itemAbsorbsAlongAxis.width).toBe(false); // sideBar
+		expect(snap.nextAbsorbsAlongAxis.width).toBe(true); // editor
+	});
+
+	test('buildResizeSnapshot: width-less non-flexible next sibling is not an absorber', () => {
+		// Regression: dragging noteList↔chatPanel where chatPanel is unsized
+		// in state but not marked flexible. Old code treated any unsized
+		// panel as an absorber and skipped writes to it.
+		const parent: LayoutItem = { key: 'root', direction: LayoutItemDirection.Row, children: [
+			{ key: 'noteList', width: 400 },
+			{ key: 'chatPanel' },
+		] };
+		const snap = buildResizeSnapshot(parent.children[0], parent, false, sampleSizes);
+		expect(snap.nextAbsorbsAlongAxis.width).toBe(false);
+	});
+
+	test('buildResizeSnapshot: picks the next sibling that is hidden in state when in moveMode', () => {
+		const parent: LayoutItem = { key: 'root', direction: LayoutItemDirection.Row, children: [
+			{ key: 'noteList', width: 400 },
+			{ key: 'chatPanel', visible: false },
+		] };
+		const snap = buildResizeSnapshot(parent.children[0], parent, true, sampleSizes);
+		expect(snap.nextSiblingKey).toBe('chatPanel');
+	});
+
+	const baseSnap = (overrides: Partial<ResizeStartSnapshot> = {}): ResizeStartSnapshot => ({
+		key: 'a',
+		initialWidth: 300,
+		initialHeight: 200,
+		nextSiblingKey: 'b',
+		nextSiblingInitialWidth: 400,
+		nextSiblingInitialHeight: 200,
+		itemAbsorbsAlongAxis: { width: false, height: false },
+		nextAbsorbsAlongAxis: { width: false, height: false },
+		...overrides,
+	});
+
+	test('planResize: drag right by 50 grows the dragged panel and shrinks the next', () => {
+		expect(planResize(baseSnap(), 'right', { width: 50, height: 0 })).toEqual([
+			{ key: 'a', props: { width: 350 } },
+			{ key: 'b', props: { width: 350 } },
+		]);
+	});
+
+	test('planResize: skips write to the next sibling when it is the absorber', () => {
+		const snap = baseSnap({ nextAbsorbsAlongAxis: { width: true, height: false } });
+		expect(planResize(snap, 'right', { width: 50, height: 0 })).toEqual([
+			{ key: 'a', props: { width: 350 } },
+		]);
+	});
+
+	test('planResize: redirects to the next sibling (inverse) when dragged is the absorber', () => {
+		// Editor is flexible and unsized; dragging its right edge should
+		// resize the panel to its right instead so the editor stays flex.
+		const snap = baseSnap({ itemAbsorbsAlongAxis: { width: true, height: false } });
+		expect(planResize(snap, 'right', { width: 50, height: 0 })).toEqual([
+			{ key: 'b', props: { width: 350 } },
+		]);
+	});
+
+	test('planResize: writes to the dragged panel when both sides are absorbers (#15934)', () => {
+		// Sidebar and note list stacked in a column, both unsized. Without
+		// the bothAbsorb branch, neither was written and the divider never
+		// moved.
+		const snap = baseSnap({
+			itemAbsorbsAlongAxis: { width: false, height: true },
+			nextAbsorbsAlongAxis: { width: false, height: true },
+		});
+		expect(planResize(snap, 'bottom', { width: 0, height: 40 })).toEqual([
+			{ key: 'a', props: { height: 240 } },
+		]);
+	});
+
+	test('planResize: no next sibling means only the dragged is written', () => {
+		const snap = baseSnap({ nextSiblingKey: null });
+		expect(planResize(snap, 'right', { width: 50, height: 0 })).toEqual([
+			{ key: 'a', props: { width: 350 } },
+		]);
+	});
+
+	test('planResize: clamps the dragged panel to itemMinWidth (40) when the delta would shrink it below', () => {
+		// Only the individual write is clamped; the reciprocal update on the
+		// next sibling isn't rebalanced. The layout system's downstream
+		// distribution handles the resulting overflow.
+		const updates = planResize(baseSnap(), 'right', { width: -500, height: 0 });
+		expect(updates[0].props.width).toBe(40);
+	});
+
+});

--- a/packages/app-desktop/gui/ResizableLayout/utils/resizeLogic.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/resizeLogic.ts
@@ -127,17 +127,26 @@ export function planResize(
 	const nextIsAbsorber = isHorizontal ? snapshot.nextAbsorbsAlongAxis.width : snapshot.nextAbsorbsAlongAxis.height;
 	const bothAbsorb = itemIsAbsorber && nextIsAbsorber;
 
-	const updates: ResizeUpdate[] = [];
+	const writeItem = !itemIsAbsorber || bothAbsorb;
+	const writeNext = !nextIsAbsorber && !!snapshot.nextSiblingKey;
 
-	if (!itemIsAbsorber || bothAbsorb) {
-		const initial = isHorizontal ? snapshot.initialWidth : snapshot.initialHeight;
-		const newSize = Math.max(minSize, initial + rawDelta);
+	const itemInitial = isHorizontal ? snapshot.initialWidth : snapshot.initialHeight;
+	const nextInitial = isHorizontal ? snapshot.nextSiblingInitialWidth : snapshot.nextSiblingInitialHeight;
+
+	// When both panels are written, clamp a single shared delta against both
+	// minimums so their combined size is preserved. When only one side is
+	// written, the other is absorbing and we don't clamp against it.
+	let effectiveDelta = rawDelta;
+	if (writeItem) effectiveDelta = Math.max(effectiveDelta, minSize - itemInitial);
+	if (writeNext) effectiveDelta = Math.min(effectiveDelta, nextInitial - minSize);
+
+	const updates: ResizeUpdate[] = [];
+	if (writeItem) {
+		const newSize = itemInitial + effectiveDelta;
 		updates.push({ key: snapshot.key, props: isHorizontal ? { width: newSize } : { height: newSize } });
 	}
-
-	if (!nextIsAbsorber && snapshot.nextSiblingKey) {
-		const initial = isHorizontal ? snapshot.nextSiblingInitialWidth : snapshot.nextSiblingInitialHeight;
-		const newSize = Math.max(minSize, initial - rawDelta);
+	if (writeNext) {
+		const newSize = nextInitial - effectiveDelta;
 		updates.push({ key: snapshot.nextSiblingKey, props: isHorizontal ? { width: newSize } : { height: newSize } });
 	}
 

--- a/packages/app-desktop/gui/ResizableLayout/utils/resizeLogic.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/resizeLogic.ts
@@ -1,0 +1,145 @@
+// Pure helpers extracted from ResizableLayout so they can be unit-tested
+// without a React harness. Everything here is state-in / state-out — no
+// re-resizable, no DOM, no hooks.
+
+import { EdgeFlags, itemMinWidth, itemMinHeight } from './useLayoutItemSizes';
+import { LayoutItem, LayoutItemDirection } from './types';
+
+export function isItemVisibleInRender(item: LayoutItem, moveMode: boolean): boolean {
+	if (moveMode) return true;
+	if (item.children && !item.children.length) return false;
+	return item.visible !== false;
+}
+
+// The subtree carries an absorber if any node in it is flagged flexible.
+export function isSubtreeFlexible(item: LayoutItem): boolean {
+	if (item.flexible) return true;
+	if (!item.children) return false;
+	for (const child of item.children) {
+		if (isSubtreeFlexible(child)) return true;
+	}
+	return false;
+}
+
+// The first visible-in-render sibling after `item` in `parent.children`, or
+// null when `item` is the last visible child (or has no parent).
+export function nextVisibleSibling(item: LayoutItem, parent: LayoutItem | null, moveMode: boolean): LayoutItem | null {
+	if (!parent || !parent.children) return null;
+	const idx = parent.children.findIndex(c => c.key === item.key);
+	for (let i = idx + 1; i < parent.children.length; i++) {
+		if (isItemVisibleInRender(parent.children[i], moveMode)) return parent.children[i];
+	}
+	return null;
+}
+
+// The index of the last visible-in-render child of `item`, or -1.
+export function lastVisibleChildIndex(item: LayoutItem, moveMode: boolean): number {
+	if (!item.children) return -1;
+	for (let i = item.children.length - 1; i >= 0; i--) {
+		if (isItemVisibleInRender(item.children[i], moveMode)) return i;
+	}
+	return -1;
+}
+
+const zeroEdges: EdgeFlags = { ownRight: false, ownBottom: false, parentRight: false, parentBottom: false };
+
+// Compute an item's edge flags from its parent's direction, its own position
+// (is it the last visible child?), and the parent's own edges. Same-axis
+// nesting is handled: a last-child of a row-in-row inherits both the outer's
+// own right gap and the outer's inherited parentRight.
+export function computeEdges(parent: LayoutItem | null, isLastChild: boolean, parentEdges: EdgeFlags = zeroEdges): EdgeFlags {
+	const parentDir = parent?.direction;
+	const ownRight = parentDir === LayoutItemDirection.Row && !isLastChild;
+	const ownBottom = parentDir === LayoutItemDirection.Column && !isLastChild;
+	const parentRight = parentDir === LayoutItemDirection.Column
+		? parentEdges.ownRight || parentEdges.parentRight
+		: (isLastChild && (parentEdges.ownRight || parentEdges.parentRight));
+	const parentBottom = parentDir === LayoutItemDirection.Row
+		? parentEdges.ownBottom || parentEdges.parentBottom
+		: (isLastChild && (parentEdges.ownBottom || parentEdges.parentBottom));
+	return { ownRight, ownBottom, parentRight, parentBottom };
+}
+
+export interface ResizeStartSnapshot {
+	key: string;
+	initialWidth: number;
+	initialHeight: number;
+	nextSiblingKey: string | null;
+	nextSiblingInitialWidth: number;
+	nextSiblingInitialHeight: number;
+	itemAbsorbsAlongAxis: { width: boolean; height: boolean };
+	nextAbsorbsAlongAxis: { width: boolean; height: boolean };
+}
+
+// Build the drag-start snapshot from the layout state. This captures which
+// side of the divider counts as the absorber on each axis (only truly
+// flexible subtrees do — an unsized panel that isn't flagged still gets
+// deltas applied to it so drags on newly-shown panels behave normally).
+export function buildResizeSnapshot(
+	item: LayoutItem,
+	parent: LayoutItem | null,
+	moveMode: boolean,
+	sizes: { [key: string]: { width: number; height: number } },
+): ResizeStartSnapshot {
+	const next = nextVisibleSibling(item, parent, moveMode);
+	const itemFlex = isSubtreeFlexible(item);
+	const nextFlex = next ? isSubtreeFlexible(next) : false;
+
+	return {
+		key: item.key,
+		initialWidth: sizes[item.key].width,
+		initialHeight: sizes[item.key].height,
+		nextSiblingKey: next?.key ?? null,
+		nextSiblingInitialWidth: next ? sizes[next.key].width : 0,
+		nextSiblingInitialHeight: next ? sizes[next.key].height : 0,
+		itemAbsorbsAlongAxis: {
+			width: itemFlex && !('width' in item),
+			height: itemFlex && !('height' in item),
+		},
+		nextAbsorbsAlongAxis: {
+			width: nextFlex && next ? !('width' in next) : false,
+			height: nextFlex && next ? !('height' in next) : false,
+		},
+	};
+}
+
+export interface ResizeUpdate {
+	key: string;
+	props: { width?: number; height?: number };
+}
+
+// Given a drag snapshot, a direction, and re-resizable's cumulative delta,
+// return the layout-state writes needed to move the divider. The dragged
+// panel and its next visible sibling exchange space; either side can be
+// skipped when it's an absorber so the layout system keeps it flexible.
+// When both sides are absorbers (e.g. two unsized column-nested siblings),
+// we write to the dragged panel so the divider still moves.
+export function planResize(
+	snapshot: ResizeStartSnapshot,
+	direction: string,
+	delta: { width: number; height: number },
+): ResizeUpdate[] {
+	const isHorizontal = direction !== 'bottom';
+	const minSize = isHorizontal ? itemMinWidth : itemMinHeight;
+	const rawDelta = isHorizontal ? delta.width : delta.height;
+
+	const itemIsAbsorber = isHorizontal ? snapshot.itemAbsorbsAlongAxis.width : snapshot.itemAbsorbsAlongAxis.height;
+	const nextIsAbsorber = isHorizontal ? snapshot.nextAbsorbsAlongAxis.width : snapshot.nextAbsorbsAlongAxis.height;
+	const bothAbsorb = itemIsAbsorber && nextIsAbsorber;
+
+	const updates: ResizeUpdate[] = [];
+
+	if (!itemIsAbsorber || bothAbsorb) {
+		const initial = isHorizontal ? snapshot.initialWidth : snapshot.initialHeight;
+		const newSize = Math.max(minSize, initial + rawDelta);
+		updates.push({ key: snapshot.key, props: isHorizontal ? { width: newSize } : { height: newSize } });
+	}
+
+	if (!nextIsAbsorber && snapshot.nextSiblingKey) {
+		const initial = isHorizontal ? snapshot.nextSiblingInitialWidth : snapshot.nextSiblingInitialHeight;
+		const newSize = Math.max(minSize, initial - rawDelta);
+		updates.push({ key: snapshot.nextSiblingKey, props: isHorizontal ? { width: newSize } : { height: newSize } });
+	}
+
+	return updates;
+}

--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
@@ -461,6 +461,42 @@ describe('useLayoutItemSizes', () => {
 		expect(after.editor.width).toBe(after.col.width);
 	});
 
+	test('itemSize propagates the ancestor divider gap through last-child same-axis nesting', () => {
+		// Same-axis nesting is unusual but valid; a row nested at the end of
+		// another row should inherit its outer sibling's right gap.
+		const sizes = { outer: { width: 200, height: 100 }, inner: { width: 200, height: 100 } };
+		const inner: LayoutItem = { key: 'inner' };
+		// The outer has its own trailing gap because it has a sibling to its right.
+		const edgesFromLastRowChild = { ownRight: false, ownBottom: false, parentRight: true, parentBottom: false };
+		const size = itemSize(inner, null, sizes, false, edgesFromLastRowChild);
+		// 5px reserved for the propagated right gap.
+		expect(size.width).toBe(195);
+	});
+
+	test('multiple width-less siblings stay within the container width even when combined fallbacks exceed it', () => {
+		const layout: LayoutItem = validateLayout({
+			key: 'root',
+			width: 400,
+			height: 100,
+			direction: LayoutItemDirection.Row,
+			children: [
+				// Three unsized non-absorber siblings would want 250 each (=750),
+				// far above the 400 container. The absorber (editor) must still
+				// get at least its minimum.
+				{ key: 'a' },
+				{ key: 'b' },
+				{ key: 'c' },
+				{ key: 'editor', flexible: true },
+			],
+		});
+
+		const { result } = renderHook(() => useLayoutItemSizes(layout));
+		const sizes = result.current;
+		const total = sizes.a.width + sizes.b.width + sizes.c.width + sizes.editor.width;
+		expect(total).toBeLessThanOrEqual(400);
+		expect(sizes.editor.width).toBeGreaterThanOrEqual(40); // itemMinWidth
+	});
+
 	test('flexible flag on a hidden child falls back to the last visible sibling', () => {
 		const layout: LayoutItem = validateLayout({
 			key: 'root',

--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
@@ -134,8 +134,11 @@ describe('useLayoutItemSizes', () => {
 		expect(itemSize(layout.children[0], layout, sizes, true)).toEqual({ width: 100, height: 100 });
 
 		const parent = layout.children[0];
-		expect(itemSize(parent.children[0], parent, sizes, false)).toEqual({ width: 95, height: 45 });
-		expect(itemSize(parent.children[1], parent, sizes, false)).toEqual({ width: 95, height: 50 });
+		// row1: inside a column that has a right divider, and row1 itself has a
+		// bottom divider (there's a visible sibling below it).
+		expect(itemSize(parent.children[0], parent, sizes, false, { ownRight: false, ownBottom: true, parentRight: true, parentBottom: false })).toEqual({ width: 95, height: 45 });
+		// row2: same column, no bottom divider (it is the last row).
+		expect(itemSize(parent.children[1], parent, sizes, false, { ownRight: false, ownBottom: false, parentRight: true, parentBottom: false })).toEqual({ width: 95, height: 50 });
 	});
 
 	test('should decrease size of the largest item if the total size would be larger than the container', () => {

--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.ts
@@ -126,14 +126,17 @@ function calculateChildrenSizes(item: LayoutItem, parent: LayoutItem | null, siz
 	if (noWidthChildren.length && item.direction === 'row' && noWidthChildren.length > 1) {
 		const absorber = noWidthChildren.find(c => containsFlexibleDescendant(c.item));
 		if (absorber) {
-			let absorberWidth = remainingSize.width;
+			const absorberMin = absorber.item.minWidth || itemMinWidth;
+			let budget = Math.max(0, remainingSize.width - absorberMin);
 			for (const child of noWidthChildren) {
 				if (child.item.key === absorber.item.key) continue;
-				const w = child.item.minWidth || nonAbsorberFallbackWidth;
+				const min = child.item.minWidth || itemMinWidth;
+				const desired = child.item.minWidth || nonAbsorberFallbackWidth;
+				const w = Math.max(min, Math.min(desired, budget));
 				sizes[child.item.key].width = w;
-				absorberWidth -= w;
+				budget -= w;
 			}
-			sizes[absorber.item.key].width = Math.max(absorber.item.minWidth || itemMinWidth, absorberWidth);
+			sizes[absorber.item.key].width = Math.max(absorberMin, remainingSize.width - (noWidthChildren.reduce((sum, c) => c.item.key === absorber.item.key ? sum : sum + sizes[c.item.key].width, 0)));
 		} else {
 			const w = Math.floor(remainingSize.width / noWidthChildren.length);
 			for (const child of noWidthChildren) sizes[child.item.key].width = w;
@@ -146,14 +149,17 @@ function calculateChildrenSizes(item: LayoutItem, parent: LayoutItem | null, siz
 	if (noHeightChildren.length && item.direction === 'column' && noHeightChildren.length > 1) {
 		const absorber = noHeightChildren.find(c => containsFlexibleDescendant(c.item));
 		if (absorber) {
-			let absorberHeight = remainingSize.height;
+			const absorberMin = absorber.item.minHeight || itemMinHeight;
+			let budget = Math.max(0, remainingSize.height - absorberMin);
 			for (const child of noHeightChildren) {
 				if (child.item.key === absorber.item.key) continue;
-				const h = child.item.minHeight || nonAbsorberFallbackHeight;
+				const min = child.item.minHeight || itemMinHeight;
+				const desired = child.item.minHeight || nonAbsorberFallbackHeight;
+				const h = Math.max(min, Math.min(desired, budget));
 				sizes[child.item.key].height = h;
-				absorberHeight -= h;
+				budget -= h;
 			}
-			sizes[absorber.item.key].height = Math.max(absorber.item.minHeight || itemMinHeight, absorberHeight);
+			sizes[absorber.item.key].height = Math.max(absorberMin, remainingSize.height - (noHeightChildren.reduce((sum, c) => c.item.key === absorber.item.key ? sum : sum + sizes[c.item.key].height, 0)));
 		} else {
 			const h = Math.floor(remainingSize.height / noHeightChildren.length);
 			for (const child of noHeightChildren) sizes[child.item.key].height = h;

--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.ts
@@ -6,18 +6,43 @@ const dragBarThickness = 5;
 export const itemMinWidth = 40;
 export const itemMinHeight = 40;
 
+// Bigger than itemMinWidth: used as a fallback for width-less non-absorber
+// siblings so newly-shown panels (moveMode) get a usable width instead of
+// squeezing to the minimum.
+const nonAbsorberFallbackWidth = 250;
+const nonAbsorberFallbackHeight = 250;
+
 export interface LayoutItemSizes {
 	[key: string]: Size;
 }
 
+function containsFlexibleDescendant(item: LayoutItem): boolean {
+	if (item.flexible) return true;
+	if (!item.children) return false;
+	for (const child of item.children) {
+		if (containsFlexibleDescendant(child)) return true;
+	}
+	return false;
+}
+
+// Whether this item's trailing (right/bottom) edge is a divider against a
+// visible-in-render sibling. The parent-side flags cover the case where the
+// item's edge coincides with an ancestor's divider (e.g. a column-nested item
+// inheriting its column container's right edge).
+export interface EdgeFlags {
+	ownRight: boolean;
+	ownBottom: boolean;
+	parentRight: boolean;
+	parentBottom: boolean;
+}
+
+const noEdges: EdgeFlags = { ownRight: false, ownBottom: false, parentRight: false, parentBottom: false };
+
 // Container always take the full space while the items within it need to
 // accommodate for the resize handle.
-export function itemSize(item: LayoutItem, parent: LayoutItem | null, sizes: LayoutItemSizes, isContainer: boolean): Size {
-	const parentResizableRight = !!parent && parent.resizableRight;
-	const parentResizableBottom = !!parent && parent.resizableBottom;
-
-	const rightGap = !isContainer && (item.resizableRight || parentResizableRight) ? dragBarThickness : 0;
-	const bottomGap = !isContainer && (item.resizableBottom || parentResizableBottom) ? dragBarThickness : 0;
+export function itemSize(item: LayoutItem, _parent: LayoutItem | null, sizes: LayoutItemSizes, isContainer: boolean, edges: EdgeFlags = noEdges): Size {
+	const rightGap = !isContainer && (edges.ownRight || edges.parentRight) ? dragBarThickness : 0;
+	const bottomGap = !isContainer && (edges.ownBottom || edges.parentBottom) ? dragBarThickness : 0;
 
 	return {
 		width: sizes[item.key].width - rightGap,
@@ -93,20 +118,49 @@ function calculateChildrenSizes(item: LayoutItem, parent: LayoutItem | null, siz
 		remainingSize.height += dh;
 	}
 
-	if (noWidthChildren.length) {
-		const w = item.direction === 'row' ? Math.floor(remainingSize.width / noWidthChildren.length) : parentSize.width;
-		for (const child of noWidthChildren) {
-			const finalWidth = w;
-			sizes[child.item.key].width = finalWidth;
+	// When several children lack a size on the parent's axis (e.g. in
+	// moveMode, where normally-hidden panels are shown without one), route
+	// remaining space to the one that carries the flexible descendant and
+	// give the others a fallback size. This keeps the absorber's role
+	// intact and avoids equal-split behaviour that would eat editor space.
+	if (noWidthChildren.length && item.direction === 'row' && noWidthChildren.length > 1) {
+		const absorber = noWidthChildren.find(c => containsFlexibleDescendant(c.item));
+		if (absorber) {
+			let absorberWidth = remainingSize.width;
+			for (const child of noWidthChildren) {
+				if (child.item.key === absorber.item.key) continue;
+				const w = child.item.minWidth || nonAbsorberFallbackWidth;
+				sizes[child.item.key].width = w;
+				absorberWidth -= w;
+			}
+			sizes[absorber.item.key].width = Math.max(absorber.item.minWidth || itemMinWidth, absorberWidth);
+		} else {
+			const w = Math.floor(remainingSize.width / noWidthChildren.length);
+			for (const child of noWidthChildren) sizes[child.item.key].width = w;
 		}
+	} else if (noWidthChildren.length) {
+		const w = item.direction === 'row' ? Math.floor(remainingSize.width / noWidthChildren.length) : parentSize.width;
+		for (const child of noWidthChildren) sizes[child.item.key].width = w;
 	}
 
-	if (noHeightChildren.length) {
-		const h = item.direction === 'column' ? Math.floor(remainingSize.height / noHeightChildren.length) : parentSize.height;
-		for (const child of noHeightChildren) {
-			const finalHeight = h;
-			sizes[child.item.key].height = finalHeight;
+	if (noHeightChildren.length && item.direction === 'column' && noHeightChildren.length > 1) {
+		const absorber = noHeightChildren.find(c => containsFlexibleDescendant(c.item));
+		if (absorber) {
+			let absorberHeight = remainingSize.height;
+			for (const child of noHeightChildren) {
+				if (child.item.key === absorber.item.key) continue;
+				const h = child.item.minHeight || nonAbsorberFallbackHeight;
+				sizes[child.item.key].height = h;
+				absorberHeight -= h;
+			}
+			sizes[absorber.item.key].height = Math.max(absorber.item.minHeight || itemMinHeight, absorberHeight);
+		} else {
+			const h = Math.floor(remainingSize.height / noHeightChildren.length);
+			for (const child of noHeightChildren) sizes[child.item.key].height = h;
 		}
+	} else if (noHeightChildren.length) {
+		const h = item.direction === 'column' ? Math.floor(remainingSize.height / noHeightChildren.length) : parentSize.height;
+		for (const child of noHeightChildren) sizes[child.item.key].height = h;
 	}
 
 	for (const child of item.children) {


### PR DESCRIPTION
## Summary

Follow-up fixes to #15774 that surfaced when the layout is rearranged via View → Change application layout:

- Fixes #15934: dragging a divider between two panels stacked in a column now resizes them (previously the whole container moved).
- In move mode, the white draggable gap now appears between every visible panel, including panels that are hidden in normal mode (e.g. AI Chat).
- Dragging that new gap now resizes the two panels on either side of it, instead of shifting the neighbour further away.
- Divider gaps follow what's actually rendered rather than persisted flags baked while panels were hidden.