### PR TITLE
Rebrand Joplin identity to Booz Allen Notes

### DIFF
--- a/.github/scripts/check_rebrand_identity.js
+++ b/.github/scripts/check_rebrand_identity.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '../..');
+const exceptionsPath = path.join(repoRoot, 'readme/dev/rebrand_identity_guard_exceptions.json');
+
+const shipCriticalPrefixes = [
+	'package.json',
+	'.github/',
+	'packages/app-desktop/',
+	'packages/app-mobile/',
+	'packages/app-cli/',
+	'packages/app-clipper/',
+	'packages/server/',
+	'packages/tools/',
+];
+
+const disallowedPatterns = [
+	/joplin:\/\//gi,
+	/\bnet\.cozic\b/g,
+	/\bjoplinapp\.org\b/g,
+	/\bjoplincloud\.com\b/g,
+	/\bobjects\.joplinusercontent\.com\b/g,
+	/\blaurent22\/joplin\b/g,
+];
+
+const parseArgs = () => {
+	const args = process.argv.slice(2);
+	const options = { baseRef: null };
+
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === '--base' && args[i + 1]) {
+			options.baseRef = args[i + 1];
+			i++;
+		}
+	}
+
+	return options;
+};
+
+const loadExceptions = () => {
+	try {
+		const raw = fs.readFileSync(exceptionsPath, 'utf8');
+		const parsed = JSON.parse(raw);
+		return Array.isArray(parsed.pathExemptions) ? parsed.pathExemptions : [];
+	} catch (error) {
+		console.error(`Failed to read exceptions file at ${exceptionsPath}:`, error.message);
+		process.exit(1);
+	}
+};
+
+const runGit = args => {
+	return execFileSync('git', args, {
+		cwd: repoRoot,
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+	}).trim();
+};
+
+const getDiffRange = options => {
+	if (options.baseRef) return `${options.baseRef}...HEAD`;
+	if (process.env.GITHUB_BASE_REF) return `origin/${process.env.GITHUB_BASE_REF}...HEAD`;
+	return 'HEAD';
+};
+
+const isShipCriticalFile = filePath => {
+	return shipCriticalPrefixes.some(prefix => filePath === prefix || filePath.startsWith(prefix));
+};
+
+const isPathExempted = (filePath, exemptions) => exemptions.includes(filePath);
+
+const getChangedFiles = range => {
+	const output = runGit(['diff', '--name-only', '--diff-filter=ACMR', range]);
+	if (!output) return [];
+	return output.split('\n').map(line => line.trim()).filter(Boolean);
+};
+
+const getAddedLinesByFile = (range, files) => {
+	const linesByFile = new Map();
+	for (const file of files) {
+		const patch = runGit(['diff', '--no-color', '--unified=0', range, '--', file]);
+		if (!patch) continue;
+		const lines = patch
+			.split('\n')
+			.filter(line => line.startsWith('+') && !line.startsWith('+++'))
+			.map(line => line.slice(1));
+		if (lines.length) linesByFile.set(file, lines);
+	}
+	return linesByFile;
+};
+
+const findViolations = addedLinesByFile => {
+	const violations = [];
+	for (const [file, lines] of addedLinesByFile.entries()) {
+		lines.forEach((line, index) => {
+			for (const regex of disallowedPatterns) {
+				regex.lastIndex = 0;
+				if (regex.test(line)) {
+					violations.push({
+						file,
+						lineNumber: index + 1,
+						pattern: regex.toString(),
+						line,
+					});
+				}
+			}
+		});
+	}
+	return violations;
+};
+
+const main = () => {
+	const options = parseArgs();
+	const exemptions = loadExceptions();
+	const range = getDiffRange(options);
+	const changedFiles = getChangedFiles(range);
+	const candidateFiles = changedFiles
+		.filter(isShipCriticalFile)
+		.filter(file => !isPathExempted(file, exemptions));
+
+	if (!candidateFiles.length) {
+		console.log('Rebrand identity guard: no ship-critical changed files to scan.');
+		return;
+	}
+
+	const addedLinesByFile = getAddedLinesByFile(range, candidateFiles);
+	const violations = findViolations(addedLinesByFile);
+
+	if (!violations.length) {
+		console.log(`Rebrand identity guard: scanned ${candidateFiles.length} file(s), no legacy identifiers found in added lines.`);
+		return;
+	}
+
+	console.error('Rebrand identity guard: found disallowed legacy identifiers in added lines:');
+	for (const violation of violations) {
+		console.error(`- ${violation.file} [added-line:${violation.lineNumber}] matches ${violation.pattern}`);
+		console.error(`  ${violation.line}`);
+	}
+	console.error('\nIf intentional, add the file path to readme/dev/rebrand_identity_guard_exceptions.json and document why.');
+	process.exit(1);
+};
+
+main();

--- a/.github/scripts/run_ci.sh
+++ b/.github/scripts/run_ci.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ROOT_DIR="$SCRIPT_DIR/../.."
 
 TRANSCRIBE_TAG_PREFIX=transcribe
-TRANSCRIBE_REPOSITORY=joplin/transcribe
+TRANSCRIBE_REPOSITORY=boozallen/bah-joplin-transcribe
 
 IS_PULL_REQUEST=0
 IS_DESKTOP_RELEASE=0
@@ -347,11 +347,11 @@ if [ "$IS_DESKTOP_RELEASE" == "1" ]; then
 	fi
 	run_yarn_dist
 elif [[ $IS_LINUX = 1 ]] && [ "$IS_SERVER_RELEASE" == "1" ]; then
-	echo "Step: Building Joplin Server Docker Image..."
+	echo "Step: Building Booz Allen Notes Server Docker Image..."
 	cd "$ROOT_DIR"
 	yarn buildServerDocker --docker-file Dockerfile.server --platform $DOCKER_IMAGE_PLATFORM --tag-name $GIT_TAG_NAME --push-images --repository $SERVER_REPOSITORY
 elif [[ $IS_LINUX = 1 ]] && [ "$IS_TRANSCRIBE_RELEASE" == "1" ]; then
-	echo "Step: Building Joplin Transcribe Docker Image..."
+	echo "Step: Building Booz Allen Notes Transcribe Docker Image..."
 	cd "$ROOT_DIR"
 	yarn buildServerDocker --docker-file Dockerfile.transcribe --platform $DOCKER_IMAGE_PLATFORM --tag-name $GIT_TAG_NAME --push-images --repository $TRANSCRIBE_REPOSITORY
 else

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -6,7 +6,7 @@ on: [push, pull_request]
 
 jobs:
   AssembleRelease:
-    if: github.repository == 'laurent22/joplin'
+    if: github.repository == 'boozallen/bah-joplin'
     runs-on: ubuntu-latest
     steps:
       - name: Install Linux dependencies

--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   Main:
     # We always process desktop release tags, because they also publish the release
-    if: github.repository == 'laurent22/joplin'
+    if: github.repository == 'boozallen/bah-joplin'
     runs-on: macos-latest
     steps:
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   CLAAssistant:
-    if: github.repository == 'laurent22/joplin'
+    if: github.repository == 'boozallen/bah-joplin'
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
@@ -20,7 +20,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'readme/cla/signatures.json'
-          path-to-document: 'https://github.com/laurent22/joplin/blob/dev/readme/cla.md' # e.g. a CLA or a DCO document
+          path-to-document: 'https://github.com/boozallen/bah-joplin/blob/dev/readme/cla.md' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'cla_signatures'
           allowlist: joplinbot,renovate[bot]

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -6,7 +6,7 @@ permissions:
   issues: write
 jobs:
   ProcessStaleIssues:
-    if: github.repository == 'laurent22/joplin'
+    if: github.repository == 'boozallen/bah-joplin'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -1,10 +1,10 @@
-name: Joplin Continuous Integration
+name: Booz Allen Notes Continuous Integration
 on: [push, pull_request]
 
 jobs:
   Main:
     # We always process server or desktop release tags, because they also publish the release
-    if: github.repository == 'laurent22/joplin'
+    if: github.repository == 'boozallen/bah-joplin'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -79,7 +79,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           IS_CONTINUOUS_INTEGRATION: 1
           BUILD_SEQUENCIAL: 1
-          SERVER_REPOSITORY: joplin/server
+          SERVER_REPOSITORY: boozallen/bah-joplin-server
           SERVER_TAG_PREFIX: server
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
         run: |
@@ -109,7 +109,7 @@ jobs:
         env:
           IS_CONTINUOUS_INTEGRATION: 1
           BUILD_SEQUENCIAL: 1
-          SERVER_REPOSITORY: joplin/server
+          SERVER_REPOSITORY: boozallen/bah-joplin-server
           SERVER_TAG_PREFIX: server
         run: |
           . "${env:GITHUB_WORKSPACE}/.github/scripts/build_windows.ps1"
@@ -118,14 +118,14 @@ jobs:
       - name: Publish Docker manifest
         if: runner.os == 'Linux'
         env:
-          SERVER_REPOSITORY: joplin/server
+          SERVER_REPOSITORY: boozallen/bah-joplin-server
           SERVER_TAG_PREFIX: server
         run: |
           chmod 700 "${GITHUB_WORKSPACE}/.github/scripts/publish_docker_manifest.sh"
           "${GITHUB_WORKSPACE}/.github/scripts/publish_docker_manifest.sh"
 
   ServerDockerImage:
-    if: github.repository == 'laurent22/joplin'
+    if: github.repository == 'boozallen/bah-joplin'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -182,16 +182,16 @@ jobs:
           echo "DOCKER_IMAGE_PLATFORM=$DOCKER_IMAGE_PLATFORM"
 
           yarn install
-          yarn buildServerDocker --docker-file Dockerfile.server --platform $DOCKER_IMAGE_PLATFORM --tag-name server-v0.0.0 --repository joplin/server
+          yarn buildServerDocker --docker-file Dockerfile.server --platform $DOCKER_IMAGE_PLATFORM --tag-name server-v0.0.0 --repository boozallen/bah-joplin-server
 
           # Basic test to ensure that the created build is valid. It should exit with
           # code 0 if it works.
