### PR TITLE
iOS: Improve drag-to-dismiss behavior for drawer menus

### DIFF
--- a/packages/app-mobile/components/BottomDrawer.tsx
+++ b/packages/app-mobile/components/BottomDrawer.tsx
@@ -360,21 +360,20 @@ const BottomDrawer: React.FC<Props> = props => {
 		dragHandleRef,
 	});
 
-	const onContainerScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+	const onScrollDragEnd = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
 		const offsetY = event.nativeEvent.contentOffset.y;
 		// Use a smaller tolerance for smaller menus to ensure that they're still dismissible
 		const overscrollTolerance = Math.min(80, menuHeightRef.current / 4);
 
-		// On iOS, support menu dismissal through the native scrollview's overscroll behavior:
+		// On platforms that support overscroll (iOS), support menu dismissal through the
+		// native scrollview's overscroll behavior:
 		if (offsetY < -overscrollTolerance) {
 			// Start the animation at the current scroll position, to avoid a jump when starting
 			// the animation:
 			menuDragOffset.setValue(-offsetY);
 			void onHide();
-		} else {
-			onPanResponderScroll(event);
 		}
-	}, [onHide, onPanResponderScroll, menuDragOffset]);
+	}, [onHide, menuDragOffset]);
 
 	return <Modal
 		visible={props.visible}
@@ -392,7 +391,8 @@ const BottomDrawer: React.FC<Props> = props => {
 		containerStyle={styles.menuStyle}
 		animationType={reduceMotionEnabled ? 'fade' : 'none'}
 		scrollOverflow={{
-			onScroll: onContainerScroll,
+			onScroll: onPanResponderScroll,
+			onScrollEndDrag: onScrollDragEnd,
 
 			// Throttling scroll events avoids a warning on web
 			scrollEventThrottle: 30,


### PR DESCRIPTION
# Problem

The iOS drag-to-dismiss behavior for the Joplin drawer menus is currently different from the same behavior on Android and web:
- On iOS, the new drawer menus (e.g. the note actions menu) dismisses *during* scroll, before the user stops dragging.
- On web and Android, the user needs to stop dragging before the menu dismisses.

The iOS behavior can result in accidental dismissals, for example, due to momentum scrolling.

# Solution

Align the iOS behavior with the web/Android behavior.

# Screen recording (iOS simulator)

| Before | After |
|-------|-----|
| <video src="https://github.com/user-attachments/assets/65fcaea0-2b92-4674-b2ee-09408d7db302"></video> | <video src="https://github.com/user-attachments/assets/e8295093-fb33-43f4-a871-a838e5b7505d"></video>|

**Note**: Additional menu items were added to help demonstrate the momentum scrolling issue.
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
