### PR TITLE
Chore: Fixes #16073: CI: Fix desktop end-to-end test failures caused by missing initial notebook

### DIFF
--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -33,7 +33,8 @@ export default class MainScreen {
 
 	public async setup() {
 		await this.waitFor();
-		await this.sidebar.createNewFolder('Test');
+		const folder = await this.sidebar.createNewFolder('Test');
+		await folder.waitFor();
 		return this;
 	}
 


### PR DESCRIPTION
# Problem

The desktop UI tests occasionally fail with:
```
Tearing down "electronApp" exceeded the test timeout of 60000ms.
```

This happens if:
1. The [`should import a single HTML file`](https://github.com/laurent22/joplin/blob/ac53434542919cd60f6126275eb6d25220ecd636/packages/app-desktop/integration-tests/main.spec.ts#L234) test runs.
2. The import test step starts **before** the initial notebook is created.

Then the importer shows an alert dialog, which prevents Playwright from closing the application. This results in a test failure during test cleanup, which cannot be retried.

# Solution

Wait for the initial notebook to be created.

Fixes #16073.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
