### PR TITLE
 Desktop: Resolves #15880: Avoid including unused `onnxruntime-node` files in the built application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -654,6 +654,7 @@ packages/app-desktop/services/plugins/types.js
 packages/app-desktop/services/restart.js
 packages/app-desktop/services/spellChecker/SpellCheckerServiceDriverNative.js
 packages/app-desktop/tools/bundleJs.js
+packages/app-desktop/tools/cleanOnnxRuntime.js
 packages/app-desktop/tools/copy7Zip.js
 packages/app-desktop/tools/generateLatestArm64Yml.js
 packages/app-desktop/tools/githubReleasesUtils.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -680,6 +680,7 @@ packages/app-desktop/services/plugins/types.js
 packages/app-desktop/services/restart.js
 packages/app-desktop/services/spellChecker/SpellCheckerServiceDriverNative.js
 packages/app-desktop/tools/bundleJs.js
+packages/app-desktop/tools/cleanOnnxRuntime.js
 packages/app-desktop/tools/copy7Zip.js
 packages/app-desktop/tools/generateLatestArm64Yml.js
 packages/app-desktop/tools/githubReleasesUtils.js

--- a/packages/app-desktop/gulpfile.ts
+++ b/packages/app-desktop/gulpfile.ts
@@ -94,7 +94,10 @@ gulp.task('before-start', gulp.series(
 	buildRequiresTsc,
 	buildBeforeStartParallel,
 ));
-gulp.task('before-dist', buildRequiresTsc);
+gulp.task('before-dist', gulp.series(
+	buildRequiresTsc,
+	'cleanOnnxRuntime',
+));
 
 // Since "build" runs before "tsc", exclude tasks that require
 // other packages to be built (i.e. don't include buildRequiresTsc).

--- a/packages/app-desktop/gulpfile.ts
+++ b/packages/app-desktop/gulpfile.ts
@@ -7,6 +7,7 @@ import copy7Zip from './tools/copy7Zip';
 import bundleJs from './tools/bundleJs';
 import { remove } from 'fs-extra';
 import execa = require('execa');
+import cleanOnnxRuntime from './tools/cleanOnnxRuntime';
 
 const tasks = {
 	installElectron: {
@@ -69,6 +70,9 @@ const tasks = {
 			);
 		},
 	},
+	cleanOnnxRuntime: {
+		fn: cleanOnnxRuntime,
+	},
 };
 
 utils.registerGulpTasks(gulp, tasks);
@@ -82,6 +86,7 @@ const buildBeforeStartParallel = gulp.parallel(
 	'updateIgnoredTypeScriptBuild',
 	'buildScriptIndexes',
 	'compileSass',
+	'cleanOnnxRuntime',
 );
 const buildRequiresTsc = gulp.series('bundle');
 

--- a/packages/app-desktop/tools/cleanOnnxRuntime.ts
+++ b/packages/app-desktop/tools/cleanOnnxRuntime.ts
@@ -1,0 +1,45 @@
+import { pathExists, readdirSync, remove } from 'fs-extra';
+import { join, sep } from 'path';
+
+const findBaseOnnxRuntimePath = () => {
+	const fullPath = require.resolve('onnxruntime-node').split(sep);
+	// require.resolve returns the path to a file within the onnxruntime-node package.
+	// Strip the other path/file components from the path.
+	for (let i = fullPath.length; i >= 0; i--) {
+		if (fullPath[i] === 'onnxruntime-node') {
+			return fullPath.slice(0, i + 1).join(sep);
+		}
+	}
+	throw new Error('Failed to resolve path to onnxruntime-node');
+};
+
+// onnxruntime-node includes large binary artifacts for all platforms. Remove these during build to
+// avoid significantly increasing the built app size.
+// See #15880
+const cleanOnnxRuntime = async () => {
+	const onnxRuntimePath = findBaseOnnxRuntimePath();
+	// Note: This path may need to be updated when updating onnxruntime-node:
+	const baseDir = join(onnxRuntimePath, 'bin', 'napi-v6');
+	if (!await pathExists(baseDir)) {
+		throw new Error(`onnxruntime-node NAPI not found. (Searching in ${baseDir})`);
+	}
+
+	const removeDir = async (fullPath: string) => {
+		if (!await pathExists(fullPath)) return;
+		console.log('rm -r', fullPath);
+		await remove(fullPath);
+	};
+
+	for (const subDir of readdirSync(baseDir)) {
+		const fullPath = join(baseDir, subDir);
+		if (subDir !== process.platform) {
+			await removeDir(fullPath);
+		} else if (process.arch === 'x64') {
+			await removeDir(join(fullPath, 'arm64'));
+		} else if (process.arch === 'arm64') {
+			await removeDir(join(fullPath, 'x64'));
+		}
+	}
+};
+
+export default cleanOnnxRuntime;

