### PR TITLE
Desktop: Fix macOS main window stays closed after application switch (#15665)

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -455,10 +455,10 @@ export default class ElectronAppWrapper {
 
 					if (w.isFullScreen()) {
 						// leave fullscreen, then hide
-						w.once('leave-full-screen', () => this.electronApp_.hide());
+						w.once('leave-full-screen', () => w.hide());
 						w.setFullScreen(false);
 					} else {
-						this.electronApp_.hide();
+						w.hide();
 					}
 				}
 			} else {
@@ -950,11 +950,19 @@ export default class ElectronAppWrapper {
 		});
 
 		this.electronApp_.on('activate', () => {
-			if (this.win_ && !this.win_.isDestroyed()) this.win_.show();
+			if (this.win_ && !this.win_.isDestroyed()) {
+				if (this.win_.isMinimized()) this.win_.restore();
+				this.win_.show();
+				this.win_.focus();
+			}
 		});
 
 		this.electronApp_.on('did-become-active', () => {
-			if (this.win_ && !this.win_.isDestroyed()) this.win_.show();
+			if (this.win_ && !this.win_.isDestroyed()) {
+				if (this.win_.isMinimized()) this.win_.restore();
+				this.win_.show();
+				this.win_.focus();
+			}
 		});
 
 		this.electronApp_.on('open-url', (event: import('electron').Event, url: string) => {

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -455,10 +455,10 @@ export default class ElectronAppWrapper {
 
 					if (w.isFullScreen()) {
 						// leave fullscreen, then hide
-						w.once('leave-full-screen', () => w.hide());
+						w.once('leave-full-screen', () => this.electronApp_.hide());
 						w.setFullScreen(false);
 					} else {
-						w.hide();
+						this.electronApp_.hide();
 					}
 				}
 			} else {
@@ -950,7 +950,11 @@ export default class ElectronAppWrapper {
 		});
 
 		this.electronApp_.on('activate', () => {
-			this.win_.show();
+			if (this.win_) this.win_.show();
+		});
+
+		this.electronApp_.on('did-become-active', () => {
+			if (this.win_) this.win_.show();
 		});
 
 		this.electronApp_.on('open-url', (event: import('electron').Event, url: string) => {

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -950,11 +950,11 @@ export default class ElectronAppWrapper {
 		});
 
 		this.electronApp_.on('activate', () => {
-			if (this.win_) this.win_.show();
+			if (this.win_ && !this.win_.isDestroyed()) this.win_.show();
 		});
 
 		this.electronApp_.on('did-become-active', () => {
-			if (this.win_) this.win_.show();
+			if (this.win_ && !this.win_.isDestroyed()) this.win_.show();
 		});
 
 		this.electronApp_.on('open-url', (event: import('electron').Event, url: string) => {

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -890,8 +890,27 @@ function useMenu(props: Props) {
 					visible: !!shim.isMac(),
 					submenu: [
 						{
+							label: _('Main Window'),
+							click() {
+								const win = bridge().mainWindow();
+								if (win) {
+									if (win.isMinimized()) win.restore();
+									win.show();
+									win.focus();
+								}
+							},
+						},
+						separator(),
+						{
 							role: 'minimize',
 							accelerator: shim.isMac() && keymapService.getAccelerator('minimizeWindow'),
+						},
+						{
+							role: 'zoom',
+						},
+						separator(),
+						{
+							role: 'front',
 						},
 					],
 				},


### PR DESCRIPTION
Desktop: Fix macOS main window stays closed after application switch (#15665)

Fixes #15665

### Description
On macOS, closing windows via `Cmd+W` leaves the application running in the background. However, switching back to Joplin via `Cmd+Tab` did not restore the main window, and there was no menu item in the macOS Menu Bar to reopen the main window.

### Changes
1. **Window Close & Activate Handling (`ElectronAppWrapper.ts`)**:
   - Updated macOS window close handler to hide the target window (`w.hide()`) instead of hiding the entire application.
   - Updated `activate` and `did-become-active` event listeners to restore, show, and focus `this.win_` when activating the application.
2. **macOS Menu Bar (`MenuBar.tsx`)**:
   - Added `Main Window` menu item to the macOS `Window` menu (`Window > Main Window`), allowing users to reopen/focus the main window at any time from the menu bar.
   - Added standard macOS `zoom` and `front` roles to the `Window` menu.
