### PR TITLE
Chore: Server: Prevent regenerating database types when there are migrations left over from switching branches

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,7 @@
     "devDropTables": "node dist/index.js --env dev --drop-tables",
     "devDropDb": "node dist/index.js --env dev --drop-db",
     "start": "node dist/index.js",
-    "generateTypes": "rm -f db-buildTypes.sqlite && yarn start --env buildTypes migrate latest && node dist/tools/generateTypes.js && mv db-buildTypes.sqlite schema.sqlite",
+    "generateTypes": "yarn run rebuild && rm -f db-buildTypes.sqlite && yarn start --env buildTypes migrate latest && node dist/tools/generateTypes.js && mv db-buildTypes.sqlite schema.sqlite",
     "tsc": "tsc --project tsconfig.json",
     "test": "NODE_OPTIONS=--disable-proto=delete jest --verbose=false",
     "test-ci": "yarn test",

--- a/packages/server/src/tools/generateTypes.ts
+++ b/packages/server/src/tools/generateTypes.ts
@@ -2,10 +2,15 @@
 
 import sqlts, { Config, Table } from '@rmp135/sql-ts';
 import { hasOwnProperty } from '@joplin/utils/object';
+import { join } from 'node:path';
+import { readdir } from 'node:fs/promises';
 
 require('source-map-support').install();
 
-const dbFilePath = `${__dirname}/../../src/services/database/types.ts`;
+const baseDir = `${__dirname}/../..`;
+const srcDir = `${baseDir}/src`;
+const distDir = `${baseDir}/dist`;
+const dbFilePath = `${srcDir}/services/database/types.ts`;
 
 const fileReplaceWithinMarker = '// AUTO-GENERATED-TYPES';
 
@@ -217,7 +222,31 @@ function createRuntimeObject(table: Table) {
 	return `\t${table.name}: {\n${colStrings.join('\n')}\n\t},`;
 }
 
+const assertNoOrphanedMigrations = async () => {
+	const migrationsSource = join(srcDir, 'migrations');
+	const migrationsDest = join(distDir, 'migrations');
+	const sourceMigrations = await readdir(migrationsSource);
+	const distMigrations = await readdir(migrationsDest);
+
+	const missingMigrations = [];
+	for (const distMigration of distMigrations) {
+		if (!distMigration.endsWith('.js')) continue;
+		if (!sourceMigrations.includes(distMigration.replace(/\.js$/, '.ts'))) {
+			missingMigrations.push(distMigration);
+		}
+	}
+
+	if (missingMigrations.length > 0) {
+		throw new Error([
+			`Missing .ts files for migrations: ${missingMigrations.join(', ')}.`,
+			'If these migrations are left over from another branch, please rebuild packages/server using "yarn rebuild".',
+		].join('\n'));
+	}
+};
+
 async function main() {
+	await assertNoOrphanedMigrations();
+
 	const definitions = await sqlts.toObject(config);
 
 	const typeStrings = [];

--- a/packages/server/src/tools/generateTypes.ts
+++ b/packages/server/src/tools/generateTypes.ts
@@ -239,7 +239,7 @@ const assertNoOrphanedMigrations = async () => {
 	if (missingMigrations.length > 0) {
 		throw new Error([
 			`Missing .ts files for migrations: ${missingMigrations.join(', ')}.`,
-			'If these migrations are left over from another branch, please rebuild packages/server using "yarn rebuild".',
+			'If these migrations are left over from another branch, please rebuild packages/server using "yarn run rebuild" (**not** "yarn rebuild").',
 		].join('\n'));
 	}
 };

--- a/packages/server/src/tools/generateTypes.ts
+++ b/packages/server/src/tools/generateTypes.ts
@@ -2,15 +2,10 @@
 
 import sqlts, { Config, Table } from '@rmp135/sql-ts';
 import { hasOwnProperty } from '@joplin/utils/object';
-import { join } from 'node:path';
-import { readdir } from 'node:fs/promises';
 
 require('source-map-support').install();
 
-const baseDir = `${__dirname}/../..`;
-const srcDir = `${baseDir}/src`;
-const distDir = `${baseDir}/dist`;
-const dbFilePath = `${srcDir}/services/database/types.ts`;
+const dbFilePath = `${__dirname}/../../src/services/database/types.ts`;
 
 const fileReplaceWithinMarker = '// AUTO-GENERATED-TYPES';
 
@@ -222,31 +217,7 @@ function createRuntimeObject(table: Table) {
 	return `\t${table.name}: {\n${colStrings.join('\n')}\n\t},`;
 }
 
-const assertNoOrphanedMigrations = async () => {
-	const migrationsSource = join(srcDir, 'migrations');
-	const migrationsDest = join(distDir, 'migrations');
-	const sourceMigrations = await readdir(migrationsSource);
-	const distMigrations = await readdir(migrationsDest);
-
-	const missingMigrations = [];
-	for (const distMigration of distMigrations) {
-		if (!distMigration.endsWith('.js')) continue;
-		if (!sourceMigrations.includes(distMigration.replace(/\.js$/, '.ts'))) {
-			missingMigrations.push(distMigration);
-		}
-	}
-
-	if (missingMigrations.length > 0) {
-		throw new Error([
-			`Missing .ts files for migrations: ${missingMigrations.join(', ')}.`,
-			'If these migrations are left over from another branch, please rebuild packages/server using "yarn run rebuild" (**not** "yarn rebuild").',
-		].join('\n'));
-	}
-};
-
 async function main() {
-	await assertNoOrphanedMigrations();
-
 	const definitions = await sqlts.toObject(config);
 
 	const typeStrings = [];


### PR DESCRIPTION
# Problem

After switching branches, `yarn generateTypes` can generate `types.ts` files containing properties that are defined by the original branch (and are never created by `src/migrations`).

**Context**: `yarn generateTypes` regenerates the database `types.ts` file and schema based on migrations in `packages/server/dist/migrations`. After switching between branches with different migrations, the `dist/migrations` folder can still contain migrations corresponding to changes on a different branch (since `tsc` doesn't remove files in `dist` with the `.ts` file is removed).

# Solution

Run `yarn run rebuild` as a part of `yarn generateTypes`. The `rebuild` command rebuilds the `packages/server/dist` folder and removes old migrations.

> [!NOTE]
>
> This needs to be `yarn run rebuild` and not just `yarn rebuild`. Running `yarn rebuild` invokes the yarn built-in `rebuild` command.

# Testing

1. Create a test migration, `20260721154230_test.ts`, in `packages/server/src/migrations/` with the following content:
    ```typescript
    import { DbConnection } from '../db';

    export const up = async (db: DbConnection) => {
	    await db.schema.alterTable('subscriptions', (table) => {
		    table.bigInteger('testing').defaultTo(0).notNullable();
	    });
    };
    
    export const down = async (db: DbConnection) => {
	    await db.schema.alterTable('subscriptions', (table) => {
		    table.dropColumn('testing');
	    });
    };
    ```
2. Run `yarn generateTypes` from `packages/server`.
3. Inspect `packages/server/src/services/database/types.ts`. Verify that a new `testing` property has been added to the `Subscription` interface.
4. Remove the new migration.
5. Run `yarn generateTypes` from `packages/server`.
6. Verify that the `testing` property has been removed from the `Subscription` interface.