--- a/packages/app-desktop/tools/cleanOnnxRuntime.ts
+++ b/packages/app-desktop/tools/cleanOnnxRuntime.ts
@@ -1,5 +1,6 @@
 import { pathExists, readdirSync, remove } from 'fs-extra';
 import { join, sep } from 'path';
+import { env } from 'process';
 
 const findBaseOnnxRuntimePath = () => {
 	const fullPath = require.resolve('onnxruntime-node').split(sep);
@@ -11,6 +12,11 @@ const findBaseOnnxRuntimePath = () => {
 		}
 	}
 	throw new Error('Failed to resolve path to onnxruntime-node');
+};
+
+// As of onnxruntime-node 1.24.3, only MacOS+ARM64 and Windows/Linux x64/ARM64 are supported
+const isUnsupportedPlatform = (platform: string, arch: string) => {
+	return !['x64', 'arm64'].includes(arch) || (platform === 'darwin' && arch === 'x64');
 };
 
 // onnxruntime-node includes large binary artifacts for all platforms. Remove these during build to
@@ -30,15 +36,23 @@ const cleanOnnxRuntime = async () => {
 		await remove(fullPath);
 	};
 
+	const targetArch = env['npm_config_target_arch'] || process.arch;
 	for (const subDir of readdirSync(baseDir)) {
 		const fullPath = join(baseDir, subDir);
 		if (subDir !== process.platform) {
 			await removeDir(fullPath);
-		} else if (process.arch === 'x64') {
+		} else if (targetArch === 'x64') {
 			await removeDir(join(fullPath, 'arm64'));
-		} else if (process.arch === 'arm64') {
+		} else if (targetArch === 'arm64') {
 			await removeDir(join(fullPath, 'x64'));
 		}
+	}
+
+	if (!await pathExists(join(baseDir, process.platform, targetArch)) && !isUnsupportedPlatform(process.platform, targetArch)) {
+		throw new Error([
+			'Missing onnxruntime-node for the current platform. It may have been deleted as part of a previous cross-platform build.',
+			`To resolve: Delete ${JSON.stringify(onnxRuntimePath)} and re-run "yarn install".`,
+		].join('\n'));
 	}
 };
 

--- a/packages/app-desktop/tools/cleanOnnxRuntime.ts
+++ b/packages/app-desktop/tools/cleanOnnxRuntime.ts
@@ -32,7 +32,7 @@ const cleanOnnxRuntime = async () => {
 
 	const removeDir = async (fullPath: string) => {
 		if (!await pathExists(fullPath)) return;
-		console.log('rm -r', fullPath);
+		console.log('Clearing unused onnxruntime files: rm -r', fullPath);
 		await remove(fullPath);
 	};
 

--- a/packages/app-desktop/tools/cleanOnnxRuntime.ts
+++ b/packages/app-desktop/tools/cleanOnnxRuntime.ts
@@ -51,7 +51,9 @@ const cleanOnnxRuntime = async () => {
 	if (!await pathExists(join(baseDir, process.platform, targetArch)) && !isUnsupportedPlatform(process.platform, targetArch)) {
 		throw new Error([
 			'Missing onnxruntime-node for the current platform. It may have been deleted as part of a previous cross-platform build.',
-			`To resolve: Delete ${JSON.stringify(onnxRuntimePath)} and re-run "yarn install".`,
+			'To resolve, either:',
+			`1. Delete ${JSON.stringify(onnxRuntimePath)} and re-run "yarn install".`,
+			`2. Update the list of platforms unsupported by onnxruntime-node in ${JSON.stringify(__filename)}.`,
 		].join('\n'));
 	}
 };


### PR DESCRIPTION
# Problem

The new `onnxruntime-node` dependency includes large artifacts for *all* supported platforms in the built app. For example, the Linux build of Joplin [currently includes the `node_modules/onnxruntime-node/bin/darwin` folder, which is about 73 MB](https://github.com/laurent22/joplin/issues/15880#issuecomment-4940230698).

# Solution

Remove the `onnxruntime-node` files specific to other platforms during build. Locally, this brings the MacOS (ARM64) DMG size from 218 MB to 198 MB.

This change *partially* resolves #15880: `onnxruntime-node` still contributes to the application size.

# Testing

**MacOS (ARM64)**: Creating a release build:
1. Run the [build steps](https://github.com/laurent22/joplin/blob/75cdbafba975dd127e71c96ad9bd37ed1b7cd25b/.github/workflows/build-macos-m1.yml#L57-L67) for configuring/creating an ARM64 build.
2. Inspect the logged output. Verify that `Clearing unused onnxruntime files` is logged for Linux and Windows.
3. Install the built DMG file.
4. Start Joplin and enable AI features.
5. Verify that note indexing completes successfully.

**Linux (ARM64)**: Running a dev build
1. Run `yarn start`.
2. Inspect the output. Verify that `Clearing unused onnxruntime files` is logged for Linux (x64), Darwin/MacOS, and Windows.
3. (From the running app) Create a new profile, create a folder, a note, and enable AI features.
4. Verify that note indexing completes successfully.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
