### PR TITLE
Mobile: Fixes #15265: Fix blank screen being shown when navigating back after a tag was unassociated or deleted

### DIFF
--- a/packages/app-mobile/components/screens/Notes/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes/Notes.tsx
@@ -11,7 +11,7 @@ import { themeStyle } from '../../global-style';
 import { FolderPickerOptions, ScreenHeader } from '../../ScreenHeader';
 import { _ } from '@joplin/lib/locale';
 import { BaseScreenComponent } from '../../base-screen';
-import { AppState } from '../../../utils/types';
+import { AppState, Route } from '../../../utils/types';
 import { FolderEntity, NoteEntity, TagEntity } from '@joplin/lib/services/database/types';
 import { getTrashFolderId, itemIsInTrash } from '@joplin/lib/services/trash';
 import AccessibleView from '../../accessibility/AccessibleView';
@@ -43,6 +43,7 @@ interface Props {
 	selectedTagId: string;
 	selectedSmartFilterId: string;
 	notesParentType: string;
+	route: Route;
 }
 
 interface State {
@@ -275,7 +276,7 @@ class NotesScreenComponent extends BaseScreenComponent<ComponentProps, State> {
 	public render() {
 		const parent = this.parentItem();
 
-		if (!parent) {
+		if (!parent && this.props.route?.routeName === 'Notes') {
 			// Avoid showing a blank notebook screen for certain routes which result in a deleted item remaining in history,
 			// such as removing all associations of a tag, or removing tags via note or tag deletions
 			this.props.dispatch({
@@ -362,6 +363,7 @@ const NotesScreen = connect((state: AppState) => {
 		themeId: state.settings.theme,
 		noteSelectionEnabled: state.noteSelectionEnabled,
 		notesOrder: stateUtils.notesOrder(state.settings),
+		route: state.route,
 	};
 })(NotesScreenWrapper);
 

--- a/packages/app-mobile/components/screens/Notes/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes/Notes.tsx
@@ -274,6 +274,16 @@ class NotesScreenComponent extends BaseScreenComponent<ComponentProps, State> {
 
 	public render() {
 		const parent = this.parentItem();
+
+		if (!parent) {
+			// Avoid showing a blank notebook screen for certain routes which result in a deleted item remaining in history,
+			// such as removing all associations of a tag, or removing tags via note or tag deletions
+			this.props.dispatch({
+				type: 'NAV_BACK',
+			});
+			return null;
+		}
+
 		const theme = themeStyle(this.props.themeId);
 
 		const rootStyle = this.props.visible ? theme.rootStyle : theme.hiddenRootStyle;


### PR DESCRIPTION
When deleting a tag, the appReducer on mobile does not currently handle cleaning of tag entries in the navigation history, to prevent a blank note list screen being shown when navigating back to where the tag was opened. This could be fixed in a similar way to https://github.com/laurent22/joplin/pull/13428, however tags will also be removed from memory and the UI when all associations of a tag are removed, either via note deletions or removing associations via the tag editor. As it would inefficient to try to remove redundant tag entries whenever the tag list have refreshed, I have instead addressed this issue with a more universal approach.

This is implemented as follows:
Whenever the note list screen tries to load a parent item and the result is null / undefined, and also the current screen is the note list, then instead of rendering the note list, fire a NAV_BACK event, to avoid showing the blank screen. This resolves the issue without any noticeable flicker, regardless of how a tag is removed. Note that this approach does not address the possibility of duplicate adjacent tag navigations or duplicate adjacent navigations to the tag list itself, but this is less of a visual quirk compared to the blank note list screen.

This fixes https://github.com/laurent22/joplin/issues/15265

### Testing

**Test scenarios:**

1. Open a tag, open a note associated with the tag and remove the tag from the associations. When going back, this results in the previously open notebook or tag being shown, and going back would go back to the previous stage in the history
2. Open a tag, then delete all notes in the tag view. This results in the previously open notebook or tag immediately being shown, and going back would go back to the previous stage in the history
3. Open a tag, then navigate to the tag list and delete the tag which was open. Going back results in the previously open notebook or tag being shown, and going back would go back to the previous stage in the history
4. Open a tag, open a note associated with the tag and remove a different tag from the associations. Going back results in navigating back to the original tag

**See video:**

https://github.com/user-attachments/assets/54d5417b-b3f4-4853-ac82-8eb7ea39dd3f