### PR TITLE
Desktop: AI chat panel: Improve accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,7 @@ packages/app-desktop/commands/toggleSafeMode.js
 packages/app-desktop/commands/toggleTabMovesFocus.js
 packages/app-desktop/gui/AiDegradedNotice.js
 packages/app-desktop/gui/Button/Button.js
+packages/app-desktop/gui/ChatPanel/ChatMessageItem.js
 packages/app-desktop/gui/ChatPanel/ChatPanel.js
 packages/app-desktop/gui/ClipperConfigScreen.js
 packages/app-desktop/gui/ConfigScreen/ButtonBar.js
@@ -583,6 +584,7 @@ packages/app-desktop/integration-tests/goToAnything.spec.js
 packages/app-desktop/integration-tests/main.spec.js
 packages/app-desktop/integration-tests/markdownEditor.spec.js
 packages/app-desktop/integration-tests/models/ChangeAppLayoutScreen.js
+packages/app-desktop/integration-tests/models/ChatPanel.js
 packages/app-desktop/integration-tests/models/EditorCodeDialog.js
 packages/app-desktop/integration-tests/models/GoToAnything.js
 packages/app-desktop/integration-tests/models/MainScreen.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -217,6 +217,7 @@ packages/app-desktop/commands/toggleSafeMode.js
 packages/app-desktop/commands/toggleTabMovesFocus.js
 packages/app-desktop/gui/AiDegradedNotice.js
 packages/app-desktop/gui/Button/Button.js
+packages/app-desktop/gui/ChatPanel/ChatMessageItem.js
 packages/app-desktop/gui/ChatPanel/ChatPanel.js
 packages/app-desktop/gui/ClipperConfigScreen.js
 packages/app-desktop/gui/ConfigScreen/ButtonBar.js
@@ -609,6 +610,7 @@ packages/app-desktop/integration-tests/goToAnything.spec.js
 packages/app-desktop/integration-tests/main.spec.js
 packages/app-desktop/integration-tests/markdownEditor.spec.js
 packages/app-desktop/integration-tests/models/ChangeAppLayoutScreen.js
+packages/app-desktop/integration-tests/models/ChatPanel.js
 packages/app-desktop/integration-tests/models/EditorCodeDialog.js
 packages/app-desktop/integration-tests/models/GoToAnything.js
 packages/app-desktop/integration-tests/models/MainScreen.js

