### PR TITLE
Chore: Testing: Fix chat panel test failure

### DIFF
--- a/packages/app-desktop/integration-tests/wcag.spec.ts
+++ b/packages/app-desktop/integration-tests/wcag.spec.ts
@@ -124,6 +124,8 @@ test.describe('wcag', () => {
 		await mainScreen.chatPanel.open(electronApp);
 
 		await mainScreen.chatPanel.sendMessage('/reply-with test');
+		await mainScreen.chatPanel.waitForMessageCount(2);
+
 		await mainScreen.chatPanel.sendMessage(
 			'/tool editor.appendToNote {"text": "test"}\n/reply-with done',
 		);


### PR DESCRIPTION
# Problem

https://github.com/laurent22/joplin/pull/15956 added a new test that scans the desktop app's chat panel using the accessibility scanner. This test sent messages in the AI chat panel without waiting for a response. This could result in an unexpected number of final messages displayed in the panel.

# Solution

Wait for a response before attempting to send a new message.
