### PR TITLE
Tools: Resolves #15974: Added new publish plugin command in plugin-repo-cli

### DIFF
--- a/packages/plugin-repo-cli/commands/updateRelease.ts
+++ b/packages/plugin-repo-cli/commands/updateRelease.ts
@@ -9,11 +9,12 @@ const fetch = require('node-fetch').default;
 
 const ghReleaseAssets = require('gh-release-assets');
 
-const apiBaseUrl = 'https://api.github.com/repos/joplin/plugins';
+const repoFullName = process.env.GITHUB_REPOSITORY || 'joplin/plugins';
+const apiBaseUrl = `https://api.github.com/repos/${repoFullName}`;
 
 interface Args {
 	pluginRepoDir: string;
-	dryRun: boolean;
+	dryRun?: boolean;
 }
 
 interface PluginInfo {

--- a/packages/plugin-repo-cli/index.ts
+++ b/packages/plugin-repo-cli/index.ts
@@ -335,7 +335,7 @@ interface CommandUpdateReleaseArgs {
 	dryRun?: boolean;
 }
 
-type CommandArgs = CommandBuildArgs | CommandPublishPluginArgs | CommandUpdateReleaseArgs | Record<string, never>;
+type CommandArgs = CommandBuildArgs | CommandPublishPluginArgs | CommandUpdateReleaseArgs;
 
 type CommandMap = {
 	build: (args: CommandBuildArgs)=> Promise<void>;
@@ -357,7 +357,7 @@ async function main() {
 	let selectedCommand = '';
 	let selectedCommandArgs: CommandArgs | null = null;
 
-	function setSelectedCommand(name: string, args: CommandArgs) {
+	function setSelectedCommand(name: string, args: CommandArgs | null) {
 		selectedCommand = name;
 		selectedCommandArgs = args;
 	}
@@ -374,7 +374,7 @@ async function main() {
 			});
 		}, (args: CommandBuildArgs) => setSelectedCommand('build', args))
 
-		.command('version', 'Gives version info', () => { }, (args: Record<string, never>) => setSelectedCommand('version', args))
+		.command('version', 'Gives version info', () => { }, () => setSelectedCommand('version', null))
 
 		.command('update-release <plugin-repo-dir>', 'Update GitHub release', () => { }, (args: CommandUpdateReleaseArgs) => setSelectedCommand('updateRelease', args))
 

--- a/packages/plugin-repo-cli/index.ts
+++ b/packages/plugin-repo-cli/index.ts
@@ -70,7 +70,7 @@ async function extractPluginFilesFromPackage(existingManifests: PluginManifests,
 
 	// We need to validate the manifest to make sure the plugin author isn't
 	// trying to override an existing plugin, use an invalid ID, etc..
-	validateUntrustedManifest(manifest, existingManifests);
+	validateUntrustedManifest(manifest, existingManifests, { source: 'npm' });
 
 	const pluginDestDir = resolveRelativePathWithinDir(destDir, manifest.id);
 	await fs.mkdirp(pluginDestDir);
@@ -300,14 +300,8 @@ const commandPublishPlugin = async (args: CommandPublishPluginArgs) => {
 		...obsoleteManifests,
 	} as PluginManifests;
 
-	// If the original manifest has _npm_package_name but the new one doesn't, preserve it
-	const originalManifest = existingManifests[manifest.id];
-	if (originalManifest && originalManifest._npm_package_name && !manifest._npm_package_name) {
-		manifest._npm_package_name = originalManifest._npm_package_name;
-	}
-
 	// Validate the manifest
-	validateUntrustedManifest(manifest, existingManifests);
+	validateUntrustedManifest(manifest, existingManifests, { source: 'repository' });
 
 	// Copy the manifest.json and plugin.jpl to plugins/<plugin_id>/
 	const destDir = path.resolve(repoDir, 'plugins', manifest.id);

--- a/packages/plugin-repo-cli/index.ts
+++ b/packages/plugin-repo-cli/index.ts
@@ -384,7 +384,6 @@ async function main() {
 
 		.command('update-release <plugin-repo-dir>', 'Update GitHub release', () => { }, (args: CommandUpdateReleaseArgs) => setSelectedCommand('updateRelease', args))
 
-		// new plugin-submission command
 		.command('publish-plugin <plugin-repo-dir> <manifest-file> <jpl-file>', 'Publish a plugin to the repository', (yargs: { positional: (name: string, opts: object)=> void }) => {
 			yargs.positional('plugin-repo-dir', {
 				type: 'string',

--- a/packages/plugin-repo-cli/index.ts
+++ b/packages/plugin-repo-cli/index.ts
@@ -275,18 +275,93 @@ async function commandVersion() {
 	throw new Error(`Cannot find package.json in any of these paths: ${JSON.stringify(paths)}`);
 }
 
+interface CommandPublishPluginArgs {
+	pluginRepoDir: string;
+	manifestFile: string;
+	jplFile: string;
+}
+
+const commandPublishPlugin = async (args: CommandPublishPluginArgs) => {
+	const repoDir = args.pluginRepoDir;
+	const manifestFile = args.manifestFile;
+	const jplFile = args.jplFile;
+
+	if (!(await fs.pathExists(repoDir))) throw new Error(`No plugin repository at: ${repoDir}`);
+	if (!(await fs.pathExists(manifestFile))) throw new Error(`Manifest file does not exist: ${manifestFile}`);
+	if (!(await fs.pathExists(jplFile))) throw new Error(`JPL file does not exist: ${jplFile}`);
+
+	const manifest = await readJsonFile<PluginManifest>(manifestFile);
+	const originalPluginManifests = await readManifests(repoDir);
+	const manifestOverrides = await readManifestOverrides(repoDir);
+	const obsoleteManifests = getObsoleteManifests(manifestOverrides);
+
+	const existingManifests: PluginManifests = {
+		...originalPluginManifests,
+		...obsoleteManifests,
+	} as PluginManifests;
+
+	// If the original manifest has _npm_package_name but the new one doesn't, preserve it
+	const originalManifest = existingManifests[manifest.id];
+	if (originalManifest && originalManifest._npm_package_name && !manifest._npm_package_name) {
+		manifest._npm_package_name = originalManifest._npm_package_name;
+	}
+
+	// Validate the manifest
+	validateUntrustedManifest(manifest, existingManifests);
+
+	// Copy the manifest.json and plugin.jpl to plugins/<plugin_id>/
+	const destDir = path.resolve(repoDir, 'plugins', manifest.id);
+	await fs.mkdirp(destDir);
+	await fs.writeFile(path.resolve(destDir, 'manifest.json'), JSON.stringify(manifest, null, '\t'), 'utf8');
+	await fs.copy(jplFile, path.resolve(destDir, 'plugin.jpl'));
+
+	// Update manifests.json
+	let manifests: PluginManifests = {};
+	if (!obsoleteManifests[manifest.id]) {
+		manifests[manifest.id] = manifest;
+	}
+
+	manifests = {
+		...originalPluginManifests,
+		...manifests,
+	};
+
+	manifests = applyManifestOverrides(manifests, manifestOverrides);
+
+	await writeManifests(repoDir, manifests);
+
+	// Update README.md
+	await updateReadme(`${repoDir}/README.md`, manifests);
+
+	console.info(`Successfully published plugin ${manifest.id}@${manifest.version} to local registry!`);
+};
+
+interface CommandUpdateReleaseArgs {
+	pluginRepoDir: string;
+	dryRun?: boolean;
+}
+
+type CommandArgs = CommandBuildArgs | CommandPublishPluginArgs | CommandUpdateReleaseArgs | Record<string, never>;
+
+type CommandMap = {
+	build: (args: CommandBuildArgs)=> Promise<void>;
+	version: ()=> Promise<void>;
+	updateRelease: (args: CommandUpdateReleaseArgs)=> Promise<void>;
+	publishPlugin: (args: CommandPublishPluginArgs)=> Promise<void>;
+};
+
 async function main() {
 	const scriptName = 'plugin-repo-cli';
 
-	type CommandArgs = CommandBuildArgs;
-	const commands: Record<string, (args: CommandArgs)=> Promise<void>> = {
+	const commands: CommandMap = {
 		build: commandBuild,
 		version: commandVersion,
 		updateRelease: commandUpdateRelease,
+		publishPlugin: commandPublishPlugin,
 	};
 
 	let selectedCommand = '';
-	let selectedCommandArgs: CommandArgs = null;
+	let selectedCommandArgs: CommandArgs | null = null;
 
 	function setSelectedCommand(name: string, args: CommandArgs) {
 		selectedCommand = name;
@@ -303,11 +378,27 @@ async function main() {
 				type: 'string',
 				describe: 'Directory where the plugin repository is located',
 			});
-		}, (args: CommandArgs) => setSelectedCommand('build', args))
+		}, (args: CommandBuildArgs) => setSelectedCommand('build', args))
 
-		.command('version', 'Gives version info', () => {}, (args: CommandArgs) => setSelectedCommand('version', args))
+		.command('version', 'Gives version info', () => { }, (args: Record<string, never>) => setSelectedCommand('version', args))
 
-		.command('update-release <plugin-repo-dir>', 'Update GitHub release', () => {}, (args: CommandArgs) => setSelectedCommand('updateRelease', args))
+		.command('update-release <plugin-repo-dir>', 'Update GitHub release', () => { }, (args: CommandUpdateReleaseArgs) => setSelectedCommand('updateRelease', args))
+
+		// new plugin-submission command
+		.command('publish-plugin <plugin-repo-dir> <manifest-file> <jpl-file>', 'Publish a plugin to the repository', (yargs: { positional: (name: string, opts: object)=> void }) => {
+			yargs.positional('plugin-repo-dir', {
+				type: 'string',
+				describe: 'Directory where the plugin repository is located',
+			});
+			yargs.positional('manifest-file', {
+				type: 'string',
+				describe: 'Path to the manifest.json file',
+			});
+			yargs.positional('jpl-file', {
+				type: 'string',
+				describe: 'Path to the plugin.jpl file',
+			});
+		}, (args: CommandPublishPluginArgs) => setSelectedCommand('publishPlugin', args))
 
 		.help()
 		.argv;
@@ -317,12 +408,13 @@ async function main() {
 		process.exit(1);
 	}
 
-	if (!commands[selectedCommand]) {
+	if (!commands[selectedCommand as keyof CommandMap]) {
 		console.error(`No such command: ${selectedCommand}`);
 		process.exit(1);
 	}
 
-	await commands[selectedCommand](selectedCommandArgs);
+	const commandName = selectedCommand as keyof CommandMap;
+	await (commands[commandName] as (args: CommandArgs | null)=> Promise<void>)(selectedCommandArgs);
 }
 
 main().catch((error) => {

--- a/packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.test.ts
+++ b/packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.test.ts
@@ -90,4 +90,48 @@ describe('checkIfPluginCanBeAdded', () => {
 		}
 	});
 
+	test('should not add if already a plugin with this ID but different repository url', () => {
+		const testCases = [
+			[
+				{
+					'test': {
+						id: 'test',
+						repository_url: 'https://github.com/laurent22/joplin',
+					},
+				},
+				{
+					id: 'test',
+					repository_url: 'https://github.com/laurent22/joplin.git',
+				},
+				true,
+			],
+			[
+				{
+					'test': {
+						id: 'test',
+						repository_url: 'https://github.com/laurent22/joplin',
+					},
+				},
+				{
+					id: 'test',
+					repository_url: 'https://github.com/someone/else',
+				},
+				false,
+			],
+		];
+
+		for (const t of testCases) {
+			const [existingManifests, manifest, shouldWork] = t;
+
+			let hasThrown = false;
+			try {
+				checkIfPluginCanBeAdded(existingManifests as unknown as Parameters<typeof checkIfPluginCanBeAdded>[0], manifest as unknown as Parameters<typeof checkIfPluginCanBeAdded>[1]);
+			} catch (error) {
+				hasThrown = true;
+			}
+
+			expect(!hasThrown).toBe(shouldWork);
+		}
+	});
+
 });

--- a/packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.test.ts
+++ b/packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.test.ts
@@ -37,7 +37,7 @@ describe('checkIfPluginCanBeAdded', () => {
 
 			let hasThrown = false;
 			try {
-				checkIfPluginCanBeAdded(existingManifests as unknown as Parameters<typeof checkIfPluginCanBeAdded>[0], manifest as unknown as Parameters<typeof checkIfPluginCanBeAdded>[1]);
+				checkIfPluginCanBeAdded(existingManifests as unknown as Parameters<typeof checkIfPluginCanBeAdded>[0], manifest as unknown as Parameters<typeof checkIfPluginCanBeAdded>[1], { source: 'npm' });
 			} catch (error) {
 				hasThrown = true;
 			}
@@ -81,7 +81,7 @@ describe('checkIfPluginCanBeAdded', () => {
 
 			let hasThrown = false;
 			try {
-				checkIfPluginCanBeAdded(existingManifests as unknown as Parameters<typeof checkIfPluginCanBeAdded>[0], manifest as unknown as Parameters<typeof checkIfPluginCanBeAdded>[1]);
+				checkIfPluginCanBeAdded(existingManifests as unknown as Parameters<typeof checkIfPluginCanBeAdded>[0], manifest as unknown as Parameters<typeof checkIfPluginCanBeAdded>[1], { source: 'npm' });
 			} catch (error) {
 				hasThrown = true;
 			}
@@ -125,13 +125,78 @@ describe('checkIfPluginCanBeAdded', () => {
 
 			let hasThrown = false;
 			try {
-				checkIfPluginCanBeAdded(existingManifests as unknown as Parameters<typeof checkIfPluginCanBeAdded>[0], manifest as unknown as Parameters<typeof checkIfPluginCanBeAdded>[1]);
+				checkIfPluginCanBeAdded(existingManifests as unknown as Parameters<typeof checkIfPluginCanBeAdded>[0], manifest as unknown as Parameters<typeof checkIfPluginCanBeAdded>[1], { source: 'repository' });
 			} catch (error) {
 				hasThrown = true;
 			}
 
 			expect(!hasThrown).toBe(shouldWork);
 		}
+	});
+
+	test('should reject moving a legacy npm plugin to an unverified repository', () => {
+		const existingManifests = {
+			'test': {
+				id: 'test',
+				_npm_package_name: 'original',
+			},
+		};
+		const manifest = {
+			id: 'test',
+			repository_url: 'https://github.com/attacker/plugin',
+		};
+
+		expect(
+			() => checkIfPluginCanBeAdded(
+				existingManifests as unknown as Parameters<typeof checkIfPluginCanBeAdded>[0],
+				manifest as unknown as Parameters<typeof checkIfPluginCanBeAdded>[1],
+				{ source: 'repository' },
+			),
+		).toThrow('A maintainer must verify and register its repository URL');
+	});
+
+	test('should reject a legacy repository migration even if the npm package name is copied', () => {
+		const existingManifests = {
+			'test': {
+				id: 'test',
+				_npm_package_name: 'original',
+			},
+		};
+		const manifest = {
+			id: 'test',
+			repository_url: 'https://github.com/attacker/plugin',
+			_npm_package_name: 'original',
+		};
+
+		expect(
+			() => checkIfPluginCanBeAdded(
+				existingManifests as unknown as Parameters<typeof checkIfPluginCanBeAdded>[0],
+				manifest as unknown as Parameters<typeof checkIfPluginCanBeAdded>[1],
+				{ source: 'repository' },
+			),
+		).toThrow('A maintainer must verify and register its repository URL');
+	});
+
+	test('should not fall back to an npm package name after repository ownership is registered', () => {
+		const existingManifests = {
+			'test': {
+				id: 'test',
+				repository_url: 'https://github.com/original/plugin',
+				_npm_package_name: 'original',
+			},
+		};
+		const manifest = {
+			id: 'test',
+			_npm_package_name: 'original',
+		};
+
+		expect(
+			() => checkIfPluginCanBeAdded(
+				existingManifests as unknown as Parameters<typeof checkIfPluginCanBeAdded>[0],
+				manifest as unknown as Parameters<typeof checkIfPluginCanBeAdded>[1],
+				{ source: 'npm' },
+			),
+		).toThrow('has already been published under repository');
 	});
 
 });

--- a/packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.test.ts
+++ b/packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.test.ts
@@ -199,4 +199,25 @@ describe('checkIfPluginCanBeAdded', () => {
 		).toThrow('has already been published under repository');
 	});
 
+	test('should report repository ownership when npm targets a repository-origin plugin', () => {
+		const existingManifests = {
+			'test': {
+				id: 'test',
+				repository_url: 'https://github.com/original/plugin',
+			},
+		};
+		const manifest = {
+			id: 'test',
+			_npm_package_name: 'attacker-package',
+		};
+
+		expect(
+			() => checkIfPluginCanBeAdded(
+				existingManifests as unknown as Parameters<typeof checkIfPluginCanBeAdded>[0],
+				manifest as unknown as Parameters<typeof checkIfPluginCanBeAdded>[1],
+				{ source: 'npm' },
+			),
+		).toThrow('is owned by repository "https://github.com/original/plugin" and cannot be updated from npm package "attacker-package"');
+	});
+
 });

--- a/packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.ts
+++ b/packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.ts
@@ -38,7 +38,7 @@ export default function(existingManifests: PluginManifests, manifest: PluginMani
 		// Don't add a plugin if there is already a plugin with the same ID
 		// but different casing
 		if (originalManifest.id !== manifest.id) {
-			throw new Error(`Plugin "${manifest.id}" cannot be published because there is already a plugin with ID "${originalManifest.id}".`);
+			throw new Error(`Plugin "${manifest.id}" cannot be published because there is already a plugin with ID "${originalManifest.id}". A new package, under a different name, should be published if the plugin ID needs to change.`);
 		}
 	}
 }

--- a/packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.ts
+++ b/packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.ts
@@ -26,6 +26,10 @@ export default function(existingManifests: PluginManifests, manifest: PluginMani
 		const newRepo = normalizeRepoUrl(manifest.repository_url);
 
 		if (options.source === 'npm') {
+			if (originalRepo && !originalManifest._npm_package_name) {
+				throw new Error(`Plugin "${manifest.id}" is owned by repository "${originalManifest.repository_url}" and cannot be updated from npm package "${manifest._npm_package_name}".`);
+			}
+
 			if (originalManifest._npm_package_name !== manifest._npm_package_name) {
 				throw new Error(`Plugin "${manifest.id}" from npm package "${manifest._npm_package_name}" has already been published under npm package "${originalManifest._npm_package_name}". Plugin from package "${originalManifest._npm_package_name}" will not be imported.`);
 			}

--- a/packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.ts
+++ b/packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.ts
@@ -1,5 +1,6 @@
 import { PluginManifest } from '@joplin/lib/services/plugins/utils/types';
 import { normalizeRepoUrl } from './utils';
+import { PluginSubmissionOptions } from './types';
 
 type PluginManifests = Record<string, PluginManifest>;
 
@@ -10,7 +11,7 @@ function caseInsensitiveFindManifest(manifests: PluginManifests, manifestId: str
 	return null;
 }
 
-export default function(existingManifests: PluginManifests, manifest: PluginManifest) {
+export default function(existingManifests: PluginManifests, manifest: PluginManifest, options: PluginSubmissionOptions) {
 	// If there's already a plugin with this ID published under a different
 	// repository/package name, we skip it. Otherwise it would allow anyone to overwrite
 	// someone else plugin just by using the same ID. So the first plugin with
@@ -24,14 +25,24 @@ export default function(existingManifests: PluginManifests, manifest: PluginMani
 		const originalRepo = normalizeRepoUrl(originalManifest.repository_url);
 		const newRepo = normalizeRepoUrl(manifest.repository_url);
 
-		if (originalRepo && newRepo && originalRepo !== newRepo) {
-			throw new Error(`Plugin "${manifest.id}" from repository "${manifest.repository_url}" has already been published under repository "${originalManifest.repository_url}".`);
-		}
-
-		// Backward compatibility fallback for npm packages if repository URL is missing on either side
-		if (!originalRepo || !newRepo) {
-			if (originalManifest._npm_package_name && manifest._npm_package_name && originalManifest._npm_package_name !== manifest._npm_package_name) {
+		if (options.source === 'npm') {
+			if (originalManifest._npm_package_name !== manifest._npm_package_name) {
 				throw new Error(`Plugin "${manifest.id}" from npm package "${manifest._npm_package_name}" has already been published under npm package "${originalManifest._npm_package_name}". Plugin from package "${originalManifest._npm_package_name}" will not be imported.`);
+			}
+
+			// We will include repository check as a mandatory check even in npm
+			// The repository URL must not be removed or changed, but this will allow
+			// updating of plugin if both old and new manifest does not have repository url
+			if (originalRepo && (!newRepo || originalRepo !== newRepo)) {
+				throw new Error(`Plugin "${manifest.id}" from repository "${manifest.repository_url}" has already been published under repository "${originalManifest.repository_url}".`);
+			}
+		} else if (options.source === 'repository') {
+			if (originalRepo) {
+				if (!newRepo || originalRepo !== newRepo) {
+					throw new Error(`Plugin "${manifest.id}" from repository "${manifest.repository_url}" has already been published under repository "${originalManifest.repository_url}".`);
+				}
+			} else if (newRepo) {
+				throw new Error(`Plugin "${manifest.id}" has already been published from npm package "${originalManifest._npm_package_name}". A maintainer must verify and register its repository URL before it can be published from a repository.`);
 			}
 		}
 

--- a/packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.ts
+++ b/packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.ts
@@ -1,4 +1,5 @@
 import { PluginManifest } from '@joplin/lib/services/plugins/utils/types';
+import { normalizeRepoUrl } from './utils';
 
 type PluginManifests = Record<string, PluginManifest>;
 
@@ -11,7 +12,7 @@ function caseInsensitiveFindManifest(manifests: PluginManifests, manifestId: str
 
 export default function(existingManifests: PluginManifests, manifest: PluginManifest) {
 	// If there's already a plugin with this ID published under a different
-	// package name, we skip it. Otherwise it would allow anyone to overwrite
+	// repository/package name, we skip it. Otherwise it would allow anyone to overwrite
 	// someone else plugin just by using the same ID. So the first plugin with
 	// this ID that was originally added is kept.
 	//
@@ -19,13 +20,25 @@ export default function(existingManifests: PluginManifests, manifest: PluginMani
 	// insensitive too.
 	const originalManifest = caseInsensitiveFindManifest(existingManifests, manifest.id);
 
-	if (originalManifest && originalManifest._npm_package_name !== manifest._npm_package_name) {
-		throw new Error(`Plugin "${manifest.id}" from npm package "${manifest._npm_package_name}" has already been published under npm package "${originalManifest._npm_package_name}". Plugin from package "${originalManifest._npm_package_name}" will not be imported.`);
-	}
+	if (originalManifest) {
+		const originalRepo = normalizeRepoUrl(originalManifest.repository_url);
+		const newRepo = normalizeRepoUrl(manifest.repository_url);
 
-	// Don't add a plugin if there is already a plugin with the same ID but
-	// different casing.
-	if (originalManifest && originalManifest.id !== manifest.id) {
-		throw new Error(`Plugin "${manifest.id}" cannot be published because there is already a plugin with ID "${originalManifest.id}". A new package, under a different name, should be published if the plugin ID needs to change.`);
+		if (originalRepo && newRepo && originalRepo !== newRepo) {
+			throw new Error(`Plugin "${manifest.id}" from repository "${manifest.repository_url}" has already been published under repository "${originalManifest.repository_url}".`);
+		}
+
+		// Backward compatibility fallback for npm packages if repository URL is missing on either side
+		if (!originalRepo || !newRepo) {
+			if (originalManifest._npm_package_name && manifest._npm_package_name && originalManifest._npm_package_name !== manifest._npm_package_name) {
+				throw new Error(`Plugin "${manifest.id}" from npm package "${manifest._npm_package_name}" has already been published under npm package "${originalManifest._npm_package_name}". Plugin from package "${originalManifest._npm_package_name}" will not be imported.`);
+			}
+		}
+
+		// Don't add a plugin if there is already a plugin with the same ID
+		// but different casing
+		if (originalManifest.id !== manifest.id) {
+			throw new Error(`Plugin "${manifest.id}" cannot be published because there is already a plugin with ID "${originalManifest.id}".`);
+		}
 	}
 }

--- a/packages/plugin-repo-cli/lib/types.ts
+++ b/packages/plugin-repo-cli/lib/types.ts
@@ -1,5 +1,11 @@
 export type ImportErrors = Record<string, string>;
 
+export type PluginSubmissionSource = 'npm' | 'repository';
+
+export interface PluginSubmissionOptions {
+	source: PluginSubmissionSource;
+}
+
 export interface NpmPackage {
 	name: string;
 	version: string;

--- a/packages/plugin-repo-cli/lib/utils.ts
+++ b/packages/plugin-repo-cli/lib/utils.ts
@@ -21,3 +21,14 @@ export function isJoplinPluginPackage(pack: { keywords?: string[]; name: string 
 	if (stripOffPackageOrg(pack.name).indexOf('joplin-plugin') !== 0) return false;
 	return true;
 }
+
+export const normalizeRepoUrl = (url: string) => {
+	if (!url) return '';
+	const normalized = url
+		.trim()
+		.toLowerCase()
+		.replace(/^(https?:\/\/)?(www\.)?github\.com\//, '')
+		.replace(/\.git$/, '')
+		.replace(/\/$/, '');
+	return normalized;
+};

--- a/packages/plugin-repo-cli/lib/validateUntrustedManifest.test.ts
+++ b/packages/plugin-repo-cli/lib/validateUntrustedManifest.test.ts
@@ -22,7 +22,7 @@ describe('validateUntrustedManifest', () => {
 		};
 
 		expect(
-			() => validateUntrustedManifest(badManifest as unknown as PluginManifest, originalManifests),
+			() => validateUntrustedManifest(badManifest as unknown as PluginManifest, originalManifests, { source: 'npm' }),
 		).toThrow('ID cannot be shorter than');
 
 
@@ -32,7 +32,7 @@ describe('validateUntrustedManifest', () => {
 		};
 
 		expect(
-			() => validateUntrustedManifest(goodManifest as unknown as PluginManifest, originalManifests),
+			() => validateUntrustedManifest(goodManifest as unknown as PluginManifest, originalManifests, { source: 'npm' }),
 		).not.toThrow();
 	});
 
@@ -44,7 +44,7 @@ describe('validateUntrustedManifest', () => {
 		};
 
 		expect(
-			() => validateUntrustedManifest(badManifest as unknown as PluginManifest, originalManifests),
+			() => validateUntrustedManifest(badManifest as unknown as PluginManifest, originalManifests, { source: 'npm' }),
 		).toThrow();
 
 
@@ -54,7 +54,7 @@ describe('validateUntrustedManifest', () => {
 		};
 
 		expect(
-			() => validateUntrustedManifest(goodManifest as unknown as PluginManifest, originalManifests),
+			() => validateUntrustedManifest(goodManifest as unknown as PluginManifest, originalManifests, { source: 'npm' }),
 		).not.toThrow();
 	});
 
@@ -67,7 +67,7 @@ describe('validateUntrustedManifest', () => {
 		};
 
 		expect(
-			() => validateUntrustedManifest(badManifest as unknown as PluginManifest, originalManifests),
+			() => validateUntrustedManifest(badManifest as unknown as PluginManifest, originalManifests, { source: 'npm' }),
 		).toThrow();
 
 		const goodManifest = {
@@ -76,7 +76,7 @@ describe('validateUntrustedManifest', () => {
 		};
 
 		expect(
-			() => validateUntrustedManifest(goodManifest as unknown as PluginManifest, originalManifests),
+			() => validateUntrustedManifest(goodManifest as unknown as PluginManifest, originalManifests, { source: 'npm' }),
 		).not.toThrow();
 	});
 
@@ -89,7 +89,7 @@ describe('validateUntrustedManifest', () => {
 		};
 
 		expect(
-			() => validateUntrustedManifest(newManifest1 as unknown as PluginManifest, originalManifests),
+			() => validateUntrustedManifest(newManifest1 as unknown as PluginManifest, originalManifests, { source: 'npm' }),
 		).toThrow('mark itself as recommended');
 
 		// Should also throw for falsey values
@@ -101,7 +101,7 @@ describe('validateUntrustedManifest', () => {
 		};
 
 		expect(
-			() => validateUntrustedManifest(newManifest2 as unknown as PluginManifest, originalManifests),
+			() => validateUntrustedManifest(newManifest2 as unknown as PluginManifest, originalManifests, { source: 'npm' }),
 		).toThrow('mark itself as recommended');
 	});
 
@@ -113,7 +113,134 @@ describe('validateUntrustedManifest', () => {
 		};
 
 		expect(
-			() => validateUntrustedManifest(newManifest as unknown as PluginManifest, originalManifests),
+			() => validateUntrustedManifest(newManifest as unknown as PluginManifest, originalManifests, { source: 'npm' }),
 		).toThrow();
+	});
+
+	test('should allow the same npm package to register its first repository URL', () => {
+		const newManifest = {
+			id: 'joplin-plugin.this.is.a.test',
+			_npm_package_name: 'joplin-plugin-this-is-a-test',
+			repository_url: 'https://github.com/example/this-is-a-test',
+			version: '0.0.2',
+		};
+
+		expect(
+			() => validateUntrustedManifest(
+				newManifest as unknown as PluginManifest,
+				originalManifests,
+				{ source: 'npm' },
+			),
+		).not.toThrow();
+	});
+
+	test('should require the same npm package after repository ownership is registered', () => {
+		const manifestsWithRepository = {
+			'joplin-plugin.this.is.a.test': {
+				...originalManifests['joplin-plugin.this.is.a.test'],
+				repository_url: 'https://github.com/example/this-is-a-test',
+			},
+		};
+		const newManifest = {
+			id: 'joplin-plugin.this.is.a.test',
+			_npm_package_name: 'joplin-plugin-attacker',
+			repository_url: 'https://github.com/example/this-is-a-test',
+			version: '0.0.2',
+		};
+
+		expect(
+			() => validateUntrustedManifest(
+				newManifest as unknown as PluginManifest,
+				manifestsWithRepository,
+				{ source: 'npm' },
+			),
+		).toThrow('has already been published under npm package');
+	});
+
+	test('should not allow the npm package to change an established repository URL', () => {
+		const manifestsWithRepository = {
+			'joplin-plugin.this.is.a.test': {
+				...originalManifests['joplin-plugin.this.is.a.test'],
+				repository_url: 'https://github.com/example/this-is-a-test',
+			},
+		};
+		const newManifest = {
+			id: 'joplin-plugin.this.is.a.test',
+			_npm_package_name: 'joplin-plugin-this-is-a-test',
+			repository_url: 'https://github.com/attacker/this-is-a-test',
+			version: '0.0.2',
+		};
+
+		expect(
+			() => validateUntrustedManifest(
+				newManifest as unknown as PluginManifest,
+				manifestsWithRepository,
+				{ source: 'npm' },
+			),
+		).toThrow('has already been published under repository');
+	});
+
+	test('should reject an unverified repository migration for a legacy npm plugin', () => {
+		const newManifest = {
+			id: 'joplin-plugin.this.is.a.test',
+			repository_url: 'https://github.com/attacker/this-is-a-test',
+			version: '0.0.2',
+		};
+
+		expect(
+			() => validateUntrustedManifest(
+				newManifest as unknown as PluginManifest,
+				originalManifests,
+				{ source: 'repository' },
+			),
+		).toThrow('A maintainer must verify and register its repository URL');
+	});
+
+	test('should require a repository URL for repository submissions', () => {
+		const manifest = {
+			id: 'com.example.repository-plugin',
+			version: '1.0.0',
+		};
+
+		expect(
+			() => validateUntrustedManifest(
+				manifest as unknown as PluginManifest,
+				originalManifests,
+				{ source: 'repository' },
+			),
+		).toThrow('must specify repository_url');
+	});
+
+	test('should not accept an npm package name from a repository submission', () => {
+		const manifest = {
+			id: 'com.example.repository-plugin',
+			version: '1.0.0',
+			repository_url: 'https://github.com/example/repository-plugin',
+			_npm_package_name: 'copied-package-name',
+		};
+
+		expect(
+			() => validateUntrustedManifest(
+				manifest as unknown as PluginManifest,
+				originalManifests,
+				{ source: 'repository' },
+			),
+		).toThrow('cannot specify _npm_package_name');
+	});
+
+	test('should accept a new repository submission with a repository URL', () => {
+		const manifest = {
+			id: 'com.example.repository-plugin',
+			version: '1.0.0',
+			repository_url: 'https://github.com/example/repository-plugin',
+		};
+
+		expect(
+			() => validateUntrustedManifest(
+				manifest as unknown as PluginManifest,
+				originalManifests,
+				{ source: 'repository' },
+			),
+		).not.toThrow();
 	});
 });

--- a/packages/plugin-repo-cli/lib/validateUntrustedManifest.ts
+++ b/packages/plugin-repo-cli/lib/validateUntrustedManifest.ts
@@ -3,11 +3,16 @@ import validatePluginVersion from '@joplin/lib/services/plugins/utils/validatePl
 import validatePluginPlatforms from '@joplin/lib/services/plugins/utils/validatePluginPlatforms';
 import checkIfPluginCanBeAdded from './checkIfPluginCanBeAdded';
 import { PluginManifest } from '@joplin/lib/services/plugins/utils/types';
+import { PluginSubmissionOptions } from './types';
 
-// Assumes that
-// 1. manifest._npm_package_name is correct,
-// 2. other fields were set by the plugin author and are thus untrusted.
-const validateUntrustedManifest = (manifest: PluginManifest, existingManifests: Record<string, PluginManifest>) => {
+// For npm submissions, assume that
+// 1. manifest._npm_package_name was assigned by the CLI.
+// 2. All fields in repository submissions are untrusted.
+const validateUntrustedManifest = (
+	manifest: PluginManifest,
+	existingManifests: Record<string, PluginManifest>,
+	options: PluginSubmissionOptions,
+) => {
 	// At this point, we need to check the manifest ID as it's used in various
 	// places including as directory name and object key in manifests.json, so
 	// it needs to be correct. It's mostly for security reasons. The other
@@ -21,7 +26,17 @@ const validateUntrustedManifest = (manifest: PluginManifest, existingManifests: 
 		throw new Error(`Plugin ${manifest.id} cannot mark itself as recommended.`);
 	}
 
-	checkIfPluginCanBeAdded(existingManifests, manifest);
+	if (options.source === 'repository') {
+		if (!manifest.repository_url?.trim()) {
+			throw new Error(`Plugin ${manifest.id} must specify repository_url when published from a repository.`);
+		}
+
+		if (typeof manifest._npm_package_name !== 'undefined') {
+			throw new Error(`Plugin ${manifest.id} cannot specify _npm_package_name when published from a repository.`);
+		}
+	}
+
+	checkIfPluginCanBeAdded(existingManifests, manifest, options);
 };
 
 export default validateUntrustedManifest;


### PR DESCRIPTION
## Problem
Resolves #15974
Currently, after reviewer review the scan report of the plugin and approve the plugin, they add a label (status: approved) to it, so that the plugin gets added to the plugins folder, README.md and get uploaded to the github releases.
Adding the label runs a github workflow that uses plugin-repo-cli package to do this mutation. Right now we don't have any command that can support our new mutation flow. Also, the current NPM polling flow should not be affected by the change.

## Solution
This PR introduces a new `publish-plugin <plugin-repo-dir> <manifest-file> <jpl-file>` command for the `plugin-repo-cli`  which can be used by the publish workflow to do the mutations in the new `plugins-test` repository without any regression to the old NPM polling architecture.

### High-Level Changes:

- Added a new `publish-plugin <plugin-repo-dir> <manifest-file> <jpl-file>` command for triggering the new mutation workflow. 

- Added new checks in `checkIfPluginCanBeAdded.ts` that checks :  
   - Verifies that the repository URL of the updated plugin matches the original plugin repository.
   - Falls back to validating the `_npm_package_name` if repository URLs are missing (ensuring backward compatibility).
  
- Added new test for checking the new **should not add if already a plugin with this ID but different repository url** case.

## Testing plan 

Several tests were done by publishing a clone npm package of `plugin-repo-cli` with updated code : 
https://github.com/akshajrawat/plugins-test/issues/58
https://github.com/akshajrawat/plugins-test/issues/54