### PR TITLE
Chore: Absorb random CI install-network flakes

### DIFF
--- a/.env.yarn
+++ b/.env.yarn
@@ -1,0 +1,9 @@
+# Environment variables injected by Yarn into every install/build-script run.
+# See the injectEnvironmentFiles setting: https://yarnpkg.com/configuration/yarnrc#injectEnvironmentFiles
+
+# onnxruntime-node bundles the CPU runtime we use, but its postinstall also
+# downloads the CUDA/GPU execution provider from nuget.org on Linux x64. Joplin
+# only does CPU inference, so that download is unused - and it randomly times
+# out and fails the whole `yarn install`. Skip it. This is a no-op on
+# macOS/Windows, where onnxruntime-node downloads nothing anyway.
+ONNXRUNTIME_NODE_INSTALL=skip

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -45,7 +45,9 @@ jobs:
       - uses: ./.github/workflows/shared/install-yarn
 
       - name: Install
-        run:  yarn install
+        run: |
+          source "${GITHUB_WORKSPACE}/.github/scripts/retry.sh"
+          retry yarn install
         env:
           SKIP_ONENOTE_CONVERTER_BUILD: 1
 

--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -53,7 +53,8 @@ jobs:
         run: |
           export npm_config_arch=arm64
           export npm_config_target_arch=arm64
-          yarn install
+          source "${GITHUB_WORKSPACE}/.github/scripts/retry.sh"
+          retry yarn install
           cd packages/app-desktop
           npm pkg set 'build.mac.artifactName'='${productName}-${version}-${arch}.${ext}'
 

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -178,7 +178,8 @@ jobs:
           echo "RUNNER_ARCH=$RUNNER_ARCH"
           echo "DOCKER_IMAGE_PLATFORM=$DOCKER_IMAGE_PLATFORM"
 
-          yarn install
+          source "${GITHUB_WORKSPACE}/.github/scripts/retry.sh"
+          retry yarn install
           yarn buildServerDocker --docker-file Dockerfile.server --platform $DOCKER_IMAGE_PLATFORM --tag-name server-v0.0.0 --repository joplin/server
 
           # Basic test to ensure that the created build is valid. It should exit with

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -25,7 +25,9 @@ jobs:
           Install-WindowsDeps
       - name: Build
         if: runner.os != 'Windows'
-        run: yarn install
+        run: |
+          source "${GITHUB_WORKSPACE}/.github/scripts/retry.sh"
+          retry yarn install
         env:
           # The onenote-converter package uses Rust, which isn't installed on all CI
           # runners. Since the onenote-converter doesn't have UI tests, it can be excluded
@@ -51,7 +53,9 @@ jobs:
       - name: Setup build environment
         uses: ./.github/workflows/shared/setup-build-environment
       - name: Build
-        run: yarn install
+        run: |
+          source "${GITHUB_WORKSPACE}/.github/scripts/retry.sh"
+          retry yarn install
         env:
           SKIP_ONENOTE_CONVERTER_BUILD: 1
       - name: Run mobile UI tests


### PR DESCRIPTION
- Skip the unused onnxruntime-node CUDA/GPU download (nuget.org), which   randomly times out and fails `yarn install`. CPU inference is unaffected;   no-op on macOS/Windows.
- Retry the remaining bare `yarn install` steps in CI, matching the existing retry wrapper already used in run_ci.sh.
