### PR TITLE
Desktop: Add getCurrentNote and createNote x-callback-url commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,6 +247,7 @@ packages/app-desktop/gui/KeymapConfig/utils/useCommandStatus.js
 packages/app-desktop/gui/KeymapConfig/utils/useKeymap.js
 packages/app-desktop/gui/MainLayoutPane.js
 packages/app-desktop/gui/MainScreen.js
+packages/app-desktop/gui/MainScreen/handleCallbackUrl.js
 packages/app-desktop/gui/MasterPasswordDialog/Dialog.js
 packages/app-desktop/gui/MenuBar.js
 packages/app-desktop/gui/MultiNoteActions.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -273,6 +273,7 @@ packages/app-desktop/gui/KeymapConfig/utils/useCommandStatus.js
 packages/app-desktop/gui/KeymapConfig/utils/useKeymap.js
 packages/app-desktop/gui/MainLayoutPane.js
 packages/app-desktop/gui/MainScreen.js
+packages/app-desktop/gui/MainScreen/handleCallbackUrl.js
 packages/app-desktop/gui/MasterPasswordDialog/Dialog.js
 packages/app-desktop/gui/MenuBar.js
 packages/app-desktop/gui/MultiNoteActions.js

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -154,19 +154,23 @@ class MainScreenComponent extends React.Component<Props, State> {
 
 		ipcRenderer.on('asynchronous-message', (_event: import('electron').IpcRendererEvent, message: string, args: { url: string }) => {
 			if (message === 'openCallbackUrl') {
-				this.openCallbackUrl(args.url);
+				void this.openCallbackUrl(args.url);
 			}
 		});
 
 		const initialCallbackUrl = (bridge().electronApp() as ElectronAppWrapper).initialCallbackUrl();
 		if (initialCallbackUrl) {
-			this.openCallbackUrl(initialCallbackUrl);
+			void this.openCallbackUrl(initialCallbackUrl);
 		}
 	}
 
