### PR TITLE
Android, Web: Fixes #15959: Increase minimum prompt button width

### DIFF
--- a/packages/app-mobile/components/DialogManager/PromptButton.tsx
+++ b/packages/app-mobile/components/DialogManager/PromptButton.tsx
@@ -63,7 +63,7 @@ const useStyles = (theme: ThemeStyle, spec: PromptButtonSpec, isMenu: boolean) =
 				paddingHorizontal: (theme.marginMedium - 1) * 2,
 				paddingTop: theme.marginMedium - 1,
 				paddingBottom: theme.marginMedium - 1,
-				minWidth: theme.margin * 4,
+				minWidth: theme.margin * 5,
 			},
 			buttonContent: {
 				display: 'flex',


### PR DESCRIPTION
# Summary

This pull request increases the minimum button width from `4*theme.margin` (64dp) to `5*theme.margin` (80dp).

**Note**: The recommended WCAG 2.2 [minimum button size is 24px x 24px](https://www.w3.org/TR/wcag2mobile-22/#success-criterion-2-5-8-target-size-minimum). Material design recommends at least [48dp x 48dp](https://m3.material.io/foundations/designing/structure#:~:text=link-,Target%20sizes). Both the before and after widths are larger than these suggestions.

Fixes #15959.

# Screenshots

| Component | Before | After |
|-----------|--------|-------|
| Folder edit dialog | <img width="284" height="103" alt="screenshot: Folder edit dialog with Cancel/Delete/Edit buttons" src="https://github.com/user-attachments/assets/3415bc19-66cc-4cce-84a4-48361d1fdebd" /> | <img width="278" height="103" alt="screenshot: Folder edit dialog, edit button is slightly larger" src="https://github.com/user-attachments/assets/271ee5a5-6e9d-4da5-a236-bb1d0ff434b2" /> |
| OK/Cancel dialog | <img width="722" height="266" alt="screenshot: confirmation dialog with cancel/OK buttons" src="https://github.com/user-attachments/assets/c10a1a0d-ee41-449c-99ab-a26cfe11a704" /> | <img width="736" height="290" alt="screenshot: confirmation dialog with cancel/OK buttons, OK button is slightly larger" src="https://github.com/user-attachments/assets/1aaeecd4-21bd-47b5-848f-3c8cb07a79dd" /> |

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
