### PR TITLE
Android, Web: Fixes #15958: Adjust fonts of dialogs with titles

### DIFF
--- a/packages/app-mobile/components/DialogManager/PromptDialog.tsx
+++ b/packages/app-mobile/components/DialogManager/PromptDialog.tsx
@@ -55,11 +55,14 @@ const PromptDialog: React.FC<Props> = ({ dialog, containerStyle, themeId }) => {
 			themeId={themeId}
 		/>;
 	});
-	const titleComponent = <Text
-		variant='titleMedium'
+
+	const hasTitle = !!dialog.title;
+	const bodyVariant = hasTitle ? 'bodyLarge' as const : 'titleMedium' as const;
+	const titleComponent = hasTitle ? <Text
+		variant='titleLarge'
 		accessibilityRole='header'
 		style={styles.dialogLabel}
-	>{dialog.title}</Text>;
+	>{dialog.title}</Text> : null;
 
 	return (
 		<Surface
@@ -69,9 +72,9 @@ const PromptDialog: React.FC<Props> = ({ dialog, containerStyle, themeId }) => {
 			elevation={1}
 		>
 			<Dialog.Content style={styles.dialogContent}>
-				{dialog.title ? titleComponent : null}
+				{titleComponent}
 				<Text
-					variant='titleMedium'
+					variant={bodyVariant}
 					style={styles.dialogLabel}
 				>{dialog.message}</Text>
 			</Dialog.Content>

--- a/packages/app-mobile/index.web.ts
+++ b/packages/app-mobile/index.web.ts
@@ -12,6 +12,7 @@ import DecryptionWorker from '@joplin/lib/services/DecryptionWorker';
 import PluginService from '@joplin/lib/services/plugins/PluginService';
 import Tag from '@joplin/lib/models/Tag';
 import SearchEngine from '@joplin/lib/services/search/SearchEngine';
+import shim from '@joplin/lib/shim';
 
 require('./web/rnVectorIconsSetup.js');
 
@@ -40,6 +41,7 @@ if (__DEV__) {
 		commandService: CommandService.instance(),
 		pluginService: PluginService.instance(),
 		searchEngine: SearchEngine.instance(),
+		shim,
 	};
 }
 


### PR DESCRIPTION
# Problem

Since #15706, dialog titles and content are displayed in the same font.

# Solution

- Increase the font size of titles (use [variant](https://oss.callstack.com/react-native-paper/docs/components/Text/Text) `titleLarge` rather than `titleMedium`).
- When a title is visible, make the body less bold (see discussion in #15958).
  - **Note**: The font weight change is only applied when the title is visible. This is to continue matching the Figma design provided for #15706, which uses a bold font for dialog text (but does not include a sample dialog with a title).

Fixes #15958.

# Screenshots (web)


| Before| After |
|------|-----|
| <img width="375" height="465" alt="image" src="https://github.com/user-attachments/assets/87965c6c-7079-4bdf-80d5-1e9a727acb22" /> | <img width="371" height="465" alt="screenshot: Three dialogs, two have titles, one does not" src="https://github.com/user-attachments/assets/eb6dbc6b-5897-4a6d-851f-58747240d83b" /> |


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
