### PR TITLE
Mobile: Fix inconsistent button order in profile switcher, tag screen, and deletion confirmation dialogs

### DIFF
--- a/packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx
+++ b/packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx
@@ -120,14 +120,14 @@ const ProfileListItem: React.FC<ProfileItemProps> = ({ profile, profileConfig, s
 			_('All data, including notes, notebooks and tags will be permanently deleted.'),
 			[
 				{
-					text: _('Delete profile "%s"', profile.name),
-					onPress: () => doIt(),
-					style: 'destructive',
-				},
-				{
 					text: _('Cancel'),
 					onPress: () => {},
 					style: 'cancel',
+				},
+				{
+					text: _('Delete profile "%s"', profile.name),
+					onPress: () => doIt(),
+					style: 'destructive',
 				},
 			],
 		);

--- a/packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx
+++ b/packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx
@@ -139,6 +139,11 @@ const ProfileListItem: React.FC<ProfileItemProps> = ({ profile, profileConfig, s
 			'',
 			[
 				{
+					text: _('Close'),
+					onPress: () => {},
+					style: 'cancel',
+				},
+				{
 					text: _('Edit'),
 					onPress: () => onEditProfile(profile.id),
 					style: 'default',
@@ -147,11 +152,6 @@ const ProfileListItem: React.FC<ProfileItemProps> = ({ profile, profileConfig, s
 					text: _('Delete'),
 					onPress: () => onDeleteProfile(profile),
 					style: 'default',
-				},
-				{
-					text: _('Close'),
-					onPress: () => {},
-					style: 'cancel',
 				},
 			],
 		);

--- a/packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx
+++ b/packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx
@@ -144,13 +144,13 @@ const ProfileListItem: React.FC<ProfileItemProps> = ({ profile, profileConfig, s
 					style: 'cancel',
 				},
 				{
-					text: _('Edit'),
-					onPress: () => onEditProfile(profile.id),
-					style: 'default',
-				},
-				{
 					text: _('Delete'),
 					onPress: () => onDeleteProfile(profile),
+					style: 'destructive',
+				},
+				{
+					text: _('Edit'),
+					onPress: () => onEditProfile(profile.id),
 					style: 'default',
 				},
 			],

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -571,6 +571,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 					{
 						buttons: [_('Yes'), _('No')],
 						title: _('Save geolocation?'),
+						cancelId: 1,
 					},
 				);
 				return result === yesIndex;

--- a/packages/app-mobile/components/screens/tags.tsx
+++ b/packages/app-mobile/components/screens/tags.tsx
@@ -158,20 +158,26 @@ const TagsScreenComponent: React.FC<Props> = props => {
 			return () => {
 				dialogs.prompt('', _('Delete tag "%s"?\n\nAll notes associated with this tag will remain, but the tag will be removed from all notes.', substrWithEllipsis(tag.title, 0, 32)), [
 					{
+						text: _('Cancel'),
+						onPress: () => { },
+						style: 'cancel',
+					},
+					{
 						text: _('OK'),
 						onPress: async () => {
 							await Tag.delete(tag.id, { sourceDescription: 'tags-screen (long-press)' });
 							setRefreshTrigger(prev => prev + 1);
 						},
 					},
-					{
-						text: _('Cancel'),
-						onPress: () => { },
-						style: 'cancel',
-					},
 				]);
 			};
 		};
+
+		menuItems.push({
+			text: _('Cancel'),
+			onPress: () => {},
+			style: 'cancel',
+		});
 
 		menuItems.push({
 			text: _('Rename'),
@@ -193,12 +199,6 @@ const TagsScreenComponent: React.FC<Props> = props => {
 			text: _('Delete'),
 			onPress: generateTagDeletion(),
 			style: 'destructive',
-		});
-
-		menuItems.push({
-			text: _('Cancel'),
-			onPress: () => {},
-			style: 'cancel',
 		});
 
 		dialogs.prompt(

--- a/packages/app-mobile/components/screens/tags.tsx
+++ b/packages/app-mobile/components/screens/tags.tsx
@@ -180,6 +180,12 @@ const TagsScreenComponent: React.FC<Props> = props => {
 		});
 
 		menuItems.push({
+			text: _('Delete'),
+			onPress: generateTagDeletion(),
+			style: 'destructive',
+		});
+
+		menuItems.push({
 			text: _('Rename'),
 			onPress: async () => {
 				const newName = await dialogs.promptForText(_('Rename tag:'), tag.title);
@@ -193,12 +199,6 @@ const TagsScreenComponent: React.FC<Props> = props => {
 					}
 				}
 			},
-		});
-
-		menuItems.push({
-			text: _('Delete'),
-			onPress: generateTagDeletion(),
-			style: 'destructive',
 		});
 
 		dialogs.prompt(

--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -363,15 +363,15 @@ const SideMenuContentComponent = (props: Props) => {
 				onPress: async () => {
 					dialogs.prompt('', _('This will permanently delete all items in the trash. Continue?'), [
 						{
+							text: _('Cancel'),
+							onPress: () => { },
+							style: 'cancel',
+						},
+						{
 							text: _('Empty trash'),
 							onPress: async () => {
 								await emptyTrash();
 							},
-						},
-						{
-							text: _('Cancel'),
-							onPress: () => { },
-							style: 'cancel',
 						},
 					]);
 				},

--- a/packages/lib/components/shared/NoteRevisionViewer/useDeleteHistoryClick.ts
+++ b/packages/lib/components/shared/NoteRevisionViewer/useDeleteHistoryClick.ts
@@ -17,6 +17,7 @@ const useDeleteHistoryClick = ({
 		const response = await shim.showMessageBox(_('Are you sure you want to delete all history for this note? This cannot be undone.'), {
 			title: _('Warning'),
 			buttons: [_('Yes'), _('No')],
+			cancelId: 1,
 			type: MessageBoxType.Confirm,
 		});
 


### PR DESCRIPTION
# Problem

#15706 changed the default mobile button order: "Cancel" is now first. This was done to align with the new design (and [the iOS/Android UI guidelines](https://github.com/laurent22/joplin/pull/16069#discussion_r3667680831)). However, some dialogs still have "Cancel" on the right.

# Solution

Adjust dialogs associated with the profile switcher, tag screen, revision screen, and trash deletion.

# Screenshots (web)

|Label | Before | After |
|----|----|----|
| Managing a profile | <img width="1004" height="950" alt="alert: Configuration: edit, delete, close" src="https://github.com/user-attachments/assets/5803876e-c2b9-4f33-a82c-3edfb789486e" /> | <img width="1004" height="950" alt="alert: Configuration: close, delete, edit" src="https://github.com/user-attachments/assets/2e56fd14-e2d5-44c6-afe9-28ae5a2d1fc9" />|
| Deleting a profile | <img width="1004" height="950" alt="Delete this profile?All data, including notes, notebooks and tags will be permanently deleted. // delete profile 'test' // cancel" src="https://github.com/user-attachments/assets/7bd2eb19-0852-4590-950c-cec7cc8ebd0f" /> | <img width="1004" height="950" alt="Delete this profile? All data, including notes, notebooks and tags will be permanently deleted. // cancel // delete profile 'test'" src="https://github.com/user-attachments/assets/288fdf3a-d4ab-4d1f-9c9a-f970749938e0" /> |
| Emptying trash | <img width="1004" height="950" alt="image" src="https://github.com/user-attachments/assets/d10f871a-6041-4dcd-9e82-abe9b58ce5fd" />| <img width="1004" height="950" alt="image" src="https://github.com/user-attachments/assets/d2440301-ca51-4967-9432-7cd1f057e66b" /> |
| Managing a tag | <img width="1004" height="950" alt="tag: test // rename // delete // cancel" src="https://github.com/user-attachments/assets/f750af4a-1b77-4f1e-a9e4-4ae3de2f34a9" /> | <img width="1004" height="950" alt="tag: test // cancel // delete // rename" src="https://github.com/user-attachments/assets/a1bbad56-136b-49a7-9d7e-6bebcc8ce5b0" /> |
| Confirming a tag deletion | <img width="1004" height="950" alt="image" src="https://github.com/user-attachments/assets/89cd9e6c-fd0b-459d-9a6b-0fb6cdc014c3" /> | <img width="1004" height="950" alt="image" src="https://github.com/user-attachments/assets/4e470e7b-c6fe-4835-b913-36cd8779cb91" /> |
| Deleting note history | <img width="1004" height="950" alt="image" src="https://github.com/user-attachments/assets/fe6c5c6e-d770-48ea-9e56-cc0e62a5f913" /> | <img width="1004" height="950" alt="image" src="https://github.com/user-attachments/assets/8b7259cb-fc84-45d3-8176-0b1aa7191b45" /> |
| Geolocation confirmation (with code changes to force visibility on web) | <img width="1004" height="950" alt="image" src="https://github.com/user-attachments/assets/a8e867b1-c326-4665-9b3d-d5796276fbfe" /> | <img width="1004" height="950" alt="image" src="https://github.com/user-attachments/assets/509b43df-d18a-4cfb-85c5-c92188b0aa48" />| 


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
