### PR TITLE
Desktop, Mobile, Cli: Fixes #15975: Fix WebDAV support for Koofr

### DIFF
--- a/packages/lib/WebDavApi.ts
+++ b/packages/lib/WebDavApi.ts
@@ -379,7 +379,7 @@ class WebDavApi {
 		let response: Response = null;
 
 		if (['GET', 'HEAD'].indexOf(fetchOptions.method) < 0 && this.excludeIfNoneMatch === ExcludeIfNoneMatch.Unknown) {
-			// some webserver, for example Apache Tomcat do not accept invalid If-None-Match header,
+			// some webserver, for example Apache Tomcat and Koofr do not accept invalid If-None-Match header,
 			// which is being sent to resolve issue with Seafile and network library on iOS
 			// to fix this issue, a request is sent with invalid If-None-Match header at first
 			//
@@ -390,9 +390,13 @@ class WebDavApi {
 			// if successful, excludeIfNoneMatch is set to Yes, to indicate,
 			// that subsequent request will be sent without If-None-Match header
 			response = await shim.fetch(url, fetchOptions);
+			// These are known error codes used for servers which reject when the If-None-Match header is sent. As these
+			// particular error codes are terminal, there should not be a risk of an intermittent failure selecting the
+			// wrong mode for the lifetime of the app
+			const terminalRejectionCodes = [400, 405];
 			if (response.ok) {
 				this.excludeIfNoneMatch = ExcludeIfNoneMatch.No;
-			} else if (response.status === 400) {
+			} else if (terminalRejectionCodes.includes(response.status)) {
 				const fetchOptionsAlt = { ... fetchOptions };
 				fetchOptionsAlt.headers = { ... fetchOptions.headers };
 				delete fetchOptionsAlt.headers['If-None-Match'];
@@ -400,7 +404,7 @@ class WebDavApi {
 				if (responseAlt.ok) {
 					this.excludeIfNoneMatch = ExcludeIfNoneMatch.Yes;
 					return responseAlt;
-				}	else if (response.status === 400) {
+				} else if (terminalRejectionCodes.includes(response.status)) {
 					this.excludeIfNoneMatch = ExcludeIfNoneMatch.No;
 				}
 			}

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -337,3 +337,4 @@ Reconnectable
 doleocent1
 Socialboom
 AABB
+Koofr


### PR DESCRIPTION
PR https://github.com/laurent22/joplin/pull/14332 introduced changes to support syncing with the latest Apache Tomcat via WebDAV, which reject requests with the If-None-Match header specified. This works by allowing the a retry without the header if the response returns a 400 error, and then sets a mode to continue making requests without the header if the response then succeeds. Koofr has been found to also reject requests with the If-None-Match header, but returns a 405 error instead of a 400. This PR addresses the issue by also catering for a 405 error in the related logic.

This fixes https://github.com/laurent22/joplin/issues/15975

### Testing

Verified using a free Koofr account the WebDAV sync works fully without any issues for downloads and uploads