### PR TITLE
Mobile: Fixes #15968: Avoid reverting to the default editor state when the editor reloads the same note

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -764,7 +764,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	}
 
 	private async reloadNoteAndUpdateRefreshKey() {
-		await shared.reloadNote(this);
+		await shared.reloadNote(this, false);
 		this.refreshKey = this.props.editorNoteReloadTimeRequest;
 	}
 

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -764,7 +764,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	}
 
 	private async reloadNoteAndUpdateRefreshKey() {
-		await shared.reloadNote(this, false);
+		await shared.reloadNote(this);
 		this.refreshKey = this.props.editorNoteReloadTimeRequest;
 	}
 

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -299,11 +299,12 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent, useDefaultEditorState 
 	const isProvisionalNote = comp.props.provisionalNoteIds.includes(comp.props.noteId);
 
 	const note = await Note.load(comp.props.noteId);
-
-	const panes = comp.props.noteVisiblePanes;
-	let mode = panes.includes('editor') ? 'edit' : 'view';
+	let mode = comp.state.mode;
 
 	if (useDefaultEditorState) {
+		const panes = comp.props.noteVisiblePanes;
+		mode = panes.includes('editor') ? 'edit' : 'view';
+
 		// Override the mode if the default state is not last
 		const defaultState = Setting.value('editor.mobile.defaultEditState');
 		if (defaultState === 'view') mode = 'view';

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -295,7 +295,7 @@ shared.isModified = function(comp: BaseNoteScreenComponent) {
 	return !!Object.getOwnPropertyNames(diff).length;
 };
 
-shared.reloadNote = async (comp: BaseNoteScreenComponent, useDefaultEditorState = true) => {
+shared.reloadNote = async (comp: BaseNoteScreenComponent, useDefaultEditorState = false) => {
 	const isProvisionalNote = comp.props.provisionalNoteIds.includes(comp.props.noteId);
 
 	const note = await Note.load(comp.props.noteId);
@@ -357,7 +357,7 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent, useDefaultEditorState 
 };
 
 shared.initState = async function(comp: BaseNoteScreenComponent) {
-	const note = await shared.reloadNote(comp);
+	const note = await shared.reloadNote(comp, true);
 
 	// Ensure that only empty notes created for shared content are populated with sharedData, because in some cases
 	// existing notes can be overwritten by the shared data. See https://github.com/laurent22/joplin/issues/11479

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -97,7 +97,7 @@ interface Shared {
 	installResourceHandling?: (refreshResourceHandler: ResourceHandler)=> void;
 	uninstallResourceHandling?: (refreshResourceHandler: ResourceHandler)=> void;
 
-	reloadNote?: (comp: BaseNoteScreenComponent)=> Promise<NoteEntity>;
+	reloadNote?: (comp: BaseNoteScreenComponent, useDefaultEditorState?: boolean)=> Promise<NoteEntity>;
 }
 
 const shared: Shared = {};
@@ -295,7 +295,7 @@ shared.isModified = function(comp: BaseNoteScreenComponent) {
 	return !!Object.getOwnPropertyNames(diff).length;
 };
 
-shared.reloadNote = async (comp: BaseNoteScreenComponent) => {
+shared.reloadNote = async (comp: BaseNoteScreenComponent, useDefaultEditorState = true) => {
 	const isProvisionalNote = comp.props.provisionalNoteIds.includes(comp.props.noteId);
 
 	const note = await Note.load(comp.props.noteId);
@@ -303,10 +303,12 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent) => {
 	const panes = comp.props.noteVisiblePanes;
 	let mode = panes.includes('editor') ? 'edit' : 'view';
 
-	// Override the mode if the default state is not last
-	const defaultState = Setting.value('editor.mobile.defaultEditState');
-	if (defaultState === 'view') mode = 'view';
-	if (defaultState === 'edit') mode = 'edit';
+	if (useDefaultEditorState) {
+		// Override the mode if the default state is not last
+		const defaultState = Setting.value('editor.mobile.defaultEditState');
+		if (defaultState === 'view') mode = 'view';
+		if (defaultState === 'edit') mode = 'edit';
+	}
 
 	// Prevent trashed notes and notes created via sharing from opening in edit mode.
 	if (note?.deleted_time || comp.props.sharedData) {


### PR DESCRIPTION
On the mobile app, the editor can be reloaded when a note is changed via the API or a plugin via the 'EDITOR_NOTE_NEEDS_RELOAD' event. When the 'Default view / edit state' setting is set to either view mode / edit mode, a refresh can result in the mode reverting if the current mode is the opposite to the value of this setting.

This PR changes the behaviour to ensure when the editor is reloaded for the current note via the 'EDITOR_NOTE_NEEDS_RELOAD' event, the current view / edit state is not changed.

This partially fixes https://github.com/laurent22/joplin/issues/15968

### Testing

I tested the change using a modified version of the secure note plugin as per https://github.com/cipherswami/joplin-plugin-secure-notes/pull/26, which relies on https://github.com/laurent22/joplin/pull/13671 in order for the note to refresh with the encrypted / decrypted contents following toggling of note encryption. I verified that when the 'Default view / edit state' setting is set to view, when toggling the encryption with the secure notes plugin while in edit mode, the view / edit state does not change. I Also verified that the note still opens in view mode afterward when exiting it and re-entering.

See video:

https://github.com/user-attachments/assets/32f78443-069b-4b23-8707-9ddcb71f673c



