### PR TITLE
Mobile: Add shadow to note actions menu

### DIFF
--- a/packages/app-mobile/components/BottomDrawer.tsx
+++ b/packages/app-mobile/components/BottomDrawer.tsx
@@ -76,6 +76,10 @@ const useStyles = ({ theme, dragging, draggable, dragOffset, backgroundOpacity }
 				borderBottomLeftRadius: 0,
 				maxWidth: Math.min(400, windowWidth - menuGapRight - menuGapLeft),
 
+				shadowRadius: 4,
+				shadowColor: theme.color,
+				shadowOpacity: 0.15,
+
 				marginBottom: -spaceBelowScreenEdge,
 
 				userSelect: dragging ? 'none' : 'auto',


### PR DESCRIPTION
# Problem

Most menus and dialogs in the Joplin mobile app have a light shadow, but the new drawer menu does not.

# Solution

Add a feint shadow to the drawer menu.

# Screenshots

This pull request adds a feint shadow to the note actions menu:
|| Before (iOS and web) | After (iOS and web) |
|---|----|----|
|Light mode| <img width="851" height="660" alt="image" src="https://github.com/user-attachments/assets/1138d2ef-891b-459c-876f-2f82cc9dd974" /> | <img width="863" height="659" alt="screenshot: drawer menus now have a feint shadow" src="https://github.com/user-attachments/assets/87fe864d-fe46-4fff-bcbb-36800e06b2fb" /> |
|Dark mode| <img width="862" height="661" alt="image" src="https://github.com/user-attachments/assets/b98d8f00-0234-4116-9906-851fcd476078" /> | <img width="845" height="653" alt="screenshot: drawer menus now have a light-gray shadow" src="https://github.com/user-attachments/assets/72ef6a9a-972a-4497-87e3-4b4c9512b701" /> |


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
