### PR TITLE
Desktop: Add "Copy external link" as a command in the Note menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -502,6 +502,7 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/WindowCommandsAndDialogs.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/addNoteToWhiteboard.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/addProfile.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/commandPalette.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/copyNoteExternalLink.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/deleteFolder.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/duplicateNote.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/editAlarm.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -528,6 +528,7 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/WindowCommandsAndDialogs.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/addNoteToWhiteboard.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/addProfile.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/commandPalette.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/copyNoteExternalLink.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/deleteFolder.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/duplicateNote.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/editAlarm.js

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -864,6 +864,7 @@ function useMenu(props: Props) {
 						menuItemDic.toggleExternalEditing,
 						separator(),
 						menuItemDic.linkToNote,
+						menuItemDic.copyNoteExternalLink,
 						menuItemDic.setTags,
 						menuItemDic.showShareNoteDialog,
 						menuItemDic.convertNoteToMarkdown,

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/copyNoteExternalLink.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/copyNoteExternalLink.ts
@@ -1,0 +1,22 @@
+import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
+import { _ } from '@joplin/lib/locale';
+import { stateUtils } from '@joplin/lib/reducer';
+import { getNoteCallbackUrl } from '@joplin/lib/callbackUrlUtils';
+import { clipboard } from 'electron';
+
+export const declaration: CommandDeclaration = {
+	name: 'copyNoteExternalLink',
+	label: () => _('Copy external link'),
+	iconName: 'fas fa-link',
+};
+
+export const runtime = (): CommandRuntime => {
+	return {
+		execute: async (context: CommandContext, noteId: string = null) => {
+			noteId = noteId || stateUtils.selectedNoteId(context.state);
+			if (!noteId) return;
+			clipboard.writeText(getNoteCallbackUrl(noteId));
+		},
+		enabledCondition: 'oneNoteSelected',
+	};
+};

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/index.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/index.ts
@@ -2,6 +2,7 @@
 import * as addNoteToWhiteboard from './addNoteToWhiteboard';
 import * as addProfile from './addProfile';
 import * as commandPalette from './commandPalette';
+import * as copyNoteExternalLink from './copyNoteExternalLink';
 import * as deleteFolder from './deleteFolder';
 import * as duplicateNote from './duplicateNote';
 import * as editAlarm from './editAlarm';
@@ -58,6 +59,7 @@ const index: any[] = [
 	addNoteToWhiteboard,
 	addProfile,
 	commandPalette,
+	copyNoteExternalLink,
 	deleteFolder,
 	duplicateNote,
 	editAlarm,

--- a/packages/app-desktop/gui/menuCommandNames.ts
+++ b/packages/app-desktop/gui/menuCommandNames.ts
@@ -2,6 +2,7 @@ export default function() {
 	return [
 		'attachFile',
 		'copyDevCommand',
+		'copyNoteExternalLink',
 		'exportPdf',
 		'focusElementNoteBody',
 		'focusElementNoteViewer',

--- a/packages/app-desktop/gui/utils/NoteListUtils.test.ts
+++ b/packages/app-desktop/gui/utils/NoteListUtils.test.ts
@@ -100,7 +100,7 @@ describe('NoteListUtils', () => {
 			'deleteNote',
 			'separator',
 			'Copy Markdown link',
-			'Copy external link',
+			'copyNoteExternalLink',
 			'separator',
 			'Export',
 

--- a/packages/app-desktop/gui/utils/NoteListUtils.ts
+++ b/packages/app-desktop/gui/utils/NoteListUtils.ts
@@ -132,8 +132,7 @@ export default class NoteListUtils {
 
 			if (noteIds.length === 1) {
 				menu.append(
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- commandToStatefulMenuItem returns lib's MenuItem shape which doesn't structurally match Electron's MenuItemConstructorOptions
-					new MenuItem(menuUtils.commandToStatefulMenuItem('copyNoteExternalLink', noteIds[0]) as any),
+					new MenuItem(menuUtils.commandToStatefulMenuItem('copyNoteExternalLink', noteIds[0])),
 				);
 			}
 

--- a/packages/app-desktop/gui/utils/NoteListUtils.ts
+++ b/packages/app-desktop/gui/utils/NoteListUtils.ts
@@ -5,7 +5,6 @@ import MenuUtils from '@joplin/lib/services/commands/MenuUtils';
 import InteropServiceHelper from '../../InteropServiceHelper';
 import { _ } from '@joplin/lib/locale';
 import { MenuItemLocation } from '@joplin/lib/services/plugins/api/types';
-import { getNoteCallbackUrl } from '@joplin/lib/callbackUrlUtils';
 import bridge from '../../services/bridge';
 import BaseModel from '@joplin/lib/BaseModel';
 import Note from '@joplin/lib/models/Note';
@@ -133,12 +132,8 @@ export default class NoteListUtils {
 
 			if (noteIds.length === 1) {
 				menu.append(
-					new MenuItem({
-						label: _('Copy external link'),
-						click: () => {
-							clipboard.writeText(getNoteCallbackUrl(noteIds[0]));
-						},
-					}),
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- commandToStatefulMenuItem returns lib's MenuItem shape which doesn't structurally match Electron's MenuItemConstructorOptions
+					new MenuItem(menuUtils.commandToStatefulMenuItem('copyNoteExternalLink', noteIds[0]) as any),
 				);
 			}
 


### PR DESCRIPTION
Promotes the note list's "Copy external link" context-menu action into a proper `copyNoteExternalLink` command, added to the Note menu.

This lets the command be:
- Assigned a keyboard shortcut (Options → Keyboard Shortcuts)
- Invoked from the menu, or triggered by external automation (e.g. macOS System Events / Hookmark) without needing a shortcut

The command copies the note's `joplin://x-callback-url/openNote?id=...` link for the selected note, so third-party apps can capture and later reopen a note. Existing context-menu behaviour is unchanged.

This should allow integration with Hookmark and similar apps.