### PR TITLE
Chore: Retry failing Markdown replacement tests in CI

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.test.ts
@@ -6,6 +6,8 @@ import replaceFormatCharacters from '../replaceFormatCharacters';
 import replaceInlineHtml from '../replaceInlineHtml';
 import replaceLinks from '../replaceLinks';
 
+jest.retryTimes(2);
+
 interface TestCase {
 	label: string;
 	markdown: string;


### PR DESCRIPTION
# Problem

CI frequently fails with the following error:
```

[@joplin/editor]: FAIL CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.test.ts
[@joplin/editor]:   ● makeInlineReplaceExtension › should include Markdown syntax for inline HTML in a forward mouse selection
[@joplin/editor]: 
[@joplin/editor]:     expect(received).toBe(expected) // Object.is equality
[@joplin/editor]: 
[@joplin/editor]:     Expected: "red text"
[@joplin/editor]:     Received: "<span style=\"color: red\">red text</span>"
[@joplin/editor]: 
[@joplin/editor]:       197 | 		}));
[@joplin/editor]:       198 | 	}
[@joplin/editor]:     > 199 | 	expect(actual).toBe(expected);
[@joplin/editor]:           | 	               ^
[@joplin/editor]:       200 | };
[@joplin/editor]:       201 |
[@joplin/editor]:       202 | describe('makeInlineReplaceExtension', () => {
[@joplin/editor]: 
[@joplin/editor]:       at expectTextContentToBe (CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.test.ts:199:17)
[@joplin/editor]:       at CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.test.ts:221:4
[@joplin/editor]: 
[@joplin/editor]: 
```

# Solution

For now, work around the issue by adding a `jest.retryTimes(2)` to the affected test suite (similar to some of the other CodeMirror tests).

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
