### PR TITLE
Chore: Server: Make the default application name match the built image name

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -102,13 +102,15 @@ WORKDIR /home/$user/packages/server
 ENTRYPOINT ["tini", "--"]
 CMD ["yarn", "start-prod"]
 
+ARG IMAGE_NAME="Joplin Server"
+ENV APP_NAME=${IMAGE_NAME}
+
 # Build-time metadata
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 ARG BUILD_DATE
 ARG REVISION
 ARG VERSION
 ARG SOURCE
-ARG IMAGE_NAME="Joplin Server"
 LABEL org.opencontainers.image.created="$BUILD_DATE" \
       org.opencontainers.image.title="$IMAGE_NAME" \
       org.opencontainers.image.description="Docker image for Joplin Server" \


### PR DESCRIPTION
# Summary

This pull request changes the default `APP_NAME` to match the `IMAGE_NAME` build variable set when building the image. This means that a Joplin Server instance built with a non-default `IMAGE_NAME` will also display this image name in its UI.

It's still possible to override `APP_NAME` from the `docker-compose.yml` or an env file.

# Testing plan

1. Build a Joplin Server image with a custom name ("Test Image"):
   ```
   yarn buildServerDocker --tagName server-v0.1.2 --platform linux/arm64 --repository joplin/server --imageName "Test Image" --dockerFile ./Dockerfile.server
   ```
2. Start Joplin Server from the Docker image (use a `docker-compose.yml` without `APP_NAME` set). Verify that the name from step 1 is used.
3. Set `APP_NAME=updated` in `docker-compose.yml` and recreate the server.
4. Verify that the name "updated" is shown in the server's login UI.
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
