### PR TITLE
Chore: Server: Update home page for users that sync with an external server

### DIFF
--- a/packages/server/src/routes/index/home.ts
+++ b/packages/server/src/routes/index/home.ts
@@ -119,6 +119,7 @@ router.get('home', async (_path: SubPath, ctx: AppContext) => {
 			betaStartSubUrl: betaStartSubUrl(user.email, user.account_type),
 			setupMessageHtml: setupMessageHtml(),
 			syncTargetName: isExternal ? 'Joplin Server Business' : config().appName,
+			isExternal,
 			isJoplinCloud: config().isJoplinCloud,
 			socialFeeds: socialFeeds(),
 		};

--- a/packages/server/src/views/index/home.mustache
+++ b/packages/server/src/views/index/home.mustache
@@ -7,20 +7,24 @@
 	</div>
 {{/showBetaMessage}}
 
-<h2 class="title">Welcome to {{global.appName}}</h2>
+<h2 class="title">Welcome to {{syncTargetName}}</h2>
 <div class="block readable-block content">
-	<p>To start using {{syncTargetName}}, make sure to <a href="{{{global.joplinAppBaseUrl}}}/download">download one of the Joplin applications</a>, either for desktop or for your mobile phone.</p>
-	<p>Once the app is installed, open the <strong>Configuration</strong> screen, then the <strong>Synchronisation</strong> section. {{{setupMessageHtml}}}<p>
-	<p>Once it is set up {{syncTargetName}} allows you to synchronise your devices, to publish notes, or to collaborate on notebooks with other {{syncTargetName}} users.</p>
+	{{^isExternal}}
+		<p>To start using {{syncTargetName}}, make sure to <a href="{{{global.joplinAppBaseUrl}}}/download">download one of the Joplin applications</a>, either for desktop or for your mobile phone.</p>
+		<p>Once the app is installed, open the <strong>Configuration</strong> screen, then the <strong>Synchronisation</strong> section. {{{setupMessageHtml}}}<p>
+		<p>Once it is set up {{syncTargetName}} allows you to synchronise your devices, to publish notes, or to collaborate on notebooks with other {{syncTargetName}} users.</p>
+	{{/isExternal}}
 </div>
 
 {{#isJoplinCloud}}
+{{^isExternal}}
 <h2 class="title">Joplin Web App</h2>
 
 <div class="block readable-block content">
 	<p>You may access your notes from any web browser using the <a href="https://app.joplincloud.com">Joplin Web App</a>. It is essentially the Joplin mobile app running in a browser, and you can synchronise it with your Joplin Cloud notes.</p>
 	<p>For more information, please see the <a href="https://joplinapp.org/help/apps/web">Joplin Web App documentation</a>.</p>
 </div>
+{{/isExternal}}
 {{/isJoplinCloud}}
 
 <h2 class="title">Your account</h2>


### PR DESCRIPTION
# Summary

Updates the Joplin Server welcome screen for users that sync with an external server (when `isExternal = true` in `home.ts`, currently never true for Joplin Server). This change, for `isExternal` users:
- Hides the "`To start using {{syncTargetName}}`"
- Hides the "`Joplin Web App`" section

See also: #15912.

# Testing

1. Start Joplin Server in dev mode.
2. Sign in as `admin@localhost` and open the "Home" tab.
3. Verify that the "To start using Joplin Server..." instructions are visible.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
