### PR TITLE
Mobile: Make the startup location the first entry in the navigation history instead of 'All Notes'

### DIFF
--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -407,12 +407,14 @@ const buildStartupTasks = (
 				type: 'NAV_GO',
 				routeName: 'Notes',
 				smartFilterId: notesParent.selectedItemId,
+				clearHistory: true,
 			});
 		} else if (notesParent && notesParent.type === 'Tag') {
 			dispatch({
 				type: 'NAV_GO',
 				routeName: 'Notes',
 				tagId: notesParent.selectedItemId,
+				clearHistory: true,
 			});
 		} else if (!folder) {
 			dispatch(DEFAULT_ROUTE);
@@ -421,6 +423,7 @@ const buildStartupTasks = (
 				type: 'NAV_GO',
 				routeName: 'Notes',
 				folderId: folder.id,
+				clearHistory: true,
 			});
 		}
 	});


### PR DESCRIPTION
Joplin will load up the last opened notebook / tag / smart filter upon starting the app. PR https://github.com/laurent22/joplin/pull/16058 recently updated the behaviour to consider tags and smart filters for the mobile app, as it used to only consider notebooks. Even with this change however, there is a historic behaviour whereby the first entry in the navigation history for the mobile app will always be the 'All Notes' notebook (which differs from desktop behaviour). On Android, this means that if you close the app by pressing the system back button multiple times, it will go back from the startup location to the 'All Notes' notebook and then become minimised when pressing back at the start of the history. This means that if the app is opened again before the OS has killed it, the app will open on the 'All Notes' notebook instead of the starting notebook.

This PR changes the notebook selection logic on app startup to clear the navigation history upon navigating, ensuring that the starting location will be the first entry in the navigation history.

### Testing

See video, demonstrating closing the app and re-opening it at that location, where the starting location is a notebook, a tag and a smart filter:

https://github.com/user-attachments/assets/351d17ed-9786-4aa9-ab8b-0eb7a40dc731