-          docker run joplin/server:$(dpkg --print-architecture)-0.0.0 node dist/index.js migrate list
+          docker run boozallen/bah-joplin-server:$(dpkg --print-architecture)-0.0.0 node dist/index.js migrate list
  
       - name: Check HTTP request
         run: |
           # Need to pass environment variables:
-          docker run --env MAX_TIME_DRIFT=0 --publish 22300:22300 joplin/server:$(dpkg --print-architecture)-0.0.0 node dist/index.js --env dev &
+          docker run --env MAX_TIME_DRIFT=0 --publish 22300:22300 boozallen/bah-joplin-server:$(dpkg --print-architecture)-0.0.0 node dist/index.js --env dev &
 
           # Wait for server to start
           sleep 120
@@ -211,7 +211,7 @@ jobs:
           
           # Check if the body response is correct
           # if the actual_body is different of expected_body exit with code 1
-          expected_body='{"status":"ok","message":"Joplin Server is running"}'
+          expected_body='{"status":"ok","message":"Booz Allen Notes Server is running"}'
           actual_body=$(curl http://localhost:22300/api/ping)
           
           if [[ "$actual_body" != "$expected_body" ]]; then

--- a/.github/workflows/rebrand-identity-guard.yml
+++ b/.github/workflows/rebrand-identity-guard.yml
@@ -1,0 +1,24 @@
+name: Rebrand Identity Guard
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - dev
+
+jobs:
+  rebrand-identity-guard:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Check rebrand identity leakage
+        run: node .github/scripts/check_rebrand_identity.js

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -6,7 +6,7 @@ permissions:
 jobs:
   Main:
     # Don't run on forks
-    if: github.repository == 'laurent22/joplin'
+    if: github.repository == 'boozallen/bah-joplin'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -44,7 +44,7 @@ jobs:
           path: packages/app-desktop/playwright-report/
           retention-days: 7
   Mobile:
-    if: github.repository == 'laurent22/joplin'
+    if: github.repository == 'boozallen/bah-joplin'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6

--- a/FORK_NOTES.md
+++ b/FORK_NOTES.md
@@ -1,0 +1,22 @@
+# Fork Notes: BAH Joplin
+
+This repository is a fork of Joplin, maintained as a Booz Allen Hamilton branded distribution.
+
+## Scope of Divergence
+
+- Rebrand of user-facing names and metadata to "Booz Allen Notes".
+- Platform identifier migration for desktop, Android, iOS, and clipper surfaces.
+- Release pipeline namespace migration for fork-owned repositories and Docker images.
+- Server/web default URL and copy updates for BAH-operated domains.
+
+## Upstream Attribution and License
+
+- Upstream project attribution is intentionally preserved in git history and retained legal files.
+- AGPL licensing and bundled third-party notices remain in place.
+- This fork does not remove or rewrite required attribution records.
+
+## Update Policy
+
+- Periodically rebase/merge from upstream Joplin after compatibility review.
+- Re-run `yarn verifyRebrand` after every upstream sync to catch identifier regressions.
+- Keep this document current when divergence grows beyond branding and namespace changes.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/laurent22/joplin.git"
+    "url": "git+https://github.com/boozallen/bah-joplin.git"
   },
   "engines": {
     "node": ">=22.12",
@@ -26,6 +26,7 @@
     "checkIgnoredFiles": "node ./packages/tools/checkIgnoredFiles.js",
     "checkLibPaths": "node ./packages/tools/checkLibPaths.js",
     "checkGeneratedFiles": "node ./packages/tools/checkGeneratedFiles.js",
+    "checkRebrandIdentity": "node .github/scripts/check_rebrand_identity.js",
     "circularDependencyCheck": "madge --warning --circular --extensions js ./",
     "clean": "npm run clean --workspaces --if-present && node packages/tools/clean && yarn cache clean",
     "crowdin": "crowdin",
@@ -33,7 +34,7 @@
     "crowdinUpload": "crowdin upload",
     "dependencyTree": "madge",
     "generateTypes": "node packages/tools/generate-database-types",
-    "linkChecker": "linkchecker https://joplinapp.org/ && linkchecker --check-extern https://joplinapp.org/api/references/plugin_api/classes/joplin.html",
+    "linkChecker": "linkchecker https://notes.boozallen.com/ && linkchecker --check-extern https://notes.boozallen.com/api/references/plugin_api/classes/joplin.html",
     "linter-ci": "eslint --quiet",
     "linter-interactive": "eslint-interactive --fix --quiet",
     "linter-precommit": "eslint --fix",

--- a/packages/app-cli/app/main.js
+++ b/packages/app-cli/app/main.js
@@ -6,7 +6,7 @@
 const compareVersion = require('compare-version');
 const nodeVersion = process && process.versions && process.versions.node ? process.versions.node : '0.0.0';
 if (compareVersion(nodeVersion, '10.0.0') < 0) {
-	console.error(`Joplin requires Node 10+. Detected version ${nodeVersion}`);
+	console.error(`Booz Allen Notes requires Node 10+. Detected version ${nodeVersion}`);
 	process.exit(1);
 }
 
@@ -57,7 +57,7 @@ BaseItem.loadClass('NoteTag', NoteTag);
 BaseItem.loadClass('MasterKey', MasterKey);
 BaseItem.loadClass('Revision', Revision);
 
-Setting.setConstant('appId', `net.cozic.joplin${env === 'dev' ? 'dev' : ''}-cli`);
+Setting.setConstant('appId', `com.boozallen.bahnotes${env === 'dev' ? 'dev' : ''}-cli`);
 Setting.setConstant('appType', 'cli');
 
 let keytar;
@@ -102,7 +102,7 @@ process.stdout.on('error', (error) => {
 application.start(process.argv).catch(error => {
 	if (error.code === 'flagError') {
 		console.error(error.message);
-		console.error(_('Type `joplin help` for usage information.'));
+		console.error(_('Type `bah-notes help` for usage information.'));
 	} else {
 		console.error(_('Fatal error:'));
 		console.error(error);

--- a/packages/app-cli/package.json
+++ b/packages/app-cli/package.json
@@ -1,8 +1,8 @@
 {
   "name": "joplin",
-  "description": "Joplin CLI Client",
+  "description": "Booz Allen Notes CLI Client",
   "license": "AGPL-3.0-or-later",
-  "author": "Laurent Cozic",
+  "author": "Booz Allen Hamilton",
   "private": true,
   "scripts": {
     "test": "jest --verbose=false --config=jest.config.js --bail --forceExit",
@@ -15,14 +15,14 @@
     "watch": "tsc --watch --preserveWatchOutput --project tsconfig.json"
   },
   "bugs": {
-    "url": "https://github.com/laurent22/joplin/issues"
+    "url": "https://github.com/boozallen/bah-joplin/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/laurent22/joplin"
+    "url": "https://github.com/boozallen/bah-joplin"
   },
   "copyright": {
-    "title": "Joplin CLI",
+    "title": "Booz Allen Notes CLI",
     "years": [
       2016,
       2017,
@@ -33,7 +33,7 @@
       2022,
       2023
     ],
-    "owner": "Laurent Cozic"
+    "owner": "Booz Allen Hamilton"
   },
   "version": "3.7.0",
   "bin": "./main.js",

--- a/packages/app-clipper/manifest.json
+++ b/packages/app-clipper/manifest.json
@@ -1,9 +1,9 @@
 {
     "manifest_version": 3,
-    "name": "Joplin Web Clipper [DEV]",
+    "name": "Booz Allen Notes Web Clipper [DEV]",
     "version": "3.7.0",
-    "description": "Capture and save web pages and screenshots from your browser to Joplin.",
-    "homepage_url": "https://joplinapp.org",
+    "description": "Capture and save web pages and screenshots from your browser to Booz Allen Notes.",
+    "homepage_url": "https://notes.boozallen.com",
     "content_security_policy": {
         "extension_pages": "script-src 'self'; object-src 'self'"
     },
@@ -25,7 +25,7 @@
     ],
     "action": {
         "default_icon": "icons/32.png",
-        "default_title": "Joplin Web Clipper",
+        "default_title": "Booz Allen Notes Web Clipper",
         "default_popup": "popup/build/index.html"
     },
     "commands": {

--- a/packages/app-clipper/popup/public/index.html
+++ b/packages/app-clipper/popup/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
-    <title>Joplin Web Clipper</title>
+    <title>Booz Allen Notes Web Clipper</title>
   </head>
   <body>
     <noscript>

--- a/packages/app-clipper/popup/src/App.js
+++ b/packages/app-clipper/popup/src/App.js
@@ -139,7 +139,7 @@ class AppComponent extends Component {
 		};
 
 		this.clipperServerHelpLink_click = () => {
-			bridge().tabsCreate({ url: 'https://joplinapp.org/help/apps/clipper' });
+			bridge().tabsCreate({ url: 'https://notes.boozallen.com/help/apps/clipper' });
 		};
 
 		this.folderSelect_change = (event) => {
@@ -251,18 +251,18 @@ class AppComponent extends Component {
 	renderStartupScreen() {
 		const messages = {
 			serverFoundState: {
-				// We need to display the "Connecting to the Joplin
+				// We need to display the "Connecting to the Booz Allen Notes
 				// application..." message because if the app doesn't currently
 				// allow access to the clipper API, the clipper tries several
 				// ports and it takes time before failing. So if we don't
 				// display any message, it looks like it's not doing anything
 				// when clicking on the extension button.
-				'searching': 'Connecting to the Joplin application...',
-				'not_found': 'Error: Could not connect to the Joplin application. Please ensure that it is started and that the clipper service is enabled in the configuration.',
+				'searching': 'Connecting to the Booz Allen Notes application...',
+				'not_found': 'Error: Could not connect to the Booz Allen Notes application. Please ensure that it is started and that the clipper service is enabled in the configuration.',
 			},
 			authState: {
 				'starting': 'Starting...',
-				'waiting': 'The Joplin Web Clipper requires your authorisation in order to access your data. To proceed, please open the Joplin desktop application and grant permission. Note: Joplin 2.1+ is needed to use this version of the Web Clipper.',
+				'waiting': 'The Booz Allen Notes Web Clipper requires your authorisation in order to access your data. To proceed, please open the Booz Allen Notes desktop application and grant permission. Note: Booz Allen Notes 2.1+ is needed to use this version of the Web Clipper.',
 				'rejected': 'Permission to access your data was not granted. To try again please close this popup and open it again.',
 			},
 		};
@@ -296,7 +296,7 @@ class AppComponent extends Component {
 
 		if (!this.state.contentScriptLoaded) {
 			let msg = 'Loading...';
-			if (this.state.contentScriptError) msg = `The Joplin extension is not available on this tab due to: ${this.state.contentScriptError}`;
+			if (this.state.contentScriptError) msg = `The Booz Allen Notes extension is not available on this tab due to: ${this.state.contentScriptError}`;
 			return (
 				<div className="App Startup">
 					{msg}
@@ -317,9 +317,9 @@ class AppComponent extends Component {
 			let msg = '';
 
 			if (operation.searchingClipperServer) {
-				msg = 'Searching clipper service... Please make sure that Joplin is running.';
+				msg = 'Searching clipper service... Please make sure that Booz Allen Notes is running.';
 			} else if (operation.uploading) {
-				msg = 'Processing note... The note will be available in Joplin as soon as the web page and images have been downloaded and converted. In the meantime you may close this popup.';
+				msg = 'Processing note... The note will be available in Booz Allen Notes as soon as the web page and images have been downloaded and converted. In the meantime you may close this popup.';
 			} else if (operation.success) {
 				msg = 'Note was successfully created!';
 			} else {
@@ -424,11 +424,11 @@ class AppComponent extends Component {
 
 			if (!this.state.newNoteId) { return null; } else {
 				return (
-					// The jopin:// link must be opened in a new tab. When it's opened for the first time, a system dialog will ask for the user's permission.
+					// The bahnotes:// link must be opened in a new tab. When it's opened for the first time, a system dialog will ask for the user's permission.
 					// The system dialog is too big to fit into the popup so the user will not be able to see the dialog buttons and get stuck.
 					<a
 						className="Button"
-						href={`joplin://x-callback-url/openNote?id=${encodeURIComponent(this.state.newNoteId)}`}
+						href={`bahnotes://x-callback-url/openNote?id=${encodeURIComponent(this.state.newNoteId)}`}
 						target="_blank"
 						onClick={() => this.setState({ newNoteId: null })}
 					>

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/WhiteboardEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/WhiteboardEditor.tsx
@@ -109,7 +109,7 @@ const WhiteboardEditor = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBody
 	const onOpenRef = useCallback((value: string) => {
 		if (!value) return;
 		// `openItem` already handles every supported link form: `:/id`,
-		// `joplin://`, `file://`, any other URL scheme (http/https/mailto/
+		// `bahnotes://`, `file://`, any other URL scheme (http/https/mailto/
 		// ftp/...), and shows a user-facing error for unsupported strings.
 		void CommandService.instance().execute('openItem', value);
 	}, []);

--- a/packages/app-desktop/gui/NoteRevisionViewer.tsx
+++ b/packages/app-desktop/gui/NoteRevisionViewer.tsx
@@ -147,7 +147,7 @@ const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack,
 	const webview_ipcMessage = useCallback(async (event: { channel?: string; args?: unknown[] }) => {
 		// For the revision view, we only support a minimal subset of the IPC messages.
 		// For example, we don't need interactive checkboxes or sync between viewer and editor view.
-		// We try to get most links work though, except for internal (joplin://) links.
+		// We try to get most links work though, except for internal app links.
 
 		const msg = event.channel ? event.channel : '';
 		// const args = event.args;
@@ -158,7 +158,7 @@ const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack,
 			if (msg.indexOf('checkboxclick:') === 0) {
 				// Revision previews are read-only. Ignore checkbox toggle IPC messages so they
 				// don't fall through to URL handling (`checkboxclick:` looks like a protocol).
-			} else if (msg.indexOf('joplin://') === 0) {
+			} else if (msg.indexOf('bahnotes://') === 0 || msg.indexOf('joplin://') === 0) {
 				throw new Error(_('Unsupported link or message: %s', msg));
 			} else if (urlUtils.urlProtocol(msg)) {
 				await bridge().openExternal(msg);

--- a/packages/app-desktop/gui/PdfViewer.tsx
+++ b/packages/app-desktop/gui/PdfViewer.tsx
@@ -50,7 +50,7 @@ export default function PdfViewer(props: Props) {
 	}, [props.dispatch]);
 
 	const openExternalViewer = useCallback(async () => {
-		await CommandService.instance().execute('openItem', `joplin://${props.resource.id}`);
+		await CommandService.instance().execute('openItem', `bahnotes://${props.resource.id}`);
 	}, [props.resource.id]);
 
 	const textSelected = useCallback(async (text: string) => {

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/openItem.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/openItem.ts
@@ -22,7 +22,7 @@ export const runtime = (): CommandRuntime => {
 				link = fromFileUrl;
 			}
 
-			if (link.startsWith('joplin://') || link.startsWith(':/')) {
+			if (link.startsWith('bahnotes://') || link.startsWith('joplin://') || link.startsWith(':/')) {
 				const parsedUrl = parseResourceUrl(link);
 				if (parsedUrl) {
 					const { itemId, hash } = parsedUrl;

--- a/packages/app-desktop/main.ts
+++ b/packages/app-desktop/main.ts
@@ -44,8 +44,8 @@ const altInstanceId = getFlagValueFromArgs(process.argv, '--alt-instance-id', ''
 
 // We initialize all these variables here because they are needed from the main process. They are
 // then passed to the renderer process via the bridge.
-const appId = `net.cozic.joplin${env === 'dev' ? 'dev' : ''}-desktop`;
-let appName = env === 'dev' ? 'joplindev' : 'joplin';
+const appId = `com.boozallen.bahnotes${env === 'dev' ? 'dev' : ''}-desktop`;
+let appName = env === 'dev' ? 'bahnotesdev' : 'bahnotes';
 if (appId.indexOf('-desktop') >= 0) appName += '-desktop';
 const { rootProfileDir } = determineBaseAppDirs(profileFromArgs, appName, altInstanceId);
 
@@ -70,7 +70,7 @@ if (pathExistsSync(settingsPath)) {
 	}
 }
 
-electronApp.setAsDefaultProtocolClient('joplin');
+electronApp.setAsDefaultProtocolClient('bahnotes');
 void registerCustomProtocols();
 
 const initialCallbackUrl = process.argv.find((arg) => isCallbackUrl(arg));

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joplin/app-desktop",
   "version": "3.7.6",
-  "description": "Joplin for Desktop",
+  "description": "Booz Allen Notes for Desktop",
   "main": "main.bundle.js",
   "private": true,
   "scripts": {
@@ -21,17 +21,17 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/laurent22/joplin.git"
+    "url": "git+https://github.com/boozallen/bah-joplin.git"
   },
-  "author": "Laurent Cozic",
+  "author": "Booz Allen Hamilton",
   "license": "AGPL-3.0-or-later",
   "bugs": {
-    "url": "https://github.com/laurent22/joplin/issues"
+    "url": "https://github.com/boozallen/bah-joplin/issues"
   },
   "build": {
-    "appId": "net.cozic.joplin-desktop",
+    "appId": "com.boozallen.bahnotes-desktop",
     "compression": "normal",
-    "productName": "Joplin",
+    "productName": "Booz Allen Notes",
     "npmRebuild": false,
     "afterSign": "./tools/notarizeMacApp.js",
     "extraResources": [
@@ -51,7 +51,7 @@
     ],
     "win": {
       "publisherName": [
-        "Joplin"
+        "Booz Allen Hamilton"
       ],
       "sign": "./sign.js",
       "rfc3161TimeStampServer": "http://timestamp.digicert.com",
@@ -118,10 +118,10 @@
         "CFBundleURLTypes": [
           {
             "CFBundleURLSchemes": [
-              "joplin"
+              "bahnotes"
             ],
             "CFBundleTypeRole": "Editor",
-            "CFBundleURLName": "org.joplinapp.x-callback-url"
+            "CFBundleURLName": "com.boozallen.bahnotes.x-callback-url"
           }
         ]
       }
@@ -131,19 +131,19 @@
       "category": "Office",
       "desktop": {
         "Icon": "joplin",
-        "MimeType": "x-scheme-handler/joplin;",
+        "MimeType": "x-scheme-handler/bahnotes;",
         "StartupWMClass": "@joplin/app-desktop"
       },
       "target": [
         "AppImage",
         "deb"
       ],
-      "executableName": "joplin",
-      "maintainer": "Joplin Team <no-reply@joplinapp.org>",
-      "artifactName": "Joplin-${version}.${ext}"
+      "executableName": "bahnotes",
+      "maintainer": "Booz Allen Hamilton <no-reply@boozallen.com>",
+      "artifactName": "BoozAllenNotes-${version}.${ext}"
     }
   },
-  "homepage": "https://github.com/laurent22/joplin#readme",
+  "homepage": "https://github.com/boozallen/bah-joplin#readme",
   "devDependencies": {
     "7zip-bin": "5.2.0",
     "@axe-core/playwright": "4.11.1",

--- a/packages/app-desktop/tools/notarizeMacApp.ts
+++ b/packages/app-desktop/tools/notarizeMacApp.ts
@@ -33,7 +33,7 @@ export default async (params: Params) => {
 	}
 
 	// Same appId in electron-builder.
-	const appId = 'net.cozic.joplin-desktop';
+	const appId = 'com.boozallen.bahnotes-desktop';
 
 	const appPath = join(params.appOutDir, `${params.packager.appInfo.productFilename}.app`);
 	if (!existsSync(appPath)) {

--- a/packages/app-mobile/android/app/BUCK
+++ b/packages/app-mobile/android/app/BUCK
@@ -35,12 +35,12 @@ android_library(
 
 android_build_config(
     name = "build_config",
-    package = "net.cozic.joplin",
+    package = "com.boozallen.bahnotes",
 )
 
 android_resource(
     name = "res",
-    package = "net.cozic.joplin",
+    package = "com.boozallen.bahnotes",
     res = "src/main/res",
 )
 

--- a/packages/app-mobile/android/app/build.gradle
+++ b/packages/app-mobile/android/app/build.gradle
@@ -78,9 +78,9 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
     compileSdk rootProject.ext.compileSdkVersion
 
-    namespace "net.cozic.joplin"
+    namespace "com.boozallen.bahnotes"
     defaultConfig {
-        applicationId "net.cozic.joplin"
+        applicationId "com.boozallen.bahnotes"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
 		versionCode 2097811
@@ -103,11 +103,15 @@ android {
             keyPassword 'android'
         }
         release {
-            if (project.hasProperty('JOPLIN_RELEASE_STORE_FILE')) {
-                storeFile file(JOPLIN_RELEASE_STORE_FILE)
-                storePassword JOPLIN_RELEASE_STORE_PASSWORD
-                keyAlias JOPLIN_RELEASE_KEY_ALIAS
-                keyPassword JOPLIN_RELEASE_KEY_PASSWORD
+            if (project.hasProperty('BAHNOTES_RELEASE_STORE_FILE') || project.hasProperty('JOPLIN_RELEASE_STORE_FILE')) {
+                def releaseStoreFile = project.hasProperty('BAHNOTES_RELEASE_STORE_FILE') ? BAHNOTES_RELEASE_STORE_FILE : JOPLIN_RELEASE_STORE_FILE
+                def releaseStorePassword = project.hasProperty('BAHNOTES_RELEASE_STORE_PASSWORD') ? BAHNOTES_RELEASE_STORE_PASSWORD : JOPLIN_RELEASE_STORE_PASSWORD
+                def releaseKeyAlias = project.hasProperty('BAHNOTES_RELEASE_KEY_ALIAS') ? BAHNOTES_RELEASE_KEY_ALIAS : JOPLIN_RELEASE_KEY_ALIAS
+                def releaseKeyPassword = project.hasProperty('BAHNOTES_RELEASE_KEY_PASSWORD') ? BAHNOTES_RELEASE_KEY_PASSWORD : JOPLIN_RELEASE_KEY_PASSWORD
+                storeFile file(releaseStoreFile)
+                storePassword releaseStorePassword
+                keyAlias releaseKeyAlias
+                keyPassword releaseKeyPassword
             }
         }
     }

--- a/packages/app-mobile/android/app/src/main/java/com/boozallen/bahnotes/MainActivity.kt
+++ b/packages/app-mobile/android/app/src/main/java/com/boozallen/bahnotes/MainActivity.kt
@@ -1,4 +1,4 @@
-package net.cozic.joplin
+package com.boozallen.bahnotes
 import expo.modules.ReactActivityDelegateWrapper
 
 import com.facebook.react.ReactActivity

--- a/packages/app-mobile/android/app/src/main/java/com/boozallen/bahnotes/MainApplication.kt
+++ b/packages/app-mobile/android/app/src/main/java/com/boozallen/bahnotes/MainApplication.kt
@@ -1,4 +1,4 @@
-package net.cozic.joplin
+package com.boozallen.bahnotes
 import android.content.res.Configuration
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ReactNativeHostWrapper
@@ -14,9 +14,9 @@ import com.facebook.react.common.ReleaseLevel
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
-import net.cozic.joplin.versioninfo.SystemVersionInformationPackage
-import net.cozic.joplin.share.SharePackage
-import net.cozic.joplin.ssl.SslPackage
+import com.boozallen.bahnotes.versioninfo.SystemVersionInformationPackage
+import com.boozallen.bahnotes.share.SharePackage
+import com.boozallen.bahnotes.ssl.SslPackage
 
 class MainApplication : Application(), ReactApplication {
     override val reactNativeHost: ReactNativeHost = ReactNativeHostWrapper(

--- a/packages/app-mobile/android/app/src/main/java/com/boozallen/bahnotes/share/SharePackage.java
+++ b/packages/app-mobile/android/app/src/main/java/com/boozallen/bahnotes/share/SharePackage.java
@@ -1,4 +1,4 @@
-package net.cozic.joplin.share;
+package com.boozallen.bahnotes.share;
 
 import android.app.Activity;
 import android.content.ContentResolver;

--- a/packages/app-mobile/android/app/src/main/java/com/boozallen/bahnotes/ssl/SslModule.java
+++ b/packages/app-mobile/android/app/src/main/java/com/boozallen/bahnotes/ssl/SslModule.java
@@ -1,4 +1,4 @@
-package net.cozic.joplin.ssl;
+package com.boozallen.bahnotes.ssl;
 
 import android.util.Log;
 
@@ -11,8 +11,8 @@ import com.facebook.react.modules.network.NetworkingModule;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static net.cozic.joplin.ssl.SslUtils.TRUST_ALL_CERTS;
-import static net.cozic.joplin.ssl.SslUtils.getTrustySocketFactory;
+import static com.boozallen.bahnotes.ssl.SslUtils.TRUST_ALL_CERTS;
+import static com.boozallen.bahnotes.ssl.SslUtils.getTrustySocketFactory;
 
 public class SslModule extends ReactContextBaseJavaModule {
 

--- a/packages/app-mobile/android/app/src/main/java/com/boozallen/bahnotes/ssl/SslPackage.java
+++ b/packages/app-mobile/android/app/src/main/java/com/boozallen/bahnotes/ssl/SslPackage.java
@@ -1,4 +1,4 @@
-package net.cozic.joplin.ssl;
+package com.boozallen.bahnotes.ssl;
 
 import androidx.annotation.NonNull;
 

--- a/packages/app-mobile/android/app/src/main/java/com/boozallen/bahnotes/ssl/SslUtils.java
+++ b/packages/app-mobile/android/app/src/main/java/com/boozallen/bahnotes/ssl/SslUtils.java
@@ -1,4 +1,4 @@
-package net.cozic.joplin.ssl;
+package com.boozallen.bahnotes.ssl;
 
 import android.annotation.SuppressLint;
 

--- a/packages/app-mobile/android/app/src/main/java/com/boozallen/bahnotes/versioninfo/SystemVersionInformationPackage.java
+++ b/packages/app-mobile/android/app/src/main/java/com/boozallen/bahnotes/versioninfo/SystemVersionInformationPackage.java
@@ -1,4 +1,4 @@
-package net.cozic.joplin.versioninfo;
+package com.boozallen.bahnotes.versioninfo;
 
 import android.content.pm.PackageInfo;
 import android.os.Build;

--- a/packages/app-mobile/android/app/src/main/res/values/strings.xml
+++ b/packages/app-mobile/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">Joplin</string>
-    <string name="default_notification_channel_id">net.cozic.joplin.notification</string>
+    <string name="app_name">Booz Allen Notes</string>
+    <string name="default_notification_channel_id">com.boozallen.bahnotes.notification</string>
 </resources>

--- a/packages/app-mobile/app.json
+++ b/packages/app-mobile/app.json
@@ -1,6 +1,6 @@
 {
-  "name": "Joplin",
-  "displayName": "Joplin",
+  "name": "BoozAllenNotes",
+  "displayName": "Booz Allen Notes",
   "plugins": [
     "@react-native-community/datetimepicker"
   ]

--- a/packages/app-mobile/commands/openItem.ts
+++ b/packages/app-mobile/commands/openItem.ts
@@ -42,7 +42,7 @@ export const runtime = (): CommandRuntime => {
 			if (!link) throw new Error('Link cannot be empty');
 
 			try {
-				if (link.startsWith('joplin://') || link.startsWith(':/')) {
+				if (link.startsWith('bahnotes://') || link.startsWith('joplin://') || link.startsWith(':/')) {
 					const parsedResourceUrl = parseResourceUrl(link);
 					const parsedCallbackUrl = isCallbackUrl(link) ? parseCallbackUrl(link) : null;
 

--- a/packages/app-mobile/components/NoteBodyViewer/hooks/useOnResourceLongPress.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/hooks/useOnResourceLongPress.ts
@@ -46,7 +46,7 @@ export default function useOnResourceLongPress(callbacks: Callbacks) {
 			const action = await dialogManager.showMenu(name, actions);
 
 			if (action === 'open') {
-				onJoplinLinkClick(`joplin://${resourceId}`);
+				onJoplinLinkClick(`bahnotes://${resourceId}`);
 			} else if (action === 'share') {
 				const fileToShare = await copyToCache(resource);
 				await shareFile(fileToShare, resource.mime);

--- a/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/utils/exportProfile.ts
+++ b/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/utils/exportProfile.ts
@@ -3,7 +3,7 @@ import { reg } from '@joplin/lib/registry';
 import Setting from '@joplin/lib/models/Setting';
 
 const exportProfile = async (profileExportPath: string) => {
-	const dbPath = '/data/data/net.cozic.joplin/databases';
+	const dbPath = '/data/data/com.boozallen.bahnotes/databases';
 	const exportPath = profileExportPath;
 	const resourcePath = `${exportPath}/resources`;
 	try {

--- a/packages/app-mobile/ios/Joplin.xcodeproj/project.pbxproj
+++ b/packages/app-mobile/ios/Joplin.xcodeproj/project.pbxproj
@@ -615,7 +615,7 @@
 					SwiftUI,
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = net.cozic.joplin;
+				PRODUCT_BUNDLE_IDENTIFIER = com.boozallen.bahnotes;
 				PRODUCT_NAME = Joplin;
 				SWIFT_OBJC_BRIDGING_HEADER = "Joplin-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -649,7 +649,7 @@
 					SwiftUI,
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = net.cozic.joplin;
+				PRODUCT_BUNDLE_IDENTIFIER = com.boozallen.bahnotes;
 				PRODUCT_NAME = Joplin;
 				SWIFT_OBJC_BRIDGING_HEADER = "Joplin-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -682,7 +682,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = net.cozic.joplin.JoplinUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.boozallen.bahnotes.JoplinUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
@@ -720,7 +720,7 @@
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = net.cozic.joplin.JoplinUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.boozallen.bahnotes.JoplinUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -932,7 +932,7 @@
 					SwiftUI,
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = net.cozic.joplin.ShareExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.boozallen.bahnotes.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -974,7 +974,7 @@
 					SwiftUI,
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = net.cozic.joplin.ShareExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.boozallen.bahnotes.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/packages/app-mobile/ios/Joplin/Info.plist
+++ b/packages/app-mobile/ios/Joplin/Info.plist
@@ -7,7 +7,7 @@
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>CFBundleDisplayName</key>
-	<string>Joplin</string>
+	<string>Booz Allen Notes</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -28,10 +28,10 @@
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
 			<key>CFBundleURLName</key>
-			<string>net.cozic.joplin</string>
+			<string>com.boozallen.bahnotes</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>joplin</string>
+				<string>bahnotes</string>
 			</array>
 		</dict>
 	</array>

--- a/packages/app-mobile/ios/Joplin/Joplin.entitlements
+++ b/packages/app-mobile/ios/Joplin/Joplin.entitlements
@@ -6,7 +6,7 @@
 	<string>development</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.net.cozic.joplin</string>
+		<string>group.com.boozallen.bahnotes</string>
 	</array>
 </dict>
 </plist>

--- a/packages/app-mobile/ios/ShareExtension/ShareExtension.entitlements
+++ b/packages/app-mobile/ios/ShareExtension/ShareExtension.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.net.cozic.joplin</string>
+		<string>group.com.boozallen.bahnotes</string>
 	</array>
 </dict>
 </plist>

--- a/packages/app-mobile/ios/ShareExtension/Source/Common/ShareExtensionConstants.m
+++ b/packages/app-mobile/ios/ShareExtension/Source/Common/ShareExtensionConstants.m
@@ -8,6 +8,6 @@
 
 #import <Foundation/Foundation.h>
 
-NSString* const ShareExtensionGroupIdentifier = @"group.net.cozic.joplin";
-NSString* const ShareExtensionShareURL = @"joplin://shareData";
+NSString* const ShareExtensionGroupIdentifier = @"group.com.boozallen.bahnotes";
+NSString* const ShareExtensionShareURL = @"bahnotes://shareData";
 NSString* const ShareExtensionShareDataFilename = @"shareData";

--- a/packages/app-mobile/services/AlarmServiceDriver.android.ts
+++ b/packages/app-mobile/services/AlarmServiceDriver.android.ts
@@ -57,7 +57,7 @@ export default class AlarmServiceDriver {
 		const alarmNotifData = {
 			title: notification.title,
 			message: notification.body ? notification.body : '-', // Required
-			channel: 'net.cozic.joplin.notification',
+			channel: 'com.boozallen.bahnotes.notification',
 			small_icon: 'ic_launcher_foreground', // Android requires the icon to be transparent
 			color: 'blue',
 			data: {

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -173,7 +173,7 @@ const buildStartupTasks = (
 	});
 	addTask('buildStartupTasks/set constants', async () => {
 		Setting.setConstant('env', __DEV__ ? Env.Dev : Env.Prod);
-		Setting.setConstant('appId', 'net.cozic.joplin-mobile');
+		Setting.setConstant('appId', 'com.boozallen.bahnotes-mobile');
 		Setting.setConstant('appType', AppType.Mobile);
 		Setting.setConstant('tempDir', await initializeTempDir());
 		Setting.setConstant('cacheDir', `${getProfilesRootDir()}/cache`);

--- a/packages/lib/callbackUrlUtils.test.ts
+++ b/packages/lib/callbackUrlUtils.test.ts
@@ -3,48 +3,49 @@ import * as callbackUrlUtils from './callbackUrlUtils';
 describe('callbackUrlUtils', () => {
 
 	it('should identify valid callback urls', () => {
-		const url = 'joplin://x-callback-url/openFolder?a=b';
+		const url = 'bahnotes://x-callback-url/openFolder?a=b';
 		expect(callbackUrlUtils.isCallbackUrl(url)).toBe(true);
+		expect(callbackUrlUtils.isCallbackUrl('joplin://x-callback-url/openFolder?a=b')).toBe(true);
 	});
 
 	it('should identify invalid callback urls', () => {
 		expect(callbackUrlUtils.isCallbackUrl('not-joplin://x-callback-url/123?a=b')).toBe(false);
-		expect(callbackUrlUtils.isCallbackUrl('joplin://xcallbackurl/123?a=b')).toBe(false);
-		expect(callbackUrlUtils.isCallbackUrl('joplin://x-callback-url/invalidCommand?a=b')).toBe(false);
+		expect(callbackUrlUtils.isCallbackUrl('bahnotes://xcallbackurl/123?a=b')).toBe(false);
+		expect(callbackUrlUtils.isCallbackUrl('bahnotes://x-callback-url/invalidCommand?a=b')).toBe(false);
 	});
 
 	it('should build valid note callback urls', () => {
 		const noteUrl = callbackUrlUtils.getNoteCallbackUrl('123456');
 		expect(callbackUrlUtils.isCallbackUrl(noteUrl)).toBe(true);
-		expect(noteUrl).toBe('joplin://x-callback-url/openNote?id=123456');
+		expect(noteUrl).toBe('bahnotes://x-callback-url/openNote?id=123456');
 	});
 
 	it('should build valid folder callback urls', () => {
 		const folderUrl = callbackUrlUtils.getFolderCallbackUrl('123456');
 		expect(callbackUrlUtils.isCallbackUrl(folderUrl)).toBe(true);
-		expect(folderUrl).toBe('joplin://x-callback-url/openFolder?id=123456');
+		expect(folderUrl).toBe('bahnotes://x-callback-url/openFolder?id=123456');
 	});
 
 	it('should build valid tag callback urls', () => {
 		const tagUrl = callbackUrlUtils.getTagCallbackUrl('123456');
 		expect(callbackUrlUtils.isCallbackUrl(tagUrl)).toBe(true);
-		expect(tagUrl).toBe('joplin://x-callback-url/openTag?id=123456');
+		expect(tagUrl).toBe('bahnotes://x-callback-url/openTag?id=123456');
 	});
 
 	it('should parse note callback urls', () => {
-		const parsed = callbackUrlUtils.parseCallbackUrl('joplin://x-callback-url/openNote?id=123456');
+		const parsed = callbackUrlUtils.parseCallbackUrl('bahnotes://x-callback-url/openNote?id=123456');
 		expect(parsed.command).toBe(callbackUrlUtils.CallbackUrlCommand.OpenNote);
 		expect(parsed.params).toStrictEqual({ id: '123456' });
 	});
 
 	it('should parse folder callback urls', () => {
-		const parsed = callbackUrlUtils.parseCallbackUrl('joplin://x-callback-url/openFolder?id=123456');
+		const parsed = callbackUrlUtils.parseCallbackUrl('bahnotes://x-callback-url/openFolder?id=123456');
 		expect(parsed.command).toBe(callbackUrlUtils.CallbackUrlCommand.OpenFolder);
 		expect(parsed.params).toStrictEqual({ id: '123456' });
 	});
 
 	it('should parse tag callback urls', () => {
-		const parsed = callbackUrlUtils.parseCallbackUrl('joplin://x-callback-url/openTag?id=123456');
+		const parsed = callbackUrlUtils.parseCallbackUrl('bahnotes://x-callback-url/openTag?id=123456');
 		expect(parsed.command).toBe(callbackUrlUtils.CallbackUrlCommand.OpenTag);
 		expect(parsed.params).toStrictEqual({ id: '123456' });
 	});
@@ -56,8 +57,8 @@ describe('callbackUrlUtils', () => {
 		expect(() => callbackUrlUtils.parseCallbackUrl('not-joplin://x-callback-url/123?a=b'))
 			.toThrowError('Invalid callback url not-joplin://x-callback-url/123?a=b');
 
-		expect(() => callbackUrlUtils.parseCallbackUrl('joplin://xcallbackurl/123?a=b'))
-			.toThrowError('Invalid callback url joplin://xcallbackurl/123?a=b');
+		expect(() => callbackUrlUtils.parseCallbackUrl('bahnotes://xcallbackurl/123?a=b'))
+			.toThrowError('Invalid callback url bahnotes://xcallbackurl/123?a=b');
 	});
 
 

--- a/packages/lib/callbackUrlUtils.ts
+++ b/packages/lib/callbackUrlUtils.ts
@@ -1,21 +1,27 @@
 const URL = require('url-parse');
 
+const callbackProtocols = ['bahnotes://', 'joplin://'];
+const callbackCommands = ['openNote', 'openFolder', 'openTag'];
+
 export function isCallbackUrl(s: string) {
-	return s.startsWith('joplin://x-callback-url/openNote?') ||
-		s.startsWith('joplin://x-callback-url/openFolder?') ||
-		s.startsWith('joplin://x-callback-url/openTag?');
+	for (const protocol of callbackProtocols) {
+		for (const command of callbackCommands) {
+			if (s.startsWith(`${protocol}x-callback-url/${command}?`)) return true;
+		}
+	}
+	return false;
 }
 
 export function getNoteCallbackUrl(noteId: string) {
-	return `joplin://x-callback-url/openNote?id=${encodeURIComponent(noteId)}`;
+	return `bahnotes://x-callback-url/openNote?id=${encodeURIComponent(noteId)}`;
 }
 
 export function getFolderCallbackUrl(folderId: string) {
-	return `joplin://x-callback-url/openFolder?id=${encodeURIComponent(folderId)}`;
+	return `bahnotes://x-callback-url/openFolder?id=${encodeURIComponent(folderId)}`;
 }
 
 export function getTagCallbackUrl(tagId: string) {
-	return `joplin://x-callback-url/openTag?id=${encodeURIComponent(tagId)}`;
+	return `bahnotes://x-callback-url/openTag?id=${encodeURIComponent(tagId)}`;
 }
 
 export const enum CallbackUrlCommand {

--- a/packages/lib/urlUtils.test.ts
+++ b/packages/lib/urlUtils.test.ts
@@ -30,9 +30,11 @@ describe('urlUtils', () => {
 			[':/1234abcd1234abcd1234abcd1234abcd#hash', { itemId: '1234abcd1234abcd1234abcd1234abcd', hash: 'hash' }],
 			[':/1234abcd1234abcd1234abcd1234abcd#Книги-из-номер', { itemId: '1234abcd1234abcd1234abcd1234abcd', hash: 'Книги-из-номер' }],
 			[':/1234abcd1234abcd1234abcd1234abcd#hash "some text"', { itemId: '1234abcd1234abcd1234abcd1234abcd', hash: 'hash' }],
+			['bahnotes://1234abcd1234abcd1234abcd1234abcd', { itemId: '1234abcd1234abcd1234abcd1234abcd', hash: '' }],
+			['bahnotes://1234abcd1234abcd1234abcd1234abcd#hash', { itemId: '1234abcd1234abcd1234abcd1234abcd', hash: 'hash' }],
 			['joplin://1234abcd1234abcd1234abcd1234abcd', { itemId: '1234abcd1234abcd1234abcd1234abcd', hash: '' }],
-			['joplin://1234abcd1234abcd1234abcd1234abcd#hash', { itemId: '1234abcd1234abcd1234abcd1234abcd', hash: 'hash' }],
 			[':/1234abcd1234abcd1234abcd1234abc', null],
+			['bahnotes://1234abcd1234abcd1234abcd1234abc', null],
 			['joplin://1234abcd1234abcd1234abcd1234abc', null],
 		];
 

--- a/packages/lib/urlUtils.ts
+++ b/packages/lib/urlUtils.ts
@@ -46,7 +46,7 @@ export const prependBaseUrl = (url: string, baseUrl: string) => {
 };
 
 
-const resourceRegex = /^(joplin:\/\/|:\/)([0-9a-zA-Z]{32})(|#[^\s]*)(|\s".*?")$/;
+const resourceRegex = /^(bahnotes:\/\/|joplin:\/\/|:\/)([0-9a-zA-Z]{32})(|#[^\s]*)(|\s".*?")$/;
 
 export const isResourceUrl = (url: string) => {
 	return !!url.match(resourceRegex);
@@ -83,7 +83,7 @@ export const fileUrlToResourceUrl = (fileUrl: string, resourceDir: string, os: s
 		result = result.replace(/\?t=\d+(#.*)?$/, '$1');
 		// Remove the file extension.
 		result = result.replace(/\.[a-z0-9]+(#.*)?$/, '$1');
-		result = `joplin://${result}`;
+		result = `bahnotes://${result}`;
 
 		if (isResourceUrl(result)) {
 			return result;

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -127,10 +127,10 @@ async function main() {
 	// routeHandler uses data from both previous middlewares. It would be good to
 	// layout these dependencies in code but not clear how to do this.
 	const corsAllowedDomains = [
-		'https://joplinapp.org',
+		'https://notes.boozallen.com',
 
-		// Allows sync with the web version of Joplin
-		'https://app.joplincloud.com',
+		// Allows sync with the web version of Booz Allen Notes
+		'https://app.notes.boozallen.com',
 	];
 
 	if (env === Env.Dev) {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -40,7 +40,7 @@ function databaseHostFromEnv(runningInDocker: boolean, env: EnvVariables, slave:
 export const fullVersionString = (config: Config) => {
 	const output: string[] = [];
 	output.push(`v${config.appVersion}`);
-	if (config.appVersion !== config.joplinServerVersion) output.push(`(Based on Joplin Server v${config.joplinServerVersion})`);
+	if (config.appVersion !== config.joplinServerVersion) output.push(`(Based on Booz Allen Notes Server v${config.joplinServerVersion})`);
 	return output.join(' ');
 };
 
@@ -190,7 +190,7 @@ export async function initConfig(envType: Env, env: EnvVariables, overrides: any
 		appVersion: forkVersion ? forkVersion : packageJson.version,
 		joplinServerVersion: packageJson.version,
 		appName,
-		isJoplinCloud: apiBaseUrl.includes('.joplincloud.com') || apiBaseUrl.includes('.joplincloud.local'),
+		isJoplinCloud: apiBaseUrl.includes('.notes.boozallen.com') || apiBaseUrl.includes('.notes.boozallen.local'),
 		defaultAdminPassword: env.DEFAULT_ADMIN_PASSWORD || 'admin',
 		env: envType,
 		rootDir: rootDir,

--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -14,7 +14,7 @@ const defaultEnvValues: EnvVariables = {
 	// General config
 	// ==================================================
 
-	APP_NAME: 'Joplin Server',
+	APP_NAME: 'Booz Allen Notes Server',
 	APP_PORT: 22300,
 	SIGNUP_ENABLED: false,
 	TERMS_ENABLED: false,
@@ -55,7 +55,7 @@ const defaultEnvValues: EnvVariables = {
 	APP_BASE_URL: '',
 	USER_CONTENT_BASE_URL: '',
 	API_BASE_URL: '',
-	JOPLINAPP_BASE_URL: 'https://joplinapp.org',
+	JOPLINAPP_BASE_URL: 'https://notes.boozallen.com',
 	TERMS_URL: '',
 	PRIVACY_URL: '',
 

--- a/packages/server/src/routes/api/ping.test.ts
+++ b/packages/server/src/routes/api/ping.test.ts
@@ -28,7 +28,7 @@ describe('api_ping', () => {
 
 		expect(context.response.status).toBe(200);
 		expect(body.status).toBe('ok');
-		expect(body.message).toBe('Joplin Server is running');
+		expect(body.message).toBe('Booz Allen Notes Server is running');
 	});
 
 });

--- a/packages/server/src/routes/index/home.ts
+++ b/packages/server/src/routes/index/home.ts
@@ -18,7 +18,7 @@ function setupMessageHtml() {
 	if (config().isJoplinCloud) {
 		return `In this screen, select "<strong>${escapeHtml(config().appName)}</strong>" as a synchronisation target and enter your username and password`;
 	} else {
-		return `In this screen, select "<strong>Joplin Server</strong>" as a synchronisation target, then enter the URL <strong>${config().apiBaseUrl}</strong> and your username and password`;
+		return `In this screen, select "<strong>Booz Allen Notes Server</strong>" as a synchronisation target, then enter the URL <strong>${config().apiBaseUrl}</strong> and your username and password`;
 	}
 }
 
@@ -26,36 +26,20 @@ function setupMessageHtml() {
 const socialFeeds = () => {
 	return [
 		{
-			label: 'Bluesky',
-			href: 'https://bsky.app/profile/joplinapp.bsky.social',
+			label: 'Website',
+			href: 'https://notes.boozallen.com',
 		},
 		{
-			label: 'Patreon',
-			href: 'https://www.patreon.com/joplin',
-		},
-		{
-			label: 'YouTube',
-			href: 'https://www.youtube.com/@joplinapp',
-		},
-		{
-			label: 'LinkedIn',
-			href: 'https://www.linkedin.com/company/joplin',
-		},
-		{
-			label: 'Discord',
-			href: 'https://discord.gg/VSj7AFHvpq',
-		},
-		{
-			label: 'Mastodon',
-			href: 'https://mastodon.social/@joplinapp',
-		},
-		{
-			label: 'Lemmy',
-			href: 'https://sopuli.xyz/c/joplinapp',
+			label: 'Support',
+			href: 'https://notes.boozallen.com/help',
 		},
 		{
 			label: 'GitHub',
-			href: 'https://github.com/laurent22/joplin/',
+			href: 'https://github.com/boozallen/bah-joplin',
+		},
+		{
+			label: 'LinkedIn',
+			href: 'https://www.linkedin.com/company/booz-allen-hamilton',
 		},
 	];
 };

--- a/packages/server/src/routes/index/stripe.ts
+++ b/packages/server/src/routes/index/stripe.ts
@@ -406,7 +406,7 @@ const getHandlers: Record<string, StripeRouteHandler> = {
 			logger.error('Could not automatically redirect user to account confirmation page. They will have to follow the link in the confirmation email. Error was:', error);
 			return `
 				<p>Thank you for signing up for ${globalConfig().appName}! You should receive an email shortly with instructions on how to connect to your account.</p>
-				<p><a href="https://joplinapp.org">Go back to JoplinApp.org</a></p>
+				<p><a href="https://notes.boozallen.com">Go back to notes.boozallen.com</a></p>
 			`;
 		}
 	},
@@ -414,7 +414,7 @@ const getHandlers: Record<string, StripeRouteHandler> = {
 	cancel: async (_stripe: Stripe, _path: SubPath, _ctx: AppContext) => {
 		return `
 			<p>Your payment has been cancelled.</p>
-			<p><a href="https://joplinapp.org">Go back to JoplinApp.org</a></p>
+			<p><a href="https://notes.boozallen.com">Go back to notes.boozallen.com</a></p>
 		`;
 	},
 

--- a/packages/server/src/utils/joplinUtils.ts
+++ b/packages/server/src/utils/joplinUtils.ts
@@ -98,7 +98,7 @@ export async function initializeJoplinUtils(config: Config, models: Models, must
 	BaseService.logger_ = new Logger();
 
 	Setting.allowFileStorage = false;
-	Setting.setConstant('appId', 'net.cozic.joplin-desktop');
+	Setting.setConstant('appId', 'com.boozallen.bahnotes-desktop');
 	Setting.setConstant('tempDir', config.tempDir);
 	Setting.setConstant('resourceDir', config.resourceDir);
 	await loadKeychainServiceAndSettings([KeychainServiceDriverDummy]);

--- a/packages/server/src/views/index/help.md
+++ b/packages/server/src/views/index/help.md
@@ -1,4 +1,4 @@
-# Joplin Cloud Help
+# Booz Allen Notes Help
 
 ## Account management
 
@@ -34,13 +34,13 @@ To update your card or other payment details, open your [profile](/users/me), th
 
 This can happen for various reasons, for example if your card is expired, if your bank has blocked the payment, or simply if the card details are not correct. So you may want to check all this, and possibly contact your bank to tell them to authorise the payment.
 
-When a payment has failed, Stripe will retry again a few times, a few days later, so you don't need to do anything. However please note that after 14 days the Joplin Cloud account will be restricted until the payment is made - it will still be possible to download your data, but it will not be possible to upload more.
+When a payment has failed, Stripe will retry again a few times, a few days later, so you don't need to do anything. However please note that after 14 days the Booz Allen Notes account will be restricted until the payment is made - it will still be possible to download your data, but it will not be possible to upload more.
 
 ### How to manually pay an invoice when a payment has failed?
 
 In case of a failed payment, Stripe will retry automatically. However you may also manually pay the invoice by following these steps:
 
-Open your [profile](/users/me), then click on "[Manage subscription](/stripe/portal)". This will open your Joplin Cloud subscription page. Scroll down and, under "Invoice history", click on the invoice that has a failed payment. This will open a new page where you can pay the invoice.
+Open your [profile](/users/me), then click on "[Manage subscription](/stripe/portal)". This will open your Booz Allen Notes subscription page. Scroll down and, under "Invoice history", click on the invoice that has a failed payment. This will open a new page where you can pay the invoice.
 
 ## Team billing
 
@@ -67,11 +67,11 @@ Open your [profile](/users/me), then scroll down and click on "[Manage subscript
 
 ## Data retention
 
-Disabled accounts on Joplin Cloud are automatically deleted 99 days after they have been disabled (*). A disabled account is one where the Stripe subscription has been cancelled either by the user or automatically (eg for unpaid invoices).
+Disabled accounts on Booz Allen Notes are automatically deleted 99 days after they have been disabled (*). A disabled account is one where the Stripe subscription has been cancelled either by the user or automatically (eg for unpaid invoices).
 
 When an account is deleted, all notes, notebooks, tags, attachments, etc. are permanently deleted. User information, in particular emails and full names will be removed from the system within 92 days, but archived for an additional 90 days for legal reasons, after which they will be deleted too.
 
-If you wish to delete your data before this delay, simply delete all your notes and notebooks from the app, then synchronise with Joplin Cloud. You can use the [Victor plugin](https://joplinapp.org/plugins/plugin/org.joplinapp.plugins.Victor/) to make this easier. After synchronisation, the data will be removed from the server too. For safety reasons, we do not delete data on request.
+If you wish to delete your data before this delay, simply delete all your notes and notebooks from the app, then synchronise with Booz Allen Notes. You can use the [Victor plugin](https://notes.boozallen.com/plugins/plugin/org.joplinapp.plugins.Victor/) to make this easier. After synchronisation, the data will be removed from the server too. For safety reasons, we do not delete data on request.
 
 (*) After 90 days, they are queued for deletion; 2 days later, they are removed from the system (no longer accessible); and 7 days later they are permanently deleted.
 
@@ -85,7 +85,7 @@ In general, cancelling a subscription does not cancel existing invoices.
 
 ## Further information
 
-- [Joplin Official Website](https://joplinapp.org)
-- [Joplin Support Forum](https://discourse.joplinapp.org/)
-- [Joplin Cloud Privacy Policy](/privacy)
-- [Joplin Cloud Terms & Conditions](/terms)
+- [Booz Allen Notes Website](https://notes.boozallen.com)
+- [Booz Allen Notes Support](https://notes.boozallen.com/help)
+- [Booz Allen Notes Privacy Policy](/privacy)
+- [Booz Allen Notes Terms & Conditions](/terms)

--- a/packages/server/src/views/index/home.mustache
+++ b/packages/server/src/views/index/home.mustache
@@ -9,17 +9,17 @@
 
 <h2 class="title">Welcome to {{global.appName}}</h2>
 <div class="block readable-block content">
-	<p>To start using {{global.appName}}, make sure to <a href="{{{global.joplinAppBaseUrl}}}/download">download one of the Joplin applications</a>, either for desktop or for your mobile phone.</p>
+	<p>To start using {{global.appName}}, make sure to <a href="{{{global.joplinAppBaseUrl}}}/download">download one of the Booz Allen Notes applications</a>, either for desktop or for your mobile phone.</p>
 	<p>Once the app is installed, open the <strong>Configuration</strong> screen, then the <strong>Synchronisation</strong> section. {{{setupMessageHtml}}}<p>
 	<p>Once it is set up {{global.appName}} allows you to synchronise your devices, to publish notes, or to collaborate on notebooks with other {{global.appName}} users.</p>
 </div>
 
 {{#isJoplinCloud}}
-<h2 class="title">Joplin Web App</h2>
+<h2 class="title">Booz Allen Notes Web App</h2>
 
 <div class="block readable-block content">
-	<p>You may access your notes from any web browser using the <a href="https://app.joplincloud.com">Joplin Web App</a>. It is essentially the Joplin mobile app running in a browser, and you can synchronise it with your Joplin Cloud notes.</p>
-	<p>For more information, please see the <a href="https://joplinapp.org/help/apps/web">Joplin Web App documentation</a>.</p>
+	<p>You may access your notes from any web browser using the <a href="https://app.notes.boozallen.com">Booz Allen Notes Web App</a>. It is essentially the Booz Allen Notes mobile app running in a browser, and you can synchronise it with your Booz Allen Notes account.</p>
+	<p>For more information, please see the <a href="https://notes.boozallen.com/help/apps/web">Booz Allen Notes Web App documentation</a>.</p>
 </div>
 {{/isJoplinCloud}}
 

--- a/packages/server/src/views/index/upgrade.mustache
+++ b/packages/server/src/views/index/upgrade.mustache
@@ -30,7 +30,7 @@
 			{{/planRows}}
 
 			<tr>
-				<td style="opacity:0.7;" colspan="2">For the complete feature list, please see the <a target="_blank" href="https://joplinapp.org/plans">Plan page</a></td>
+				<td style="opacity:0.7;" colspan="2">For the complete feature list, please see the <a target="_blank" href="https://notes.boozallen.com/plans">Plan page</a></td>
 			</tr>
 
 			<tr>

--- a/readme/dev/rebrand_identity_guard.md
+++ b/readme/dev/rebrand_identity_guard.md
@@ -1,0 +1,20 @@
+# Rebrand Identity Guard
+
+Phase 1 introduces a lightweight guard to prevent new legacy identifiers from being added to ship-critical files by accident.
+
+## Command
+
+- `yarn checkRebrandIdentity`
+
+This command scans added lines from `git diff` in ship-critical paths and fails if they contain blocked legacy identifiers (for example `net.cozic`, `joplinapp.org`, or `laurent22/joplin`).
+
+## Intentional Exceptions
+
+- Edit `readme/dev/rebrand_identity_guard_exceptions.json`.
+- Add only file paths that must intentionally include legacy terms (for example migration docs or attribution references).
+- Keep the list short and remove entries when no longer needed.
+
+## Matrix Update Rule
+
+- Update `readme/rebrand_identity_matrix.md` before implementation PRs change runtime identifiers.
+- If matrix values change, update this guard's block patterns or exceptions in the same PR when needed.

--- a/readme/dev/rebrand_identity_guard_exceptions.json
+++ b/readme/dev/rebrand_identity_guard_exceptions.json
@@ -1,0 +1,12 @@
+{
+  "pathExemptions": [
+    "readme/rebrand_identity_matrix.md",
+    "readme/dev/rebrand_identity_guard.md",
+    "readme/dev/rebrand_identity_guard_exceptions.json",
+    ".github/scripts/check_rebrand_identity.js",
+    "packages/lib/callbackUrlUtils.ts",
+    "packages/app-mobile/commands/openItem.ts",
+    "packages/app-desktop/gui/WindowCommandsAndDialogs/commands/openItem.ts",
+    "packages/app-desktop/gui/NoteRevisionViewer.tsx"
+  ]
+}

--- a/readme/dev/rebrand_identity_matrix.md
+++ b/readme/dev/rebrand_identity_matrix.md
@@ -1,0 +1,46 @@
+# Booz Allen Hamilton Rebrand Identity Matrix
+
+This file is the canonical mapping for the BAH Joplin fork identity.
+
+## Product Display Names
+
+- Desktop: `Booz Allen Notes`
+- Mobile: `Booz Allen Notes`
+- CLI: `bah-notes`
+- Server: `Booz Allen Notes Server`
+- Browser extension: `Booz Allen Notes Web Clipper`
+
+## Technical Identifiers
+
+- Desktop app ID: `com.boozallen.bahnotes-desktop`
+- Desktop AUMID (runtime): `com.boozallen.bahnotes-desktop`
+- Android package / namespace: `com.boozallen.bahnotes`
+- iOS bundle identifier: `com.boozallen.bahnotes`
+- iOS share extension bundle identifier: `com.boozallen.bahnotes.ShareExtension`
+- iOS app group: `group.com.boozallen.bahnotes`
+
+## Protocol and Callback Schemes
+
+- Legacy: `joplin://`
+- New: `bahnotes://`
+- x-callback URL name: `com.boozallen.bahnotes.x-callback-url`
+
+## Namespace and Distribution
+
+- Fork repository URL: `https://github.com/boozallen/bah-joplin`
+- Docker server repository: `boozallen/bah-joplin-server`
+- Docker transcribe repository: `boozallen/bah-joplin-transcribe`
+
+## Domain and Endpoint Map
+
+- Product website: `https://notes.boozallen.com`
+- Help/docs: `https://notes.boozallen.com/help`
+- Download page: `https://notes.boozallen.com/download`
+- Web app endpoint: `https://app.notes.boozallen.com`
+- Sync server endpoint pattern: `https://api.notes.boozallen.com`
+
+## Signing and Publisher Metadata
+
+- Windows publisher name: `Booz Allen Hamilton`
+- Linux package maintainer: `Booz Allen Hamilton <no-reply@boozallen.com>`
+- Apple team/provider variables: keep existing `APPLE_ASC_PROVIDER` secret model, but scoped to BAH signing account.

--- a/readme/rebrand_identity_matrix.md
+++ b/readme/rebrand_identity_matrix.md
@@ -1,0 +1,46 @@
+# Booz Allen Hamilton Rebrand Identity Matrix
+
+This file is the canonical mapping for the BAH Joplin fork identity.
+
+## Product Display Names
+
+- Desktop: `Booz Allen Notes`
+- Mobile: `Booz Allen Notes`
+- CLI: `bah-notes`
+- Server: `Booz Allen Notes Server`
+- Browser extension: `Booz Allen Notes Web Clipper`
+
+## Technical Identifiers
+
+- Desktop app ID: `com.boozallen.bahnotes-desktop`
+- Desktop AUMID (runtime): `com.boozallen.bahnotes-desktop`
+- Android package / namespace: `com.boozallen.bahnotes`
+- iOS bundle identifier: `com.boozallen.bahnotes`
+- iOS share extension bundle identifier: `com.boozallen.bahnotes.ShareExtension`
+- iOS app group: `group.com.boozallen.bahnotes`
+
+## Protocol and Callback Schemes
+
+- Legacy: `joplin://`
+- New: `bahnotes://`
+- x-callback URL name: `com.boozallen.bahnotes.x-callback-url`
+
+## Namespace and Distribution
+
+- Fork repository URL: `https://github.com/boozallen/bah-joplin`
+- Docker server repository: `boozallen/bah-joplin-server`
+- Docker transcribe repository: `boozallen/bah-joplin-transcribe`
+
+## Domain and Endpoint Map
+
+- Product website: `https://notes.boozallen.com`
+- Help/docs: `https://notes.boozallen.com/help`
+- Download page: `https://notes.boozallen.com/download`
+- Web app endpoint: `https://app.notes.boozallen.com`
+- Sync server endpoint pattern: `https://api.notes.boozallen.com`
+
+## Signing and Publisher Metadata
+
+- Windows publisher name: `Booz Allen Hamilton`
+- Linux package maintainer: `Booz Allen Hamilton <no-reply@boozallen.com>`
+- Apple team/provider variables: keep existing `APPLE_ASC_PROVIDER` secret model, but scoped to BAH signing account.

--- a/tools/rebrand-allowlist.txt
+++ b/tools/rebrand-allowlist.txt
@@ -1,0 +1,9 @@
+# Runtime compatibility: accept legacy links while parsers/readers migrate.
+^packages/lib/callbackUrlUtils\.ts:\d+:const callbackProtocols = \['bahnotes://', 'joplin://'\];
+^packages/app-mobile/commands/openItem\.ts:\d+:\s*if \(link\.startsWith\('bahnotes://'\) \|\| link\.startsWith\('joplin://'\) \|\| link\.startsWith\(':/'\)\) \{
+^packages/app-desktop/gui/WindowCommandsAndDialogs/commands/openItem\.ts:\d+:\s*if \(link\.startsWith\('bahnotes://'\) \|\| link\.startsWith\('joplin://'\) \|\| link\.startsWith\(':/'\)\) \{
+^packages/app-desktop/gui/NoteRevisionViewer\.tsx:\d+:\s*\} else if \(msg\.indexOf\('bahnotes://'\) === 0 \|\| msg\.indexOf\('joplin://'\) === 0\) \{
+
+# Historical fixtures retained for regression coverage.
+^packages/server/src/utils/testing/serializedItems\.ts:\d+:source_application: net\.cozic\.joplindev-desktop
+^packages/server/src/migrations/20210412110640_item_refactor\.ts:\d+:// source_application: net\.cozic\.joplindev-desktop

--- a/tools/verify-rebrand.sh
+++ b/tools/verify-rebrand.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "Running rebrand guard checks..."
+
+scan_paths=(
+  "packages/app-desktop"
+  "packages/app-mobile"
+  "packages/app-clipper"
+  "packages/server/src"
+  "packages/lib/callbackUrlUtils.ts"
+  "packages/lib/urlUtils.ts"
+  ".github"
+)
+
+patterns=(
+  "net\\.cozic\\.joplin-desktop"
+  "net\\.cozic\\.joplin"
+  "x-scheme-handler/joplin"
+  "joplin://"
+)
+
+allowlist_file="tools/rebrand-allowlist.txt"
+raw_matches_file="/tmp/rebrand_matches_raw.txt"
+filtered_matches_file="/tmp/rebrand_matches_filtered.txt"
+
+for pattern in "${patterns[@]}"; do
+  if rg -n "$pattern" "${scan_paths[@]}" --glob '!**/*.test.*' --glob '!**/tests/**' --glob '!**/test/**' --glob '!**/readme/**' >"$raw_matches_file"; then
+    if [ -f "$allowlist_file" ]; then
+      rg -v -f "$allowlist_file" "$raw_matches_file" >"$filtered_matches_file" || true
+    else
+      cp "$raw_matches_file" "$filtered_matches_file"
+    fi
+
+    if [ ! -s "$filtered_matches_file" ]; then
+      continue
+    fi
+
+    echo "Found forbidden legacy pattern: $pattern"
+    while IFS= read -r line; do
+      echo "$line"
+    done < "$filtered_matches_file"
+    exit 1
+  fi
+done
+
+echo "Rebrand guard checks passed."

--- a/yarn.lock
+++ b/yarn.lock
@@ -22975,6 +22975,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bah-notes@workspace:packages/app-cli":
+  version: 0.0.0-use.local
+  resolution: "bah-notes@workspace:packages/app-cli"
+  dependencies:
+    "@joplin/lib": "npm:~3.7"
+    "@joplin/renderer": "npm:~3.7"
+    "@joplin/tools": "npm:~3.7"
+    "@joplin/utils": "npm:~3.7"
+    "@types/fs-extra": "npm:11.0.4"
+    "@types/jest": "npm:29.5.14"
+    "@types/node": "npm:18.19.130"
+    "@types/proper-lockfile": "npm:^4.1.2"
+    aws-sdk: "npm:2.1340.0"
+    chalk: "npm:4.1.2"
+    compare-version: "npm:0.1.2"
+    file-type: "npm:16.5.4"
+    fs-extra: "npm:11.3.4"
+    gulp: "npm:4.0.2"
+    html-entities: "npm:1.4.0"
+    jest: "npm:29.7.0"
+    keytar: "npm:7.9.0"
+    md5: "npm:2.3.0"
+    node-rsa: "npm:1.1.1"
+    open: "npm:8.4.2"
+    proper-lockfile: "npm:4.1.2"
+    redux: "npm:4.2.1"
+    server-destroy: "npm:1.0.1"
+    sharp: "npm:0.34.5"
+    sprintf-js: "npm:1.1.3"
+    sqlite3: "npm:5.1.6"
+    string-padding: "npm:1.0.2"
+    strip-ansi: "npm:6.0.1"
+    tcp-port-used: "npm:1.0.2"
+    temp: "npm:0.9.4"
+    terminal-kit: "npm:3.1.2"
+    tkwidgets: "npm:0.5.27"
+    typescript: "npm:5.9.3"
+    url-parse: "npm:1.5.10"
+    word-wrap: "npm:1.2.5"
+    yargs-parser: "npm:21.1.1"
+  bin:
+    bah-notes: ./main.js
+  languageName: unknown
+  linkType: soft
+
 "bail@npm:^1.0.0":
   version: 1.0.5
   resolution: "bail@npm:1.0.5"
@@ -38643,51 +38688,6 @@ __metadata:
   checksum: 10/b9ee96e149637f4bd52e894f75ba72e5c64b2512002df3a95ecf23c0b6593fdb260d61c0a30cab5450da142520b1aec63c709b11bf3a2491caa3049db0174fdf
   languageName: node
   linkType: hard
-
-"joplin@workspace:packages/app-cli":
-  version: 0.0.0-use.local
-  resolution: "joplin@workspace:packages/app-cli"
-  dependencies:
-    "@joplin/lib": "npm:~3.7"
-    "@joplin/renderer": "npm:~3.7"
-    "@joplin/tools": "npm:~3.7"
-    "@joplin/utils": "npm:~3.7"
-    "@types/fs-extra": "npm:11.0.4"
-    "@types/jest": "npm:29.5.14"
-    "@types/node": "npm:18.19.130"
-    "@types/proper-lockfile": "npm:^4.1.2"
-    aws-sdk: "npm:2.1340.0"
-    chalk: "npm:4.1.2"
-    compare-version: "npm:0.1.2"
-    file-type: "npm:16.5.4"
-    fs-extra: "npm:11.3.4"
-    gulp: "npm:4.0.2"
-    html-entities: "npm:1.4.0"
-    jest: "npm:29.7.0"
-    keytar: "npm:7.9.0"
-    md5: "npm:2.3.0"
-    node-rsa: "npm:1.1.1"
-    open: "npm:8.4.2"
-    proper-lockfile: "npm:4.1.2"
-    redux: "npm:4.2.1"
-    server-destroy: "npm:1.0.1"
-    sharp: "npm:0.34.5"
-    sprintf-js: "npm:1.1.3"
-    sqlite3: "npm:5.1.6"
-    string-padding: "npm:1.0.2"
-    strip-ansi: "npm:6.0.1"
-    tcp-port-used: "npm:1.0.2"
-    temp: "npm:0.9.4"
-    terminal-kit: "npm:3.1.2"
-    tkwidgets: "npm:0.5.27"
-    typescript: "npm:5.9.3"
-    url-parse: "npm:1.5.10"
-    word-wrap: "npm:1.2.5"
-    yargs-parser: "npm:21.1.1"
-  bin:
-    joplin: ./main.js
-  languageName: unknown
-  linkType: soft
 
 "jpeg-js@npm:^0.4.1":
   version: 0.4.3


### PR DESCRIPTION
## Summary
- Rebrands core product identity references from Joplin/laurent22 to Booz Allen Notes/boozallen across desktop, mobile, CLI, clipper, and server surfaces.
- Updates package identifiers, callback URL schemes, Android/iOS app metadata, and CI/workflow checks to align with the new Booz Allen Notes naming.
- Adds rebrand guardrails and documentation (`check_rebrand_identity.js`, workflow guard, allowlist, verification script, and rebrand matrix docs) to keep naming consistent over time.

## Test plan
- [x] Run targeted validation for URL/callback behavior: `yarn test packages/lib/callbackUrlUtils.test.ts packages/lib/urlUtils.test.ts`
- [x] Run server smoke checks touched by branding changes: `yarn test packages/server/src/routes/api/ping.test.ts`
- [x] Run rebrand guard script: `bash tools/verify-rebrand.sh`
- [x] Verify mobile/desktop/CLI metadata updates build and launch without regression in local QA.

Made with [Cursor](https://cursor.com)