### PR TITLE
Desktop: Chat panel: Fix rate limit handling

### DIFF
--- a/packages/lib/services/ai/providers/JoplinCloud.ts
+++ b/packages/lib/services/ai/providers/JoplinCloud.ts
@@ -61,9 +61,11 @@ export const mapErrorByCode = (code: string | number | null, status: number, det
 // For now, avoid more than one event every second or two.
 const minimumTimeBetweenEvents = Second;
 
-type ApiError = Error & { code?: number; retryAfterSeconds?: number };
+type ApiError = Error & { code?: number|string; retryAfterSeconds?: number };
 
-const isRateLimitError = (error: ApiError) => error.code === 429 && typeof error.retryAfterSeconds === 'number';
+const isRateLimitError = (error: ApiError) => (
+	(error.code === 429 || error.code === 'aiRateLimitExceeded') && typeof error.retryAfterSeconds === 'number'
+);
 
 const canAutoRetryError = (error: ApiError) => {
 	return isRateLimitError(error) && error.retryAfterSeconds < 10;


### PR DESCRIPTION
# Problem

The chat panel no longer supports retrying Joplin Cloud rate-limited requests after a delay.

# Solution

Consider errors with code `aiRateLimitExceeded` to be rertryable, in addition to errors with code 429.

# Testing

1. Open the chat panel.
2. Create a new note containing:
    ```
    3 + 3 = ANS_1
    3 - 3 = ANS_2
    3 * 3 = ANS_3
    4^2 = ANS_4
    $\sqrt{144}$ = ANS_5
    $\int_0^1 x dx$ = ANS_6
    $\int_1^2 \frac{1}{x} dx$ = ANS_7
    $\int_1^2 \frac{\sin x}{x} dx$ = ANS_8
    $\int_{-\infty}^\infty \frac{1}{1 + x^2} dx$ = ANS_9
    $\int_{-\infty}^\infty \frac{x}{1 + x^2} dx$ = ANS_10
    ```
3. Send `Please solve the math problems one-by-one. Do edits sequentially: Wait for each edit to complete before continuing.`
4. Verify that the edits complete successfully without a user-visible rate-limiting error.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
