### PR TITLE
Mobile: Note actions menu: Decrease padding size

### DIFF
--- a/packages/app-mobile/components/ScreenHeader/Menu.tsx
+++ b/packages/app-mobile/components/ScreenHeader/Menu.tsx
@@ -45,9 +45,7 @@ const useStyles = (themeId: number) => {
 			menuContent: { flexDirection: 'column', width: '100%' },
 			menuItem: {
 				alignItems: 'flex-start',
-				padding: theme.margin,
-				paddingLeft: theme.marginLeft,
-				paddingRight: theme.marginRight,
+				padding: theme.marginMedium,
 				minWidth: Math.min(350, windowWidth),
 			},
 			menuItemContent: {

--- a/packages/app-mobile/components/ScreenHeader/Menu.tsx
+++ b/packages/app-mobile/components/ScreenHeader/Menu.tsx
@@ -46,6 +46,8 @@ const useStyles = (themeId: number) => {
 			menuItem: {
 				alignItems: 'flex-start',
 				padding: theme.marginMedium,
+				paddingLeft: theme.marginLeft,
+				paddingRight: theme.marginRight,
 				minWidth: Math.min(350, windowWidth),
 			},
 			menuItemContent: {


### PR DESCRIPTION
# Summary

This pull request decreases the padding applied to each item in the note actions menu (and similar menus throughout the app).

# Screenshots (web)

| Before | After |
|--------|--------|
| <img width="390" height="476" alt="screenshot: note actions menu, dark mode" src="https://github.com/user-attachments/assets/39a46ae2-4f02-4d0c-815d-bac3e4bfe698" /> | <img width="394" height="480" alt="screenshot: note actions menu with slightly less vertical space" src="https://github.com/user-attachments/assets/8c9338f5-3489-4acd-b14e-39ede4dec8c3" /> |
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