--- a/packages/app-desktop/gui/ChatPanel/ChatMessageItem.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatMessageItem.tsx
@@ -21,10 +21,10 @@ interface Props {
 
 const ChatMessageItem: React.FC<Props> = ({ message }) => {
 	if (message.role === 'separator') {
-		return <div key={message.id} className='separator'>{message.text}</div>;
+		return <div className='separator'>{message.text}</div>;
 	}
 	if (message.role === 'error') {
-		return <div key={message.id} className='error'>{message.text}</div>;
+		return <div className='error'>{message.text}</div>;
 	}
 
 	const summary = message.role === 'assistant' ? editsSummary(message.raw, message.editsApplied ?? 0, message.editsMissed ?? 0) : '';
@@ -40,7 +40,7 @@ const ChatMessageItem: React.FC<Props> = ({ message }) => {
 		: <div className='content'>{textContent}</div>;
 
 	return (
-		<li className={`turn -${message.role}`}>
+		<div className={`chat-message turn -${message.role}`}>
 			{content}
 			{summary && (
 				<div className='meta'>
@@ -49,7 +49,7 @@ const ChatMessageItem: React.FC<Props> = ({ message }) => {
 						: <span>{summary}</span>}
 				</div>
 			)}
-		</li>
+		</div>
 	);
 };
 

--- a/packages/app-desktop/gui/ChatPanel/ChatMessageItem.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatMessageItem.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { _ } from '@joplin/lib/locale';
+import { AiChatMessage } from '../../app.reducer';
+import InlineMarkdownDisplay from '../InlineMarkdownDisplay';
+import { ChatMessage, ChatRole } from '@joplin/lib/services/ai/types';
+
+
+const editsSummary = (actions: ChatMessage[], applied: number, missed: number) => {
+	if (applied + missed === 0) return '';
+	if (missed === 0 && applied > 1) return _('%d edit(s) applied.', applied);
+	if (missed === 0) {
+		const toolResults = actions.filter(action => action.role === ChatRole.Tool);
+		return toolResults.map(result => result.userDescription).join('\n');
+	}
+	return _('%d edit(s) applied, %d could not be placed automatically.', applied, missed);
+};
+
+interface Props {
+	message: AiChatMessage;
+}
+
+const ChatMessageItem: React.FC<Props> = ({ message }) => {
+	if (message.role === 'separator') {
+		return <div key={message.id} className='separator'>{message.text}</div>;
+	}
+	if (message.role === 'error') {
+		return <div key={message.id} className='error'>{message.text}</div>;
+	}
+
+	const summary = message.role === 'assistant' ? editsSummary(message.raw, message.editsApplied ?? 0, message.editsMissed ?? 0) : '';
+	// Always show something in the message box:
+	const textContent = !message.text && !summary ? _('(no message)') : message.text;
+
+	const renderMarkdown = message.role === 'assistant';
+	const content = renderMarkdown
+		? <InlineMarkdownDisplay
+			className='content'
+			markdown={textContent}
+			allowLinks={false} />
+		: <div className='content'>{textContent}</div>;
+
+	return (
+		<li className={`turn -${message.role}`}>
+			{content}
+			{summary && (
+				<div className='meta'>
+					{(message.editsMissed ?? 0) > 0
+						? <span className='warning'>{summary}</span>
+						: <span>{summary}</span>}
+				</div>
+			)}
+		</li>
+	);
+};
+
+export default ChatMessageItem;

--- a/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
@@ -81,6 +81,24 @@ const useCancelCallback = () => {
 	return { abortControllerRef, cancelRequest };
 };
 
+const useHasFocus = () => {
+	const [hasFocus, setHasFocus] = useState(false);
+	const onFocus = useCallback(() => setHasFocus(true), []);
+	const onBlur: React.FocusEventHandler<HTMLDivElement> = useCallback((event) => {
+		const chatPanelContainer = event.currentTarget;
+		const newElementWithFocus = event.relatedTarget;
+		const movingFocusOut = !chatPanelContainer.contains(newElementWithFocus);
+
+		// Avoid quickly toggling hasFocus: onBlur/onFocus are emitted when moving focus between
+		// elements within the container.
+		if (movingFocusOut) {
+			setHasFocus(false);
+		}
+	}, []);
+
+	return { hasFocus, onFocus, onBlur };
+};
+
 // Single-window for v1: mapStateToProps hard-codes defaultWindowId and the
 // toggle writes to the app-wide layout. A second window would mirror the main.
 const ChatPanel: React.FC<Props> = (props) => {
@@ -103,9 +121,7 @@ const ChatPanel: React.FC<Props> = (props) => {
 	noteIdRef.current = props.noteId;
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 
-	const [hasFocus, setHasFocus] = useState(false);
-	const onFocus = useCallback(() => setHasFocus(true), []);
-	const onBlur = useCallback(() => setHasFocus(false), []);
+	const { hasFocus, onFocus, onBlur } = useHasFocus();
 
 	const { abortControllerRef, cancelRequest } = useCancelCallback();
 

--- a/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
@@ -103,6 +103,10 @@ const ChatPanel: React.FC<Props> = (props) => {
 	noteIdRef.current = props.noteId;
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 
+	const [hasFocus, setHasFocus] = useState(false);
+	const onFocus = useCallback(() => setHasFocus(true), []);
+	const onBlur = useCallback(() => setHasFocus(false), []);
+
 	const { abortControllerRef, cancelRequest } = useCancelCallback();
 
 	const windowId = useContext(WindowIdContext);
@@ -326,7 +330,11 @@ const ChatPanel: React.FC<Props> = (props) => {
 		const content = <>
 			{props.aiDegraded && <AiDegradedNotice className='degraded-status' />}
 			<div className='messages'>
-				<ul className='chat-messages-list'>
+				<ul
+					className='chat-messages-list'
+					aria-label={_('Messages')}
+					aria-live={hasFocus ? 'polite' : undefined}
+				>
 					{messages.length === 0 && (
 						<li className='empty'>
 							{_('Ask about this note, or request changes. Select text in the editor first to scope the request to that selection.')}
@@ -375,9 +383,15 @@ const ChatPanel: React.FC<Props> = (props) => {
 	const { content, showingMessages } = renderContent();
 
 	return (
-		<div className='chat-panel' role='region' aria-labelledby={headerId}>
+		<div
+			className='chat-panel'
+			role='region'
+			aria-labelledby={headerId}
+			onFocus={onFocus}
+			onBlur={onBlur}
+		>
 			<div className='header'>
-				<h2 className='title' id={headerId}>{_('AI Chat')}</h2>
+				<h1 className='title' id={headerId}>{_('AI Chat')}</h1>
 				{showingMessages && (
 					<button type='button' className='reset' onClick={handleReset}>{_('Reset')}</button>
 				)}

--- a/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
@@ -329,19 +329,13 @@ const ChatPanel: React.FC<Props> = (props) => {
 
 		const content = <>
 			{props.aiDegraded && <AiDegradedNotice className='degraded-status' />}
-			<div className='messages'>
-				<ul
-					className='chat-messages-list'
-					aria-label={_('Messages')}
-					aria-live={hasFocus ? 'polite' : undefined}
-				>
-					{messages.length === 0 && (
-						<li className='empty'>
-							{_('Ask about this note, or request changes. Select text in the editor first to scope the request to that selection.')}
-						</li>
-					)}
-					{messages.map(m => <ChatMessageItem key={m.id} message={m}/>)}
-				</ul>
+			<div className='messages' aria-live={hasFocus ? 'polite' : undefined}>
+				{messages.length === 0 && (
+					<div className='empty'>
+						{_('Ask about this note, or request changes. Select text in the editor first to scope the request to that selection.')}
+					</div>
+				)}
+				{messages.map(m => <ChatMessageItem key={m.id} message={m}/>)}
 				<div ref={messagesEndRef} />
 			</div>
 			<div className='composer'>

--- a/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { _ } from '@joplin/lib/locale';
@@ -17,7 +17,7 @@ import { ChatMessage, ChatRole, ChatToolMessage } from '@joplin/lib/services/ai/
 import JoplinError from '@joplin/lib/JoplinError';
 import eventManager, { EventName, ItemChangeEvent } from '@joplin/lib/eventManager';
 import { Second } from '@joplin/utils/time';
-import InlineMarkdownDisplay from '../InlineMarkdownDisplay';
+import ChatMessageItem from './ChatMessageItem';
 
 const logger = Logger.create('ChatPanel');
 
@@ -38,16 +38,6 @@ const disclosureSetting = 'ai.chat.disclosureAcknowledged';
 
 let nextMessageId = 0;
 const makeId = () => `m-${Date.now()}-${++nextMessageId}`;
-
-const editsSummary = (actions: ChatMessage[], applied: number, missed: number) => {
-	if (applied + missed === 0) return '';
-	if (missed === 0 && applied > 1) return _('%d edit(s) applied.', applied);
-	if (missed === 0) {
-		const toolResults = actions.filter(action => action.role === ChatRole.Tool);
-		return toolResults.map(result => result.userDescription).join('\n');
-	}
-	return _('%d edit(s) applied, %d could not be placed automatically.', applied, missed);
-};
 
 const waitForNextNoteChangeOrTimeout = (noteId: string, timeout: number) => {
 	return new Promise<void>((resolve) => {
@@ -315,82 +305,35 @@ const ChatPanel: React.FC<Props> = (props) => {
 		}
 	}, [handleSend, sending]);
 
-	if (!props.available) {
-		return (
-			<div className='chat-panel'>
-				<div className='header'>
-					<span className='title'>{_('AI Chat')}</span>
-				</div>
+	const renderContent = () => {
+		if (!props.available) {
+			const content = (
 				<div className='disabled-message'>
 					{props.unavailableHint}
 				</div>
-			</div>
-		);
-	}
-
-	if (props.noteIsEncrypted) {
-		return (
-			<div className='chat-panel'>
-				<div className='header'>
-					<span className='title'>{_('AI Chat')}</span>
-				</div>
+			);
+			return { content, showingMessages: false };
+		}
+		if (props.noteIsEncrypted) {
+			const content = (
 				<div className='disabled-message'>
 					{_('This note is encrypted and cannot be used with AI Chat.')}
 				</div>
-			</div>
-		);
-	}
+			);
+			return { content, showingMessages: false };
+		}
 
-	const sendButtonLabel = sending ? _('Stop generating') : _('Send');
-
-	return (
-		<div className='chat-panel'>
-			<div className='header'>
-				<span className='title'>{_('AI Chat')}</span>
-				{messages.length > 0 && (
-					<button type='button' className='reset' onClick={handleReset}>{_('Reset')}</button>
-				)}
-			</div>
+		const content = <>
 			{props.aiDegraded && <AiDegradedNotice className='degraded-status' />}
 			<div className='messages'>
-				{messages.length === 0 && (
-					<div className='empty'>
-						{_('Ask about this note, or request changes. Select text in the editor first to scope the request to that selection.')}
-					</div>
-				)}
-				{messages.map(m => {
-					if (m.role === 'separator') {
-						return <div key={m.id} className='separator'>{m.text}</div>;
-					}
-					if (m.role === 'error') {
-						return <div key={m.id} className='error'>{m.text}</div>;
-					}
-
-					const summary = m.role === 'assistant' ? editsSummary(m.raw, m.editsApplied ?? 0, m.editsMissed ?? 0) : '';
-					// Always show something in the message box:
-					const textContent = !m.text && !summary ? _('(no message)') : m.text;
-
-					const renderMarkdown = m.role === 'assistant';
-					const content = renderMarkdown
-						? <InlineMarkdownDisplay
-							className='content'
-							markdown={textContent}
-							allowLinks={false} />
-						: <div className='content'>{textContent}</div>;
-
-					return (
-						<div key={m.id} className={`turn -${m.role}`}>
-							{content}
-							{summary && (
-								<div className='meta'>
-									{(m.editsMissed ?? 0) > 0
-										? <span className='warning'>{summary}</span>
-										: <span>{summary}</span>}
-								</div>
-							)}
-						</div>
-					);
-				})}
+				<ul className='chat-messages-list'>
+					{messages.length === 0 && (
+						<li className='empty'>
+							{_('Ask about this note, or request changes. Select text in the editor first to scope the request to that selection.')}
+						</li>
+					)}
+					{messages.map(m => <ChatMessageItem key={m.id} message={m}/>)}
+				</ul>
 				<div ref={messagesEndRef} />
 			</div>
 			<div className='composer'>
@@ -422,6 +365,24 @@ const ChatPanel: React.FC<Props> = (props) => {
 					</button>
 				</div>
 			</div>
+		</>;
+
+		return { content, showingMessages: messages.length > 0 };
+	};
+
+	const sendButtonLabel = sending ? _('Stop generating') : _('Send');
+	const headerId = useId();
+	const { content, showingMessages } = renderContent();
+
+	return (
+		<div className='chat-panel' role='region' aria-labelledby={headerId}>
+			<div className='header'>
+				<h2 className='title' id={headerId}>{_('AI Chat')}</h2>
+				{showingMessages && (
+					<button type='button' className='reset' onClick={handleReset}>{_('Reset')}</button>
+				)}
+			</div>
+			{content}
 		</div>
 	);
 };

--- a/packages/app-desktop/gui/ChatPanel/style.scss
+++ b/packages/app-desktop/gui/ChatPanel/style.scss
@@ -56,19 +56,12 @@
 	flex: 1;
 	overflow-y: auto;
 	padding: 8px;
-}
-
-.chat-messages-list {
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
-
-	list-style: none;
-	margin: 0;
-	padding: 0;
 }
 
-.chat-messages-list > .empty {
+.chat-panel > .messages > .empty {
 	color: var(--joplin-color-faded);
 	font-style: italic;
 	text-align: center;
@@ -77,7 +70,7 @@
 	line-height: 1.5;
 }
 
-.chat-messages-list > .turn {
+.chat-panel > .messages > .turn {
 	padding: 8px 10px;
 	border-radius: 6px;
 	overflow-wrap: anywhere;
@@ -85,7 +78,7 @@
 }
 
 // User turn uses the sidebar colour scheme (dark blue bg, white text).
-.chat-messages-list > .turn.-user {
+.chat-panel > .messages > .turn.-user {
 	background-color: var(--joplin-background-color2);
 	color: var(--joplin-color2);
 	align-self: flex-end;
@@ -100,31 +93,31 @@
 // near-black in dark theme), with regular text colour so contrast is correct
 // in both themes. align-self stretch so a short reply still fills the column
 // width instead of leaving empty space on the right.
-.chat-messages-list > .turn.-assistant {
+.chat-panel > .messages > .turn.-assistant {
 	background-color: var(--joplin-background-color3);
 	color: var(--joplin-color);
 	align-self: stretch;
 }
 
-.chat-messages-list > .turn > .meta {
+.chat-panel > .messages > .turn > .meta {
 	font-size: 0.8em;
 	color: var(--joplin-color-faded);
 	margin-top: 4px;
 	white-space: pre-wrap;
 }
 
-.chat-messages-list > .turn > .meta > .warning {
+.chat-panel > .messages > .turn > .meta > .warning {
 	color: var(--joplin-color-warn);
 }
 
-.chat-messages-list > .separator {
+.chat-panel > .messages > .separator {
 	text-align: center;
 	color: var(--joplin-color-faded);
 	font-size: 0.8em;
 	margin: 6px 0;
 }
 
-.chat-messages-list > .error {
+.chat-panel > .messages > .error {
 	color: var(--joplin-color-warn);
 	background-color: var(--joplin-background-color3);
 	border-left: 3px solid var(--joplin-color-warn);

--- a/packages/app-desktop/gui/ChatPanel/style.scss
+++ b/packages/app-desktop/gui/ChatPanel/style.scss
@@ -21,6 +21,8 @@
 
 .chat-panel > .header > .title {
 	flex: 1;
+	font-size: inherit;
+	margin: 0;
 }
 
 .chat-panel > .header > .reset {
@@ -54,12 +56,19 @@
 	flex: 1;
 	overflow-y: auto;
 	padding: 8px;
+}
+
+.chat-messages-list {
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
+
+	list-style: none;
+	margin: 0;
+	padding: 0;
 }
 
-.chat-panel > .messages > .empty {
+.chat-messages-list > .empty {
 	color: var(--joplin-color-faded);
 	font-style: italic;
 	text-align: center;
@@ -68,7 +77,7 @@
 	line-height: 1.5;
 }
 
-.chat-panel > .messages > .turn {
+.chat-messages-list > .turn {
 	padding: 8px 10px;
 	border-radius: 6px;
 	overflow-wrap: anywhere;
@@ -76,7 +85,7 @@
 }
 
 // User turn uses the sidebar colour scheme (dark blue bg, white text).
-.chat-panel > .messages > .turn.-user {
+.chat-messages-list > .turn.-user {
 	background-color: var(--joplin-background-color2);
 	color: var(--joplin-color2);
 	align-self: flex-end;
@@ -91,31 +100,31 @@
 // near-black in dark theme), with regular text colour so contrast is correct
 // in both themes. align-self stretch so a short reply still fills the column
 // width instead of leaving empty space on the right.
-.chat-panel > .messages > .turn.-assistant {
+.chat-messages-list > .turn.-assistant {
 	background-color: var(--joplin-background-color3);
 	color: var(--joplin-color);
 	align-self: stretch;
 }
 
-.chat-panel > .messages > .turn > .meta {
+.chat-messages-list > .turn > .meta {
 	font-size: 0.8em;
 	color: var(--joplin-color-faded);
 	margin-top: 4px;
 	white-space: pre-wrap;
 }
 
-.chat-panel > .messages > .turn > .meta > .warning {
+.chat-messages-list > .turn > .meta > .warning {
 	color: var(--joplin-color-warn);
 }
 
-.chat-panel > .messages > .separator {
+.chat-messages-list > .separator {
 	text-align: center;
 	color: var(--joplin-color-faded);
 	font-size: 0.8em;
 	margin: 6px 0;
 }
 
-.chat-panel > .messages > .error {
+.chat-messages-list > .error {
 	color: var(--joplin-color-warn);
 	background-color: var(--joplin-background-color3);
 	border-left: 3px solid var(--joplin-color-warn);

--- a/packages/app-desktop/integration-tests/models/ChatPanel.ts
+++ b/packages/app-desktop/integration-tests/models/ChatPanel.ts
@@ -1,0 +1,34 @@
+import { ElectronApplication, Locator, Page } from '@playwright/test';
+import setSettingValue from '../util/setSettingValue';
+import MainScreen from './MainScreen';
+import { expect } from '../util/test';
+
+export default class ChatPanel {
+	public readonly container: Locator;
+	public readonly textInput: Locator;
+
+	public constructor(private page_: Page, private mainScreen_: MainScreen) {
+		this.container = page_.getByRole('region', { name: 'AI Chat' });
+		this.textInput = page_.getByRole('textbox', { name: 'Chat message' });
+	}
+
+	public async configure(electronApp: ElectronApplication) {
+		await setSettingValue(electronApp, this.page_, 'ai.enabled', true);
+		await setSettingValue(electronApp, this.page_, 'ai.allowRemote', true);
+		await setSettingValue(electronApp, this.page_, 'ai.chat.providerType', 'test-provider');
+	}
+
+	public async open(electronApp: ElectronApplication) {
+		await this.mainScreen_.goToAnything.runCommand(electronApp, 'toggleAiChat');
+		await this.container.waitFor();
+	}
+
+	public async sendMessage(message: string) {
+		await this.textInput.fill(message);
+		await this.textInput.press('Enter');
+	}
+
+	public async waitForMessageCount(count: number) {
+		await expect(this.container.locator('li.turn')).toHaveCount(count);
+	}
+}

--- a/packages/app-desktop/integration-tests/models/ChatPanel.ts
+++ b/packages/app-desktop/integration-tests/models/ChatPanel.ts
@@ -29,6 +29,6 @@ export default class ChatPanel {
 	}
 
 	public async waitForMessageCount(count: number) {
-		await expect(this.container.locator('li.turn')).toHaveCount(count);
+		await expect(this.container.locator('.chat-message.turn')).toHaveCount(count);
 	}
 }

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -8,6 +8,7 @@ import NoteList from './NoteList';
 import { expect } from '../util/test';
 import ChangeAppLayoutScreen from './ChangeAppLayoutScreen';
 import waitForNextWindowMatching from '../util/waitForNextWindowMatching';
+import ChatPanel from './ChatPanel';
 
 export default class MainScreen {
 	public readonly newNoteButton: Locator;
@@ -17,6 +18,7 @@ export default class MainScreen {
 	public readonly noteEditor: NoteEditorScreen;
 	public readonly goToAnything: GoToAnything;
 	public readonly changeLayoutScreen: ChangeAppLayoutScreen;
+	public readonly chatPanel: ChatPanel;
 
 	public constructor(private page: Page) {
 		this.newNoteButton = page.locator('.new-note-button');
@@ -26,6 +28,7 @@ export default class MainScreen {
 		this.noteEditor = new NoteEditorScreen(page);
 		this.goToAnything = new GoToAnything(page, this);
 		this.changeLayoutScreen = new ChangeAppLayoutScreen(page, this);
+		this.chatPanel = new ChatPanel(page, this);
 	}
 
 	public async setup() {

--- a/packages/app-desktop/integration-tests/wcag.spec.ts
+++ b/packages/app-desktop/integration-tests/wcag.spec.ts
@@ -115,5 +115,21 @@ test.describe('wcag', () => {
 		await mainScreen.changeLayoutScreen.open(electronApp);
 		await expectNoViolations(mainWindow);
 	});
+
+	test('should not detect significant issues in the AI chat panel', async ({ mainWindow, electronApp }) => {
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		await mainScreen.createNewNote('test');
+
+		await mainScreen.chatPanel.configure(electronApp);
+		await mainScreen.chatPanel.open(electronApp);
+
+		await mainScreen.chatPanel.sendMessage('/reply-with test');
+		await mainScreen.chatPanel.sendMessage(
+			'/tool appendToNote {"text": "test"}\n/reply-with done',
+		);
+		await mainScreen.chatPanel.waitForMessageCount(5);
+
+		await expectNoViolations(mainWindow);
+	});
 });
 


### PR DESCRIPTION
# Problem

The automated accessibility scanner (see [wcag.spec.ts](https://github.com/laurent22/joplin/blob/dev/packages/app-desktop/integration-tests/wcag.spec.ts)) flags issues in the AI chat panel:
- The panel isn't contained in a region ([all content must be contained within landmarks](https://dequeuniversity.com/rules/axe/4.1/region)).
- (Not fixed in this PR) Error messages have low contrast.

Additionally, when using a screen reader:
- Chat replies are not announced: It's necessary to manually inspect the chat message list.
- (Not fixed in this PR) It's sometimes difficult/impossible to determine where one message starts and another ends.
- (Not fixed in this PR) There's no distinction between messages from the user and from the assistant.

# Solution


- Announce assistant replies: Mark the messages list with `aria-live='polite'`.
  - This is currently only done when the chat panel has focus. This avoids extra announcements when, for example, switching notes.
- Add a `region` role to the AI chat panel.
- Mark the AI chat panel heading as a heading.
- Enable automated accessibility testing for the AI chat panel.

Supporting refactoring:
- Deduplicated code for creating the chat panel container and header.
- Moved chat message list items to a new component.

# Screen recording

## MacOS


**Requesting an edit to a note** (with a slow, local LLM):

https://github.com/user-attachments/assets/d3b97df1-3430-4a6e-891f-4eef976878ee

Notice, above:
- Messages are announced when the assistant finishes responding.
- With messages that contain formatting (e.g. **bold**), it's difficult to tell where one message begins and another ends.



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
