### PR TITLE
Mobile: Fixes #15915: Add file extension validation to import actions

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -590,11 +590,11 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 				<NoteImportButton key='import_as_jex_button' styles={this.styles()} defaultTitle={importJexLabel()} description={importJexDescription()} format='jex' />,
 				[importJexLabel(), importJexDescription()],
 			);
-			const importTxtLabel = () => _('Import from TXT');
+			const importTxtLabel = () => _('Import from text file');
 			const importTxtDescription = () => {
 				let folderTitle = importedFolderTitle();
 				if (this.state.activeFolder) folderTitle = this.state.activeFolder.title;
-				return _('Import a note from a Text file. The note will be imported into notebook \'%s\'.', substrWithEllipsis(folderTitle, 0, 32));
+				return _('Import a note from an md, markdown, txt, or html file. The note will be imported into notebook \'%s\'.', substrWithEllipsis(folderTitle, 0, 32));
 			};
 			addSettingComponent(
 				<NoteImportButton key='import_as_txt_button' styles={this.styles()} defaultTitle={importTxtLabel()} description={importTxtDescription()} format='txt' activeFolder={this.state.activeFolder} />,

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -31,7 +31,7 @@ import { TextInput, List } from 'react-native-paper';
 import PluginService, { PluginSettings } from '@joplin/lib/services/plugins/PluginService';
 import PluginStates, { getSearchText as getPluginStatesSearchText } from './plugins/PluginStates';
 import PluginUploadButton, { canInstallPluginsFromFile, buttonLabel as pluginUploadButtonSearchText } from './plugins/PluginUploadButton';
-import NoteImportButton, { importedFolderTitle } from './NoteExportSection/NoteImportButton';
+import NoteImportButton, { importedFolderTitle, textImportExtensions } from './NoteExportSection/NoteImportButton';
 import SectionDescription from './SectionDescription';
 import EnablePluginSupportPage from './plugins/EnablePluginSupportPage';
 import getVersionInfoText from '../../../utils/getVersionInfoText';
@@ -594,7 +594,7 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 			const importTxtDescription = () => {
 				let folderTitle = importedFolderTitle();
 				if (this.state.activeFolder) folderTitle = this.state.activeFolder.title;
-				return _('Import a note from an md, markdown, txt, or html file. The note will be imported into notebook \'%s\'.', substrWithEllipsis(folderTitle, 0, 32));
+				return _('Import a note from a text file (%s). The note will be imported into notebook \'%s\'.', textImportExtensions.join(', '), substrWithEllipsis(folderTitle, 0, 32));
 			};
 			addSettingComponent(
 				<NoteImportButton key='import_as_txt_button' styles={this.styles()} defaultTitle={importTxtLabel()} description={importTxtDescription()} format='txt' activeFolder={this.state.activeFolder} />,

--- a/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx
@@ -28,6 +28,8 @@ export const importedFolderTitle = () => {
 	return _('Imported Notes');
 };
 
+export const textImportExtensions = ['md', 'markdown', 'txt', 'html'];
+
 const importedFolder = async () => {
 	let folder = await Folder.loadByFields({
 		title: importedFolderTitle(),
@@ -67,7 +69,7 @@ const NoteImportButton: FunctionComponent<Props> = props => {
 		});
 
 		let validExtensions = ['jex'];
-		if (props.format === 'txt') validExtensions = ['md', 'markdown', 'txt', 'html'];
+		if (props.format === 'txt') validExtensions = textImportExtensions;
 
 		// importFiles[0].fileName can be null on iOS
 		const sourceFileName = importFiles[0].fileName ?? basename(sourceFilePath);

--- a/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx
@@ -12,6 +12,7 @@ import TaskButton, { OnProgressCallback, SetAfterCompleteListenerCallback, TaskS
 import { Platform } from 'react-native';
 import { FolderEntity } from '@joplin/lib/services/database/types';
 import Folder from '@joplin/lib/models/Folder';
+import { fileExtension } from '@joplin/lib/path-utils';
 
 const logger = Logger.create('NoteImportButton');
 
@@ -64,8 +65,17 @@ const NoteImportButton: FunctionComponent<Props> = props => {
 			default: sourceFileUri,
 			ios: decodeURIComponent(sourceFileUri),
 		});
+
+		let validExtensions = ['jex'];
+		if (props.format === 'txt') validExtensions = ['md', 'markdown', 'txt', 'html'];
+
 		// importFiles[0].fileName can be null on iOS
 		const sourceFileName = importFiles[0].fileName ?? basename(sourceFilePath);
+		const extension = fileExtension(sourceFileName).toLowerCase();
+
+		if (!validExtensions.includes(extension)) {
+			throw new Error(_('Unsupported file extension. Expected: %s', validExtensions.join(', ')));
+		}
 
 		const importTargetPath = join(await makeImportExportCacheDirectory(), sourceFileName);
 		setAfterCompleteListener(async (_success: boolean) => {


### PR DESCRIPTION
The import actions in the mobile app use the InteropService, which does not do any file extension validation of it's own. On the desktop app, the file picker restricts the file types which are visible in the picker. This PR introduces some validation upon picking a file via the mobile / web app, which will present an error if an invalid file type is selected for either of the import options. In the case of the txt import, the underlying importer uses InteropService_Importer_Md, which supports the extensions md, markdown, txt and html, so I have amended the label and description for this function (see screenshots) and restricted to these formats.

Please note, there are no translations existing yet for the modified strings, so no translation files need to be amended.

This fixes https://github.com/laurent22/joplin/issues/15915

### Testing

Before:

<img width="300" alt="Screenshot 2026-07-16 231738" src="https://github.com/user-attachments/assets/7710aa56-4f46-442f-83d0-be4a7517350d" />

After:

<img width="300" alt="Screenshot 2026-07-16 235438" src="https://github.com/user-attachments/assets/09bc9319-4899-4b68-95b3-901e34f37258" />

See video:

https://github.com/user-attachments/assets/175a063e-11f6-42cc-85d0-dc329530e9f8

