### PR TITLE
Desktop: Plugin API: Fix panels hidden on startup are incorrectly shown in some cases

### DIFF
--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -186,6 +186,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 				if (!existingItem) {
 					draftLayout.children.push({
 						key: viewId,
+						visible: info.view.opened,
 						context: {
 							pluginId: info.plugin.id,
 						},


### PR DESCRIPTION
# Problem

The `panels.js` test plugin creates an initially-hidden panel with `.hide`:
https://github.com/laurent22/joplin/blob/ac53434542919cd60f6126275eb6d25220ecd636/packages/app-desktop/integration-tests/resources/test-plugins/panels.js#L43

However, this panel is sometimes initially visible. This caused test failures in CI.

# Solution

Correctly set the initial visibility state of plugin panels when creating the main app layout.

# Testing

1. Verify that the `pluginApi` tests pass.
2. Remove the `.hide` line in `panels.js`:
  https://github.com/laurent22/joplin/blob/ac53434542919cd60f6126275eb6d25220ecd636/packages/app-desktop/integration-tests/resources/test-plugins/panels.js#L43
3. Run the `pluginApi` tests. Verify that the plugin panel is initially visible and that the plugin panels test fails.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
