### PR TITLE
Desktop: Fixes #15918: Keep trailing spaces in table cells while editing

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/renderTables.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderTables.test.ts
@@ -125,4 +125,32 @@ describe('renderTables', () => {
 		const editor = await createEditor(source);
 		expect(editor.state.doc.toString()).toBe(source);
 	});
+
+	test('typing a trailing space in a cell should keep it visible after live-sync', async () => {
+		jest.useFakeTimers();
+		try {
+			const editor = await createEditor('| Head | b |\n|---|---|\n| x | y |');
+			// The widget must be connected for the live-sync flush to run.
+			document.body.appendChild(editor.dom);
+
+			const cell = findCellTextDivs(editor)[0];
+			focusCell(cell);
+
+			// Simulate the user typing "Hello " (with a trailing space).
+			cell.textContent = 'Hello ';
+			cell.dispatchEvent(new Event('input'));
+
+			// Fire the 500ms debounced live-sync and the follow-up rAF that
+			// restores focus + caret to the rebuilt cell.
+			jest.advanceTimersByTime(600);
+			jest.runOnlyPendingTimers();
+
+			// The rebuilt-and-refocused cell must still show the trailing space
+			// rather than the markdown-trimmed "Hello".
+			const refocused = findCellTextDivs(editor)[0];
+			expect(refocused.textContent).toBe('Hello ');
+		} finally {
+			jest.useRealTimers();
+		}
+	});
 });

--- a/packages/editor/CodeMirror/extensions/rendering/renderTables.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderTables.test.ts
@@ -128,15 +128,15 @@ describe('renderTables', () => {
 
 	test('typing a trailing space in a cell should keep it visible after live-sync', async () => {
 		jest.useFakeTimers();
+		let editor: EditorView | null = null;
 		try {
-			const editor = await createEditor('| Head | b |\n|---|---|\n| x | y |');
+			editor = await createEditor('| Head | b |\n|---|---|\n| x | y |');
 			// The widget must be connected for the live-sync flush to run.
 			document.body.appendChild(editor.dom);
 
 			const cell = findCellTextDivs(editor)[0];
 			focusCell(cell);
 
-			// Simulate the user typing "Hello " (with a trailing space).
 			cell.textContent = 'Hello ';
 			cell.dispatchEvent(new Event('input'));
 
@@ -150,6 +150,7 @@ describe('renderTables', () => {
 			const refocused = findCellTextDivs(editor)[0];
 			expect(refocused.textContent).toBe('Hello ');
 		} finally {
+			editor?.destroy();
 			jest.useRealTimers();
 		}
 	});

--- a/packages/editor/CodeMirror/extensions/rendering/renderTables.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderTables.ts
@@ -249,8 +249,10 @@ class TableWidget extends WidgetType {
 			// Called on every input so the model stays in sync even if a
 			// rebuild is triggered by an external event (image paste, toolbar
 			// command, etc.) before the deferred blur handler runs.
+			// Not trimmed: an edge space the user just typed is real content
+			// and must stay visible while editing (see #15918).
 			const pushToModel = () => {
-				const v = (textDiv.textContent || '').trim()
+				const v = (textDiv.textContent || '')
 					.replace(/\n/g, '<br>').replace(/\|/g, '\\|');
 				if (isHdr) table.header.cells[c].content = v;
 				else if (r - 1 < table.body.length) table.body[r - 1].cells[c].content = v;
@@ -278,6 +280,9 @@ class TableWidget extends WidgetType {
 					if (!container.isConnected) return;
 					const newText = serializeTable(table);
 					if (newText === this.tableText) return;
+					// The serialize/parse round-trip strips edge whitespace, so
+					// keep the raw value to re-inject after the rebuild (#15918).
+					const rawValue = textDiv.textContent || '';
 					this.apply(view, table, 'input.type');
 					// Rebuild discards this DOM — locate the same cell in the
 					// new widget and restore focus + caret.
@@ -288,6 +293,8 @@ class TableWidget extends WidgetType {
 						const target = cells && idx < cells.length ? cells[idx] as HTMLElement : null;
 						if (!target) return;
 						focus('TableWidget', target);
+						// Restore the raw value onfocus trimmed.
+						if (target.textContent !== rawValue) target.textContent = rawValue;
 						// Caret restoration: put it `offset` characters into
 						// the cell's text content.
 						const sel = win.getSelection();


### PR DESCRIPTION
The new CodeMirror table editor stripped a trailing space while typing, so "Hello World" became "HelloWorld". The debounced live-sync trimmed the cell in the model and the markdown serialize/parse round-trip dropped edge whitespace, rebuilding the cell mid-typing.

Fix: don't trim in `pushToModel`, and re-inject the raw cell value after the live-sync rebuild so a just-typed edge space stays visible during editing. Added a regression test.
