### PR TITLE
Desktop: Resolves #16057: Add preference to hide "Joplin - " prefix from window titles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,9 +250,11 @@ packages/app-desktop/gui/MainScreen.js
 packages/app-desktop/gui/MasterPasswordDialog/Dialog.js
 packages/app-desktop/gui/MenuBar.js
 packages/app-desktop/gui/MultiNoteActions.js
+packages/app-desktop/gui/Navigator.test.js
 packages/app-desktop/gui/Navigator.js
 packages/app-desktop/gui/NewWindowOrIFrame.js
 packages/app-desktop/gui/NoteContentPropertiesDialog.js
+packages/app-desktop/gui/NoteEditor/EditorWindow.test.js
 packages/app-desktop/gui/NoteEditor/EditorWindow.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Toolbar.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/index.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -276,9 +276,11 @@ packages/app-desktop/gui/MainScreen.js
 packages/app-desktop/gui/MasterPasswordDialog/Dialog.js
 packages/app-desktop/gui/MenuBar.js
 packages/app-desktop/gui/MultiNoteActions.js
+packages/app-desktop/gui/Navigator.test.js
 packages/app-desktop/gui/Navigator.js
 packages/app-desktop/gui/NewWindowOrIFrame.js
 packages/app-desktop/gui/NoteContentPropertiesDialog.js
+packages/app-desktop/gui/NoteEditor/EditorWindow.test.js
 packages/app-desktop/gui/NoteEditor/EditorWindow.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Toolbar.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/index.js

--- a/packages/app-desktop/gui/Navigator.test.ts
+++ b/packages/app-desktop/gui/Navigator.test.ts
@@ -1,0 +1,16 @@
+import { buildWindowTitle } from './Navigator';
+
+describe('buildWindowTitle', () => {
+
+	test.each([
+		['', true, '', 'Joplin'],
+		['', false, '', 'Joplin'],
+		['Options', true, '', 'Joplin - Options'],
+		['Options', false, '', 'Options'],
+		['Options', true, ' (DEV - /tmp/profile)', 'Joplin (DEV - /tmp/profile) - Options'],
+		['Options', false, ' (DEV - /tmp/profile)', 'Options (DEV - /tmp/profile)'],
+	])('should build the window title for screenTitle=%p showAppNameInWindowTitle=%p devMarker=%p', (screenTitle, showAppNameInWindowTitle, devMarker, expected) => {
+		expect(buildWindowTitle(screenTitle, showAppNameInWindowTitle, devMarker)).toBe(expected);
+	});
+
+});

