### PR TITLE
Mobile: Consider tags and smart filters when opening the last open location on app start

### DIFF
--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -229,10 +229,24 @@ const generalMiddleware = (store: any) => (next: any) => async (action: any) => 
 			Setting.setValue('activeFolderId', newState.selectedFolderId);
 		}
 
-		const notesParent: NotesParent = {
-			type: action.smartFilterId ? 'SmartFilter' : 'Folder',
-			selectedItemId: action.smartFilterId ? action.smartFilterId : newState.selectedFolderId,
-		};
+		let notesParent: NotesParent;
+		if (action.smartFilterId) {
+			notesParent = {
+				type: 'SmartFilter',
+				selectedItemId: action.smartFilterId,
+			};
+		} else if (action.tagId) {
+			notesParent = {
+				type: 'Tag',
+				selectedItemId: action.tagId,
+			};
+		} else {
+			notesParent = {
+				type: 'Folder',
+				selectedItemId: newState.selectedFolderId,
+			};
+		}
+
 		Setting.setValue('notesParent', serializeNotesParent(notesParent));
 	}
 

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -392,10 +392,31 @@ const buildStartupTasks = (
 	addTask('buildStartupTasks/go: initial route', async () => {
 		const folder = await getInitialActiveFolder();
 
-		const notesParent = parseNotesParent(Setting.value('notesParent'), Setting.value('activeFolderId'));
+		const getNotesParent = async () => {
+			let notesParent = parseNotesParent(Setting.value('notesParent'), Setting.value('activeFolderId'));
+			if (notesParent.type === 'Tag' && !(await Tag.load(notesParent.selectedItemId))) {
+				notesParent = {
+					type: 'Folder',
+					selectedItemId: Setting.value('activeFolderId'),
+				};
+			}
+			return notesParent;
+		};
+
+		const notesParent = await getNotesParent();
 
 		if (notesParent && notesParent.type === 'SmartFilter') {
-			dispatch(DEFAULT_ROUTE);
+			dispatch({
+				type: 'NAV_GO',
+				routeName: 'Notes',
+				smartFilterId: notesParent.selectedItemId,
+			});
+		} else if (notesParent && notesParent.type === 'Tag') {
+			dispatch({
+				type: 'NAV_GO',
+				routeName: 'Notes',
+				tagId: notesParent.selectedItemId,
+			});
 		} else if (!folder) {
 			dispatch(DEFAULT_ROUTE);
 		} else {

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -393,12 +393,9 @@ const buildStartupTasks = (
 		const folder = await getInitialActiveFolder();
 
 		const getNotesParent = async () => {
-			let notesParent = parseNotesParent(Setting.value('notesParent'), Setting.value('activeFolderId'));
+			const notesParent = parseNotesParent(Setting.value('notesParent'), Setting.value('activeFolderId'));
 			if (notesParent.type === 'Tag' && !(await Tag.load(notesParent.selectedItemId))) {
-				notesParent = {
-					type: 'Folder',
-					selectedItemId: Setting.value('activeFolderId'),
-				};
+				return null;
 			}
 			return notesParent;
 		};


### PR DESCRIPTION
Upon opening the mobile app, it will load either the last selected notebook or the all notes notebook. This is inconsistent with the desktop app behaviour, which will also start up with the last selected tag or any smart filter (eg. the trash) if the last selected location was not a notebook. This PR unifies the mobile app behaviour, so that the app will start up with either the last selected notebook, tag, or smart filter.

### Testing

1. Verified that opening a notebook and then restarting the app restores the selected notebook
2. Verified that opening a tag and then restarting the app restores the selected tag
3. Verified that opening the all notes notebook and then restarting the app restores the all notes notebook
4. Verified that opening the trash and then restarting the app restores the trash
5. Verified that selecting a notebook, then permanently deleting the notebook (without switching notebook), then restarting the app will switch to another notebook upon deletion, and load up the all notes notebook on app start (the default route)
6. Verified that selecting a tag, then deleting that tag, then restarting the app will load up the last selected notebook on app start. Note that if you go back from the tag screen after deleting the currently selected tag, this will take you back to a blank screen with a hamburger menu, but this is an existing issue which is related to https://github.com/laurent22/joplin/issues/15265
7. Verified that when opening an note and using the reveal in notebook menu option, when restarting the app, the notebook which was revealed is restored

**See video:**

https://github.com/user-attachments/assets/d607a828-935c-4476-8ffb-d40f9b49a3bc
