### PR TITLE
Desktop: Resolves #16039: Add hidden feature flag for conflict resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1613,6 +1613,7 @@ packages/lib/services/commands/isEditorCommand.js
 packages/lib/services/commands/propsHaveChanged.js
 packages/lib/services/commands/stateToWhenClauseContext.test.js
 packages/lib/services/commands/stateToWhenClauseContext.js
+packages/lib/services/conflict/isConflictResolutionEnabled.js
 packages/lib/services/contextkey/contextkey.js
 packages/lib/services/database/addMigrationFile.js
 packages/lib/services/database/isSqliteSyntaxError.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1639,6 +1639,7 @@ packages/lib/services/commands/isEditorCommand.js
 packages/lib/services/commands/propsHaveChanged.js
 packages/lib/services/commands/stateToWhenClauseContext.test.js
 packages/lib/services/commands/stateToWhenClauseContext.js
+packages/lib/services/conflict/isConflictResolutionEnabled.js
 packages/lib/services/contextkey/contextkey.js
 packages/lib/services/database/addMigrationFile.js
 packages/lib/services/database/isSqliteSyntaxError.js

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -2312,6 +2312,16 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			advanced: true,
 		},
 
+		// Controls the new conflict resolution UI. It is hidden and turned off by
+		// default so the feature can be developed over multiple releases without
+		// affecting users. Make it public and enable it by default once it is ready.
+		'featureFlag.conflictResolution': {
+			value: false,
+			type: SettingItemType.Bool,
+			public: false,
+			storage: SettingStorage.File,
+			isGlobal: true,
+		},
 
 		// 'featureFlag.syncAccurateTimestamps': {
 		// 	value: false,

--- a/packages/lib/services/conflict/isConflictResolutionEnabled.ts
+++ b/packages/lib/services/conflict/isConflictResolutionEnabled.ts
@@ -1,0 +1,9 @@
+import Setting from '../../models/Setting';
+
+// Controls the whole conflict resolution feature. Use this wherever the UI
+// or related code should stay hidden until the feature is ready.
+const isConflictResolutionEnabled = () => {
+	return Setting.value('featureFlag.conflictResolution');
+};
+
+export default isConflictResolutionEnabled;


### PR DESCRIPTION
Fixes #16039 

### PR Summary:

This PR adds the main feature flag for the new conflict resolution UI. The setting for UI  is hidden and is turned off by default, so users won't see it. It can only be enabled by editing the settings file manually

This needs to be merged first  before any UI related PRs are implemented. With this flag, we can merge parts of the UI step by step without  affecting the current release for users. Once the feature is finished, we can make the setting public and enable it by default

This PR adds a small helper, isConflictResolutionEnabled(). Future PRs will use this helper to check whether the feature is enabled

Nothing uses this flag yet, and it does not change the sync or any auto-merge logic. it is safe to merge regardless of the order of auto-merge PR #16023 