### PR TITLE
Mobile: Add padding to right side of the title field

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -532,6 +532,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			flexDirection: 'row',
 			flexBasis: 'auto',
 			paddingLeft: theme.marginLeft,
+			paddingRight: theme.marginRight,
 			borderBottomColor: theme.dividerColor,
 			borderBottomWidth: 1,
 			maxHeight: '40%',
@@ -1780,8 +1781,6 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			}
 		}
 
-		const titleContainerStyle = isTodo ? this.styles().titleContainerTodo : this.styles().titleContainer;
-
 		const dueDate = Note.dueDateObject(note);
 
 		const textWrapCalculator_updateState = (showToggle: boolean, enableMultiline: boolean) => {
@@ -1796,6 +1795,12 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 				size={30}
 				style={{ width: 30, height: 30, alignSelf: 'center' }}
 			/>;
+
+		let titleContainerStyle = isTodo ? this.styles().titleContainerTodo : this.styles().titleContainer;
+		titleContainerStyle = {
+			...titleContainerStyle,
+			paddingRight: titleToggleButton ? 0 : titleContainerStyle.paddingRight,
+		};
 
 		const titleComp = (
 			<View

--- a/packages/app-mobile/components/screens/NoteRevisionViewer.tsx
+++ b/packages/app-mobile/components/screens/NoteRevisionViewer.tsx
@@ -107,6 +107,7 @@ const useStyles = (themeId: number) => {
 			},
 			titleViewContainer: {
 				paddingLeft: theme.marginLeft,
+				paddingRight: theme.marginRight,
 				borderTopColor: theme.dividerColor,
 				borderTopWidth: 1,
 				borderBottomColor: theme.dividerColor,
@@ -239,9 +240,14 @@ const NoteRevisionViewer: React.FC<Props> = props => {
 			style={{ width: 30, height: 30, alignSelf: 'center' }}
 		/>;
 
+	const titleViewContainer = {
+		...styles.titleViewContainer,
+		paddingRight: titleToggleButton ? 0 : styles.titleViewContainer.paddingRight,
+	};
+
 	const titleComponent = (
 		<View
-			style={styles.titleViewContainer}
+			style={titleViewContainer}
 			onLayout={(e) => {
 				const width = e.nativeEvent.layout.width;
 				if (width !== titleContainerWidth) {


### PR DESCRIPTION
On the mobile app, the title field of the note viewer / editor currently has padding on the left side of the input, but not on the right side. On the native mobile apps, a title expansion button appears when the title exceeds the length of the text input, but on the web app, the title value will flow all the way to the right edge of the screen, without any padding. When using the web app on a mobile device, this can make it difficult to place the cursor at the end of an overflowing title, particularly if the mobile a curved screen. Also the web app shows the boundary box and looks odd with the uneven padding. This PR addresses the issue by adding padding to the right side of the input which matches the left side, while the title expansion button is not visible.

Please note, as a small compromise, on mobile this change slightly increases the boundaries in which the title overflows the right side of the input, without showing the title expansion button. It does mean however that when a title's length is between the boundaries, it makes it easier to select the end of the title on the note viewer / editor. On the note history screen, the title wraps to the next line in this case already.

This supersedes https://github.com/laurent22/joplin/pull/16051.

### Testing

**Screenshot before change on web:**

<img width="250" alt="Screenshot 2026-07-27 123606" src="https://github.com/user-attachments/assets/8919e017-454d-4e2d-91d3-24cd87f1861a" />

**Screenshots after change on web:**

<img width="250" alt="Screenshot 2026-07-27 123716" src="https://github.com/user-attachments/assets/e4b925cf-bf23-45f0-ac2a-762d026a629b" />
<img width="250" alt="Screenshot 2026-07-27 123828" src="https://github.com/user-attachments/assets/0f80e029-cfeb-4344-aecc-a333b6131c08" />

**Video on Android emulator:**

https://github.com/user-attachments/assets/9862ef69-d5e3-4c9c-bf0a-05bd0952d38d

