### PR TITLE
Mobile: Note action menu: Vertically align icons

### DIFF
--- a/packages/app-mobile/components/ScreenHeader/Menu.tsx
+++ b/packages/app-mobile/components/ScreenHeader/Menu.tsx
@@ -50,7 +50,11 @@ const useStyles = (themeId: number) => {
 				paddingRight: theme.marginRight,
 				minWidth: Math.min(350, windowWidth),
 			},
-			menuItemContent: { flexDirection: 'row', gap: theme.marginSmall },
+			menuItemContent: {
+				flexDirection: 'row',
+				gap: theme.marginSmall,
+				alignItems: 'center',
+			},
 			menuItemText: {
 				color: theme.color,
 				fontSize: theme.fontSize,


### PR DESCRIPTION
# Problem 

#15873 redesigned the note actions/kebab menu. However, icons in the menu were not properly aligned:

# Solution

Vertically center the icons in the note actions menu.

# Screenshots (web)

| Before | After |
|----|----|
| <img width="362" height="466" alt="screenshot: Icons vertically offset from text" src="https://github.com/user-attachments/assets/50fc236a-628f-4e7d-a551-b1f1b22ee627" /> | <img width="374" height="463" alt="screenshot: Icons are roughly vertically aligned with text" src="https://github.com/user-attachments/assets/ff3377b8-2575-4937-8f59-ee7b7ac376d0" /> |

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