-	private openCallbackUrl(url: string) {
-		if (!isCallbackUrl(url)) throw new Error(`Invalid callback URL: ${url}`);
-		void executeCallbackUrl(url);
+	private async openCallbackUrl(url: string) {
+		try {
+			if (!isCallbackUrl(url)) throw new Error(`Invalid callback URL: ${url}`);
+			await executeCallbackUrl(url);
+		} catch (error) {
+			logger.error('Error handling callback URL:', error);
+		}
 	}
 
 	private updateLayoutPluginViews(layout: LayoutItem, plugins: PluginStates) {

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -27,7 +27,8 @@ import EncryptionService from '@joplin/lib/services/e2ee/EncryptionService';
 import { ShareInvitation } from '@joplin/lib/services/share/reducer';
 import removeKeylessItems from './ResizableLayout/utils/removeKeylessItems';
 import { localSyncInfoFromState } from '@joplin/lib/services/synchronizer/syncInfoUtils';
-import { isCallbackUrl, parseCallbackUrl } from '@joplin/lib/callbackUrlUtils';
+import { isCallbackUrl } from '@joplin/lib/callbackUrlUtils';
+import executeCallbackUrl from './MainScreen/handleCallbackUrl';
 import ElectronAppWrapper from '../ElectronAppWrapper';
 import { showMissingMasterKeyMessage } from '@joplin/lib/services/e2ee/utils';
 import { MasterKeyEntity } from '@joplin/lib/services/e2ee/types';
@@ -165,8 +166,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 
 	private openCallbackUrl(url: string) {
 		if (!isCallbackUrl(url)) throw new Error(`Invalid callback URL: ${url}`);
-		const { command, params } = parseCallbackUrl(url);
-		void CommandService.instance().execute(command.toString(), params.id);
+		void executeCallbackUrl(url);
 	}
 
 	private updateLayoutPluginViews(layout: LayoutItem, plugins: PluginStates) {

--- a/packages/app-desktop/gui/MainScreen/handleCallbackUrl.ts
+++ b/packages/app-desktop/gui/MainScreen/handleCallbackUrl.ts
@@ -78,23 +78,25 @@ const openCommands: string[] = [
 const executeCallbackUrl = async (url: string) => {
 	const info = parseCallbackUrl(url);
 
-	if (info.command === CallbackUrlCommand.GetCurrentNote) {
-		await handleGetCurrentNote(info.params);
-		return;
+	if (!openCommands.includes(info.command) &&
+		info.command !== CallbackUrlCommand.GetCurrentNote &&
+		info.command !== CallbackUrlCommand.CreateNote) {
+		throw new Error(`Unhandled callback URL command: ${info.command}`);
 	}
 
-	if (info.command === CallbackUrlCommand.CreateNote) {
-		await handleCreateNote(info.params);
-		return;
+	try {
+		if (info.command === CallbackUrlCommand.GetCurrentNote) {
+			await handleGetCurrentNote(info.params);
+		} else if (info.command === CallbackUrlCommand.CreateNote) {
+			await handleCreateNote(info.params);
+		} else {
+			await CommandService.instance().execute(info.command.toString(), info.params.id);
+			logger.info(`Executed callback URL command: ${info.command}`);
+		}
+	} catch (error) {
+		logger.error(`Error handling callback URL command "${info.command}":`, error);
+		respond(info.params['x-error'], { errorMessage: error.message });
 	}
-
-	if (openCommands.includes(info.command)) {
-		await CommandService.instance().execute(info.command.toString(), info.params.id);
-		logger.info(`Executed callback URL command: ${info.command}`);
-		return;
-	}
-
-	throw new Error(`Unhandled callback URL command: ${info.command}`);
 };
 
 export default executeCallbackUrl;

--- a/packages/app-desktop/gui/MainScreen/handleCallbackUrl.ts
+++ b/packages/app-desktop/gui/MainScreen/handleCallbackUrl.ts
@@ -1,0 +1,96 @@
+import { CallbackUrlCommand, getNoteCallbackUrl, parseCallbackUrl } from '@joplin/lib/callbackUrlUtils';
+import CommandService, { utils as commandUtils } from '@joplin/lib/services/CommandService';
+import Note from '@joplin/lib/models/Note';
+import Folder from '@joplin/lib/models/Folder';
+import { stateUtils } from '@joplin/lib/reducer';
+import { AppState } from '../../app.reducer';
+import bridge from '../../services/bridge';
+import Logger from '@joplin/utils/Logger';
+
+const logger = Logger.create('handleCallbackUrl');
+
+// Opens the caller's x-success / x-error URL with the result appended as query params.
+const respond = (target: string, params: Record<string, string> = {}) => {
+	if (!target) return;
+	const query = Object.entries(params)
+		.map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+		.join('&');
+	const separator = target.includes('?') ? '&' : '?';
+	const responseUrl = query ? `${target}${separator}${query}` : target;
+	void bridge().openExternal(responseUrl);
+};
+
+const handleGetCurrentNote = async (params: Record<string, string>) => {
+	const state = commandUtils.store.getState() as AppState;
+	const noteId = stateUtils.selectedNoteId(state);
+	if (!noteId) {
+		respond(params['x-error'], { errorMessage: 'No note is currently selected' });
+		return;
+	}
+
+	const note = await Note.load(noteId);
+	if (!note) {
+		respond(params['x-error'], { errorMessage: 'The selected note could not be loaded' });
+		return;
+	}
+
+	respond(params['x-success'], {
+		title: note.title,
+		url: getNoteCallbackUrl(note.id),
+	});
+};
+
+const handleCreateNote = async (params: Record<string, string>) => {
+	const folder = await Folder.getValidActiveFolder();
+	if (!folder) {
+		respond(params['x-error'], { errorMessage: 'No valid notebook is available to create the note in' });
+		return;
+	}
+
+	// Not provisional: an externally-requested note should persist even if unedited.
+	const note = await Note.save({
+		...Note.previewFieldsWithDefaultValues({ includeTimestamps: false }),
+		title: params.title ?? '',
+		body: params.body ?? '',
+		parent_id: folder.id,
+	});
+
+	commandUtils.store.dispatch({ type: 'NOTE_SELECT', id: note.id });
+
+	respond(params['x-success'], {
+		title: note.title,
+		url: getNoteCallbackUrl(note.id),
+	});
+};
+
+// Verbs dispatched directly to CommandService by name. Kept as an explicit
+// allowlist (not a catch-all) so a crafted URL can't run arbitrary commands. See 69826610a.
+const openCommands: string[] = [
+	CallbackUrlCommand.OpenNote,
+	CallbackUrlCommand.OpenFolder,
+	CallbackUrlCommand.OpenTag,
+];
+
+const executeCallbackUrl = async (url: string) => {
+	const info = parseCallbackUrl(url);
+
+	if (info.command === CallbackUrlCommand.GetCurrentNote) {
+		await handleGetCurrentNote(info.params);
+		return;
+	}
+
+	if (info.command === CallbackUrlCommand.CreateNote) {
+		await handleCreateNote(info.params);
+		return;
+	}
+
+	if (openCommands.includes(info.command)) {
+		await CommandService.instance().execute(info.command.toString(), info.params.id);
+		logger.info(`Executed callback URL command: ${info.command}`);
+		return;
+	}
+
+	throw new Error(`Unhandled callback URL command: ${info.command}`);
+};
+
+export default executeCallbackUrl;

--- a/packages/app-desktop/gui/MainScreen/handleCallbackUrl.ts
+++ b/packages/app-desktop/gui/MainScreen/handleCallbackUrl.ts
@@ -15,8 +15,12 @@ const respond = (target: string, params: Record<string, string> = {}) => {
 	const query = Object.entries(params)
 		.map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
 		.join('&');
-	const separator = target.includes('?') ? '&' : '?';
-	const responseUrl = query ? `${target}${separator}${query}` : target;
+
+	const fragmentIndex = target.indexOf('#');
+	const base = fragmentIndex === -1 ? target : target.substring(0, fragmentIndex);
+	const fragment = fragmentIndex === -1 ? '' : target.substring(fragmentIndex);
+	const separator = base.includes('?') ? '&' : '?';
+	const responseUrl = query ? `${base}${separator}${query}${fragment}` : target;
 	void bridge().openExternal(responseUrl);
 };
 

--- a/packages/lib/callbackUrlUtils.test.ts
+++ b/packages/lib/callbackUrlUtils.test.ts
@@ -13,6 +13,28 @@ describe('callbackUrlUtils', () => {
 		expect(callbackUrlUtils.isCallbackUrl('joplin://x-callback-url/invalidCommand?a=b')).toBe(false);
 	});
 
+	it('should identify getCurrentNote and createNote callback urls', () => {
+		expect(callbackUrlUtils.isCallbackUrl('joplin://x-callback-url/getCurrentNote?x-success=hook://a')).toBe(true);
+		expect(callbackUrlUtils.isCallbackUrl('joplin://x-callback-url/createNote?title=Hello&x-success=hook://a')).toBe(true);
+	});
+
+	// The trailing "?" pins the command name so a prefix can't bypass validation. See 69826610a.
+	it('should reject callback urls whose command name is only a prefix match', () => {
+		expect(callbackUrlUtils.isCallbackUrl('joplin://x-callback-url/getCurrentNoteEvil?x-success=hook://a')).toBe(false);
+		expect(callbackUrlUtils.isCallbackUrl('joplin://x-callback-url/createNoteEvil?title=x')).toBe(false);
+		expect(callbackUrlUtils.isCallbackUrl('joplin://x-callback-url/openNoteEvil?id=x')).toBe(false);
+	});
+
+	it('should parse getCurrentNote and createNote callback urls', () => {
+		const getCurrent = callbackUrlUtils.parseCallbackUrl('joplin://x-callback-url/getCurrentNote?x-success=hook://a');
+		expect(getCurrent.command).toBe(callbackUrlUtils.CallbackUrlCommand.GetCurrentNote);
+		expect(getCurrent.params).toStrictEqual({ 'x-success': 'hook://a' });
+
+		const create = callbackUrlUtils.parseCallbackUrl('joplin://x-callback-url/createNote?title=Hello&x-success=hook://a');
+		expect(create.command).toBe(callbackUrlUtils.CallbackUrlCommand.CreateNote);
+		expect(create.params).toStrictEqual({ title: 'Hello', 'x-success': 'hook://a' });
+	});
+
 	it('should build valid note callback urls', () => {
 		const noteUrl = callbackUrlUtils.getNoteCallbackUrl('123456');
 		expect(callbackUrlUtils.isCallbackUrl(noteUrl)).toBe(true);

--- a/packages/lib/callbackUrlUtils.ts
+++ b/packages/lib/callbackUrlUtils.ts
@@ -3,7 +3,9 @@ const URL = require('url-parse');
 export function isCallbackUrl(s: string) {
 	return s.startsWith('joplin://x-callback-url/openNote?') ||
 		s.startsWith('joplin://x-callback-url/openFolder?') ||
-		s.startsWith('joplin://x-callback-url/openTag?');
+		s.startsWith('joplin://x-callback-url/openTag?') ||
+		s.startsWith('joplin://x-callback-url/getCurrentNote?') ||
+		s.startsWith('joplin://x-callback-url/createNote?');
 }
 
 export function getNoteCallbackUrl(noteId: string) {
@@ -22,6 +24,8 @@ export const enum CallbackUrlCommand {
 	OpenNote = 'openNote',
 	OpenFolder = 'openFolder',
 	OpenTag = 'openTag',
+	GetCurrentNote = 'getCurrentNote',
+	CreateNote = 'createNote',
 }
 
 export interface CallbackUrlInfo {


### PR DESCRIPTION
Adds two x-callback-url verbs so external apps (e.g. Hookmark) can integrate with Joplin:

- `joplin://x-callback-url/getCurrentNote?x-success=…&x-error=…` — returns the selected note's `title` and `url`

- `joplin://x-callback-url/createNote?title=…&body=…&x-success=…&x-error=…` — creates a note and returns its `title` and `url`

Both reply by opening the caller's `x-success` (or `x-error`) URL with the result appended as query parameters. The existing `openNote`/`openFolder`/`openTag` verbs are unchanged.