--- a/packages/app-desktop/gui/Navigator.tsx
+++ b/packages/app-desktop/gui/Navigator.tsx
@@ -17,20 +17,29 @@ interface AppScreen {
 interface Props {
 	route: AppStateRoute;
 	screens: Record<string, AppScreen>;
+	showAppNameInWindowTitle: boolean;
 
 	style: React.CSSProperties;
 	className?: string;
 }
 
-const useWindowTitleManager = (screenInfo: AppScreen) => {
+export const buildWindowTitle = (screenTitle: string, showAppNameInWindowTitle: boolean, devMarker: string) => {
+	if (!showAppNameInWindowTitle && screenTitle) {
+		return `${screenTitle}${devMarker}`;
+	}
+	const windowTitle = [`Joplin${devMarker}`];
+	if (screenTitle) {
+		windowTitle.push(screenTitle);
+	}
+	return windowTitle.join(' - ');
+};
+
+const useWindowTitleManager = (screenInfo: AppScreen, showAppNameInWindowTitle: boolean) => {
 	const windowTitle = useMemo(() => {
 		const devMarker = Setting.value('env') === 'dev' ? ` (DEV - ${Setting.value('profileDir')})` : '';
-		const windowTitle = [`Joplin${devMarker}`];
-		if (screenInfo?.title) {
-			windowTitle.push(screenInfo.title());
-		}
-		return windowTitle.join(' - ');
-	}, [screenInfo]);
+		const screenTitle = screenInfo?.title ? screenInfo.title() : '';
+		return buildWindowTitle(screenTitle, showAppNameInWindowTitle, devMarker);
+	}, [screenInfo, showAppNameInWindowTitle]);
 
 	const windowId = useContext(WindowIdContext);
 	useEffect(() => {
@@ -96,7 +105,7 @@ const NavigatorComponent: React.FC<Props> = props => {
 	const screenInfo = props.screens[route?.routeName];
 	const [container, setContainer] = useState<HTMLElement|null>(null);
 
-	useWindowTitleManager(screenInfo);
+	useWindowTitleManager(screenInfo, props.showAppNameInWindowTitle);
 	useWindowRefocusManager(route);
 	const size = useContainerSize(container);
 
@@ -115,6 +124,7 @@ const NavigatorComponent: React.FC<Props> = props => {
 const Navigator = connect((state: AppState) => {
 	return {
 		route: state.route,
+		showAppNameInWindowTitle: state.settings.showAppNameInWindowTitle,
 	};
 })(NavigatorComponent);
 

--- a/packages/app-desktop/gui/NoteEditor/EditorWindow.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/EditorWindow.test.ts
@@ -1,0 +1,14 @@
+import { buildEditorWindowTitle } from './EditorWindow';
+
+describe('buildEditorWindowTitle', () => {
+
+	test.each([
+		['My note', true, 'Joplin - My note'],
+		['My note', false, 'My note'],
+		['Untitled', true, 'Joplin - Untitled'],
+		['Untitled', false, 'Untitled'],
+	])('should build the editor window title for noteTitle=%p showAppNameInWindowTitle=%p', (noteTitle, showAppNameInWindowTitle, expected) => {
+		expect(buildEditorWindowTitle(noteTitle, showAppNameInWindowTitle)).toBe(expected);
+	});
+
+});

--- a/packages/app-desktop/gui/NoteEditor/EditorWindow.tsx
+++ b/packages/app-desktop/gui/NoteEditor/EditorWindow.tsx
@@ -26,10 +26,15 @@ interface Props {
 	plugins: PluginStates;
 	newWindow: boolean;
 	windowId: string;
+	showAppNameInWindowTitle: boolean;
 }
 
+export const buildEditorWindowTitle = (noteTitle: string, showAppNameInWindowTitle: boolean) => {
+	return showAppNameInWindowTitle ? `Joplin - ${noteTitle}` : noteTitle;
+};
+
 const emptyCallback = () => {};
-const useWindowTitle = (isNewWindow: boolean) => {
+const useWindowTitle = (isNewWindow: boolean, showAppNameInWindowTitle: boolean) => {
 	const [title, setTitle] = useState('Untitled');
 
 	if (!isNewWindow) {
@@ -39,7 +44,7 @@ const useWindowTitle = (isNewWindow: boolean) => {
 		};
 	}
 
-	return { windowTitle: `Joplin - ${title}`, onNoteTitleChange: setTitle };
+	return { windowTitle: buildEditorWindowTitle(title, showAppNameInWindowTitle), onNoteTitleChange: setTitle };
 };
 
 const defaultLayout = {
@@ -110,7 +115,7 @@ const useLayout = ({ windowId, layout, plugins, dispatch }: Props) => {
 };
 
 const SecondaryWindow: React.FC<Props> = props => {
-	const { windowTitle, onNoteTitleChange } = useWindowTitle(props.newWindow);
+	const { windowTitle, onNoteTitleChange } = useWindowTitle(props.newWindow, props.showAppNameInWindowTitle);
 
 	const newWindow = props.newWindow;
 	const onWindowClose = useCallback(() => {
@@ -195,6 +200,7 @@ export default connect((state: AppState, ownProps: ConnectProps) => {
 	return {
 		themeId: state.settings.theme,
 		isSafeMode: state.settings.isSafeMode,
+		showAppNameInWindowTitle: state.settings.showAppNameInWindowTitle,
 		layout: windowState.secondaryWindowLayout,
 		codeView: windowState?.editorCodeView ?? state.settings['editor.codeView'],
 		legacyMarkdown: state.settings['editor.legacyMarkdown'],

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1517,6 +1517,18 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			appTypes: [AppType.Desktop],
 		},
 
+		showAppNameInWindowTitle: {
+			value: true,
+			type: SettingItemType.Bool,
+			storage: SettingStorage.File,
+			isGlobal: true,
+			section: 'appearance',
+			public: true,
+			appTypes: [AppType.Desktop],
+			label: () => _('Show "Joplin" in the window title'),
+			description: () => _('If disabled, window titles will show only the current note or screen name, without the leading "Joplin - " prefix.'),
+		},
+
 		startMinimized: { value: false, type: SettingItemType.Bool, storage: SettingStorage.File, isGlobal: true, section: 'application', public: true, appTypes: [AppType.Desktop], label: () => _('Start application minimised in the tray icon'), show: settings => !!settings['showTrayIcon'] },
 
 		'globalHotkey': {


### PR DESCRIPTION
Adds a new "Show "Joplin" in the window title" option (on by default, preserving current behaviour) under Options > General. When disabled, window titles show only the current screen/note name instead of "Joplin - ".

As a desktop power user I often have many Joplin note windows open and I want to be able to find them quickly/easily. Coming over from Evernote I'm used to doing this by window title but the leading 'Joplin -' is a distraction that makes them look similar at first glance.

This PR adds the ability to suppress the leading 'Joplin -' but preserves the default behavior to avoid any unexpected/unwanted changes. Tests are included to verify on/off behavior.

**Preferences Pane**
<img width="1008" height="588" alt="Screenshot 2026-07-27 at 10 59 25 AM" src="https://github.com/user-attachments/assets/9177be9f-eaf9-4c7f-b019-7dc4de0647a9" />


**Flag disabled**
<img width="648" height="370" alt="Screenshot 2026-07-27 at 10 53 18 AM" src="https://github.com/user-attachments/assets/758ed387-2a75-4bcc-98df-60511afb7746" />


**Flag enabled (default)**
<img width="584" height="368" alt="Screenshot 2026-07-27 at 11 01 36 AM" src="https://github.com/user-attachments/assets/a99b81d6-bb71-4339-9c98-77df2795e564" />



