### PR TITLE
All: Translation: Update fa.po

### DIFF
--- a/packages/tools/locales/fa.po
+++ b/packages/tools/locales/fa.po
@@ -7,14 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Joplin-CLI 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"Last-Translator: Mohammad Ashouri <mimeyn.git@gmail.com>\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Reza Bahmani <rezabahmani085@gmail.com>\n"
 "Language-Team: \n"
 "Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n==0 || n==1);\n"
-"X-Generator: Poedit 2.2\n"
+"X-Generator: Poedit 3.9\n"
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:621
 msgid "- Camera: to allow taking a picture and attaching it to a note."
@@ -25,12 +27,8 @@ msgid "- Location: to allow attaching geo-location information to a note."
 msgstr "- موقعیت: دسترسی برای پیوست اطلاعات موقعیت جغرافیایی به یک یادداشت."
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:618
-msgid ""
-"- Storage: to allow attaching files to notes and to enable filesystem "
-"synchronisation."
-msgstr ""
-"- فضای ذخیره‌سازی: برای پیوست فایل‌ها به یادداشت‌ها و فعال کردن همگام‌سازی "
-"فایل‌های سیستمی ."
+msgid "- Storage: to allow attaching files to notes and to enable filesystem synchronisation."
+msgstr "- فضای ذخیره‌سازی: برای پیوست فایل‌ها به یادداشت‌ها و فعال کردن همگام‌سازی فایل‌های سیستمی ."
 
 #: packages/lib/services/KeymapService.ts:333
 #: packages/lib/services/KeymapService.ts:339
@@ -47,7 +45,7 @@ msgstr "(در افزونه: %s )"
 
 #: packages/app-mobile/components/side-menu-content.tsx:269
 msgid "(level %d)"
-msgstr ""
+msgstr "(سطح %d)"
 
 #: packages/lib/SyncTargetNone.ts:16
 msgid "(None)"
@@ -55,7 +53,7 @@ msgstr "(هیچ کدام)"
 
 #: packages/app-cli/app/command-share.ts:141
 msgid "(Read-only)"
-msgstr ""
+msgstr "(فقط خواندنی)"
 
 #: packages/lib/models/settings/builtInMetadata.ts:54
 #: packages/lib/models/settings/builtInMetadata.ts:55
@@ -68,9 +66,8 @@ msgid "(You may disable this prompt in the options)"
 msgstr "(شما می توانید این درخواست را در گزینه ها غیرفعال کنید)"
 
 #: packages/app-cli/app/command-share.ts:31
-#, fuzzy
 msgid "[None]"
-msgstr "(هیچ کدام)"
+msgstr "[هیچ‌کدام]"
 
 #: packages/app-desktop/gui/MenuBar.tsx:688
 #: packages/app-desktop/gui/MenuBar.tsx:999
@@ -109,7 +106,6 @@ msgstr "&صفحه"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1700
 #: packages/lib/models/settings/builtInMetadata.ts:2033
-#, fuzzy
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d روز"
@@ -130,7 +126,6 @@ msgstr "%d گیگابایت فضای ذخیره‌سازی"
 #: packages/lib/models/settings/builtInMetadata.ts:1412
 #: packages/lib/models/settings/builtInMetadata.ts:1413
 #: packages/lib/models/settings/builtInMetadata.ts:1414
-#, fuzzy
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d ساعت"
@@ -151,21 +146,18 @@ msgstr "%d مگابایت به ازای هر یادداشت یا فایل پیو
 #: packages/lib/models/settings/builtInMetadata.ts:1409
 #: packages/lib/models/settings/builtInMetadata.ts:1410
 #: packages/lib/models/settings/builtInMetadata.ts:1411
-#, fuzzy
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d دقیقه"
 msgstr[1] "%d دقیقه"
 
 #: packages/app-cli/app/command-rmnote.ts:34
-#, fuzzy
 msgid "%d note matches this pattern. Delete it?"
 msgid_plural "%d notes match this pattern. Delete them?"
 msgstr[0] "%d یادداشت‌هایی که مطابق این الگو هستند. آیا حذف شوند؟"
 msgstr[1] "%d یادداشت‌هایی که مطابق این الگو هستند. آیا حذف شوند؟"
 
 #: packages/app-cli/app/command-rmnote.ts:40
-#, fuzzy
 msgid "%d note will be permanently deleted. Continue?"
 msgid_plural "%d notes will be permanently deleted. Continue?"
 msgstr[0] "%d یادداشت برای همیشه حذف خواهد شد. ادامه هید؟"
@@ -173,7 +165,7 @@ msgstr[1] "%d یادداشت برای همیشه حذف خواهد شد. ادا�
 
 #: packages/app-mobile/components/CameraView/PhotoPreview.tsx:60
 msgid "%d photo(s) taken"
-msgstr ""
+msgstr "%d عکس ها گرفته شدند"
 
 #: packages/app-desktop/gui/NoteListControls/NoteListControls.tsx:229
 #: packages/app-desktop/gui/NoteListControls/NoteListControls.tsx:239
@@ -224,30 +216,24 @@ msgid "%s = %s (%s)"
 msgstr "%s = %s (%s)"
 
 #: packages/app-mobile/components/screens/ConfigScreen/ValidatedIntegerInput.tsx:32
-#, fuzzy
 msgid "%s cannot be greater than %s"
-msgstr "نمی‌توان یادداشت جدید ایجاد نمود: %s"
+msgstr "%s نمی‌تواند بزرگتر از %s باشد"
 
 #: packages/app-mobile/components/screens/ConfigScreen/ValidatedIntegerInput.tsx:36
 msgid "%s cannot be less than %s"
-msgstr ""
+msgstr "%s نمی‌تواند کمتر از %s باشد"
 
 #: packages/app-cli/app/command-share.ts:202
-#, fuzzy
 msgid "%s from %s"
-msgstr "آیا برچسب «%s» از همه‌ی یادداشت‌ها حذف شود؟"
+msgstr "%s از %s"
 
 #: packages/app-desktop/gui/SyncWizard/Dialog.tsx:238
-msgid ""
-"%s is not optimised for synchronising many small files so your initial "
-"synchronisation will be slow."
-msgstr ""
-"%s برای همگام سازی بسیاری از فایل های کوچک بهینه نشده است، بنابراین همگام "
-"سازی اولیه شما کند خواهد بود."
+msgid "%s is not optimised for synchronising many small files so your initial synchronisation will be slow."
+msgstr "%s برای همگام سازی بسیاری از فایل های کوچک بهینه نشده است، بنابراین همگام سازی اولیه شما کند خواهد بود."
 
 #: packages/app-mobile/components/screens/ConfigScreen/ValidatedIntegerInput.tsx:26
 msgid "%s must be a valid whole number"
-msgstr ""
+msgstr "%s باید یک عدد معتبر باشد"
 
 #: packages/app-mobile/components/plugins/dialogs/PluginPanelViewer.tsx:74
 msgid "%s tab opened"
@@ -261,7 +247,6 @@ msgid "%s: %d"
 msgstr "%s: %d"
 
 #: packages/lib/services/ReportService.ts:378
-#, fuzzy
 msgid "%s: %d note"
 msgid_plural "%s: %d notes"
 msgstr[0] "%s: %d یادداشت"
@@ -282,44 +267,24 @@ msgid "%s: Missing password."
 msgstr "%s: گذرواژه وجود ندارد."
 
 #: packages/app-cli/app/command-tag.js:14
-msgid ""
-"<tag-command> can be \"add\", \"remove\", \"list\", or \"notetags\" to "
-"assign or remove [tag] from [note], to list notes associated with [tag], or "
-"to list tags associated with [note]. The command `tag list` can be used to "
-"list all the tags (use -l for long option)."
-msgstr ""
-"<tag-command> می‌تواند \"افزودن\"، \"حذف\"، \"فهرست\" یا \"برچسب یادداشت\" "
-"برای تخصیص یا حذف [tag] از [note]، برای فهرست کردن یادداشت های مرتبط با "
-"[tag] و یا برای فهرست کردن برچسب های مرتبط با [note] باشد. دستور `tag list` "
-"می تواند برای فهرست کردن تمام برچسب‌ها باشد (از -l برای جزئیات بیشتر استفاده "
-"نمایید)."
+msgid "<tag-command> can be \"add\", \"remove\", \"list\", or \"notetags\" to assign or remove [tag] from [note], to list notes associated with [tag], or to list tags associated with [note]. The command `tag list` can be used to list all the tags (use -l for long option)."
+msgstr "<tag-command> می‌تواند \"افزودن\"، \"حذف\"، \"فهرست\" یا \"برچسب یادداشت\" برای تخصیص یا حذف [tag] از [note]، برای فهرست کردن یادداشت های مرتبط با [tag] و یا برای فهرست کردن برچسب های مرتبط با [note] باشد. دستور `tag list` می تواند برای فهرست کردن تمام برچسب‌ها باشد (از -l برای جزئیات بیشتر استفاده نمایید)."
 
 #: packages/app-cli/app/command-todo.js:14
-msgid ""
-"<todo-command> can either be \"toggle\" or \"clear\". Use \"toggle\" to "
-"toggle the given to-do between completed and uncompleted state (If the "
-"target is a regular note it will be converted to a to-do). Use \"clear\" to "
-"convert the to-do back to a regular note."
-msgstr ""
-"<todo-command> می‌تواند \"تغییر وضعیت\" یا \"پاکسازی\" باشد. از \"تغییر "
-"وضعیت\" برای تغییر وضعیت کارها بین حالت تکمیل شده و ناتمام استفاده نمایید. "
-"(اگر هدف یک یادداشت معمولی باشد، تبدیل به یک کار می‌شود). از \"پاکسازی\" برای "
-"تبدیل یک کار به یک یادداشت معمولی استفاده نمایید."
+msgid "<todo-command> can either be \"toggle\" or \"clear\". Use \"toggle\" to toggle the given to-do between completed and uncompleted state (If the target is a regular note it will be converted to a to-do). Use \"clear\" to convert the to-do back to a regular note."
+msgstr "<todo-command> می‌تواند \"تغییر وضعیت\" یا \"پاکسازی\" باشد. از \"تغییر وضعیت\" برای تغییر وضعیت کارها بین حالت تکمیل شده و ناتمام استفاده نمایید. (اگر هدف یک یادداشت معمولی باشد، تبدیل به یک کار می‌شود). از \"پاکسازی\" برای تبدیل یک کار به یک یادداشت معمولی استفاده نمایید."
 
 #: packages/editor/ProseMirror/plugins/imagePlugin.ts:148
 msgid "A brief description of the image:"
-msgstr ""
+msgstr "توضیحی مختصر درباره تصویر:"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1993
-msgid ""
-"A comma-separated list of words. May be used for uncommon words, to help "
-"voice typing spell them correctly."
-msgstr ""
+msgid "A comma-separated list of words. May be used for uncommon words, to help voice typing spell them correctly."
+msgstr "فهرستی از کلمات که با ویرگول از هم جدا شده‌اند. این فهرست ممکن است برای کلمات غیرمعمول استفاده شود تا به تایپ صوتی در املای صحیح آن‌ها کمک کند."
 
 #: packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx:37
-#, fuzzy
 msgid "A new update (%s) is available"
-msgstr "به روز رسانی موجود است"
+msgstr "بروز رسانی نسخه جدید %s در دسترس است"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1438
 msgid "A3"
@@ -335,7 +300,7 @@ msgstr "A5"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1121
 msgid "ABC musical notation: Options"
-msgstr ""
+msgstr "نت‌نویسی موسیقی ABC:گزینه ها"
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx:62
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx:240
@@ -357,12 +322,8 @@ msgid "Accelerator \"%s\" is not valid."
 msgstr "شتابدهنده «%s» نامعتبر است."
 
 #: packages/lib/services/KeymapService.ts:365
-msgid ""
-"Accelerator \"%s\" is used for \"%s\" and \"%s\" commands. This may lead to "
-"unexpected behaviour."
-msgstr ""
-"شتابدهنده «%s» برای دستورات «%s» و «%s» استفاده شده است. این ممکن است منجر "
-"به رفتار غیرمنتظره‌ای شود."
+msgid "Accelerator \"%s\" is used for \"%s\" and \"%s\" commands. This may lead to unexpected behaviour."
+msgstr "شتابدهنده «%s» برای دستورات «%s» و «%s» استفاده شده است. این ممکن است منجر به رفتار غیرمنتظره‌ای شود."
 
 #: packages/app-desktop/gui/MainScreen.tsx:564
 #: packages/app-mobile/components/screens/ShareManager/IncomingShareItem.tsx:40
@@ -374,14 +335,12 @@ msgid "Accepted invitations"
 msgstr "دعوت نامه های پذیرفته شده"
 
 #: packages/app-cli/app/command-share.ts:179
-#, fuzzy
 msgid "Accepted: Notebook %s from %s"
-msgstr "دفترچه: %s (%s)"
+msgstr "قبول شده: دفترچه %s از %s"
 
 #: packages/app-cli/app/command-share.ts:229
-#, fuzzy
 msgid "Accepting share..."
-msgstr "در حال ایجاد گزارش..."
+msgstr "در حال تایید اشتراک گذاری ..."
 
 #: packages/lib/WebDavApi.js:460
 msgid "Access denied: Please check your username and password"
@@ -432,7 +391,7 @@ msgstr "افزودن بدنه"
 
 #: packages/editor/ProseMirror/plugins/tablePlugin.ts:31
 msgid "Add column"
-msgstr ""
+msgstr "افزودن ستون"
 
 #: packages/app-mobile/components/buttons/FloatingActionButton.tsx:66
 #: packages/app-mobile/components/ComboBox.tsx:103
@@ -449,14 +408,12 @@ msgid "Add recipient:"
 msgstr "افزودن دریافت کننده:"
 
 #: packages/editor/ProseMirror/plugins/tablePlugin.ts:26
-#, fuzzy
 msgid "Add row"
-msgstr "افزودن جدید"
+msgstr "افزودن ردیف"
 
 #: packages/app-mobile/components/TagEditor.tsx:281
-#, fuzzy
 msgid "Add tags:"
-msgstr "برچسب جدید:"
+msgstr "افزودن برچسب ها:"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:1777
 msgid "Add title"
@@ -467,22 +424,20 @@ msgid "Add to dictionary"
 msgstr "افزودن به لغت‌نامه"
 
 #: packages/app-mobile/components/CameraView/ScannedBarcodes.tsx:99
-#, fuzzy
 msgid "Add to note"
-msgstr "افزودن عنوان"
+msgstr "افزودن به یادداشت"
 
 #: packages/app-mobile/components/ComboBox.tsx:93
-#, fuzzy
 msgid "Added new: %s"
-msgstr "افزودن جدید"
+msgstr "مورد جدید اضافه شد: %s"
 
 #: packages/app-mobile/components/TagEditor.tsx:233
 msgid "Added tag: %s"
-msgstr ""
+msgstr "افزودن برچسب: %s"
 
 #: packages/app-mobile/components/TagEditor.tsx:220
 msgid "Adds tag"
-msgstr ""
+msgstr "برچسب اضافه می‌کند"
 
 #: packages/server/src/services/MustacheService.ts:162
 #: packages/server/src/services/MustacheService.ts:286
@@ -506,20 +461,16 @@ msgid "Advanced tools"
 msgstr "ابزارهای پیشرفته"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:18
-#, fuzzy
 msgid "all"
-msgstr "نصب"
+msgstr "همه"
 
 #: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:108
-msgid ""
-"All data, including notes, notebooks and tags will be permanently deleted."
-msgstr ""
-"تمام داده ها اعم از یادداشت‌ها، دفترچه‌ها و برچسب‌ها به طور دائمی حذف خواهند شد."
+msgid "All data, including notes, notebooks and tags will be permanently deleted."
+msgstr "تمام داده ها اعم از یادداشت‌ها، دفترچه‌ها و برچسب‌ها به طور دائمی حذف خواهند شد."
 
 #: packages/lib/services/ReportService.ts:227
 msgid "All item sync failures have been marked as \"ignored\"."
-msgstr ""
-"همه خطاهای همگام سازی به عنوان \"نادیده گرفته شده\" علامت گذاری شده اند."
+msgstr "همه خطاهای همگام سازی به عنوان \"نادیده گرفته شده\" علامت گذاری شده اند."
 
 #: packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts:72
 #: packages/app-mobile/components/screens/Notes/Notes.tsx:208
@@ -529,18 +480,15 @@ msgstr "همه یادداشت‌ها"
 
 #: packages/lib/onedrive-api-node-utils.js:46
 msgid "All potential ports are in use - please report the issue at %s"
-msgstr ""
-"تمام پورت‌های بالقوه در حال استفاده هستند- لطفا این مشکل را در %s گزارش نمایید"
+msgstr "تمام پورت‌های بالقوه در حال استفاده هستند- لطفا این مشکل را در %s گزارش نمایید"
 
 #: packages/app-cli/app/command-share.ts:191
 msgid "All shared folders:"
-msgstr ""
+msgstr "همه پوشه های اشتراک گذاری شده:"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1033
 msgid "Allows debugging mobile plugins. See %s for details."
-msgstr ""
-"اجازه اشکال زدایی به افزونه های موبایل را می دهد. برای جزئیات بیشتر به %s "
-"مراجعه کنید."
+msgstr "اجازه اشکال زدایی به افزونه های موبایل را می دهد. برای جزئیات بیشتر به %s مراجعه کنید."
 
 #: packages/app-cli/app/command-config.ts:19
 msgid "Also displays unset and hidden config variables."
@@ -551,9 +499,8 @@ msgid "Also publish linked notes"
 msgstr "همچنین یادداشت‌های مرتبط را منتشر کن"
 
 #: packages/lib/versionInfo.ts:93
-#, fuzzy
 msgid "Alternative instance ID: %s"
-msgstr "شناسه کاربر: %s"
+msgstr "شناسه نمونه جایگزین: %s"
 
 #: packages/lib/models/settings/builtInMetadata.ts:471
 msgid "Always"
@@ -572,34 +519,25 @@ msgid "Always resize"
 msgstr "همیشه اندازه را تغییر بده"
 
 #: packages/app-cli/app/command-mv.ts:37
-msgid ""
-"Ambiguous notebook \"%s\". Please use notebook id instead - press \"ti\" to "
-"see the short notebook id or use $b for current selected notebook"
-msgstr ""
-"دفترچه «%s» دارای ابهام است. لطفا از شناسه دفترچه استفاده نمایید - برای دیدن "
-"شناسه کوتاه دفترچه از \"ti\" و یا برای دفترچه انتخاب شده از $b استفاده نمایید"
+msgid "Ambiguous notebook \"%s\". Please use notebook id instead - press \"ti\" to see the short notebook id or use $b for current selected notebook"
+msgstr "دفترچه «%s» دارای ابهام است. لطفا از شناسه دفترچه استفاده نمایید - برای دیدن شناسه کوتاه دفترچه از \"ti\" و یا برای دفترچه انتخاب شده از $b استفاده نمایید"
 
 #: packages/app-cli/app/command-mkbook.ts:33
 #: packages/app-cli/app/command-mv.ts:30
-msgid ""
-"Ambiguous notebook \"%s\". Please use short notebook id instead - press "
-"\"ti\" to see the short notebook id"
-msgstr ""
-"دفترچه «%s» دارای ابهام است. لطفا از شناسه دفترچه استفاده نمایید - برای دیدن "
-"شناسه کوتاه دفترچه از \"ti\" استفاده کنید"
+msgid "Ambiguous notebook \"%s\". Please use short notebook id instead - press \"ti\" to see the short notebook id"
+msgstr "دفترچه «%s» دارای ابهام است. لطفا از شناسه دفترچه استفاده نمایید - برای دیدن شناسه کوتاه دفترچه از \"ti\" استفاده کنید"
 
 #: packages/app-mobile/components/NoteEditor/ImageEditor/promptRestoreAutosave.ts:13
 msgid "An autosaved drawing was found. Attach a copy of it to the note?"
-msgstr ""
-"یک طراحی ذخیره شده خودکار پیدا شد. آیا می‌خواهید یک کپی از آن را به یادداشت "
-"پیوست کنید؟"
+msgstr "یک طراحی ذخیره شده خودکار پیدا شد. آیا می‌خواهید یک کپی از آن را به یادداشت پیوست کنید؟"
 
 #: packages/app-mobile/components/FeedbackBanner.tsx:125
 msgid ""
-"An error occurred while sending the response. This can happen if the app is "
-"offline or cannot connect to the server.\n"
+"An error occurred while sending the response. This can happen if the app is offline or cannot connect to the server.\n"
 "Error: %s"
 msgstr ""
+"خطایی در هنگام ارسال پاسخ رخ داد. این اتفاق ممکن است زمانی بیفتد که برنامه آفلاین باشد یا نتواند به سرور متصل شود.\n"
+"خطا: %s"
 
 #: packages/app-desktop/ElectronAppWrapper.ts:190
 msgid "An error occurred: %s"
@@ -615,12 +553,8 @@ msgstr "سطح api اندروید : %d"
 
 #: packages/app-desktop/gui/JoplinCloudConfigScreen.tsx:48
 #: packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.tsx:24
-msgid ""
-"Any email sent to this address will be converted into a note and added to "
-"your collection. The note will be saved into the Inbox notebook"
-msgstr ""
-"هر ایمیلی که به این آدرس ارسال شود به یادداشت تبدیل شده و به مجموعه شما "
-"اضافه می شود. یادداشت در صندوق دفترچه ذخیره خواهد شد"
+msgid "Any email sent to this address will be converted into a note and added to your collection. The note will be saved into the Inbox notebook"
+msgstr "هر ایمیلی که به این آدرس ارسال شود به یادداشت تبدیل شده و به مجموعه شما اضافه می شود. یادداشت در صندوق دفترچه ذخیره خواهد شد"
 
 #: packages/lib/models/Setting.ts:1354
 msgid "Appearance"
@@ -636,34 +570,24 @@ msgid "Apply"
 msgstr "اعمال"
 
 #: packages/app-mobile/components/EditorToolbar/ToolbarEditorDialog.tsx:146
-#, fuzzy
 msgid ""
 "Are you sure that you want to restore the default toolbar layout?\n"
 "This cannot be undone."
 msgstr ""
-"آیا مطمئن هستید که می خواهید به چیدمان پیش فرض بازگردید؟ در صورت تایید، "
-"نحوه  چیدمان فعلی از بین خواهد رفت."
+"آیا مطمئن هستید که می‌خواهید چیدمان پیش‌فرض نوار ابزار را بازیابی کنید؟\n"
+"این عمل قابل بازگشت نیست."
 
 #: packages/lib/components/shared/NoteRevisionViewer/useDeleteHistoryClick.ts:19
-#, fuzzy
-msgid ""
-"Are you sure you want to delete all history for this note? This cannot be "
-"undone."
-msgstr ""
-"آیا مطمئن هستید که می خواهید به چیدمان پیش فرض بازگردید؟ در صورت تایید، "
-"نحوه  چیدمان فعلی از بین خواهد رفت."
+msgid "Are you sure you want to delete all history for this note? This cannot be undone."
+msgstr "آیا مطمئن هستید که می‌خواهید تمام تاریخچه این یادداشت را حذف کنید؟ این عمل قابل بازگشت نیست."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:39
 msgid "Are you sure you want to renew the authorisation token?"
 msgstr "آیا مطمئن هستید که می خواهید توکن مجوز را تمدید کنید؟"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/resetLayout.ts:14
-msgid ""
-"Are you sure you want to return to the default layout? The current layout "
-"configuration will be lost."
-msgstr ""
-"آیا مطمئن هستید که می خواهید به چیدمان پیش فرض بازگردید؟ در صورت تایید، "
-"نحوه  چیدمان فعلی از بین خواهد رفت."
+msgid "Are you sure you want to return to the default layout? The current layout configuration will be lost."
+msgstr "آیا مطمئن هستید که می خواهید به چیدمان پیش فرض بازگردید؟ در صورت تایید، نحوه  چیدمان فعلی از بین خواهد رفت."
 
 #: packages/app-desktop/gui/ConfigScreen/controls/SettingComponent.tsx:235
 msgid "Arguments:"
@@ -675,13 +599,11 @@ msgstr "Aritim Dark"
 
 #: packages/app-mobile/components/TagEditor.tsx:188
 msgid "Associated tags:"
-msgstr ""
+msgstr "برچسب های مرتبط:"
 
 #: packages/app-mobile/utils/lockToSingleInstance.ts:16
-msgid ""
-"At present, Joplin Web can only be open in one tab at a time. Please close "
-"the other instance of Joplin."
-msgstr ""
+msgid "At present, Joplin Web can only be open in one tab at a time. Please close the other instance of Joplin."
+msgstr "درحال حاضر، Joblin web فقط در یک زبانه قابل اجرا است. لطفا سایر زبانه های دیگر Joplin را ببندید."
 
 #: packages/app-mobile/components/NoteEditor/ImageEditor/promptRestoreAutosave.ts:25
 msgid "Attach"
@@ -712,7 +634,6 @@ msgid "attachment"
 msgstr "پیوست"
 
 #: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:77
-#, fuzzy
 msgid "Attachment"
 msgstr "پیوست‌ها"
 
@@ -733,20 +654,13 @@ msgid "Attachments that could not be downloaded"
 msgstr "پیوست‌هایی که دانلود نشده‌اند"
 
 #: packages/lib/models/settings/builtInMetadata.ts:58
-msgid ""
-"Attention: If you change this location, make sure you copy all your content "
-"to it before syncing, otherwise all files will be removed! See the FAQ for "
-"more details: %s"
-msgstr ""
-"هشدار: اگر این مکان را تغییر دادید، قبل از همگام‌سازی مطمئن شوید که تمام "
-"محتوای خود را در آن کپی کنید، در غیر این صورت تمام فایل ها حذف خواهند شد! "
-"برای جزئیات بیشتر به سوالات متداول مراجعه کنید:  %s"
+msgid "Attention: If you change this location, make sure you copy all your content to it before syncing, otherwise all files will be removed! See the FAQ for more details: %s"
+msgstr "هشدار: اگر این مکان را تغییر دادید، قبل از همگام‌سازی مطمئن شوید که تمام محتوای خود را در آن کپی کنید، در غیر این صورت تمام فایل ها حذف خواهند شد! برای جزئیات بیشتر به سوالات متداول مراجعه کنید:  %s"
 
 #: packages/app-cli/app/command-sync.ts:73
 #: packages/app-cli/app/command-sync.ts:87
 #: packages/app-desktop/gui/OneDriveLoginScreen.tsx:49
-msgid ""
-"Authentication was not completed (did not receive an authentication token)."
+msgid "Authentication was not completed (did not receive an authentication token)."
 msgstr "احراز هویت انجام نشد (توکن احراز هویت دریافت نشد)."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:152
@@ -768,7 +682,7 @@ msgstr "افزودن خودکار حساب های غیرفعال برای حذف
 
 #: packages/lib/models/settings/builtInMetadata.ts:786
 msgid "Auto-format Markdown in the Rich Text Editor"
-msgstr ""
+msgstr "قالب بندی خودکار Markdown در ویرایشگر متن غنی"
 
 #: packages/lib/models/settings/builtInMetadata.ts:743
 msgid "Auto-pair braces, parentheses, quotations, etc."
@@ -776,7 +690,7 @@ msgstr "جفت‌سازی خودکار کروشه، پرانتز، نقل قول
 
 #: packages/lib/models/settings/builtInMetadata.ts:754
 msgid "Autocomplete Markdown and HTML"
-msgstr ""
+msgstr "کامل کردن خودکار Markdown و HTML"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1383
 msgid "Automatically check for updates"
@@ -812,7 +726,7 @@ msgstr "بتا"
 
 #: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:123
 msgid "Block code"
-msgstr ""
+msgstr "بلوک کد"
 
 #: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:55
 #: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:80
@@ -844,11 +758,11 @@ msgstr "توسط %s"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:20
 msgid "by word"
-msgstr ""
+msgstr "توسط کلمه"
 
 #: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:79
 msgid "Camera"
-msgstr ""
+msgstr "دوربین"
 
 #: packages/server/src/routes/admin/users.ts:160
 msgid "Can Share"
@@ -905,10 +819,8 @@ msgid "Cancelling background synchronisation... Please wait."
 msgstr "در حال لغو همگام سازی در پس‌زمینه... لطفا صبور باشید."
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:200
-msgid ""
-"Cancelling will discard the recording. This cannot be undone. Are you sure "
-"you want to proceed?"
-msgstr ""
+msgid "Cancelling will discard the recording. This cannot be undone. Are you sure you want to proceed?"
+msgstr "با لغو کردن رکورد حذف خواهد شد. این قابل بازگشت نیست. آیا از ادامه مطمئن هستید؟"
 
 #: packages/app-desktop/gui/TrashNotification/TrashNotificationMessage.tsx:23
 #: packages/lib/Synchronizer.ts:208
@@ -928,9 +840,8 @@ msgid "Cannot change encrypted item"
 msgstr "آیتم رمزنگاری شده را نمی‌توان تغییر داد"
 
 #: packages/lib/commands/convertNoteToMarkdown.ts:42
-#, fuzzy
 msgid "Cannot convert read-only item: \"%s\""
-msgstr "نمی‌توان یادداشت جدید ایجاد نمود: %s"
+msgstr "امکان تبدیل مورد فقط‌ خواندنی «%s» وجود ندارد."
 
 #: packages/lib/models/Note.ts:622
 msgid "Cannot copy note to \"%s\" notebook"
@@ -994,34 +905,20 @@ msgid "Cannot move notebook to this location"
 msgstr "دفترچه را نمی‌توان به این مکان انتقال داد"
 
 #: packages/lib/onedrive-api.ts:468
-msgid ""
-"Cannot refresh token: authentication data is missing. Starting the "
-"synchronisation again may fix the problem."
-msgstr ""
-"توکن را نمی‌توان تازه‌سازی کرد: داده های احراز هویت یافت نشد. با همگام‌سازی "
-"مجدد، ممکن است این مشکل را حل کند."
+msgid "Cannot refresh token: authentication data is missing. Starting the synchronisation again may fix the problem."
+msgstr "توکن را نمی‌توان تازه‌سازی کرد: داده های احراز هویت یافت نشد. با همگام‌سازی مجدد، ممکن است این مشکل را حل کند."
 
 #: packages/server/src/models/UserModel.ts:330
 msgid "Cannot save %s \"%s\" because it is larger than the allowed limit (%s)"
 msgstr "«%s» «%s» را نمی‌توان  به علت بزرگ بودن بیش از حد ذخیره نمود (%s)"
 
 #: packages/server/src/models/UserModel.ts:347
-msgid ""
-"Cannot save %s \"%s\" because it would go over the total allowed size (%s) "
-"for this account"
-msgstr ""
-"«%s» «%s» را نمی‌توان به علت عبور از مقدار اندازه مجاز برای این حساب (%s) "
-"ذخیره نمود"
+msgid "Cannot save %s \"%s\" because it would go over the total allowed size (%s) for this account"
+msgstr "«%s» «%s» را نمی‌توان به علت عبور از مقدار اندازه مجاز برای این حساب (%s) ذخیره نمود"
 
 #: packages/lib/services/share/ShareService.ts:367
-msgid ""
-"Cannot share encrypted notebook with recipient %s because they have not "
-"enabled end-to-end encryption. They may do so from the screen Configuration "
-"> Encryption."
-msgstr ""
-"نمی توان دفترچه رمزنگاری شده را با گیرنده %s به اشتراک گذاشت؛ زیرا آنها "
-"رمزنگاری انتها به انتها (end-to-end) را فعال نکرده‌اند. آنها می‌توانند از طریق "
-"صفحه تنظیمات > رمزنگاری، این کار را انجام دهند."
+msgid "Cannot share encrypted notebook with recipient %s because they have not enabled end-to-end encryption. They may do so from the screen Configuration > Encryption."
+msgstr "نمی توان دفترچه رمزنگاری شده را با گیرنده %s به اشتراک گذاشت؛ زیرا آنها رمزنگاری انتها به انتها (end-to-end) را فعال نکرده‌اند. آنها می‌توانند از طریق صفحه تنظیمات > رمزنگاری، این کار را انجام دهند."
 
 #: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:342
 msgid "Case sensitive"
@@ -1036,13 +933,12 @@ msgid "Change language"
 msgstr "ویرایش زبان"
 
 #: packages/app-mobile/components/CameraView/ActionButtons.tsx:124
-#, fuzzy
 msgid "Change ratio"
-msgstr "تنظیمات"
+msgstr "نسبت تغییر"
 
 #: packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx:98
 msgid "Change shortcut for \"%s\""
-msgstr ""
+msgstr "میان‌بر را برای %s تغییر دهید"
 
 #: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:112
 msgid "Characters"
@@ -1053,13 +949,12 @@ msgid "Characters excluding spaces"
 msgstr "کاراکترها به غیر از فاصله‌ها"
 
 #: packages/app-desktop/gui/SyncWizard/Dialog.tsx:165
-#, fuzzy
 msgid "Check"
-msgstr "چک‌باکس"
+msgstr "بررسی"
 
 #: packages/app-mobile/components/EditorToolbar/ToolbarEditorDialog.tsx:168
 msgid "Check elements to display in the toolbar"
-msgstr ""
+msgstr "عناصر را چک کنید تا در نوار ابزار نمایان شوند"
 
 #: packages/app-desktop/gui/MenuBar.tsx:583
 #: packages/app-desktop/gui/MenuBar.tsx:891
@@ -1080,9 +975,8 @@ msgid "Checkbox list"
 msgstr "لیست چک‌باکس"
 
 #: packages/app-mobile/components/Checkbox.tsx:49
-#, fuzzy
 msgid "Checked"
-msgstr "چک‌باکس"
+msgstr "بررسی شده"
 
 #: packages/lib/components/shared/config/config-shared.ts:97
 msgid "Checking... Please wait."
@@ -1090,7 +984,7 @@ msgstr "در حال بررسی... لطفا صبور باشید."
 
 #: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:114
 msgid "Chinese/Japanese/Korean characters"
-msgstr ""
+msgstr "کاراکتر های چینی/ژاپنی/کره‌ای"
 
 #: packages/app-mobile/components/screens/Note/commands/attachFile.ts:98
 msgid "Choose an option"
@@ -1118,16 +1012,12 @@ msgid "Clear search"
 msgstr "پاکسازی جستجو"
 
 #: packages/lib/components/shared/NoteRevisionViewer/getHelpMessage.ts:5
-msgid ""
-"Click \"%s\" to restore the note. It will be copied in the notebook named "
-"\"%s\". The current version of the note will not be replaced or modified."
-msgstr ""
-"برای بازیابی یادداشت بر روی «%s» کلیک نمایید. یادداشت در دفترچه‌ای به نام "
-"«%s» کپی می‌شود. این نسخه از یادداشت جایگزین یا تغییر داده نمی‌شود."
+msgid "Click \"%s\" to restore the note. It will be copied in the notebook named \"%s\". The current version of the note will not be replaced or modified."
+msgstr "برای بازیابی یادداشت بر روی «%s» کلیک نمایید. یادداشت در دفترچه‌ای به نام «%s» کپی می‌شود. این نسخه از یادداشت جایگزین یا تغییر داده نمی‌شود."
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:234
 msgid "Click \"start\" to attach a new voice memo to the note."
-msgstr ""
+msgstr "بر روی \"شروع\" کلید کنید تا یک یادداشت صوتی جدید به یادداشت اضافه کنید."
 
 #: packages/app-desktop/gui/NoteEditor/StatusBar.tsx:61
 msgid "Click to add tags..."
@@ -1138,7 +1028,6 @@ msgid "Client ID: %s"
 msgstr "شناسه کاربر: %s"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:23
-#, fuzzy
 msgid "close"
 msgstr "بستن"
 
@@ -1157,7 +1046,6 @@ msgid "Close"
 msgstr "بستن"
 
 #: packages/app-mobile/components/Modal.tsx:155
-#, fuzzy
 msgid "Close dialog"
 msgstr "بستن صفحه"
 
@@ -1167,17 +1055,11 @@ msgstr "بستن حالت کشویی"
 
 #: packages/app-mobile/components/SideMenu.tsx:303
 msgid "Close side menu"
-msgstr ""
+msgstr "منوی کناری را ببندید"
 
 #: packages/lib/models/settings/settingValidations.ts:33
-msgid ""
-"Close the application, then delete your profile in \"%s\", and start the "
-"application again. Make sure you create a backup first by exporting all your "
-"notes as JEX."
-msgstr ""
-"برنامه را ببندید، سپس نمایه خود را در \"%s\" حذف کنید و برنامه را دوباره "
-"شروع کنید. اطمینان حاصل کنید که ابتدا با صادرات تمام یادداشت های خود به "
-"عنوان JEX یک نسخه پشتیبان ایجاد کرده اید."
+msgid "Close the application, then delete your profile in \"%s\", and start the application again. Make sure you create a backup first by exporting all your notes as JEX."
+msgstr "برنامه را ببندید، سپس نمایه خود را در \"%s\" حذف کنید و برنامه را دوباره شروع کنید. اطمینان حاصل کنید که ابتدا با صادرات تمام یادداشت های خود به عنوان JEX یک نسخه پشتیبان ایجاد کرده اید."
 
 #: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:26
 #: packages/app-desktop/gui/MenuBar.tsx:648
@@ -1186,7 +1068,7 @@ msgstr "بستن صفحه"
 
 #: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:161
 msgid "Closing session..."
-msgstr ""
+msgstr "درحال بستن جلسه..."
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.ts:40
 msgid "Cmd-click to open"
@@ -1219,18 +1101,15 @@ msgid "Collaborate on notebooks with others"
 msgstr "همکاری با دیگران در دفترچه‌ها"
 
 #: packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx:28
-#, fuzzy
 msgid "Collapse all notebooks"
-msgstr "ایجاد دفترچه"
+msgstr "جمع کردن همه دفترچه‌ها"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:1758
 #: packages/app-mobile/components/screens/NoteRevisionViewer.tsx:225
-#, fuzzy
 msgid "Collapse title"
-msgstr "کوچک کردن %s"
+msgstr "جمع کردن عنوان"
 
 #: packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.tsx:23
-#, fuzzy
 msgid "Collapsed"
 msgstr "بستن"
 
@@ -1239,16 +1118,8 @@ msgid "Coming alarms"
 msgstr "هشدار‌های آینده"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1595
-msgid ""
-"Comma-separated list of paths to directories to load the certificates from, "
-"or path to individual cert files. For example: /my/cert_dir, /other/"
-"custom.pem. Note that if you make changes to the TLS settings, you must save "
-"your changes before clicking on \"Check synchronisation configuration\"."
-msgstr ""
-"لیست مسیرهای دایرکتوری های جدا شده با کاما برای دانلود گواهی‌نامه‌ها، یا مسیری "
-"به فایل‌های گواهی‌نامه شخصی. برای مثال: /my/cert_dir, /other/custom.pem . توجه "
-"داشته باشید که اگر تغییراتی در تنظیمات TLS ایجاد کنید، باید تغییرات خود را "
-"قبل از کلیک بر روی گزینه \"بررسی پیکربندی همگام سازی\" ذخیره نمایید."
+msgid "Comma-separated list of paths to directories to load the certificates from, or path to individual cert files. For example: /my/cert_dir, /other/custom.pem. Note that if you make changes to the TLS settings, you must save your changes before clicking on \"Check synchronisation configuration\"."
+msgstr "لیست مسیرهای دایرکتوری های جدا شده با کاما برای دانلود گواهی‌نامه‌ها، یا مسیری به فایل‌های گواهی‌نامه شخصی. برای مثال: /my/cert_dir, /other/custom.pem . توجه داشته باشید که اگر تغییراتی در تنظیمات TLS ایجاد کنید، باید تغییرات خود را قبل از کلیک بر روی گزینه \"بررسی پیکربندی همگام سازی\" ذخیره نمایید."
 
 #: packages/lib/services/KeymapService.ts:333
 msgid "command"
@@ -1260,7 +1131,7 @@ msgstr "فرمان"
 
 #: packages/app-cli/app/command-keymap.ts:30
 msgid "COMMAND"
-msgstr ""
+msgstr "دستور"
 
 #: packages/app-desktop/plugins/GotoAnything.tsx:783
 msgid "Command palette"
@@ -1271,23 +1142,20 @@ msgid "Command palette..."
 msgstr "پالت فرمان ..."
 
 #: packages/app-cli/app/command-share.ts:59
-msgid ""
-"Commands: `add`, `remove`, `list`, `delete`, `accept`, `leave`, and `reject`."
-msgstr ""
+msgid "Commands: `add`, `remove`, `list`, `delete`, `accept`, `leave`, and `reject`."
+msgstr "دستورات:`اضافه کردن`, `حذف کردن`, `لیست کردن`, `پاکسازی کردن`, `قبول کردن`, `ترک کردن`, و  `رد کردن`."
 
 #: packages/lib/services/noteList/defaultListRenderer.ts:24
 msgid "Compact"
 msgstr "فشرده"
 
 #: packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts:174
-#, fuzzy
 msgid "Complete"
-msgstr "کامل شده"
+msgstr "تکمیل"
 
 #: packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.ts:40
-#, fuzzy
 msgid "Complete to-do"
-msgstr "کامل شده"
+msgstr "تکمیل فهرست کارها"
 
 #: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:12
 #: packages/app-desktop/gui/NotePropertiesDialog.tsx:84
@@ -1325,13 +1193,12 @@ msgid "Configuration"
 msgstr "تنظیمات"
 
 #: packages/app-cli/app/command-keymap.ts:24
-#, fuzzy
 msgid "Configured keyboard shortcuts:"
-msgstr "میانبرهای صفحه‌کلید"
+msgstr "میانبرهای صفحه‌کلید پیکربندی‌شده:"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1296
 msgid "Configures the size of scrollbars used in the app."
-msgstr ""
+msgstr "اندازه نوارهای پیمایش در برنامه را تنظیم می‌کند."
 
 #: packages/app-mobile/components/screens/encryption-config.tsx:155
 msgid "Confirm password cannot be empty"
@@ -1367,18 +1234,17 @@ msgstr "اتصال به سرویس ابری joplin"
 #: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:277
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:485
 msgid "Connect using your organisation account"
-msgstr ""
+msgstr "با استفاده از حساب سازمانی خود متصل شوید"
 
 #: packages/lib/utils/joplinCloud/index.ts:224
 msgid "Consolidated billing"
 msgstr "صورتحساب تلفیقی"
 
 #: packages/app-desktop/gui/Sidebar/listItemComponents/NoteCount.tsx:11
-#, fuzzy
 msgid "Contains %d note"
 msgid_plural "Contains %d notes"
-msgstr[0] "تبدیل به یادداشت"
-msgstr[1] "تبدیل به یادداشت"
+msgstr[0] "شامل %d یادداشت است"
+msgstr[1] "شامل %d یادداشت است"
 
 #: packages/app-desktop/gui/ConfigScreen/controls/plugins/SearchPlugins.tsx:106
 msgid "Content provided by %s"
@@ -1395,19 +1261,16 @@ msgid "Continue"
 msgstr "ادامه"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:6
-#, fuzzy
 msgid "Control character"
-msgstr "کاراکترها"
+msgstr "کنترل کاراکتر"
 
 #: packages/app-desktop/gui/NoteEditor/NoteEditor.tsx:666
-#, fuzzy
 msgid "Convert it"
-msgstr "تبدیل به یادداشت"
+msgstr "تبدیل‌اش کن"
 
 #: packages/lib/commands/convertNoteToMarkdown.ts:18
-#, fuzzy
 msgid "Convert to Markdown"
-msgstr "تبدیل به کار"
+msgstr "تبدیل به Markdown"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:1350
 msgid "Convert to note"
@@ -1456,7 +1319,7 @@ msgstr "کپی کردن لینک برای وبسایت"
 #: packages/app-desktop/gui/utils/NoteListUtils.ts:122
 #: packages/app-mobile/components/screens/Note/Note.tsx:1359
 msgid "Copy Markdown link"
-msgstr "کپی کردن پیوند نشانه‌گذاری"
+msgstr "کپی کردن پیوند Markdown"
 
 #: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:201
 msgid "Copy path to clipboard"
@@ -1498,13 +1361,11 @@ msgstr ""
 
 #: packages/lib/JoplinServerApi.ts:122
 msgid ""
-"Could not connect to Joplin Server. Please check the Synchronisation options "
-"in the config screen. Full error was:\n"
+"Could not connect to Joplin Server. Please check the Synchronisation options in the config screen. Full error was:\n"
 "\n"
 "%s"
 msgstr ""
-"اتصال به سرور joplin برقرار نشد. لطفاً گزینه‌های همگام‌سازی را در صفحه تنظیمات "
-"بررسی نمایید. جزئیات کامل خطا:\n"
+"اتصال به سرور joplin برقرار نشد. لطفاً گزینه‌های همگام‌سازی را در صفحه تنظیمات بررسی نمایید. جزئیات کامل خطا:\n"
 "\n"
 "%s"
 
@@ -1513,9 +1374,8 @@ msgid "Could not connect to plugin repository."
 msgstr "نمی توان به مخزن افزونه متصل شد."
 
 #: packages/lib/commands/convertNoteToMarkdown.ts:70
-#, fuzzy
 msgid "Could not convert notes to Markdown: %s"
-msgstr "یادداشت‌ها صادر نشدند: %s"
+msgstr "تبدیل یادداشت‌ها به Markdown امکان‌پذیر نبود: %s"
 
 #: packages/app-desktop/InteropServiceHelper.ts:235
 msgid "Could not export notes: %s"
@@ -1523,17 +1383,15 @@ msgstr "یادداشت‌ها صادر نشدند: %s"
 
 #: packages/lib/components/shared/config/plugins/useOnInstallHandler.ts:71
 msgid "Could not install plugin: %s"
-msgstr "افزونه نصب نصب نشد: %s"
+msgstr "افزونه نصب نشد: %s"
 
 #: packages/lib/services/share/invitationRespond.ts:24
 msgid ""
-"Could not respond to the invitation. Please try again, or check with the "
-"notebook owner if they are still sharing it.\n"
+"Could not respond to the invitation. Please try again, or check with the notebook owner if they are still sharing it.\n"
 "\n"
 "The error was: \"%s\""
 msgstr ""
-"به دعوت نمی‌توان پاسخ داد. لطفاً دوباره امتحان کنید و یا با صاحب دفترچه بررسی "
-"کنید که آیا کماکان آن را به اشتراک گذاشته است.\n"
+"به دعوت نمی‌توان پاسخ داد. لطفاً دوباره امتحان کنید و یا با صاحب دفترچه بررسی کنید که آیا کماکان آن را به اشتراک گذاشته است.\n"
 "\n"
 "خطا: %s"
 
@@ -1546,12 +1404,8 @@ msgid "Could not upgrade master key: %s"
 msgstr "کلید اصلی ارتقا نیافت: %s"
 
 #: packages/lib/commands/leaveSharedFolder.ts:33
-msgid ""
-"Could not verify the share status of this notebook - aborting. Please try "
-"again when you are connected to the internet."
-msgstr ""
-"وضعیت اشتراک‌گذاری این دفترچه تأیید نشد و بی‌نتیحه ماند. لطفاً زمانی که به "
-"اینترنت وصل شدید، دوباره امتحان نمایید."
+msgid "Could not verify the share status of this notebook - aborting. Please try again when you are connected to the internet."
+msgstr "وضعیت اشتراک‌گذاری این دفترچه تأیید نشد و بی‌نتیحه ماند. لطفاً زمانی که به اینترنت وصل شدید، دوباره امتحان نمایید."
 
 #: packages/app-mobile/components/biometrics/biometricAuthenticate.ts:26
 msgid "Could not verify your identity: %s"
@@ -1570,9 +1424,8 @@ msgid "Create a notebook"
 msgstr "ایجاد دفترچه"
 
 #: packages/app-mobile/components/FolderPicker.tsx:112
-#, fuzzy
 msgid "Create new notebook"
-msgstr "ایجاد دفترچه جدید."
+msgstr "ایجاد دفترچه جدید"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/addProfile.ts:9
 #: packages/app-mobile/components/ProfileSwitcher/ProfileEditor.tsx:88
@@ -1580,9 +1433,8 @@ msgid "Create new profile..."
 msgstr "ایجاد حساب‌کاربری جدید..."
 
 #: packages/app-mobile/components/screens/DocumentScanner/NotePreview.tsx:212
-#, fuzzy
 msgid "Create note"
-msgstr "ایجاد دفترچه"
+msgstr "ایجاد یادداشت"
 
 #: packages/app-desktop/gui/EditFolderDialog/Dialog.tsx:166
 msgid "Create notebook"
@@ -1628,9 +1480,8 @@ msgid "Created: %s"
 msgstr "ایجاد شده: %s"
 
 #: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:70
-#, fuzzy
 msgid "Creates a new note with an attachment of type %s"
-msgstr "یک دفترچه‌ جدید در زیر دفترچه والد ایجاد نمایید."
+msgstr "یک یادداشت با یک پیوست از نوع %s ایجاد می‌نمایید"
 
 #: packages/app-cli/app/command-mknote.js:12
 msgid "Creates a new note."
@@ -1653,14 +1504,12 @@ msgid "Creating new to-do..."
 msgstr "ایجاد فهرست کار جدید..."
 
 #: packages/app-mobile/components/screens/DocumentScanner/DocumentScanner.tsx:79
-#, fuzzy
 msgid "Creating note \"%s\"..."
-msgstr "ایجاد یادداشت جدید..."
+msgstr "درحال ایجاد یادداشت \"%s\" ..."
 
 #: packages/app-mobile/components/screens/DocumentScanner/DocumentScanner.tsx:142
-#, fuzzy
 msgid "Creating note."
-msgstr "ایجاد یادداشت جدید..."
+msgstr "درحال ایجاد یادداشت."
 
 #: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportDebugReportButton.tsx:29
 msgid "Creating report..."
@@ -1675,14 +1524,12 @@ msgid "Ctrl-click to open: %s"
 msgstr "کلیک کنترل برای باز کردن: %s"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:24
-#, fuzzy
 msgid "current match"
-msgstr "تطابق بعدی"
+msgstr "تطابق فعلی"
 
 #: packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx:153
-#, fuzzy
 msgid "Current password"
-msgstr "گذرواژه"
+msgstr "گذرواژه کنونی"
 
 #: packages/app-desktop/checkForUpdates.ts:90
 msgid "Current version is up-to-date."
@@ -1702,7 +1549,7 @@ msgstr "استایل سفارشی برای joplin در سراسر برنامه"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1335
 msgid "Custom stylesheet for rendered Markdown"
-msgstr "استایل سفارشی برای نشانه‌گذاری ارائه شده"
+msgstr "استایل سفارشی برای Markdown ارائه شده"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1594
 msgid "Custom TLS certificates"
@@ -1764,7 +1611,7 @@ msgstr "پیش‌فرض"
 
 #: packages/lib/models/settings/builtInMetadata.ts:2004
 msgid "Default title to use for documents created by the scanner."
-msgstr ""
+msgstr "عنوان پیشفرض برای استفاده در مستندات ساخته شده توسط اسکنر."
 
 #: packages/app-cli/app/help-utils.js:71
 msgid "Default: %s"
@@ -1792,9 +1639,8 @@ msgid "Delete attachment \"%s\"?"
 msgstr "پیوست «%s» حذف شود؟"
 
 #: packages/editor/ProseMirror/plugins/tablePlugin.ts:41
-#, fuzzy
 msgid "Delete column"
-msgstr "حذف خط"
+msgstr "حذف ستون"
 
 #: packages/server/src/services/TaskService.ts:27
 msgid "Delete expired sessions"
@@ -1806,9 +1652,8 @@ msgstr "حذف توکن‌های منقضی شده"
 
 #: packages/app-desktop/gui/NoteRevisionViewer.tsx:188
 #: packages/app-mobile/components/screens/NoteRevisionViewer.tsx:194
-#, fuzzy
 msgid "Delete history"
-msgstr "فعال‌سازی تاریخچه‌ یادداشت"
+msgstr "حذف تاریخچه"
 
 #: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:110
 #: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:148
@@ -1836,18 +1681,18 @@ msgid "Delete profile \"%s\""
 msgstr "حساب‌کاربری «%s» حذف شود؟"
 
 #: packages/app-desktop/gui/ProfileEditor.tsx:147
-#, fuzzy
 msgid ""
 "Delete profile \"%s\"?\n"
 "\n"
 "All data, including notes, notebooks and tags will be permanently deleted."
 msgstr ""
-"تمام داده ها اعم از یادداشت‌ها، دفترچه‌ها و برچسب‌ها به طور دائمی حذف خواهند شد."
+"حساب‌کاربری «%s» حذف شود؟\n"
+"\n"
+"تمام داده‌ها، از جمله یادداشت‌ها، دفترچه‌ها و برچسب‌ها، برای همیشه حذف خواهند شد."
 
 #: packages/editor/ProseMirror/plugins/tablePlugin.ts:36
-#, fuzzy
 msgid "Delete row"
-msgstr "حذف یادداشت"
+msgstr "حذف ردیف"
 
 #: packages/app-mobile/components/ScreenHeader/index.tsx:487
 msgid "Delete selected notes"
@@ -1857,29 +1702,23 @@ msgstr "حذف یادداشت‌های انتخاب شده"
 msgid ""
 "Delete tag \"%s\"?\n"
 "\n"
-"All notes associated with this tag will remain, but the tag will be removed "
-"from all notes."
-msgstr ""
+"All notes associated with this tag will remain, but the tag will be removed from all notes."
+msgstr "آیا برچسب \"%s\" حذف شود؟ تمامی یادداشت های مرتبط با این برچسب باقی خواهند ماند، اما برچسب از تمامی یادداشت ها حذف خواهد شد."
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/deleteFolder.ts:38
 #: packages/app-mobile/components/side-menu-content.tsx:414
 msgid ""
 "Delete the Inbox notebook?\n"
 "\n"
-"If you delete the inbox notebook, any email that's recently been sent to it "
-"may be lost."
+"If you delete the inbox notebook, any email that's recently been sent to it may be lost."
 msgstr ""
 "دفترچه‌ی صندوق ورودی حذف شود؟\n"
 "\n"
-"اگر دفترچه صندوق ورودی را حذف کنید، ممکن است هر ایمیلی که اخیراً به آن ارسال "
-"شده است نیز از بین برود."
+"اگر دفترچه صندوق ورودی را حذف کنید، ممکن است هر ایمیلی که اخیراً به آن ارسال شده است نیز از بین برود."
 
 #: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:236
-msgid ""
-"Delete this invitation? The recipient will no longer have access to this "
-"shared notebook."
-msgstr ""
-"این دعوتنامه حذف شود؟ گیرنده دیگر به این دفترچه‌ی مشترک دسترسی نخواهد داشت."
+msgid "Delete this invitation? The recipient will no longer have access to this shared notebook."
+msgstr "این دعوتنامه حذف شود؟ گیرنده دیگر به این دفترچه‌ی مشترک دسترسی نخواهد داشت."
 
 #: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:107
 msgid "Delete this profile?"
@@ -1900,8 +1739,7 @@ msgstr "موارد ریموت حذف شده: %d."
 
 #: packages/app-cli/app/command-rmnote.ts:20
 msgid "Deletes notes permanently, skipping the trash."
-msgstr ""
-"یادداشت ها را برای همیشه حذف می کند و از نگهداری در سطل زباله صرف نظر می کند."
+msgstr "یادداشت ها را برای همیشه حذف می کند و از نگهداری در سطل زباله صرف نظر می کند."
 
 #: packages/app-cli/app/command-rmbook.ts:14
 msgid "Deletes the given notebook."
@@ -1920,14 +1758,12 @@ msgid "Deletes the notes without asking for confirmation."
 msgstr "یادداشت‌ها را بدون پرسش برای تایید حذف می‌کند."
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:579
-#, fuzzy
 msgid "Deletion log"
-msgstr "حذف خط"
+msgstr "گزارش حذف"
 
 #: packages/app-mobile/components/NoteItem.tsx:152
-#, fuzzy
 msgid "Deselect"
-msgstr "انتخاب"
+msgstr "لغو انتخاب"
 
 #: packages/app-cli/app/command-export.ts:24
 msgid "Destination format: %s"
@@ -1939,13 +1775,12 @@ msgid "Detailed"
 msgstr "اطلاعات دقیق"
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/PluginChips.tsx:99
-#, fuzzy
 msgid "Dev"
-msgstr "به واسطه"
+msgstr "توسعه"
 
 #: packages/lib/versionInfo.ts:88
 msgid "Device: %s"
-msgstr ""
+msgstr "دستگاه: %s"
 
 #: packages/lib/services/interop/Module.ts:61
 msgid "Directory"
@@ -1969,9 +1804,8 @@ msgid "Disable safe mode and restart"
 msgstr "غیرفعال کردن حالت امن و راه‌اندازی مجدد"
 
 #: packages/app-desktop/gui/MainScreen.tsx:594
-#, fuzzy
 msgid "Disable synchronisation"
-msgstr "لغو سینک"
+msgstr "غیرفعال کردن همگام‌سازی"
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:97
 msgid "Disable Web Clipper Service"
@@ -1987,24 +1821,17 @@ msgid "Disabled"
 msgstr "غیر‌فعال شده"
 
 #: packages/app-mobile/components/screens/encryption-config.tsx:322
-#, fuzzy
 msgid "Disabled keys"
-msgstr "پنهان‌سازی کلیدها غیرفعال است"
+msgstr "کلیدهای غیرفعال"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:200
 #: packages/app-mobile/components/screens/encryption-config.tsx:276
-msgid ""
-"Disabling encryption means *all* your notes and attachments are going to be "
-"re-synchronised and sent unencrypted to the sync target. Do you wish to "
-"continue?"
-msgstr ""
-"غیرفعال کردن رمزنگاری به این معنی است که *تمام* یادداشت‌ها و پیوست‌های شما "
-"دوباره همگام‌سازی شده و بدون رمزنگاری به هدف همگام‌سازی ارسال ‌شوند. آیا مایل "
-"هستید ادامه دهید؟"
+msgid "Disabling encryption means *all* your notes and attachments are going to be re-synchronised and sent unencrypted to the sync target. Do you wish to continue?"
+msgstr "غیرفعال کردن رمزنگاری به این معنی است که *تمام* یادداشت‌ها و پیوست‌های شما دوباره همگام‌سازی شده و بدون رمزنگاری به هدف همگام‌سازی ارسال ‌شوند. آیا مایل هستید ادامه دهید؟"
 
 #: packages/app-mobile/components/NoteEditor/ImageEditor/promptRestoreAutosave.ts:19
 msgid "Discard"
-msgstr "لغو تغییرات"
+msgstr "لغو"
 
 #: packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx:46
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:290
@@ -2029,15 +1856,8 @@ msgid "Displays only the first top <num> notes."
 msgstr "فقط <num> یادداشت اول را نمایش می‌دهد."
 
 #: packages/app-cli/app/command-ls.ts:31
-msgid ""
-"Displays only the items of the specific type(s). Can be `n` for notes, `t` "
-"for to-dos, or `nt` for notes and to-dos (eg. `-tt` would display only the "
-"to-dos, while `-tnt` would display notes and to-dos."
-msgstr ""
-"تنها موارد نوع/انواع مشخص شده را نمایش می‌دهد. می‌تواند برای یادداشت‌ها `n`، "
-"برای فهرست کار‌ها `t` یا برای یادداشت‌ها و فهرست کار‌ها `nt` باشد. (به عنوان "
-"مثال: `-tt` تنها فهرست کار‌ها را نمایش خواهد داد در حالی که `-tnt` یادداشت‌ها "
-"و فهرست کار‌ها را نمایش خواهد داد.)"
+msgid "Displays only the items of the specific type(s). Can be `n` for notes, `t` for to-dos, or `nt` for notes and to-dos (eg. `-tt` would display only the to-dos, while `-tnt` would display notes and to-dos."
+msgstr "تنها موارد نوع/انواع مشخص شده را نمایش می‌دهد. می‌تواند برای یادداشت‌ها `n`، برای فهرست کار‌ها `t` یا برای یادداشت‌ها و فهرست کار‌ها `nt` باشد. (به عنوان مثال: `-tt` تنها فهرست کار‌ها را نمایش خواهد داد در حالی که `-tnt` یادداشت‌ها و فهرست کار‌ها را نمایش خواهد داد.)"
 
 #: packages/app-cli/app/command-status.js:13
 msgid "Displays summary about the notes and notebooks."
@@ -2049,19 +1869,15 @@ msgstr "مشخصات کامل یادداشت را نمایش می‌دهد."
 
 #: packages/app-cli/app/command-keymap.ts:14
 msgid "Displays the configured keyboard shortcuts."
-msgstr ""
+msgstr "میان‌بر های صفحه کلید پیکربندی شده را نمایش می‌دهد."
 
 #: packages/app-cli/app/command-cat.ts:14
 msgid "Displays the given note."
 msgstr "یادداشت مشخص شده را نمایش بده."
 
 #: packages/app-cli/app/command-ls.ts:19
-msgid ""
-"Displays the notes in the current notebook. Use `ls /` to display the list "
-"of notebooks."
-msgstr ""
-"یادداشت های موجود در دفترچه کنونی را نمایش می‌دهد. برای نمایش لیست دفترچه ها "
-"از `ls /` استفاده کنید."
+msgid "Displays the notes in the current notebook. Use `ls /` to display the list of notebooks."
+msgstr "یادداشت های موجود در دفترچه کنونی را نمایش می‌دهد. برای نمایش لیست دفترچه ها از `ls /` استفاده کنید."
 
 #: packages/app-cli/app/command-help.ts:13
 msgid "Displays usage information."
@@ -2083,37 +1899,28 @@ msgstr "برای تایید سوال نکن."
 #: packages/app-cli/app/command-publish.ts:32
 #: packages/app-cli/app/command-share.ts:66
 #: packages/app-cli/app/command-unpublish.ts:29
-#, fuzzy
 msgid "Do not ask for user confirmation."
-msgstr "برای تایید سوال نکن."
+msgstr "از کاربر برای تایید سوال نکن."
 
 #: packages/lib/components/EncryptionConfigScreen/utils.ts:55
-msgid ""
-"Do not lose the password as, for security purposes, this will be the *only* "
-"way to decrypt the data! To enable encryption, please enter your password "
-"below."
-msgstr ""
-"گذرواژه را از دست ندهید زیرا، برای اهداف امنیتی، این *تنها* راه برای "
-"رمزگشایی داده ها خواهد بود! برای فعال نمودن رمزنگاری، لطفا گذرواژه خود را در "
-"زیر وارد نمایید."
+msgid "Do not lose the password as, for security purposes, this will be the *only* way to decrypt the data! To enable encryption, please enter your password below."
+msgstr "گذرواژه را از دست ندهید زیرا، برای اهداف امنیتی، این *تنها* راه برای رمزگشایی داده ها خواهد بود! برای فعال نمودن رمزنگاری، لطفا گذرواژه خود را در زیر وارد نمایید."
 
 #: packages/app-mobile/components/FeedbackBanner.tsx:167
 msgid "Do you find the Joplin web app useful?"
-msgstr ""
+msgstr "آیا اپلیکیشن تحت وب Joplin را مفید می‌دانید؟"
 
 #: packages/lib/models/settings/builtInMetadata.ts:2003
 msgid "Document scanner: Title template"
-msgstr ""
+msgstr "اسکنر اسناد: الگوی قالب"
 
 #: packages/app-cli/app/command-share.ts:65
-msgid ""
-"Don't allow the share recipient to write to the shared notebook. Valid only "
-"for the `add` subcommand."
-msgstr ""
+msgid "Don't allow the share recipient to write to the shared notebook. Valid only for the `add` subcommand."
+msgstr "به گیرنده اشتراک گذاری اجازه ندهید تا دفترچه یادداشت مشترک را ویرایش کند. فقط برای زیردستور `add` معتبر است."
 
 #: packages/app-desktop/gui/NoteEditor/NoteEditor.tsx:668
 msgid "Don't show this message again"
-msgstr ""
+msgstr "این پیام را دوباره نشان نده"
 
 #: packages/lib/models/Setting.ts:1400
 msgid "Donate, website"
@@ -2137,9 +1944,8 @@ msgid "Download and install the relevant extension for your browser:"
 msgstr "افزونه های مرتبط را برای مرورگر خود دانلود و نصب نمایید:"
 
 #: packages/app-desktop/gui/MainScreen.tsx:586
-#, fuzzy
 msgid "Download it now"
-msgstr "در حال دانلود"
+msgstr "اکنون دانلود کنید"
 
 #: packages/lib/models/Resource.ts:409
 msgid "Downloaded"
@@ -2214,17 +2020,12 @@ msgid "Duplicate selected notes"
 msgstr "یادداشت‌های انتخاب‌شده تکراری"
 
 #: packages/app-cli/app/command-cp.ts:13
-msgid ""
-"Duplicates the notes matching <note> to [notebook]. If no notebook is "
-"specified the note is duplicated in the current notebook."
-msgstr ""
-"یادداشت های مطابق با <note> را در [notebook] کپی می‌کند. اگر هیچ دفترچه‌ای "
-"مشخص نشده باشد، یادداشت در دفترچه کنونی کپی می‌شود."
+msgid "Duplicates the notes matching <note> to [notebook]. If no notebook is specified the note is duplicated in the current notebook."
+msgstr "یادداشت های مطابق با <note> را در [notebook] کپی می‌کند. اگر هیچ دفترچه‌ای مشخص نشده باشد، یادداشت در دفترچه کنونی کپی می‌شود."
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:224
-#, fuzzy
 msgid "Duration: %s"
-msgstr "نسخه شما: %s"
+msgstr "مدت زمان: %s"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts:101
 #: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useEditDialog.ts:85
@@ -2241,13 +2042,12 @@ msgid "Edit"
 msgstr "ویرایش"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:1386
-#, fuzzy
 msgid "Edit as Markdown"
-msgstr "نشانه‌گذاری"
+msgstr "ویرایش به‌صورت Markdown"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:1386
 msgid "Edit as Rich Text"
-msgstr ""
+msgstr "ویرایش به صورت متن غنی"
 
 #: packages/app-mobile/components/NoteEditor/EditLinkDialog.tsx:138
 msgid "Edit link"
@@ -2271,9 +2071,8 @@ msgid "Edit profile configuration..."
 msgstr "ویرایش تنظیمات حساب کاربری..."
 
 #: packages/app-mobile/components/screens/tags.tsx:64
-#, fuzzy
 msgid "Edit tag"
-msgstr "ویرایش یادداشت."
+msgstr "ویرایش برچسب"
 
 #: packages/app-desktop/gui/MainScreen.tsx:129
 #: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:151
@@ -2284,9 +2083,8 @@ msgid "Editor"
 msgstr "ویرایشگر"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Toolbar.tsx:40
-#, fuzzy
 msgid "Editor actions"
-msgstr "فونت ویرایشگر"
+msgstr "عملکردهای ویرایشگر"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1221
 msgid "Editor font"
@@ -2384,9 +2182,8 @@ msgid "Enable abbreviation syntax"
 msgstr "فعال‌سازی نحوه نوشتار مختصر"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1093
-#, fuzzy
 msgid "Enable ABC musical notation support"
-msgstr "فعال‌سازی پشتیبانی از نحوه نوشتار فواره‌ای"
+msgstr "فعال‌سازی پشتیبانی از نت‌نویسی موسیقی ABC"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1095
 msgid "Enable audio player"
@@ -2407,7 +2204,7 @@ msgstr "فعال‌سازی رمزنگاری"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1118
 msgid "Enable file:// URLs for images and videos"
-msgstr ""
+msgstr "به file:// URL ها برای تصاویر و ویدیو ها اجازه دهید"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1099
 msgid "Enable footnotes"
@@ -2418,14 +2215,12 @@ msgid "Enable Fountain syntax support"
 msgstr "فعال‌سازی پشتیبانی از نحوه نوشتار فواره‌ای"
 
 #: packages/lib/models/settings/builtInMetadata.ts:587
-#, fuzzy
 msgid "Enable handwritten transcription"
-msgstr "فعال‌سازی رمزنگاری"
+msgstr "فعال‌سازی رونویسی دست‌نویس"
 
 #: packages/lib/models/settings/builtInMetadata.ts:766
-#, fuzzy
 msgid "Enable HTML-to-Markdown conversion banner"
-msgstr "فعال‌سازی نوار ابزار نشانه‌گذاری"
+msgstr "فعال‌سازی نوار تبدیل HTML به Markdown"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1088
 msgid "Enable Linkify"
@@ -2433,7 +2228,7 @@ msgstr "فعال‌سازی تبدیل به لینک"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1105
 msgid "Enable markdown emoji"
-msgstr "فعال‌سازی شکلک نشانه‌گذاری"
+msgstr "فعال‌سازی شکلک‌های Markdown"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1090
 msgid "Enable math expressions"
@@ -2445,7 +2240,7 @@ msgstr "فعال‌سازی پشتیبانی از نمودارهای روندن�
 
 #: packages/lib/models/settings/builtInMetadata.ts:1107
 msgid "Enable multimarkdown table extension"
-msgstr "فعال‌سازی افزونه جدول نشانه‌گذاری چندگانه"
+msgstr "فعال‌سازی افزونه جدول MultiMarkdown"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1690
 msgid "Enable note history"
@@ -2473,9 +2268,8 @@ msgid "Enable soft breaks"
 msgstr "فعال‌سازی شکستن نرم خطوط"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1488
-#, fuzzy
 msgid "Enable spell checking in Markdown editor"
-msgstr "فعال‌سازی بررسی صحت املاء در ویرایشگر متن"
+msgstr "فعال‌سازی بررسی صحت املا در ویرایشگر Markdown"
 
 #: packages/lib/models/settings/builtInMetadata.ts:928
 msgid "Enable spellcheck in the text editor"
@@ -2487,7 +2281,7 @@ msgstr "فعال‌سازی افزونه جدول مطالب"
 
 #: packages/lib/models/settings/builtInMetadata.ts:939
 msgid "Enable the Markdown toolbar"
-msgstr "فعال‌سازی نوار ابزار نشانه‌گذاری"
+msgstr "فعال‌سازی نوار ابزار Markdown"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1087
 msgid "Enable typographer support"
@@ -2510,24 +2304,16 @@ msgid "Enabled"
 msgstr "فعال‌شده"
 
 #: packages/lib/models/settings/builtInMetadata.ts:755
-msgid ""
-"Enables Markdown list continuation, auto-closing HTML tags, and other markup "
-"autocompletions."
-msgstr ""
+msgid "Enables Markdown list continuation, auto-closing HTML tags, and other markup autocompletions."
+msgstr "امکان ادامه فهرست‌های Markdown، بستن خودکار برچسب‌های HTML و سایر قابلیت‌ های تکمیل خودکار نشانه‌ گذاری را فراهم می‌کند."
 
 #: packages/lib/models/settings/builtInMetadata.ts:787
-msgid ""
-"Enables Markdown pattern replacement in the Rich Text Editor. For example, "
-"when enabled, typing **bold** creates bold text."
-msgstr ""
+msgid "Enables Markdown pattern replacement in the Rich Text Editor. For example, when enabled, typing **bold** creates bold text."
+msgstr "امکان جایگزینی الگو های Markdown را در ویرایشگر متن غنی فراهم می‌کند. برای مثال، در صورت فعال بودن این قابلیت، تایپ کردن **bold** متن را به صورت ضخیم (Bold) درمی‌آورد."
 
 #: packages/lib/components/EncryptionConfigScreen/utils.ts:50
-msgid ""
-"Enabling encryption means *all* your notes and attachments are going to be "
-"re-synchronised and sent encrypted to the sync target."
-msgstr ""
-"فعال‌سازی رمزنگاری به این معنی است که *تمام* یادداشت‌ها و پیوست‌های شما دوباره "
-"همگام‌سازی می‌شوند و به صورت رمزنگاری شده به هدف همگام‌سازی ارسال می‌شوند."
+msgid "Enabling encryption means *all* your notes and attachments are going to be re-synchronised and sent encrypted to the sync target."
+msgstr "فعال‌سازی رمزنگاری به این معنی است که *تمام* یادداشت‌ها و پیوست‌های شما دوباره همگام‌سازی می‌شوند و به صورت رمزنگاری شده به هدف همگام‌سازی ارسال می‌شوند."
 
 #: packages/lib/models/BaseItem.ts:951
 msgid "Encrypted"
@@ -2565,9 +2351,8 @@ msgid "End-to-end encryption"
 msgstr "رمز نگاری انتها به انتها یا end-to -end"
 
 #: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:192
-#, fuzzy
 msgid "Ends voice typing"
-msgstr "تایپ صوتی..."
+msgstr "پایان تایپ صوتی"
 
 #: packages/app-mobile/components/screens/dropbox-login.tsx:70
 msgid "Enter code here"
@@ -2587,19 +2372,16 @@ msgid "Enter password"
 msgstr "گذرواژه"
 
 #: packages/app-mobile/components/screens/SsoLoginScreen.tsx:73
-#, fuzzy
 msgid "Enter the code"
 msgstr "کد را وارد نمایید"
 
 #: packages/app-desktop/gui/SsoLoginScreen/SsoLoginScreen.tsx:43
-#, fuzzy
 msgid "Enter the code:"
-msgstr "کد را وارد نمایید"
+msgstr "کد را وارد نمایید:"
 
 #: packages/app-mobile/components/NoteItem.tsx:130
-#, fuzzy
 msgid "Entering selection mode"
-msgstr "بازکردن بخش در %s"
+msgstr "ورود به حالت انتخاب"
 
 #: packages/app-cli/app/help-utils.js:56
 msgid "Enum"
@@ -2622,7 +2404,7 @@ msgstr "خطای بازکردن یادداشت در ویرایشگر: %s"
 
 #: packages/app-mobile/components/CameraView/Camera/index.tsx:52
 msgid "Error starting camera: %s"
-msgstr ""
+msgstr "خطا در راه اندازی دوربین : %s"
 
 #: packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx:64
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginUploadButton.tsx:85
@@ -2634,12 +2416,8 @@ msgid "Error: %s"
 msgstr "خطا: %s"
 
 #: packages/lib/components/shared/config/config-shared.ts:101
-msgid ""
-"Error. Please check that URL, username, password, etc. are correct and that "
-"the sync target is accessible. The reported error was:"
-msgstr ""
-"خطا. لطفا بررسی کنید که آدرس اینترنتی، نام‌کاربری، گذرواژه و غیره صحیح هستند "
-"و هدف همگام‌سازی قابل دسترس است. خطای گزارش شده:"
+msgid "Error. Please check that URL, username, password, etc. are correct and that the sync target is accessible. The reported error was:"
+msgstr "خطا. لطفا بررسی کنید که آدرس اینترنتی، نام‌کاربری، گذرواژه و غیره صحیح هستند و هدف همگام‌سازی قابل دسترس است. خطای گزارش شده:"
 
 #: packages/app-mobile/components/screens/LogScreen.tsx:237
 msgid "Errors only"
@@ -2651,7 +2429,7 @@ msgstr "فایل صادر شده Evernote (به صورت HTML)"
 
 #: packages/lib/services/interop/InteropService.ts:89
 msgid "Evernote Export File (as Markdown)"
-msgstr "فایل صادر شده Evernote (به صورت نشانه‌گذاری)"
+msgstr "فایل صادر شده Evernote (به صورت Markdown)"
 
 #: packages/lib/services/interop/InteropService.ts:98
 msgid "Evernote Export Files (Directory, as HTML)"
@@ -2659,7 +2437,7 @@ msgstr "فایلهای صادر شده Evernote (به صورت HTML)"
 
 #: packages/lib/services/interop/InteropService.ts:107
 msgid "Evernote Export Files (Directory, as Markdown)"
-msgstr "فایلهای صادر شده Evernote (به صورت نشانه‌گذاری)"
+msgstr "فایلهای صادر شده Evernote (به صورت Markdown)"
 
 #: packages/app-cli/app/command-exit.ts:11
 msgid "Exits the application."
@@ -2670,18 +2448,15 @@ msgid "Expand %s"
 msgstr "گسترش %s"
 
 #: packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx:28
-#, fuzzy
 msgid "Expand all notebooks"
-msgstr "ویرایش دفترچه"
+msgstr "باز کردن همه دفترچه‌ها"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:1758
 #: packages/app-mobile/components/screens/NoteRevisionViewer.tsx:225
-#, fuzzy
 msgid "Expand title"
-msgstr "منبسط"
+msgstr "گسترش عنوان"
 
 #: packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.tsx:21
-#, fuzzy
 msgid "Expanded"
 msgstr "منبسط"
 
@@ -2710,9 +2485,8 @@ msgid "Export Debug Report"
 msgstr "صدور گزارش اشکال‌زدایی"
 
 #: packages/app-desktop/commands/exportDeletionLog.ts:11
-#, fuzzy
 msgid "Export deletion log"
-msgstr "صدور همه"
+msgstr "صدور گزارش حذف"
 
 #: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportProfileButton.tsx:16
 msgid "Export profile"
@@ -2736,12 +2510,8 @@ msgid "Exporting..."
 msgstr "در حال ضدور..."
 
 #: packages/app-cli/app/command-export.ts:14
-msgid ""
-"Exports Joplin data to the given path. By default, it will export the "
-"complete database including notebooks, notes, tags and resources."
-msgstr ""
-"داده‌های joplin را در محل مورد نظر صدور می‌کند. به طور پیش‌فرض، تمام پایگاه‌داده "
-"شامل دفترچه‌ها، یادداشت‌ها، برچسب‌ها و منابع را صدور می‌کند."
+msgid "Exports Joplin data to the given path. By default, it will export the complete database including notebooks, notes, tags and resources."
+msgstr "داده‌های joplin را در محل مورد نظر صدور می‌کند. به طور پیش‌فرض، تمام پایگاه‌داده شامل دفترچه‌ها، یادداشت‌ها، برچسب‌ها و منابع را صدور می‌کند."
 
 #: packages/app-cli/app/command-export.ts:24
 msgid "Exports only the given note."
@@ -2756,24 +2526,17 @@ msgid "Fail-safe"
 msgstr "شکست ایمن"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1662
-msgid ""
-"Fail-safe: Do not wipe out local data when sync target is empty (often the "
-"result of a misconfiguration or bug)"
-msgstr ""
-"شکست ایمن: وقتی هدف همگام‌سازی خالی است، داده‌های محلی را پاک نکنید (اغلب "
-"نتیجه یک پیکربندی اشتباه یا اشکال است)"
+msgid "Fail-safe: Do not wipe out local data when sync target is empty (often the result of a misconfiguration or bug)"
+msgstr "شکست ایمن: وقتی هدف همگام‌سازی خالی است، داده‌های محلی را پاک نکنید (اغلب نتیجه یک پیکربندی اشتباه یا اشکال است)"
 
 #: packages/lib/services/synchronizer/syncInfoUtils.ts:134
-msgid ""
-"Fail-safe: Sync was interrupted to prevent data loss, because the sync "
-"target is empty or damaged. To override this behaviour disable the fail-safe "
-"in the sync settings."
-msgstr ""
+msgid "Fail-safe: Sync was interrupted to prevent data loss, because the sync target is empty or damaged. To override this behaviour disable the fail-safe in the sync settings."
+msgstr "مکانیزم ایمنی: عملیات همگام سازی برای جلوگیری از دست رفتن داده ها متوقف شد، زیرا مقصد همگام سازی خالی یا آسیب دیده است. برای نادیده گرفتن این رفتار، مکانیزم ایمنی را در تنظیمات همگام سازی غیرفعال کنید."
 
 #: packages/app-desktop/gui/SsoLoginScreen/SsoLoginScreen.tsx:29
 #: packages/app-mobile/components/screens/SsoLoginScreen.tsx:54
 msgid "Failed to connect to your account. Please try again."
-msgstr ""
+msgstr "اتصال به حساب کاربری شکست خورد. لطفا دوباره امتحان کنید."
 
 #: packages/app-cli/app/main.js:107
 msgid "Fatal error:"
@@ -2786,7 +2549,7 @@ msgstr "پرچم‌های ویژه"
 
 #: packages/app-mobile/components/FeedbackBanner.tsx:180
 msgid "Feedback"
-msgstr ""
+msgstr "بازخورد"
 
 #: packages/lib/Synchronizer.ts:207
 msgid "Fetched items: %d/%d."
@@ -2811,9 +2574,8 @@ msgid "Filter"
 msgstr "فیلتر"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:14
-#, fuzzy
 msgid "Find"
-msgstr "یافت‌شده: "
+msgstr "جستجو"
 
 #: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:264
 msgid "Find: "
@@ -2821,7 +2583,7 @@ msgstr "یافت‌شده: "
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:215
 msgid "Finishes recording"
-msgstr ""
+msgstr "پایان ضبط"
 
 #: packages/app-desktop/gui/ExtensionBadge.tsx:65
 msgid "Firefox Extension"
@@ -2857,11 +2619,11 @@ msgstr "عنوان تمرکز"
 
 #: packages/app-cli/app/command-share.ts:139
 msgid "Folder \"%s\" is shared with:"
-msgstr ""
+msgstr "پوشه \"%s\" با این موارد به اشتراک گذاشته شده است:"
 
 #: packages/app-mobile/components/CameraView/ScannedBarcodes.tsx:98
 msgid "Follow link"
-msgstr ""
+msgstr "لینک را دنبال کنید"
 
 #: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportProfileButton.tsx:38
 msgid "For debugging purpose only: export your profile to an external SD card."
@@ -2873,24 +2635,15 @@ msgstr "برای مثال «%s»"
 
 #: packages/app-cli/app/command-help.ts:37
 msgid "For information on how to customise the shortcuts please visit %s"
-msgstr ""
-"برای اطلاع از اینکه چگونه میانبر‌ها را شخصی‌سازی نمایید، لطفاً به %s مراجعه "
-"نمایید"
+msgstr "برای اطلاع از اینکه چگونه میانبر‌ها را شخصی‌سازی نمایید، لطفاً به %s مراجعه نمایید"
 
 #: packages/app-mobile/components/screens/encryption-config.tsx:338
-msgid ""
-"For more information about End-To-End Encryption (E2EE) and advice on how to "
-"enable it please check the documentation:"
-msgstr ""
-"برای اطلاعات بیشتر در مورد رمزنگاری انتها به انتها (E2EE یا End-To-"
-"Encryption) و آگاهی از نحوه‌ی فعال‌سازی آن، لطفا به مستندات مراجعه نمایید:"
+msgid "For more information about End-To-End Encryption (E2EE) and advice on how to enable it please check the documentation:"
+msgstr "برای اطلاعات بیشتر در مورد رمزنگاری انتها به انتها (E2EE یا End-To-Encryption) و آگاهی از نحوه‌ی فعال‌سازی آن، لطفا به مستندات مراجعه نمایید:"
 
 #: packages/app-cli/app/command-help.ts:85
-msgid ""
-"For the list of keyboard shortcuts and config options, type `help keymap`"
-msgstr ""
-"برای فهرست میانبرهای صفحه‌کلید و گزینه‌های تنظیمات، `help keymap` را تایپ "
-"نمایید"
+msgid "For the list of keyboard shortcuts and config options, type `help keymap`"
+msgstr "برای فهرست میانبرهای صفحه‌کلید و گزینه‌های تنظیمات، `help keymap` را تایپ نمایید"
 
 #: packages/lib/models/settings/builtInMetadata.ts:334
 msgid "Force path style"
@@ -2934,12 +2687,11 @@ msgstr[1] "در حال بوجود آوردن پیوند..."
 
 #: packages/lib/models/Setting.ts:1395
 msgid "Geolocation, spellcheck, editor toolbar, image resize"
-msgstr ""
-"موقعیت جغرافیایی، بررسی املایی، نوار ابزار ویرایشگر، تغییر اندازه تصویر"
+msgstr "موقعیت جغرافیایی، بررسی املایی، نوار ابزار ویرایشگر، تغییر اندازه تصویر"
 
 #: packages/lib/utils/joplinCloud/index.ts:461
 msgid "Get a quote"
-msgstr ""
+msgstr "دریافت استعلام قیمت"
 
 #: packages/app-desktop/gui/ExtensionBadge.tsx:93
 msgid "Get it now:"
@@ -2950,26 +2702,20 @@ msgid "Get pre-releases when checking for updates"
 msgstr "دریافت نسخه پیش از انتشار در زمان بررسی برای بروزرسانی"
 
 #: packages/app-cli/app/command-config.ts:14
-msgid ""
-"Gets or sets a config value. If [value] is not provided, it will show the "
-"value of [name]. If neither [name] nor [value] is provided, it will list the "
-"current configuration."
-msgstr ""
-"یک مقدار تنظیمات را دریافت یا قرار می‌دهد. اگر [value] (مقدار) داده نشود، "
-"مقدار [name] (اسم) نمایش داده خواهد شد. اگر نه [name] (اسم) و نه [value] "
-"(مقدار) داده نشده باشند، تنظیمات فعلی لیست می‌شود."
+msgid "Gets or sets a config value. If [value] is not provided, it will show the value of [name]. If neither [name] nor [value] is provided, it will list the current configuration."
+msgstr "یک مقدار تنظیمات را دریافت یا قرار می‌دهد. اگر [value] (مقدار) داده نشود، مقدار [name] (اسم) نمایش داده خواهد شد. اگر نه [name] (اسم) و نه [value] (مقدار) داده نشده باشند، تنظیمات فعلی لیست می‌شود."
 
 #: packages/app-mobile/services/voiceTyping/whisper.ts:189
 msgid "Glossary:"
-msgstr ""
+msgstr "واژه نامه:"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:13
 msgid "go"
-msgstr ""
+msgstr "برو"
 
 #: packages/app-mobile/components/CameraView/CameraView.tsx:150
 msgid "Go back"
-msgstr ""
+msgstr "برگشتن"
 
 #: packages/app-desktop/gui/JoplinCloudConfigScreen.tsx:44
 #: packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.tsx:59
@@ -2978,7 +2724,7 @@ msgstr "ورود به حساب سرویس ابری joplin"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:12
 msgid "Go to line"
-msgstr ""
+msgstr "رفتن به خط"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:1237
 msgid "Go to source URL"
@@ -3035,7 +2781,7 @@ msgstr "پنهان‌سازی غیرفعال است"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:160
 msgid "Hide disabled keys"
-msgstr "پنهان‌سازی کلیدها غیرفعال است"
+msgstr "پنهان کردن کلیدهای غیرفعال"
 
 #: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:22
 msgid "Hide Joplin"
@@ -3047,14 +2793,12 @@ msgid "Hide keyboard"
 msgstr "پنهان‌سازی صفحه‌کلید"
 
 #: packages/app-desktop/gui/PasswordInput/PasswordInput.tsx:21
-#, fuzzy
 msgid "Hide password"
-msgstr "گذرواژه نامعتبر"
+msgstr "پنهان کردن گذرواژه"
 
 #: packages/app-mobile/components/NoteEditor/WarningBanner.tsx:24
-#, fuzzy
 msgid "Hides warning"
-msgstr "هشدار"
+msgstr "پنهان کردن هشدار"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.ts:14
 msgid "Highlight"
@@ -3103,18 +2847,12 @@ msgid "Idle"
 msgstr "بیکار"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1509
-msgid ""
-"If an image attachment is on its own line and followed by a blank line, it "
-"will be rendered just below its Markdown source."
-msgstr ""
+msgid "If an image attachment is on its own line and followed by a blank line, it will be rendered just below its Markdown source."
+msgstr "اگر یک تصویرِ پیوست‌شده در سطری جداگانه قرار داشته باشد و پس از آن یک سطر خالی بیاید، درست در زیر Markdown خود نمایش داده خواهد شد."
 
 #: packages/lib/services/joplinCloudUtils.ts:37
-msgid ""
-"If you have already authorised, please wait for the application to sync to "
-"Joplin Cloud."
-msgstr ""
-"اگر قبلاً احراز هویت شده‌اید، لطفاً منتظر بمانید تا برنامه با سرویس ابری Joplin "
-"همگام شود."
+msgid "If you have already authorised, please wait for the application to sync to Joplin Cloud."
+msgstr "اگر قبلاً احراز هویت شده‌اید، لطفاً منتظر بمانید تا برنامه با سرویس ابری Joplin همگام شود."
 
 #: packages/app-desktop/ElectronAppWrapper.ts:184
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:360
@@ -3167,9 +2905,8 @@ msgid "Import or export your data"
 msgstr "داده های خود را وارد یا صادر کنید"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts:20
-#, fuzzy
 msgid "Import..."
-msgstr "در حال صدور..."
+msgstr "وارد کردن..."
 
 #: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx:76
 msgid "Imported successfully!"
@@ -3185,62 +2922,42 @@ msgstr "در حال وارد کردن یادداشت‌ها..."
 
 #: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx:26
 msgid "Importing..."
-msgstr "در حال صدور..."
+msgstr "در حال وارد کردن..."
 
 #: packages/app-cli/app/command-import.ts:17
 msgid "Imports data into Joplin."
 msgstr "داده را در joplin وارد می‌کند."
 
 #: packages/lib/models/settings/builtInMetadata.ts:468
-msgid ""
-"In \"Manual\" mode, attachments are downloaded only when you click on them. "
-"In \"Auto\", they are downloaded when you open the note. In \"Always\", all "
-"the attachments are downloaded whether you open the note or not."
-msgstr ""
-"در حالت «دستی»، پیوست‌ها تنها زمانی دانلود می‌شوند که روی آن‌ها کلیک کنید. در "
-"حالت «خودکار»، وقتی یادداشت را باز می‌کنید، دانلود می‌شوند. در حالت«همیشه»، چه "
-"یادداشت را باز کنید یا نه، همه پیوست‌ها دانلود می‌شوند."
+msgid "In \"Manual\" mode, attachments are downloaded only when you click on them. In \"Auto\", they are downloaded when you open the note. In \"Always\", all the attachments are downloaded whether you open the note or not."
+msgstr "در حالت «دستی»، پیوست‌ها تنها زمانی دانلود می‌شوند که روی آن‌ها کلیک کنید. در حالت «خودکار»، وقتی یادداشت را باز می‌کنید، دانلود می‌شوند. در حالت«همیشه»، چه یادداشت را باز کنید یا نه، همه پیوست‌ها دانلود می‌شوند."
 
 #: packages/app-cli/app/command-help.ts:78
-msgid ""
-"In any command, a note or notebook can be referred to by title or ID, or "
-"using the shortcuts `$n` or `$b` for, respectively, the currently selected "
-"note or notebook. `$c` can be used to refer to the currently selected item."
-msgstr ""
-"در هر دستوری، یک یادداشت یا دفترچه را می توان با عنوان یا شناسه یا با "
-"استفاده از میانبرهای `$n` یا `$b` به ترتیب برای یادداشت یا دفترچه انتخاب شده "
-"در حال حاضر ارجاع داد. میانبر `$c` را می توان برای اشاره به مورد انتخاب شده "
-"فعلی استفاده نمود."
+msgid "In any command, a note or notebook can be referred to by title or ID, or using the shortcuts `$n` or `$b` for, respectively, the currently selected note or notebook. `$c` can be used to refer to the currently selected item."
+msgstr "در هر دستوری، یک یادداشت یا دفترچه را می توان با عنوان یا شناسه یا با استفاده از میانبرهای `$n` یا `$b` به ترتیب برای یادداشت یا دفترچه انتخاب شده در حال حاضر ارجاع داد. میانبر `$c` را می توان برای اشاره به مورد انتخاب شده فعلی استفاده نمود."
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:346
 msgid ""
-"In order to do so, your entire data set will have to be encrypted and "
-"synchronised, so it is best to run it overnight.\n"
+"In order to do so, your entire data set will have to be encrypted and synchronised, so it is best to run it overnight.\n"
 "\n"
 "To start, please follow these instructions:\n"
 "\n"
 "1. Synchronise all your devices.\n"
 "2. Click \"%s\".\n"
-"3. Let it run to completion. While it runs, avoid changing any note on your "
-"other devices, to avoid conflicts.\n"
-"4. Once sync is done on this device, sync all your other devices and let it "
-"run to completion.\n"
+"3. Let it run to completion. While it runs, avoid changing any note on your other devices, to avoid conflicts.\n"
+"4. Once sync is done on this device, sync all your other devices and let it run to completion.\n"
 "\n"
 "Important: you only need to run this ONCE on one device."
 msgstr ""
-"برای انجام این کار، کل مجموعه داده شما باید رمزنگاری و همگام شود، بنابراین "
-"بهتر است آن را به یکباره اجرا نماید.\n"
+"برای انجام این کار، کل مجموعه داده شما باید رمزنگاری و همگام شود، بنابراین بهتر است آن را به یکباره اجرا نماید.\n"
 "\n"
 "برای شروع، لطفا این دستورالعمل‌ها را دنبال کنید:\n"
 "1. همه دستگاه های خود را همگام سازی کنید.\n"
 "2. بر روی «%s» کلیک نمایید.\n"
-"3. اجازه دهید تا کامل شود. در حین اجرا، از تغییر هر یادداشتی در دستگاه‌های "
-"دیگر خود اجتناب نمایید  تا از بروز تداخل جلوگیری شود.\n"
-"4.پس از انجام همگام‌سازی در این دستگاه، همه دستگاه‌های دیگر خود را همگام‌سازی "
-"کنید و اجازه دهید تا کامل شود.\n"
+"3. اجازه دهید تا کامل شود. در حین اجرا، از تغییر هر یادداشتی در دستگاه‌های دیگر خود اجتناب نمایید  تا از بروز تداخل جلوگیری شود.\n"
+"4.پس از انجام همگام‌سازی در این دستگاه، همه دستگاه‌های دیگر خود را همگام‌سازی کنید و اجازه دهید تا کامل شود.\n"
 "\n"
-"نکته‌ی مهم: شما فقط باید این عملیات را یک مرتبه و تنها روی یک دستگاه اجرا "
-"کنید."
+"نکته‌ی مهم: شما فقط باید این عملیات را یک مرتبه و تنها روی یک دستگاه اجرا کنید."
 
 #: packages/lib/services/synchronizer/syncInfoUtils.ts:499
 msgid "In order to synchronise, please upgrade your application to version %s+"
@@ -3248,12 +2965,8 @@ msgstr "برای همگام سازی، لطفاً برنامه خود را به 
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:143
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:245
-msgid ""
-"In order to use file system synchronisation your permission to write to "
-"external storage is required."
-msgstr ""
-"برای استفاده از همگام‌سازی سیستم فایل، اجازه نوشتن روی حافظه خارجی مورد نیاز "
-"است."
+msgid "In order to use file system synchronisation your permission to write to external storage is required."
+msgstr "برای استفاده از همگام‌سازی سیستم فایل، اجازه نوشتن روی حافظه خارجی مورد نیاز است."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:133
 msgid "In order to use the web clipper, you need to do the following:"
@@ -3268,23 +2981,20 @@ msgid "In: %s"
 msgstr "در: %s"
 
 #: packages/app-cli/app/command-share.ts:170
-#, fuzzy
 msgid "Incoming shares:"
-msgstr "هشدار‌های آینده"
+msgstr "اشتراک‌های دریافتی:"
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/PluginChips.tsx:69
 msgid "Incompatible"
 msgstr "ناسازگار"
 
 #: packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts:174
-#, fuzzy
 msgid "Incomplete"
-msgstr "کامل شده"
+msgstr "ناتمام"
 
 #: packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.ts:40
-#, fuzzy
 msgid "Incomplete to-do"
-msgstr "نمایش فهرست کار‌های کامل شده"
+msgstr "کار ناتمام"
 
 #: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:133
 msgid "Increase indent level"
@@ -3301,7 +3011,7 @@ msgstr "تورفتگی بیشتر"
 #: packages/app-desktop/gui/PopupNotification/NotificationItem.tsx:22
 #: packages/app-mobile/components/DialogManager/hooks/useDialogControl.ts:21
 msgid "Info"
-msgstr ""
+msgstr "اطلاعات"
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:244
 msgid "Information"
@@ -3370,7 +3080,7 @@ msgstr "دستور نامعتبر: «%s»"
 
 #: packages/app-desktop/gui/NotePropertiesDialog.tsx:373
 msgid "Invalid format. E.g.: 48.8581372, 2.2926735"
-msgstr ""
+msgstr "فرمت نامعتبر. مثال: 48.8581372،2.2926735"
 
 #: packages/lib/models/Setting.ts:818
 msgid "Invalid option value: \"%s\". Possible values are: %s."
@@ -3408,23 +3118,17 @@ msgid "Items that cannot be synchronised"
 msgstr "مواردی که نمی‌توانند همگام‌سازی شوند"
 
 #: packages/lib/services/ReportService.ts:294
-#, fuzzy
 msgid "Items with error: %s"
-msgstr "آخرین خطا: %s"
+msgstr "موارد دارای خطا: %s"
 
 #: packages/app-desktop/gui/MenuBar.tsx:885
-#, fuzzy
 msgid "Join us on %s"
-msgstr "به توئیتر ما بپیوندید"
+msgstr "به ما در %s بپیوندید"
 
 #: packages/app-desktop/gui/SyncWizard/Dialog.tsx:310
 #: packages/app-mobile/components/SyncWizard/SyncWizard.tsx:114
-msgid ""
-"Joplin can synchronise your notes using various providers. Select one from "
-"the list below."
-msgstr ""
-"جاپلین می تواند یادداشت های شما را با استفاده از ارائه دهندگان مختلف همگام "
-"سازی کند. از لیست زیر یکی را انتخاب کنید."
+msgid "Joplin can synchronise your notes using various providers. Select one from the list below."
+msgstr "جاپلین می تواند یادداشت های شما را با استفاده از ارائه دهندگان مختلف همگام سازی کند. از لیست زیر یکی را انتخاب کنید."
 
 #: packages/app-mobile/components/SyncWizard/SyncWizard.tsx:118
 #: packages/lib/models/Setting.ts:1364 packages/lib/SyncTargetJoplinCloud.ts:31
@@ -3438,15 +3142,11 @@ msgstr "ورود سرویس ابری joplin"
 
 #: packages/lib/services/plugins/PluginService.ts:533
 msgid "Joplin Desktop"
-msgstr "joplin نسخه دسکتاپ"
+msgstr "Joplin نسخه دسکتاپ"
 
 #: packages/app-desktop/bridge.ts:480
-msgid ""
-"Joplin doesn't recognise the %s extension. Opening this file could be "
-"dangerous. What would you like to do?"
-msgstr ""
-"joplin پسوند %s را نمی شناسد. باز کردن این فایل ممکن است خطرناک باشد. دوست "
-"دارید چه کار کنید؟"
+msgid "Joplin doesn't recognise the %s extension. Opening this file could be dangerous. What would you like to do?"
+msgstr "Joplin پسوند %s را نمی شناسد. باز کردن این فایل ممکن است خطرناک باشد. دوست دارید چه کار کنید؟"
 
 #: packages/lib/services/interop/InteropService.ts:168
 #: packages/lib/services/interop/InteropService.ts:72
@@ -3459,41 +3159,32 @@ msgid "Joplin Export File"
 msgstr "فایل صدور joplin"
 
 #: packages/lib/services/ReportService.ts:254
-msgid ""
-"Joplin failed to decrypt these items multiple times, possibly because they "
-"are corrupted or too large. These items will remain on the device but Joplin "
-"will no longer attempt to decrypt them."
-msgstr ""
-"جاپلین چندین بار نتوانست این موارد را رمزگشایی کند، احتمالا به این خاطر که "
-"خراب یا بسیار بزرگ هستند. این موارد بر روی دستگاه باقی می‌مانند اما joplin "
-"دیگر تلاشی برای رمزگشایی آن‌ها نخواهد کرد."
+msgid "Joplin failed to decrypt these items multiple times, possibly because they are corrupted or too large. These items will remain on the device but Joplin will no longer attempt to decrypt them."
+msgstr "جاپلین چندین بار نتوانست این موارد را رمزگشایی کند، احتمالا به این خاطر که خراب یا بسیار بزرگ هستند. این موارد بر روی دستگاه باقی می‌مانند اما joplin دیگر تلاشی برای رمزگشایی آن‌ها نخواهد کرد."
 
 #: packages/app-desktop/gui/MenuBar.tsx:882
 msgid "Joplin Forum"
 msgstr "انجمن joplin"
 
 #: packages/app-mobile/utils/lockToSingleInstance.ts:17
-#, fuzzy
 msgid "Joplin is already running."
-msgstr "سرور در حال حاضر بر روی پورت %d در حال اجراست"
+msgstr "Joplin در حال حاضر در حال اجراست."
 
 #: packages/lib/services/plugins/PluginService.ts:531
 msgid "Joplin Mobile"
-msgstr "joplin نسخه موبایل"
+msgstr "Joplin نسخه موبایل"
 
 #: packages/lib/SyncTargetJoplinServer.ts:64
 msgid "Joplin Server"
 msgstr "سرور joplin"
 
 #: packages/lib/SyncTargetJoplinServerSAML.ts:68
-#, fuzzy
 msgid "Joplin Server (SAML)"
-msgstr "آدرس سرور joplin"
+msgstr "سرور Joplin (SAML)"
 
 #: packages/lib/utils/joplinCloud/index.ts:454
-#, fuzzy
 msgid "Joplin Server Business"
-msgstr "سرور joplin"
+msgstr "سرور Joplin Business"
 
 #: packages/lib/models/settings/builtInMetadata.ts:365
 msgid "Joplin Server email"
@@ -3501,9 +3192,8 @@ msgstr "سرور ایمیل joplin"
 
 #: packages/app-desktop/gui/Root.tsx:165
 #: packages/app-mobile/components/screens/SsoLoginScreen.tsx:60
-#, fuzzy
 msgid "Joplin Server Login"
-msgstr "آدرس سرور joplin"
+msgstr "ورود به سرور Joplin"
 
 #: packages/lib/models/settings/builtInMetadata.ts:377
 msgid "Joplin Server password"
@@ -3516,21 +3206,15 @@ msgstr "آدرس سرور joplin"
 
 #: packages/server/src/utils/saml.ts:55
 msgid "Joplin SSO Authentication"
-msgstr ""
+msgstr "احراز هویت Joplin SSO"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:572
-msgid ""
-"Joplin supports saving the location at which notes are saved or created. Do "
-"you want to enable it? This can be changed at any time in settings."
-msgstr ""
+msgid "Joplin supports saving the location at which notes are saved or created. Do you want to enable it? This can be changed at any time in settings."
+msgstr "Joplin از ذخیره موقعیت مکانیِ محل ذخیره یا ایجاد یادداشت‌ ها پشتیبانی می‌کند. آیا می‌خواهید این قابلیت را فعال کنید؟ این تنظیمات را می‌توان هر زمان در بخش تنظیمات تغییر داد."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:132
-msgid ""
-"Joplin Web Clipper allows saving web pages and screenshots from your browser "
-"to Joplin."
-msgstr ""
-"Joplin Web Clipper اجازه می دهد تا صفحات وب و اسکرین‌شات ها را از مرورگر خود "
-"در joplin ذخیره کنید."
+msgid "Joplin Web Clipper allows saving web pages and screenshots from your browser to Joplin."
+msgstr "Joplin Web Clipper اجازه می دهد تا صفحات وب و اسکرین‌شات ها را از مرورگر خود در joplin ذخیره کنید."
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:633
 msgid "Joplin website"
@@ -3538,12 +3222,8 @@ msgstr "سایت joplin"
 
 #: packages/app-mobile/components/SyncWizard/SyncWizard.tsx:119
 #: packages/lib/SyncTargetJoplinCloud.ts:35
-msgid ""
-"Joplin's own sync service. Also gives access to Joplin-specific features "
-"such as publishing notes or collaborating on notebooks with others."
-msgstr ""
-"سرویس همگام‌سازی اختصاصی joplin. همچنین به ویژگی‌های خاص joplin مانند انتشار "
-"یادداشت‌ها یا همکاری در دفترچه‌ها با دیگران دسترسی می‌دهد."
+msgid "Joplin's own sync service. Also gives access to Joplin-specific features such as publishing notes or collaborating on notebooks with others."
+msgstr "سرویس همگام‌سازی اختصاصی joplin. همچنین به ویژگی‌های خاص joplin مانند انتشار یادداشت‌ها یا همکاری در دفترچه‌ها با دیگران دسترسی می‌دهد."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1702
 msgid "Keep note history for"
@@ -3571,7 +3251,7 @@ msgstr "Keychain پشتیبانی می‌شود: %s"
 
 #: packages/app-cli/app/command-keymap.ts:30
 msgid "KEYS"
-msgstr ""
+msgstr "کلید ها"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:74
 msgid "Keys that need upgrading"
@@ -3579,7 +3259,7 @@ msgstr "کلید‌ها نیازمند ارتقاء می‌باشند"
 
 #: packages/editor/ProseMirror/plugins/imagePlugin.ts:265
 msgid "Label"
-msgstr ""
+msgstr "برچسب"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1447
 msgid "Landscape"
@@ -3595,7 +3275,7 @@ msgstr "زبان، فرمت تاریخ"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1292
 msgid "Large"
-msgstr ""
+msgstr "بزرگ"
 
 #: packages/lib/Synchronizer.ts:210
 msgid "Last error: %s"
@@ -3649,12 +3329,8 @@ msgid "Light"
 msgstr "روشن"
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:110
-msgid ""
-"Like any software you install, plugins can potentially cause security issues "
-"or data loss."
-msgstr ""
-"مانند هر نرم افزاری که نصب می کنید، افزونه ها به طور بالقوه می توانند باعث "
-"مشکلات امنیتی یا از دست دادن داده ها شوند."
+msgid "Like any software you install, plugins can potentially cause security issues or data loss."
+msgstr "مانند هر نرم افزاری که نصب می کنید، افزونه ها به طور بالقوه می توانند باعث مشکلات امنیتی یا از دست دادن داده ها شوند."
 
 #: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:115
 msgid "Lines"
@@ -3665,11 +3341,10 @@ msgid "Link"
 msgstr "لینک"
 
 #: packages/lib/components/shared/ShareNoteDialog/useShareStatusMessage.ts:21
-#, fuzzy
 msgid "Link created!"
 msgid_plural "Links created!"
-msgstr[0] "متن لینک"
-msgstr[1] "متن لینک"
+msgstr[0] "پیوندها ایجاد شدند!"
+msgstr[1] "پیوند ایجاد شد!"
 
 #: packages/app-mobile/components/NoteEditor/EditLinkDialog.tsx:92
 msgid "Link description"
@@ -3686,12 +3361,10 @@ msgid "Link text"
 msgstr "متن لینک"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.ts:13
-#, fuzzy
 msgid "Link to note..."
-msgstr "انتقال به دفترچه..."
+msgstr "پیوند به یادداشت..."
 
 #: packages/app-mobile/components/screens/ShareNoteDialog.tsx:158
-#, fuzzy
 msgid "Links"
 msgstr "لینک"
 
@@ -3711,20 +3384,15 @@ msgstr "دانلود‌شده"
 #: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:157
 #: packages/app-mobile/root.tsx:685
 msgid "Loading..."
-msgstr "در حال دانلود..."
+msgstr "در حال بارگذاری..."
 
 #: packages/app-desktop/gui/NotePropertiesDialog.tsx:85
 msgid "Location"
 msgstr "موقعیت"
 
 #: packages/app-cli/app/command-sync.ts:156
-msgid ""
-"Lock file is already being hold. If you know that no synchronisation is "
-"taking place, you may delete the lock file at \"%s\" and resume the "
-"operation."
-msgstr ""
-"فایل قفل در حال حاضر نگه داشته شده است. اگر می‌دانید که هیچ همگام‌سازی صورت "
-"نمی‌گیرد، می‌توانید فایل قفل را در «%s» حذف کرده و عملیات را ادامه دهید."
+msgid "Lock file is already being hold. If you know that no synchronisation is taking place, you may delete the lock file at \"%s\" and resume the operation."
+msgstr "فایل قفل در حال حاضر نگه داشته شده است. اگر می‌دانید که هیچ همگام‌سازی صورت نمی‌گیرد، می‌توانید فایل قفل را در «%s» حذف کرده و عملیات را ادامه دهید."
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:578
 #: packages/app-mobile/components/screens/LogScreen.tsx:215
@@ -3734,14 +3402,12 @@ msgstr "لاگ"
 
 #: packages/app-desktop/gui/SsoLoginScreen/SsoLoginScreen.tsx:39
 #: packages/app-mobile/components/screens/SsoLoginScreen.tsx:69
-#, fuzzy
 msgid "Log in with your web browser"
-msgstr "ورود با Dropbox"
+msgstr "ورود با مرورگر وب"
 
 #: packages/app-desktop/gui/MainScreen.tsx:592
-#, fuzzy
 msgid "Login to Joplin Cloud."
-msgstr "اتصال به سرویس ابری joplin"
+msgstr "ورود به سرویس ابری Joplin."
 
 #: packages/app-mobile/components/screens/dropbox-login.tsx:59
 msgid "Login with Dropbox"
@@ -3792,29 +3458,21 @@ msgid "Manage shared notebooks"
 msgstr "مدیریت دفترچه‌های مشترک"
 
 #: packages/app-mobile/components/EditorToolbar/ToolbarEditorDialog.tsx:165
-#, fuzzy
 msgid "Manage toolbar options"
-msgstr "مدیریت افزونه‌های شما"
+msgstr "مدیریت گزینه‌های نوار ابزار"
 
 #: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx:331
 msgid "Manage your plugins"
 msgstr "مدیریت افزونه‌های شما"
 
 #: packages/app-desktop/gui/ProfileEditor.tsx:171
-msgid ""
-"Manage your profiles. You can rename or delete profiles. The active profile "
-"cannot be deleted."
-msgstr ""
+msgid "Manage your profiles. You can rename or delete profiles. The active profile cannot be deleted."
+msgstr "نمایه های خود را مدیریت کنید. می‌توانید نام نمایه ها را تغییر دهید یا آن ها را حذف کنید. نمایه فعال را نمی‌توان حذف کرد."
 
 #. `generate-ppk`
 #: packages/app-cli/app/command-e2ee.ts:19
-msgid ""
-"Manages E2EE configuration. Commands are `enable`, `disable`, `decrypt`, "
-"`status`, `decrypt-file`, and `target-status`."
-msgstr ""
-"تنظیمات رمزنگاری انتها به انتها (E2EE) را مدیریت می‌کند. دستورات شامل "
-"`enable`، `disable`، `decrypt`، `status`، `decrypt-file` و `target-status` "
-"هستند."
+msgid "Manages E2EE configuration. Commands are `enable`, `disable`, `decrypt`, `status`, `decrypt-file`, and `target-status`."
+msgstr "تنظیمات رمزنگاری انتها به انتها (E2EE) را مدیریت می‌کند. دستورات شامل `enable`، `disable`، `decrypt`، `status`، `decrypt-file` و `target-status` هستند."
 
 #: packages/lib/models/settings/builtInMetadata.ts:472
 msgid "Manual"
@@ -3825,32 +3483,29 @@ msgstr "دستی"
 #: packages/lib/services/interop/InteropService.ts:124
 #: packages/lib/services/interop/InteropService.ts:174
 msgid "Markdown"
-msgstr "نشانه‌گذاری"
+msgstr "Markdown"
 
 #: packages/lib/services/interop/InteropService.ts:132
 #: packages/lib/services/interop/InteropService.ts:180
 msgid "Markdown + Front Matter"
-msgstr "نشانه گذاری + موضوع روبه‌رو"
+msgstr "Markdown + Front Matter"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx:372
 #: packages/app-mobile/components/NoteEditor/NoteEditor.tsx:307
-#, fuzzy
 msgid "Markdown editor"
-msgstr "نشانه‌گذاری"
+msgstr "ویرایشگر Markdown"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1519
-#, fuzzy
 msgid "Markdown editor: Highlight active line"
-msgstr "نشانه‌گذاری"
+msgstr "ویرایشگر Markdown: برجسته‌سازی خط فعال"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1508
-#, fuzzy
 msgid "Markdown editor: Render images"
-msgstr "نشانه‌گذاری"
+msgstr "ویرایشگر Markdown: نمایش تصاویر"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1498
 msgid "Markdown editor: Render markup in editor"
-msgstr ""
+msgstr "ویرایشگر Markdown: نمایش markup در ویرایشگر"
 
 #: packages/app-cli/app/command-done.ts:15
 msgid "Marks a to-do as done."
@@ -3881,11 +3536,11 @@ msgstr "گذرواژه اصلی:"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:19
 msgid "match case"
-msgstr ""
+msgstr "حساس به حروف بزرگ و کوچک"
 
 #: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:98
 msgid "Math"
-msgstr ""
+msgstr "ریاضیات"
 
 #: packages/lib/models/settings/builtInMetadata.ts:497
 msgid "Max concurrent connections"
@@ -3909,29 +3564,27 @@ msgstr "پخش کننده رسانه، ریاضی، نمودارها، فهرس�
 
 #: packages/lib/models/settings/builtInMetadata.ts:1291
 msgid "Medium"
-msgstr ""
+msgstr "متوسط"
 
 #: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:24
 msgid "Minimise"
 msgstr "کوچک کردن"
 
 #: packages/app-mobile/components/CameraView/CameraView.tsx:148
-#, fuzzy
 msgid "Missing camera permission"
-msgstr "کلید‌های اصلی یافت نشدند"
+msgstr "دسترسی دوربین وجود ندارد"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:320
 msgid "Missing keys"
-msgstr "کلیدها‌ یافت نشدند"
+msgstr "کلیدها‌ نشدند"
 
 #: packages/app-mobile/components/screens/encryption-config.tsx:307
 msgid "Missing Master Keys"
 msgstr "کلید‌های اصلی یافت نشدند"
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:121
-#, fuzzy
 msgid "Missing permission to record audio."
-msgstr "کلید‌های اصلی یافت نشدند"
+msgstr "مجوز ضبط صدا موجود نیست."
 
 #: packages/app-cli/app/cli-utils.js:112
 msgid "Missing required argument: %s"
@@ -3958,37 +3611,32 @@ msgid "More than one item match \"%s\". Please narrow down your query."
 msgstr "بیش از یک مورد مطابق «%s» وجود دارد. لطفاً عبارت جستجو را محدودتر کنید."
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:115
-msgid ""
-"Most plugins have source code available for review on the plugin website."
+msgid "Most plugins have source code available for review on the plugin website."
 msgstr "اکثر افزونه ها دارای کد منبع برای بررسی در وب سایت افزونه هستند."
 
 #: packages/app-mobile/components/ScreenHeader/index.tsx:601
-#, fuzzy
 msgid "Move %d note to notebook \"%s\"?"
 msgid_plural "Move %d notes to notebook \"%s\"?"
-msgstr[0] "انتقال یادداشت‌های  %d به دفترچه «%s»؟"
-msgstr[1] "انتقال یادداشت‌های  %d به دفترچه «%s»؟"
+msgstr[0] "%d یادداشت به دفترچه «%s» منتقل شود؟"
+msgstr[1] "%d یادداشت به دفترچه «%s» منتقل شود؟"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/deleteFolder.ts:34
-#, fuzzy
 msgid ""
 "Move %d notebooks to the trash?\n"
 "\n"
-"All notes and sub-notebooks within these notebooks will also be moved to the "
-"trash."
+"All notes and sub-notebooks within these notebooks will also be moved to the trash."
 msgstr ""
-"دفترچه «%s» حذف شود؟\n"
+"%d دفترچه به سطل زباله منتقل شود؟\n"
 "\n"
-"تمامی یادداشت‌ها و دفترچه‌های فرزند این دفترچه نیز حذف خواهند شد."
+"تمامی یادداشت‌ها و دفترچه‌های فرزند این دفترچه‌ها نیز به سطل زباله منتقل خواهند شد."
 
 #: packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx:73
-#, fuzzy
 msgid "Move down"
-msgstr "بستن حالت کشویی"
+msgstr "رفتن به پایین"
 
 #: packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx:74
 msgid "Move left"
-msgstr ""
+msgstr "رفتن به چپ"
 
 #: packages/app-cli/app/command-rmbook.ts:37
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/deleteFolder.ts:32
@@ -3996,8 +3644,7 @@ msgstr ""
 msgid ""
 "Move notebook \"%s\" to the trash?\n"
 "\n"
-"All notes and sub-notebooks within this notebook will also be moved to the "
-"trash."
+"All notes and sub-notebooks within this notebook will also be moved to the trash."
 msgstr ""
 "دفترچه «%s» حذف شود؟\n"
 "\n"
@@ -4005,7 +3652,7 @@ msgstr ""
 
 #: packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx:75
 msgid "Move right"
-msgstr ""
+msgstr "رفتن به راست"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/moveToFolder.ts:15
 msgid "Move to notebook"
@@ -4021,11 +3668,11 @@ msgstr "انتقال به دفترچه..."
 
 #: packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx:72
 msgid "Move up"
-msgstr ""
+msgstr "رفتن به بالا"
 
 #: packages/app-cli/app/command-mv.ts:14
 msgid "Moves the given <item> to [notebook]"
-msgstr "یادداشت‌هایی که مطابق <note> هستند را به [notebook] منتقل می‌کند."
+msgstr "مورد <item> داده‌شده را به [notebook] منتقل می‌کند."
 
 #: packages/app-cli/app/cli-utils.js:177
 #: packages/app-cli/app/setupCommand.ts:23
@@ -4041,25 +3688,24 @@ msgid "Never resize"
 msgstr "هرگز بدون تغییر اندازه"
 
 #: packages/app-mobile/setupQuickActions.ts:33
-#, fuzzy
 msgid "New attachment"
-msgstr "پیوست‌های یادداشت"
+msgstr "پیوست جدید"
 
 #: packages/app-mobile/setupQuickActions.ts:34
-#, fuzzy
 msgid "New drawing"
-msgstr "طراحی"
+msgstr "طراحی جدید"
 
 #: packages/app-mobile/components/screens/ShareManager/index.tsx:120
 msgid "New invitations"
 msgstr "دعوت نامه های جدید"
 
 #: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:56
-#, fuzzy
 msgid ""
 "New model available\n"
 "A new voice typing model is available. Do you want to download it?"
-msgstr "یک بروزرسانی موجود است، آیا میخواهید الآن دانلود‌ شود؟"
+msgstr ""
+"مدل جدیدی موجود است\n"
+"مدل جدیدی برای تایپ صوتی موجود است. آیا می‌خواهید آن را دانلود کنید؟"
 
 #: packages/app-desktop/gui/NoteListControls/NoteListControls.tsx:112
 #: packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx:72
@@ -4080,24 +3726,20 @@ msgid "New Notebook"
 msgstr "دفترچه جدید"
 
 #: packages/app-desktop/gui/ImportScreen.tsx:81
-msgid ""
-"New notebook \"%s\" will be created and file \"%s\" will be imported into it"
+msgid "New notebook \"%s\" will be created and file \"%s\" will be imported into it"
 msgstr "دفترچه جدید «%s» ساخته می‌شود و فایل «%s» به آن افزوده خواهد شد"
 
 #: packages/app-mobile/components/FolderPicker.tsx:71
-#, fuzzy
 msgid "New notebook title"
-msgstr "عنوان دفترچه:"
+msgstr "عنوان دفترچه جدید"
 
 #: packages/app-mobile/setupQuickActions.ts:32
-#, fuzzy
 msgid "New photo"
-msgstr "عکس گرفتن"
+msgstr "عکس جدید"
 
 #: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:211
-#, fuzzy
 msgid "New profile"
-msgstr "تغییر حساب کاربری"
+msgstr "حساب‌کاربری جدید"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newSubFolder.ts:6
 msgid "New sub-notebook"
@@ -4118,12 +3760,11 @@ msgstr "نسخه جدید: %s"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:16
 msgid "next"
-msgstr ""
+msgstr "بعدی"
 
 #: packages/app-mobile/components/CameraView/CameraViewMultiPage.tsx:92
-#, fuzzy
 msgid "Next"
-msgstr "Nextcloud"
+msgstr "بعدی"
 
 #: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:282
 msgid "Next match"
@@ -4191,9 +3832,8 @@ msgid "No results"
 msgstr "بدون نتیجه"
 
 #: packages/app-mobile/components/screens/NoteRevisionViewer.tsx:283
-#, fuzzy
 msgid "No revision selected"
-msgstr "هیچ برگه ای انتخاب نشده است"
+msgstr "هیچ نسخه‌ای انتخاب نشده است"
 
 #: packages/app-cli/app/app.ts:237
 msgid "No such command: %s"
@@ -4208,32 +3848,26 @@ msgid "No tab selected"
 msgstr "هیچ برگه ای انتخاب نشده است"
 
 #: packages/app-mobile/components/TagEditor.tsx:183
-#, fuzzy
 msgid "No tags"
-msgstr "برچسب جدید:"
+msgstr "برچسبی وجود ندارد"
 
 #: packages/app-cli/app/command-edit.ts:31
-msgid ""
-"No text editor is defined. Please set it using `config editor <editor-path>`"
-msgstr ""
-"هیچ ویرایشگر متنی مشخص نشده است. لطفا با استفاده از `<editor-path> تنظیمات "
-"ویرایشگر` آن را مشخص کنید"
+msgid "No text editor is defined. Please set it using `config editor <editor-path>`"
+msgstr "هیچ ویرایشگر متنی مشخص نشده است. لطفا با استفاده از `<editor-path> تنظیمات ویرایشگر` آن را مشخص کنید"
 
 #: packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx:63
-#, fuzzy
 msgid "No updates available"
-msgstr "به روز رسانی موجود است"
+msgstr "به‌روزرسانی جدیدی موجود نیست"
 
 #: packages/lib/components/shared/SamlShared.ts:12
 msgid "No URL for SAML authentication set."
-msgstr ""
+msgstr "هیچ URLای برای احراز هویت SAML تنظیم نشده است."
 
 #: packages/app-cli/app/command-share.ts:188
 #: packages/app-cli/app/command-share.ts:208
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/utils/showFolderPicker.ts:28
-#, fuzzy
 msgid "None"
-msgstr "(هیچ کدام)"
+msgstr "هیچ‌کدام"
 
 #: packages/lib/models/settings/builtInMetadata.ts:72
 msgid "Nord"
@@ -4245,7 +3879,7 @@ msgstr "با %s تایید نشد. لطفا هر گواهی‌نامه‌ی نا
 
 #: packages/app-desktop/gui/SyncWizard/Dialog.tsx:165
 msgid "Not checked"
-msgstr ""
+msgstr "بررسی نشده"
 
 #: packages/lib/models/Resource.ts:407
 msgid "Not downloaded"
@@ -4261,7 +3895,7 @@ msgstr "فعلاً نه"
 
 #: packages/app-mobile/components/FeedbackBanner.tsx:188
 msgid "Not useful"
-msgstr ""
+msgstr "غیر مفید"
 
 #: packages/app-desktop/gui/NoteListControls/NoteListControls.tsx:110
 #: packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx:71
@@ -4306,7 +3940,6 @@ msgid "Note has been saved."
 msgstr "یادداشت ذخیره شد."
 
 #: packages/app-mobile/components/screens/NoteRevisionViewer.tsx:257
-#, fuzzy
 msgid "Note history"
 msgstr "تاریخچه‌ی یادداشت"
 
@@ -4316,9 +3949,8 @@ msgid "Note History"
 msgstr "تاریخچه‌ی یادداشت"
 
 #: packages/lib/components/shared/NoteRevisionViewer/useDeleteHistoryClick.ts:34
-#, fuzzy
 msgid "Note history has been deleted."
-msgstr "یادداشت ذخیره شد."
+msgstr "تاریخچه یادداشت حذف شد."
 
 #: packages/app-cli/app/command-done.ts:23
 msgid "Note is not a to-do: \"%s\""
@@ -4340,14 +3972,12 @@ msgid "Note list style"
 msgstr "استایل فهرست یادداشت"
 
 #: packages/app-cli/app/command-unpublish.ts:41
-#, fuzzy
 msgid "Note not published: %s"
-msgstr "محتوای ارائه شده توسط: %s"
+msgstr "یادداشت منتشر نشد: %s"
 
 #: packages/app-mobile/components/screens/DocumentScanner/DocumentScanner.tsx:140
-#, fuzzy
 msgid "Note preview"
-msgstr "عنوان یادداشت"
+msgstr "پیش‌نمایش یادداشت"
 
 #: packages/app-desktop/gui/NotePropertiesDialog.tsx:500
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/showNoteProperties.ts:7
@@ -4361,20 +3991,16 @@ msgstr "عنوان یادداشت"
 
 #: packages/app-desktop/gui/NoteEditor/commands/focusElementNoteViewer.ts:8
 #: packages/app-desktop/gui/NoteTextViewer.tsx:244
-#, fuzzy
 msgid "Note viewer"
-msgstr "عنوان یادداشت"
+msgstr "نمایشگر یادداشت"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1135
 msgid "Note: Does not work in all desktop environments."
 msgstr "توجه: در همه محیط‌های دسکتاپ کار نمی کند."
 
 #: packages/lib/components/shared/ShareNoteDialog/useEncryptionWarningMessage.ts:6
-msgid ""
-"Note: When a note is shared, it will no longer be encrypted on the server."
-msgstr ""
-"توجه: زمانی که یادداشتی به اشتراک گذاشته می شود، دیگر روی سرور رمزنگاری نمی "
-"شود."
+msgid "Note: When a note is shared, it will no longer be encrypted on the server."
+msgstr "توجه: زمانی که یادداشتی به اشتراک گذاشته می شود، دیگر روی سرور رمزنگاری نمی شود."
 
 #: packages/app-desktop/gui/MenuBar.tsx:831
 msgid "Note&book"
@@ -4424,9 +4050,8 @@ msgid "Notes can only be created within a notebook."
 msgstr "یادداشت‌ها فقط می‌توانند در دفترچه ایجاد شوند."
 
 #: packages/app-desktop/gui/PopupNotification/PopupNotificationList.tsx:32
-#, fuzzy
 msgid "Notifications"
-msgstr "موقعیت"
+msgstr "اعلان‌ها"
 
 #: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:80
 msgid "Numbered List"
@@ -4434,17 +4059,15 @@ msgstr "لیست شماره گذاری شده"
 
 #: packages/lib/models/settings/builtInMetadata.ts:619
 msgid "OCR: Clear cache and re-download language data files"
-msgstr ""
+msgstr "OCR: پاک‌سازی حافظه پنهان و دانلود مجدد فایل‌های داده زبان"
 
 #: packages/lib/models/settings/builtInMetadata.ts:600
-#, fuzzy
 msgid "OCR: Language data URL or path"
-msgstr "زبان، فرمت تاریخ"
+msgstr "OCR: آدرس یا مسیر داده زبان"
 
 #: packages/lib/models/settings/builtInMetadata.ts:629
-#, fuzzy
 msgid "OCR: Search in extracted content"
-msgstr "جستجو در تمام یادداشت‌ها"
+msgstr "OCR: جستجو در محتوای استخراج‌شده"
 
 #: packages/app-cli/app/utils/shimInitCli.ts:12
 #: packages/app-desktop/bridge.ts:392 packages/app-desktop/bridge.ts:405
@@ -4485,23 +4108,15 @@ msgstr "در %s: %s"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:27
 msgid "on line"
-msgstr ""
+msgstr "بر  خط"
 
 #: packages/app-desktop/gui/MainScreen.tsx:548
 msgid "One of your master keys use an obsolete encryption method."
 msgstr "یکی از کلید‌های اصلی شما از یک روش رمزنگاری منسوخ شده استفاده می‌کند."
 
 #: packages/app-cli/app/gui/NoteWidget.js:48
-msgid ""
-"One or more items are currently encrypted and you may need to supply a "
-"master password. To do so please type `e2ee decrypt`. If you have already "
-"supplied the password, the encrypted items are being decrypted in the "
-"background and will be available soon."
-msgstr ""
-"در حال حاضر یک یا چند مورد رمزنگاری شده‌اند و ممکن است شما به ارائه یک "
-"گذرواژه اصلی نیاز داشته باشید. برای اینکار لطفا «e2ee decrypt» را تایپ کنید. "
-"اگر در حال حاضر گذرواژه را ارائه کرده‌اید، موارد رمزنگاری شده در پس‌زمینه در "
-"حال رمزگشایی هستند و به زودی در دسترس خواهند بود."
+msgid "One or more items are currently encrypted and you may need to supply a master password. To do so please type `e2ee decrypt`. If you have already supplied the password, the encrypted items are being decrypted in the background and will be available soon."
+msgstr "در حال حاضر یک یا چند مورد رمزنگاری شده‌اند و ممکن است شما به ارائه یک گذرواژه اصلی نیاز داشته باشید. برای اینکار لطفا «e2ee decrypt» را تایپ کنید. اگر در حال حاضر گذرواژه را ارائه کرده‌اید، موارد رمزنگاری شده در پس‌زمینه در حال رمزگشایی هستند و به زودی در دسترس خواهند بود."
 
 #: packages/app-desktop/gui/MainScreen.tsx:577
 msgid "One or more master keys need a password."
@@ -4516,9 +4131,8 @@ msgid "OneDrive Login"
 msgstr "ورود به OneDrive"
 
 #: packages/lib/services/interop/InteropService.ts:153
-#, fuzzy
 msgid "OneNote Notebook"
-msgstr "دفترچه جدید"
+msgstr "دفترچه OneNote"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/print.ts:18
 msgid "Only one note can be printed at a time."
@@ -4533,22 +4147,20 @@ msgid "Open %s"
 msgstr "بازکردن %s"
 
 #: packages/app-desktop/commands/startExternalEditing.ts:10
-#, fuzzy
 msgid "Open in external editor"
 msgstr "ویرایش در ویرایشگر خارجی"
 
 #: packages/app-desktop/commands/openNoteInNewWindow.ts:10
 msgid "Open in new window"
-msgstr ""
+msgstr "در یک پنجره جدید باز کن"
 
 #: packages/app-desktop/bridge.ts:486
 msgid "Open it"
 msgstr "باز کن"
 
 #: packages/app-desktop/bridge.ts:557
-#, fuzzy
 msgid "Open log"
-msgstr "بازکردن %s"
+msgstr "بازکردن گزارش"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/openPdfViewer.ts:7
 msgid "Open PDF viewer"
@@ -4556,7 +4168,7 @@ msgstr "بازکردن مشاهده‌کننده PDF"
 
 #: packages/app-desktop/commands/openPrimaryAppInstance.ts:8
 msgid "Open primary app instance..."
-msgstr ""
+msgstr "باز کردن نمونه اصلی برنامه..."
 
 #: packages/app-desktop/commands/openProfileDirectory.ts:8
 msgid "Open profile directory"
@@ -4564,12 +4176,11 @@ msgstr "بازکردن مسیر حساب کاربری"
 
 #: packages/app-desktop/commands/openSecondaryAppInstance.ts:8
 msgid "Open secondary app instance..."
-msgstr ""
+msgstr "باز کردن نمونه ثانویهٔ برنامه..."
 
 #: packages/app-mobile/components/CameraView/CameraView.tsx:149
-#, fuzzy
 msgid "Open settings"
-msgstr "بازکردن بخش در %s"
+msgstr "بازکردن تنظیمات"
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:115
 msgid "Open Source"
@@ -4582,7 +4193,7 @@ msgstr "بازکردن راهنمای همگام‌سازی..."
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:635
 msgid "Open-source licences"
-msgstr ""
+msgstr "مجوز های متن باز"
 
 #: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:87
 msgid "Open..."
@@ -4593,19 +4204,16 @@ msgid "Opening section %s"
 msgstr "بازکردن بخش در %s"
 
 #: packages/app-mobile/components/Dropdown.tsx:241
-#, fuzzy
 msgid "Opens dropdown"
-msgstr "بستن حالت کشویی"
+msgstr "باز کردن حالت کشویی"
 
 #: packages/app-mobile/components/NoteItem.tsx:164
-#, fuzzy
 msgid "Opens note"
-msgstr "باز کن"
+msgstr "باز کردن یادداشت"
 
 #: packages/app-mobile/components/side-menu-content.tsx:278
-#, fuzzy
 msgid "Opens notebook"
-msgstr "دفترچه جدید"
+msgstr "باز کردن دفترچه"
 
 #: packages/app-cli/app/command-e2ee.ts:42
 #: packages/app-cli/app/command-e2ee.ts:88
@@ -4620,10 +4228,8 @@ msgid "Options"
 msgstr "گزینه ها"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1121
-msgid ""
-"Options that should be used whenever rendering ABC code. It must be a JSON5 "
-"object. The full list of options is available at: %s"
-msgstr ""
+msgid "Options that should be used whenever rendering ABC code. It must be a JSON5 object. The full list of options is available at: %s"
+msgstr "گزینه‌ هایی که باید هنگام اجرای کد ABC استفاده شوند. این مورد باید یک شیء JSON5 باشد. فهرست کامل گزینه‌ها در این آدرس موجود است: %s"
 
 #: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:103
 msgid "Ordered list"
@@ -4631,7 +4237,7 @@ msgstr "لیست مرتب شده"
 
 #: packages/app-mobile/components/SyncWizard/SyncWizard.tsx:130
 msgid "Other"
-msgstr ""
+msgstr "سایر"
 
 #: packages/app-desktop/gui/MenuBar.tsx:459
 msgid "Other applications..."
@@ -4651,11 +4257,11 @@ msgstr "اندازه صفحه برای صدور PDF"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowControl.ts:46
 msgid "Panel \"%s\" is visible"
-msgstr ""
+msgstr "پنل \"%s\" قابل مشاهده است"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowControl.ts:46
 msgid "Panel %s is hidden"
-msgstr ""
+msgstr "پنل %s مخفی است"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:170
 msgid "Password"
@@ -4697,9 +4303,8 @@ msgid "PDF File"
 msgstr "فایل PDF"
 
 #: packages/lib/utils/joplinCloud/index.ts:448
-#, fuzzy
 msgid "Per user. Minimum of 2 users."
-msgstr "به ازای هر کاربر. حداقل %d کاربر."
+msgstr "به ازای هر کاربر. حداقل 2 کاربر نیاز است."
 
 #: packages/lib/commands/permanentlyDeleteNote.ts:8
 msgid "Permanently delete note"
@@ -4720,68 +4325,42 @@ msgstr ""
 "همه یادداشت‌ها و زیر دفترچه‌های این دفترچه برای همیشه حذف خواهند شد."
 
 #: packages/lib/models/Note.ts:967
-#, fuzzy
 msgid "Permanently delete this note?"
 msgid_plural "Permanently delete these %d notes?"
-msgstr[0] "آیا یادداشت‌های پوشه %d به طور دائم حذف شود؟"
-msgstr[1] "آیا یادداشت‌های پوشه %d به طور دائم حذف شود؟"
+msgstr[0] "%d یادداشت برای همیشه حذف شود؟"
+msgstr[1] "%d یادداشت برای همیشه حذف شود؟"
 
 #: packages/app-cli/app/command-rmbook.ts:20
 msgid "Permanently deletes the notebook, skipping the trash."
-msgstr ""
-"دفترچه را برای همیشه حذف می کند و از نگهداری در سطل زباله صرف نظر می کند."
+msgstr "دفترچه را برای همیشه حذف می کند و از نگهداری در سطل زباله صرف نظر می کند."
 
 #: packages/app-mobile/components/screens/DocumentScanner/DocumentScanner.tsx:105
 msgid "Photo %d"
-msgstr ""
+msgstr "تصویر %d"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:261
-msgid ""
-"Please click on \"%s\" to proceed, or set the passwords in the \"%s\" list "
-"below."
-msgstr ""
-"لطفاً برای ادامه روی «%s» کلیک کنید یا گذرواژه‌ها را در لیست «%s» زیر تنظیم "
-"نمایید."
+msgid "Please click on \"%s\" to proceed, or set the passwords in the \"%s\" list below."
+msgstr "لطفاً برای ادامه روی «%s» کلیک کنید یا گذرواژه‌ها را در لیست «%s» زیر تنظیم نمایید."
 
 #: packages/lib/components/EncryptionConfigScreen/utils.ts:64
-msgid ""
-"Please confirm that you would like to re-encrypt your complete database."
-msgstr ""
-"لطفا تایید کنید که شما می‌خواهید تمام پایگاه داده خود را دوباره رمزنگاری "
-"نمایید."
+msgid "Please confirm that you would like to re-encrypt your complete database."
+msgstr "لطفا تایید کنید که شما می‌خواهید تمام پایگاه داده خود را دوباره رمزنگاری نمایید."
 
 #: packages/lib/components/EncryptionConfigScreen/utils.ts:213
-msgid ""
-"Please enter your password in the master key list below before upgrading the "
-"key."
-msgstr ""
-"لطفا قبل از ارتقای کلید، گذرواژه خود را در لیست کلید اصلی زیر وارد کنید."
+msgid "Please enter your password in the master key list below before upgrading the key."
+msgstr "لطفا قبل از ارتقای کلید، گذرواژه خود را در لیست کلید اصلی زیر وارد کنید."
 
 #: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:370
-msgid ""
-"Please note that if it is a large notebook, it may take a few minutes for "
-"all the notes to show up on the recipient's device."
-msgstr ""
-"لطفاً توجه داشته باشید که اگر یک دفترچه حجیم باشد، ممکن است چند دقیقه طول "
-"بکشد تا همه یادداشت‌ها در دستگاه گیرنده نمایش داده شوند."
+msgid "Please note that if it is a large notebook, it may take a few minutes for all the notes to show up on the recipient's device."
+msgstr "لطفاً توجه داشته باشید که اگر یک دفترچه حجیم باشد، ممکن است چند دقیقه طول بکشد تا همه یادداشت‌ها در دستگاه گیرنده نمایش داده شوند."
 
 #: packages/lib/onedrive-api-node-utils.js:118
-msgid ""
-"Please open the following URL in your browser to authenticate the "
-"application. The application will create a directory in \"Apps/Joplin\" and "
-"will only read and write files in this directory. It will have no access to "
-"any files outside this directory nor to any other personal data. No data "
-"will be shared with any third party."
-msgstr ""
-"لطفاً آدرس زیر را در مرورگر خود باز کنید تا برنامه تأیید اعتبار شود. برنامه "
-"یک دایرکتوری در \"Apps/Joplin\" ایجاد می کند و فقط فایل ها را در این فهرست "
-"می خواند و می نویسد. به هیچ فایلی خارج از این فهرست دسترسی نخواهد داشت و به "
-"هیچ اطلاعات شخصی دیگری دسترسی نخواهد داشت. هیچ داده ای با هیچ شخص ثالثی به "
-"اشتراک گذاشته نخواهد شد."
+msgid "Please open the following URL in your browser to authenticate the application. The application will create a directory in \"Apps/Joplin\" and will only read and write files in this directory. It will have no access to any files outside this directory nor to any other personal data. No data will be shared with any third party."
+msgstr "لطفاً آدرس زیر را در مرورگر خود باز کنید تا برنامه تأیید اعتبار شود. برنامه یک دایرکتوری در \"Apps/Joplin\" ایجاد می کند و فقط فایل ها را در این فهرست می خواند و می نویسد. به هیچ فایلی خارج از این فهرست دسترسی نخواهد داشت و به هیچ اطلاعات شخصی دیگری دسترسی نخواهد داشت. هیچ داده ای با هیچ شخص ثالثی به اشتراک گذاشته نخواهد شد."
 
 #: packages/lib/services/share/ShareService.ts:361
 msgid "Please provide the recipient email"
-msgstr ""
+msgstr "لطفا ایمیل گیرنده را وارد کنید"
 
 #: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:159
 msgid "Please record your voice..."
@@ -4809,20 +4388,15 @@ msgstr "لطفا دفترچه‌ای که یادداشت‌ها باید به آ
 
 #: packages/lib/services/plugins/PluginService.ts:527
 msgid "Please upgrade Joplin to version %s or later to use this plugin."
-msgstr ""
-"لطفاً برای استفاده از این افزونه، Joplin را به نسخه %s یا جدیدتر ارتقا دهید."
+msgstr "لطفاً برای استفاده از این افزونه، Joplin را به نسخه %s یا جدیدتر ارتقا دهید."
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx:1580
-msgid ""
-"Please wait for all attachments to be downloaded and decrypted. You may also "
-"switch to %s to edit the note."
-msgstr ""
-"لطفا صبر کنید تا همه پیوست‌ها دانلود و رمزگشایی شوند. شما همچنین می‌توانید به "
-"%s برای ویرایش یادداشت بروید."
+msgid "Please wait for all attachments to be downloaded and decrypted. You may also switch to %s to edit the note."
+msgstr "لطفا صبر کنید تا همه پیوست‌ها دانلود و رمزگشایی شوند. شما همچنین می‌توانید به %s برای ویرایش یادداشت بروید."
 
 #: packages/server/src/utils/saml.ts:58
 msgid "Please wait while we load your organisation sign-in page..."
-msgstr ""
+msgstr "لطفا منتظر بمانید تا صفحه ورود سازمان شما بارگذاری شود..."
 
 #: packages/app-desktop/gui/ConfigScreen/controls/plugins/SearchPlugins.tsx:118
 #: packages/app-desktop/gui/ResourceScreen.tsx:315
@@ -4865,13 +4439,8 @@ msgid "Plugins"
 msgstr "پلاگین‌ها"
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:103
-msgid ""
-"Plugins extend Joplin with features that are not present by default. Plugins "
-"can extend Joplin's editor, viewer, and more."
-msgstr ""
-"افزونه ها Joplin را با ویژگی هایی گسترش می دهند که به طور پیش فرض وجود "
-"ندارند. پلاگین ها می توانند ویرایشگر، بیننده و موارد دیگر Joplin را گسترش "
-"دهند."
+msgid "Plugins extend Joplin with features that are not present by default. Plugins can extend Joplin's editor, viewer, and more."
+msgstr "افزونه ها Joplin را با ویژگی هایی گسترش می دهند که به طور پیش فرض وجود ندارند. پلاگین ها می توانند ویرایشگر، بیننده و موارد دیگر Joplin را گسترش دهند."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1446
 msgid "Portrait"
@@ -4887,7 +4456,7 @@ msgstr "مقادیر احتمالی: %s."
 
 #: packages/app-cli/app/command-share.ts:67
 msgid "Prefer JSON output."
-msgstr ""
+msgstr "خروجی JSON را ترجیح می‌دهم."
 
 #: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:28
 msgid "Preferences"
@@ -4907,7 +4476,7 @@ msgstr "تم روشن ترجیحی"
 
 #: packages/lib/models/settings/builtInMetadata.ts:776
 msgid "Preserve colours when pasting text in Rich Text Editor"
-msgstr ""
+msgstr "حفظ رنگ‌ها هنگام جای‌گذاری متن در ویرایشگر متن غنی"
 
 #: packages/app-cli/app/app-gui.js:767
 msgid "Press Ctrl+D or type \"exit\" to exit the application"
@@ -4918,30 +4487,24 @@ msgid "Press the shortcut"
 msgstr "میانبر را فشار دهید"
 
 #: packages/app-desktop/gui/KeymapConfig/ShortcutRecorder.tsx:69
-msgid ""
-"Press the shortcut and then press ENTER. Or, press BACKSPACE to clear the "
-"shortcut."
-msgstr ""
-"میانبر را فشار دهید و سپس ENTER را فشار دهید. یا BACKSPACE برای پاکسازی "
-"میانبر، فشار دهید."
+msgid "Press the shortcut and then press ENTER. Or, press BACKSPACE to clear the shortcut."
+msgstr "میانبر را فشار دهید و سپس ENTER را فشار دهید. یا BACKSPACE برای پاکسازی میانبر، فشار دهید."
 
 #: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:40
 msgid "Press to set the decryption password."
 msgstr "برای تنظیم گذرواژه رمزگشایی بفشارید."
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:17
-#, fuzzy
 msgid "previous"
-msgstr "تطابق قبلی"
+msgstr "قبلی"
 
 #: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:292
 msgid "Previous match"
 msgstr "تطابق قبلی"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:1227
-#, fuzzy
 msgid "Previous versions"
-msgstr "نسخه‌های قبلی این یادداشت"
+msgstr "نسخه‌های قبلی"
 
 #: packages/app-desktop/gui/NotePropertiesDialog.tsx:433
 msgid "Previous versions of this note"
@@ -4980,9 +4543,8 @@ msgid "Processing"
 msgstr "در حال پردازش"
 
 #: packages/app-mobile/components/CameraView/ActionButtons.tsx:111
-#, fuzzy
 msgid "Processing photo..."
-msgstr "در حال پردازش"
+msgstr "در حال پردازش عکس..."
 
 #: packages/server/src/routes/admin/users.ts:254
 msgid "Profile"
@@ -4994,9 +4556,8 @@ msgid "Profile name"
 msgstr "نام حساب‌ کاربری"
 
 #: packages/app-desktop/gui/ProfileEditor.tsx:120
-#, fuzzy
 msgid "Profile name cannot be empty"
-msgstr "تایید گذرواژه نمی‌تواند خالی باشد"
+msgstr "نام حساب‌کاربری نمی‌تواند خالی باشد"
 
 #: packages/app-desktop/gui/ProfileEditor.tsx:116
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/addProfile.ts:18
@@ -5032,14 +4593,12 @@ msgid "Public-private key pair:"
 msgstr "جفت کلید عمومی-خصوصی:"
 
 #: packages/app-mobile/components/screens/ShareNoteDialog.tsx:195
-#, fuzzy
 msgid "Publish Note"
-msgstr "اشتراک‌گذاری یادداشت‌ها"
+msgstr "اشتراک‌گذاری یادداشت"
 
 #: packages/app-cli/app/command-publish.ts:47
-#, fuzzy
 msgid "Publish note \"%s\" (in notebook \"%s\")?"
-msgstr "انتقال یادداشت‌های  %d به دفترچه «%s»؟"
+msgstr "یادداشت «%s» منتشر شود؟ (در دفترچه «%s»)"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/showShareNoteDialog.ts:6
 msgid "Publish note..."
@@ -5057,22 +4616,20 @@ msgstr "اشتراک‌گذاری یادداشت‌ها در اینترنت"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:1245
 msgid "Publish/unpublish"
-msgstr ""
+msgstr "انتشار/لغو انتشار"
 
 #: packages/app-cli/app/command-publish.ts:60
-#, fuzzy
 msgid "Published at URL: %s"
-msgstr "اشتراک‌گذاری یادداشت‌ها"
+msgstr "منتشر شده در آدرس: %s"
 
 #: packages/app-cli/app/command-publish.ts:27
 #: packages/app-cli/app/command-unpublish.ts:24
 msgid "Publishes a note to Joplin Server or Joplin Cloud"
-msgstr ""
+msgstr "یک یادداشت را در سرور Joplin یا فضای ابری Joplin منتشر می‌کند"
 
 #: packages/app-mobile/components/CameraView/ScannedBarcodes.tsx:79
-#, fuzzy
 msgid "QR Code"
-msgstr "کد"
+msgstr "کد QR"
 
 #: packages/app-desktop/app.ts:215
 #: packages/app-desktop/ElectronAppWrapper.ts:180
@@ -5083,7 +4640,7 @@ msgstr "خروج"
 
 #: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:183
 msgid "Re-download model"
-msgstr ""
+msgstr "دانلود دوباره مدل"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:342
 msgid "Re-encrypt data"
@@ -5094,18 +4651,16 @@ msgid "Re-encryption"
 msgstr "رمزنگاری مجدد"
 
 #: packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx:181
-#, fuzzy
 msgid "Re-enter password"
-msgstr "گذرواژه"
+msgstr "گذرواژه را مجدداً وارد کنید"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1365
 msgid "Re-upload local data to sync target"
 msgstr "بارگذاری مجدد داده مجلی در هدف همگام‌سازی"
 
 #: packages/app-mobile/components/NoteEditor/WarningBanner.tsx:19
-#, fuzzy
 msgid "Read more"
-msgstr "بیشتر بدانید"
+msgstr "بیشتر بخوانید"
 
 #: packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx:40
 msgid "Read more about it"
@@ -5116,9 +4671,8 @@ msgid "Read time: %s min"
 msgstr "زمان تقریبی خواندن: %s دقیقه"
 
 #: packages/app-cli/app/command-batch.ts:45
-#, fuzzy
 msgid "Reading commands from standard input is only available in CLI mode."
-msgstr "دستور «%s» فقط در حالت گرافیکی (GUI) کاربرد دارد"
+msgstr "خواندن دستورات از ورودی استاندارد فقط در حالت CLI امکان‌پذیر است."
 
 #: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:303
 msgid "Recipient has accepted the invitation"
@@ -5137,14 +4691,12 @@ msgid "Recipients:"
 msgstr "گیرندگان:"
 
 #: packages/app-mobile/components/screens/DocumentScanner/NotePreview.tsx:162
-#, fuzzy
 msgid "Recognise text:"
-msgstr "متن تأکید شده"
+msgstr "شناسایی متن:"
 
 #: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:142
-#, fuzzy
 msgid "Recognize handwritten image"
-msgstr "تغییر اندازه تصاویر بزرگ:"
+msgstr "شناسایی تصویر دست‌نویس"
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/RecommendedBadge.tsx:72
 msgid "Recommended"
@@ -5156,17 +4708,15 @@ msgstr "افزونه های پیشنهادی"
 
 #: packages/app-mobile/components/screens/Note/commands/attachFile.ts:91
 msgid "Record audio"
-msgstr ""
+msgstr "ضبط صدا"
 
 #: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:78
-#, fuzzy
 msgid "Recording"
-msgstr "سرفصل"
+msgstr "ضبط"
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:231
-#, fuzzy
 msgid "Recording..."
-msgstr "در حال دانلود..."
+msgstr "در حال ضبط..."
 
 #: packages/app-desktop/gui/MenuBar.tsx:705
 #: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:122
@@ -5192,28 +4742,24 @@ msgid "Reject"
 msgstr "رد کردن"
 
 #: packages/app-cli/app/command-share.ts:229
-#, fuzzy
 msgid "Rejecting share..."
-msgstr "در حال ایجاد گزارش..."
+msgstr "در حال رد کردن اشتراک‌گذاری..."
 
 #: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:127
 msgid "Remove"
 msgstr "حذف"
 
 #: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:134
-#, fuzzy
 msgid "Remove %d tags from all notes? This cannot be undone."
-msgstr "آیا برچسب «%s» از همه‌ی یادداشت‌ها حذف شود؟"
+msgstr "آیا %d برچسب از همه یادداشت‌ها حذف شود؟ این کار قابل بازگشت نیست."
 
 #: packages/app-mobile/components/TagEditor.tsx:136
-#, fuzzy
 msgid "Remove %s"
-msgstr "حذف"
+msgstr "حذف %s"
 
 #: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:320
-#, fuzzy
 msgid "Remove %s from share"
-msgstr "آیا برچسب «%s» از همه‌ی یادداشت‌ها حذف شود؟"
+msgstr "حذف %s از اشتراک‌گذاری"
 
 #: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:132
 msgid "Remove tag \"%s\" from all notes?"
@@ -5224,14 +4770,12 @@ msgid "Remove this search from the sidebar?"
 msgstr "این جستجو از نوار کناری حذف شود؟"
 
 #: packages/app-cli/app/command-share.ts:112
-#, fuzzy
 msgid "Removed %s from share."
-msgstr "آیا برچسب «%s» از همه‌ی یادداشت‌ها حذف شود؟"
+msgstr "%s از اشتراک‌گذاری حذف شد."
 
 #: packages/app-mobile/components/TagEditor.tsx:247
-#, fuzzy
 msgid "Removed tag: %s"
-msgstr "تغییر نام برچسب:"
+msgstr "برچسب حذف شد: %s"
 
 #: packages/app-desktop/gui/ProfileEditor.tsx:68
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/renameFolder.ts:8
@@ -5255,14 +4799,13 @@ msgstr "تغییر نام مورد <item> (یادداشت یا دفترچه) ب�
 
 #: packages/lib/models/settings/builtInMetadata.ts:1499
 msgid "Renders markup on all lines that don't include the cursor."
-msgstr ""
+msgstr "مارک‌ آپ را در تمام خطوطی که شامل مکان‌نما نیستند، ارائه می‌دهد."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:162
 msgid "Renew token"
 msgstr "تمدید توکن"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:21
-#, fuzzy
 msgid "replace"
 msgstr "جایگزین کردن"
 
@@ -5272,7 +4815,6 @@ msgid "Replace"
 msgstr "جایگزین کردن"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:22
-#, fuzzy
 msgid "replace all"
 msgstr "جایگزین کردن همه"
 
@@ -5290,11 +4832,11 @@ msgstr "جایگزین کردن: "
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:25
 msgid "replaced $ matches"
-msgstr ""
+msgstr "مطابقت‌های $ جایگزین شدند"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:26
 msgid "replaced match on line $"
-msgstr ""
+msgstr "تطابق در خط $ جایگزین شد"
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx:162
 msgid "Report an issue"
@@ -5358,9 +4900,8 @@ msgid "Restore"
 msgstr "بازگرداندن"
 
 #: packages/app-mobile/components/EditorToolbar/ToolbarEditorDialog.tsx:156
-#, fuzzy
 msgid "Restore defaults"
-msgstr "موارد بازیابی شده"
+msgstr "بازیابی پیش‌فرض‌ها"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/restoreNote.ts:10
 msgid "Restore note"
@@ -5368,7 +4909,7 @@ msgstr "بازیابی یادداشت"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/restoreFolder.ts:9
 msgid "Restore notebook"
-msgstr "بازیابی دفترچه دفترچه"
+msgstr "بازیابی دفترچه"
 
 #: packages/app-cli/app/command-restore.ts:12
 msgid "Restore the items matching <pattern> from the trash."
@@ -5413,9 +4954,8 @@ msgid "Reverses the sorting order."
 msgstr "معکوس کردن ترتیب مرتب‌سازی."
 
 #: packages/app-mobile/components/screens/NoteRevisionViewer.tsx:213
-#, fuzzy
 msgid "Revision:"
-msgstr "تجدید نظر: %s (%s)"
+msgstr "تجدید نظر:"
 
 #: packages/lib/versionInfo.ts:65
 msgid "Revision: %s (%s)"
@@ -5423,19 +4963,15 @@ msgstr "تجدید نظر: %s (%s)"
 
 #: packages/app-desktop/gui/ToggleEditorsButton/ToggleEditorsButton.tsx:28
 msgid "Rich Text"
-msgstr ""
+msgstr "متن غنی"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx:716
 msgid "Rich Text editor. Press Escape then Tab to escape focus."
-msgstr ""
+msgstr "ویرایشگر متن غنی. برای خروج از حالت تمرکز، کلید Escape و سپس Tab را فشار دهید."
 
 #: packages/app-cli/app/command-batch.ts:29
-msgid ""
-"Runs the commands contained in the text file. There should be one command "
-"per line."
-msgstr ""
-"دستورات موجود در فایل متنی را اجرا می کند. در هر خط باید یک دستور وجود داشته "
-"باشد."
+msgid "Runs the commands contained in the text file. There should be one command per line."
+msgstr "دستورات موجود در فایل متنی را اجرا می کند. در هر خط باید یک دستور وجود داشته باشد."
 
 #: packages/lib/SyncTargetAmazonS3.js:28
 msgid "S3"
@@ -5462,12 +4998,8 @@ msgid "S3 URL"
 msgstr "آدرس S3"
 
 #: packages/app-desktop/gui/MainScreen.tsx:524
-msgid ""
-"Safe mode is currently active. Note rendering and all plugins are "
-"temporarily disabled."
-msgstr ""
-"حالت ایمن در حال حاضر فعال است. ارائه یادداشت و همه افزونه ها به طور موقت "
-"غیرفعال هستند."
+msgid "Safe mode is currently active. Note rendering and all plugins are temporarily disabled."
+msgstr "حالت ایمن در حال حاضر فعال است. ارائه یادداشت و همه افزونه ها به طور موقت غیرفعال هستند."
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:129
 #: packages/app-desktop/gui/KeymapConfig/ShortcutRecorder.tsx:93
@@ -5485,7 +5017,7 @@ msgstr "ذخیره هشدار"
 #: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:116
 #: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:123
 msgid "Save as %s"
-msgstr "ذخیره به عنوان $s"
+msgstr "ذخیره به عنوان %s"
 
 #: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:103
 msgid "Save as..."
@@ -5508,22 +5040,20 @@ msgid "Save geo-location with notes"
 msgstr "ذخیره موقعیت مکانی با یادداشت‌ها"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:575
-#, fuzzy
 msgid "Save geolocation?"
-msgstr "ذخیره موقعیت مکانی با یادداشت‌ها"
+msgstr "موقعیت مکانی ذخیره شود؟"
 
 #: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:81
-#, fuzzy
 msgid "Scan notebook"
-msgstr "انتخاب دفترچه والد"
+msgstr "پویش دفترچه"
 
 #: packages/app-mobile/components/CameraView/ScannedBarcodes.tsx:90
 msgid "Scanned code"
-msgstr ""
+msgstr "کد اسکن‌ شده"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1295
 msgid "Scrollbar size"
-msgstr ""
+msgstr "اندازه نوار پیمایش"
 
 #: packages/app-desktop/gui/lib/SearchInput/SearchInput.tsx:67
 #: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:163
@@ -5556,9 +5086,8 @@ msgid "Search in current note"
 msgstr "جستجو در یادداشت جاری"
 
 #: packages/app-desktop/plugins/GotoAnything.tsx:695
-#, fuzzy
 msgid "Search results"
-msgstr "بدون نتیجه"
+msgstr "نتایج جستجو"
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:191
 msgid "Search shown"
@@ -5566,9 +5095,8 @@ msgstr "جستجوی نمایش داده شده"
 
 #: packages/app-mobile/components/screens/tags.tsx:234
 #: packages/app-mobile/components/TagEditor.tsx:289
-#, fuzzy
 msgid "Search tags"
-msgstr "بدون نتیجه"
+msgstr "جستجوی برچسب‌ها"
 
 #: packages/app-cli/app/gui/FolderListWidget.ts:70
 msgid "Search:"
@@ -5587,9 +5115,8 @@ msgid "Searches for the given <pattern> in all the notes."
 msgstr "برای <pattern> داده شده، بین تمام یادداشت‌ها جستجو می‌کند."
 
 #: packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx:39
-#, fuzzy
 msgid "See changelog"
-msgstr "تغییرات کامل"
+msgstr "مشاهده تغییرات"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1384
 msgid "See the pre-release page for more details: %s"
@@ -5601,9 +5128,8 @@ msgid "Select"
 msgstr "انتخاب"
 
 #: packages/app-mobile/components/screens/NoteRevisionViewer.tsx:268
-#, fuzzy
 msgid "Select a revision..."
-msgstr "انتخاب شکلک..."
+msgstr "انتخاب یک نسخه..."
 
 #: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:50
 #: packages/app-mobile/components/ScreenHeader/index.tsx:384
@@ -5619,13 +5145,12 @@ msgid "Select file..."
 msgstr "انتخاب فایل..."
 
 #: packages/app-mobile/components/screens/DocumentScanner/NotePreview.tsx:189
-#, fuzzy
 msgid "Select notebook"
-msgstr "انتخاب دفترچه والد"
+msgstr "انتخاب دفترچه"
 
 #: packages/app-mobile/components/SyncWizard/SyncWizard.tsx:131
 msgid "Select one of the other supported sync targets."
-msgstr ""
+msgstr "یکی دیگر از مقصد های همگام‌ سازیِ پشتیبانی ‌شده را انتخاب کنید."
 
 #: packages/app-mobile/components/screens/folder.js:109
 msgid "Select parent notebook"
@@ -5633,26 +5158,23 @@ msgstr "انتخاب دفترچه والد"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts:42
 msgid "Select the type of file to be imported:"
-msgstr ""
+msgstr "نوع فایل مورد نظر برای وارد کردن را انتخاب کنید:"
 
 #: packages/app-mobile/components/ComboBox.tsx:378
-#, fuzzy
 msgid "Selected: %s"
-msgstr "ایجاد شده: %s"
+msgstr "انتخاب شده: %s"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:9
-#, fuzzy
 msgid "Selection deleted"
-msgstr "تاریخ تکمیل"
+msgstr "انتخاب حذف شد"
 
 #: packages/app-mobile/components/FolderPicker.tsx:80
-#, fuzzy
 msgid "Selects a notebook"
-msgstr "انتخاب دفترچه والد"
+msgstr "یک دفترچه را انتخاب می‌کند"
 
 #: packages/lib/utils/joplinCloud/index.ts:246
 msgid "Self-hosted"
-msgstr ""
+msgstr "خود میزبان"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts:149
 msgid "Send bug report"
@@ -5682,11 +5204,8 @@ msgid "Set alarm:"
 msgstr "تنظیم هشدار:"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1279
-msgid ""
-"Set it to 0 to make it take the complete available space. Recommended width "
-"is 600."
-msgstr ""
-"آن را روی 0 تنظیم کنید تا فضای کامل موجود را اشغال کند. عرض پیشنهادی 600 است."
+msgid "Set it to 0 to make it take the complete available space. Recommended width is 600."
+msgstr "آن را روی 0 تنظیم کنید تا فضای کامل موجود را اشغال کند. عرض پیشنهادی 600 است."
 
 #: packages/app-desktop/gui/MainScreen.tsx:531
 #: packages/app-desktop/gui/MainScreen.tsx:578
@@ -5695,19 +5214,17 @@ msgstr "گذرواژه را تعیین کنید"
 
 #: packages/app-cli/app/command-set.ts:22
 msgid ""
-"Sets the property <name> of the given <note> to the given [value]. Possible "
-"properties are:\n"
+"Sets the property <name> of the given <note> to the given [value]. Possible properties are:\n"
 "\n"
 "%s"
 msgstr ""
-"ویژگی <name> از <note> داده شده را به [value] (مقدار) داده شده تغییر می‌دهد. "
-"ویژگی‌های احتمالی شامل:\n"
+"ویژگی <name> از <note> داده شده را به [value] (مقدار) داده شده تغییر می‌دهد. ویژگی‌های احتمالی شامل:\n"
 "\n"
 "%s"
 
 #: packages/app-mobile/components/EditorToolbar/EditorToolbar.tsx:74
 msgid "Settings"
-msgstr ""
+msgstr "تنظیمات"
 
 #: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:271
 #: packages/app-mobile/components/NoteBodyViewer/hooks/useOnResourceLongPress.ts:44
@@ -5717,12 +5234,8 @@ msgid "Share"
 msgstr "اشتراک گذاری"
 
 #: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteExportButton.tsx:21
-msgid ""
-"Share a copy of all notes in a file format that can be imported by Joplin on "
-"a computer."
-msgstr ""
-"یک کپی از همه یادداشت ها را در قالب فایلی که می تواند توسط joplin در رایانه "
-"وارد شود، به اشتراک بگذارید."
+msgid "Share a copy of all notes in a file format that can be imported by Joplin on a computer."
+msgstr "یک کپی از همه یادداشت ها را در قالب فایلی که می تواند توسط joplin در رایانه وارد شود، به اشتراک بگذارید."
 
 #: packages/lib/utils/joplinCloud/index.ts:134
 msgid "Share a notebook with others"
@@ -5746,19 +5259,16 @@ msgid "Share permissions"
 msgstr "مجوزهای اشتراک‌گذاری"
 
 #: packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx:58
-#, fuzzy
 msgid "Shared"
-msgstr "اشتراک گذاری"
+msgstr "مشترک"
 
 #: packages/app-mobile/components/screens/ShareManager/index.tsx:107
 msgid "Shares"
 msgstr "اشتراک‌ها"
 
 #: packages/app-cli/app/command-share.ts:58
-msgid ""
-"Shares or unshares the specified [notebook] with [user]. Requires Joplin "
-"Cloud or Joplin Server."
-msgstr ""
+msgid "Shares or unshares the specified [notebook] with [user]. Requires Joplin Cloud or Joplin Server."
+msgstr "دفترچه مشخص‌شده در [notebook] را با [user] به اشتراک می‌گذارد یا اشتراک آن را لغو می‌کند. نیازمند Joplin Cloud یا Joplin Server است."
 
 #: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:354
 msgid "Sharing notebook..."
@@ -5801,14 +5311,12 @@ msgid "Show note counts"
 msgstr "نمایش تعداد یادداشت‌ها"
 
 #: packages/app-mobile/components/side-menu-content.tsx:262
-#, fuzzy
 msgid "Show notebook options"
-msgstr "نمایش تعداد یادداشت‌ها"
+msgstr "نمایش گزینه‌های دفترچه"
 
 #: packages/app-desktop/gui/PasswordInput/PasswordInput.tsx:21
-#, fuzzy
 msgid "Show password"
-msgstr "گذرواژه را تعیین کنید"
+msgstr "نمایش گذرواژه"
 
 #: packages/lib/models/settings/builtInMetadata.ts:837
 msgid "Show sort order buttons"
@@ -5823,9 +5331,8 @@ msgid "Show/hide the sidebar"
 msgstr "نماش/پنهان نوار کناری"
 
 #: packages/app-mobile/components/screens/tags.tsx:68
-#, fuzzy
 msgid "Shows notes for tag"
-msgstr "نمایش تعداد یادداشت‌ها"
+msgstr "یادداشت‌های این برچسب را نمایش می‌دهد"
 
 #: packages/lib/models/settings/builtInMetadata.ts:986
 msgid "Shrink large images before adding them to notes."
@@ -5848,9 +5355,8 @@ msgid "Sidebar"
 msgstr "نوار کناری"
 
 #: packages/app-desktop/gui/JoplinCloudSignUpCallToAction.tsx:15
-#, fuzzy
 msgid "Sign up to Joplin Cloud"
-msgstr "اتصال به سرویس ابری joplin"
+msgstr "ثبت‌نام در سرویس ابری joplin"
 
 #: packages/app-desktop/gui/ResourceScreen.tsx:117
 msgid "Size"
@@ -5862,9 +5368,7 @@ msgstr "از این نسخه بگذرید"
 
 #: packages/app-cli/app/command-e2ee.ts:67
 msgid "Skipped items: %d (use --retry-failed-items to retry decrypting them)"
-msgstr ""
-"موارد رد شده: %d (از retry-failed-items-- برای تلاش مجدد رمزگشایی آن‌ها "
-"استفاده کنید)"
+msgstr "موارد رد شده: %d (از retry-failed-items-- برای تلاش مجدد رمزگشایی آن‌ها استفاده کنید)"
 
 #: packages/app-cli/app/command-import.ts:56
 #: packages/app-desktop/gui/ImportScreen.tsx:92
@@ -5873,7 +5377,7 @@ msgstr "رد شده: %d."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1290
 msgid "Small"
-msgstr ""
+msgstr "کوچک"
 
 #: packages/lib/models/settings/builtInMetadata.ts:71
 msgid "Solarised Dark"
@@ -5884,18 +5388,12 @@ msgid "Solarised Light"
 msgstr "Solarised Light"
 
 #: packages/lib/models/settings/settingValidations.ts:21
-msgid ""
-"Some attachments could not be downloaded. Please try to download them again."
-msgstr ""
-"برخی از پیوست ها دانلود نشدند. لطفا سعی کنید دوباره آنها را دانلود کنید."
+msgid "Some attachments could not be downloaded. Please try to download them again."
+msgstr "برخی از پیوست ها دانلود نشدند. لطفا سعی کنید دوباره آنها را دانلود کنید."
 
 #: packages/lib/models/settings/settingValidations.ts:18
-msgid ""
-"Some attachments need to be downloaded. Set the attachment download mode to "
-"\"always\" and try again."
-msgstr ""
-"برخی از پیوست ها باید دانلود شوند. حالت دانلود پیوست را روی «همیشه» تنظیم "
-"کنید و دوباره امتحان کنید."
+msgid "Some attachments need to be downloaded. Set the attachment download mode to \"always\" and try again."
+msgstr "برخی از پیوست ها باید دانلود شوند. حالت دانلود پیوست را روی «همیشه» تنظیم کنید و دوباره امتحان کنید."
 
 #: packages/app-desktop/gui/MainScreen.tsx:542
 #: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:52
@@ -5911,19 +5409,16 @@ msgid "Some items cannot be synchronised. Press for more info."
 msgstr "بعضی از موارد نمی‌توانند همگام‌سازی شوند. برای اطلاعات بیشتر بفشارید."
 
 #: packages/lib/models/settings/settingValidations.ts:24
-msgid ""
-"Some items could not be synchronised. Please try to synchronise them first."
-msgstr ""
-"برخی از موارد را نمی توان همگام سازی کرد. لطفا ابتدا سعی کنید آنها را همگام "
-"سازی کنید."
+msgid "Some items could not be synchronised. Please try to synchronise them first."
+msgstr "برخی از موارد را نمی توان همگام سازی کرد. لطفا ابتدا سعی کنید آنها را همگام سازی کنید."
 
 #: packages/app-desktop/gui/ResourceScreen.tsx:98
 msgid "Sort \"%s\" in ascending order"
-msgstr ""
+msgstr "مرتب‌سازی «%s» به ترتیب صعودی"
 
 #: packages/app-desktop/gui/ResourceScreen.tsx:98
 msgid "Sort \"%s\" in descending order"
-msgstr ""
+msgstr "مرتب‌سازی «%s» به ترتیب نزولی"
 
 #: packages/lib/models/settings/builtInMetadata.ts:893
 msgid "Sort notebooks by"
@@ -5942,18 +5437,15 @@ msgstr "مرتب‌سازی خطوط انتخاب شده"
 
 #: packages/app-cli/app/command-ls.ts:29
 msgid "Sorts the item by <field> (eg. title, updated_time, created_time)."
-msgstr ""
-"مورد را بر‌ اساس <field> مرتب می‌کند (به عنوان مثال: عنوان، زمان به‌روزرسانی، "
-"زمان ایجاد)."
+msgstr "مورد را بر‌ اساس <field> مرتب می‌کند (به عنوان مثال: عنوان، زمان به‌روزرسانی، زمان ایجاد)."
 
 #: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:9
 msgid "Source"
 msgstr "منبع"
 
 #: packages/lib/utils/joplinCloud/index.ts:253
-#, fuzzy
 msgid "Source code available"
-msgstr "به روز رسانی موجود است"
+msgstr "کد منبع در دسترس است"
 
 #: packages/app-cli/app/command-import.ts:28
 msgid "Source format: %s"
@@ -5965,19 +5457,15 @@ msgstr "منبع "
 
 #: packages/app-cli/app/command-keymap.ts:35
 msgid "SPACE"
-msgstr ""
+msgstr "فضا"
 
 #: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:456
 msgid "Spacer"
 msgstr "فاصله‌ساز"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1680
-msgid ""
-"Specify the port that should be used by the API server. If not set, a "
-"default will be used."
-msgstr ""
-"پورتی که باید توسط سرور API استفاده شود را مشخص نمایید. در غیر اینصورت، یک "
-"پورت پیشفرض استفاده خواهد شد."
+msgid "Specify the port that should be used by the API server. If not set, a default will be used."
+msgstr "پورتی که باید توسط سرور API استفاده شود را مشخص نمایید. در غیر اینصورت، یک پورت پیشفرض استفاده خواهد شد."
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/showSpellCheckerMenu.ts:11
 #: packages/lib/services/spellChecker/SpellCheckerService.ts:218
@@ -5996,20 +5484,14 @@ msgstr "شروع برنامه و کوچک‌شده در آیکن تسک‌بار
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:206
 msgid "Start recording"
-msgstr ""
+msgstr "ضبط را شروع کن"
 
 #: packages/app-cli/app/command-server.js:14
-msgid ""
-"Start, stop or check the API server. To specify on which port it should run, "
-"set the api.port config variable. Commands are (%s)."
-msgstr ""
-"شروع، توقف یا بررسی سرور API. از متغیر تنظیمات api.port برای مشخص کردن پورتی "
-"که باید روی آن اجرا شود استفاده کنید. دستورات بصورت (%s) هستند."
+msgid "Start, stop or check the API server. To specify on which port it should run, set the api.port config variable. Commands are (%s)."
+msgstr "شروع، توقف یا بررسی سرور API. از متغیر تنظیمات api.port برای مشخص کردن پورتی که باید روی آن اجرا شود استفاده کنید. دستورات بصورت (%s) هستند."
 
 #: packages/app-cli/app/command-e2ee.ts:58
-msgid ""
-"Starting decryption... Please wait as it may take several minutes depending "
-"on how much there is to decrypt."
+msgid "Starting decryption... Please wait as it may take several minutes depending on how much there is to decrypt."
 msgstr "شروع رمزگشایی... این کار ممکن است چند دقیقه طول بکشد، لطفا صبور باشید."
 
 #: packages/app-cli/app/command-sync.ts:238
@@ -6050,9 +5532,7 @@ msgstr "مرحله 1: سرویس Clipper را فعال نمایید"
 #: packages/app-desktop/gui/DropboxLoginScreen.tsx:46
 #: packages/app-mobile/components/screens/dropbox-login.tsx:63
 msgid "Step 1: Open this URL in your browser to authorise the application:"
-msgstr ""
-"مرحله ۱: برای اجازه دادن به برنامه این آدرس اینترنتی را در مرورگر خود باز "
-"نمایید:"
+msgstr "مرحله ۱: برای اجازه دادن به برنامه این آدرس اینترنتی را در مرورگر خود باز نمایید:"
 
 #: packages/app-cli/app/command-sync.ts:85
 #: packages/app-desktop/gui/DropboxLoginScreen.tsx:50
@@ -6094,18 +5574,16 @@ msgid "Subscript"
 msgstr "اشتراک"
 
 #: packages/app-desktop/gui/PopupNotification/NotificationItem.tsx:16
-#, fuzzy
 msgid "Success"
-msgstr "کلید دسترسی S3"
+msgstr "موفقیت"
 
 #: packages/lib/components/shared/config/config-shared.ts:99
 msgid "Success! Synchronisation configuration appears to be correct."
 msgstr "موفق! تنظیمات همگام‌سازی به نظر صحیح است."
 
 #: packages/app-desktop/gui/InlineCombobox.tsx:182
-#, fuzzy
 msgid "Suggestions"
-msgstr "هیچ پیشنهادی وجود ندارد"
+msgstr "پیشنهادها"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.ts:30
 msgid "Superscript"
@@ -6132,12 +5610,11 @@ msgstr "تغییر حساب کاربری"
 
 #: packages/app-mobile/components/CameraView/ActionButtons.tsx:101
 msgid "Switch to back-facing camera"
-msgstr ""
+msgstr "تغییر به دوربین پشت"
 
 #: packages/app-mobile/components/CameraView/ActionButtons.tsx:101
-#, fuzzy
 msgid "Switch to front-facing camera"
-msgstr "به حساب‌کاربری‌ %d بروید"
+msgstr "تغییر به دوربین جلو"
 
 #: packages/app-desktop/gui/utils/NoteListUtils.ts:84
 msgid "Switch to note type"
@@ -6150,35 +5627,28 @@ msgid "Switch to profile %d"
 msgstr "به حساب‌کاربری‌ %d بروید"
 
 #: packages/app-desktop/gui/ToggleEditorsButton/ToggleEditorsButton.tsx:28
-#, fuzzy
 msgid "Switch to the %s Editor"
-msgstr "تغییر به نوع یادداشت"
+msgstr "تغییر به ویرایشگر %s"
 
 #: packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx:71
-#, fuzzy
 msgid "Switch to the legacy editor"
-msgstr "تغییر به نوع یادداشت"
+msgstr "تغییر به ویرایشگر قدیمی"
 
 #: packages/app-desktop/gui/ErrorBoundary.tsx:52
-#, fuzzy
 msgid "Switch to the new editor"
-msgstr "تغییر به نوع یادداشت"
+msgstr "تغییر به ویرایشگر جدید"
 
 #: packages/app-desktop/gui/utils/NoteListUtils.ts:93
 msgid "Switch to to-do type"
 msgstr "تغییر به نوع فهرست کار"
 
 #: packages/app-cli/app/command-use.ts:13
-msgid ""
-"Switches to [notebook] - all further operations will happen within this "
-"notebook."
-msgstr ""
-"به [notebook] تغییر می‌کند - تمامی فعالیت های آینده  در این دفترچه انجام "
-"می‌گیرد."
+msgid "Switches to [notebook] - all further operations will happen within this notebook."
+msgstr "به [notebook] تغییر می‌کند - تمامی فعالیت های آینده  در این دفترچه انجام می‌گیرد."
 
 #: packages/app-mobile/components/SyncWizard/SyncWizard.tsx:111
 msgid "Sync"
-msgstr ""
+msgstr "همگام سازی"
 
 #: packages/lib/utils/joplinCloud/index.ts:170
 msgid "Sync as many devices as you want"
@@ -6215,7 +5685,7 @@ msgstr "یادداشت‌های خود را همگام‌سازی کنید"
 
 #: packages/lib/models/Setting.ts:1392
 msgid "Sync, encryption, proxy"
-msgstr "همگام سازی، رمزگذاری، پروکسی"
+msgstr "همگام سازی، رمزنگاری، پروکسی"
 
 #: packages/lib/models/Setting.ts:1353
 msgid "Synchronisation"
@@ -6268,26 +5738,24 @@ msgstr "در حال همگام سازی..."
 
 #: packages/app-desktop/gui/NoteEditor/StatusBar.tsx:72
 msgid "Tab indents"
-msgstr ""
+msgstr "ایجاد تورفتگی با کلید Tab"
 
 #: packages/app-desktop/gui/NoteEditor/StatusBar.tsx:72
 #: packages/lib/models/settings/builtInMetadata.ts:806
 msgid "Tab moves focus"
-msgstr ""
+msgstr "کلید Tab تمرکز را جابه‌جا می‌کند"
 
 #: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:118
-#, fuzzy
 msgid "Table"
-msgstr "فعال سازی"
+msgstr "جدول"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1440
 msgid "Tabloid"
 msgstr "چکیده"
 
 #: packages/app-mobile/components/screens/tags.tsx:206
-#, fuzzy
 msgid "Tag: %s"
-msgstr "کارکرد: %s"
+msgstr "برچسب: %s"
 
 #: packages/app-cli/app/command-import.ts:58
 #: packages/app-desktop/gui/ImportScreen.tsx:94
@@ -6309,9 +5777,8 @@ msgid "Take photo"
 msgstr "عکس گرفتن"
 
 #: packages/app-mobile/components/FeedbackBanner.tsx:164
-#, fuzzy
 msgid "Take survey"
-msgstr "رسم تصویر"
+msgstr "شرکت در نظرسنجی"
 
 #: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/TaskButton.tsx:73
 msgid "Task \"%s\" failed with error: %s"
@@ -6343,26 +5810,20 @@ msgid ""
 "Thank you for the feedback!\n"
 "Do you have time to complete a short survey?"
 msgstr ""
+"از بازخورد شما سپاسگزاریم!\n"
+"آیا فرصت دارید در یک نظرسنجی کوتاه شرکت کنید؟"
 
 #: packages/app-desktop/gui/ProfileEditor.tsx:143
 #: packages/lib/services/profileConfig/index.ts:106
-msgid ""
-"The active profile cannot be deleted. Switch to a different profile and try "
-"again."
-msgstr ""
-"حساب‌کاربری فعال را نمی توان حذف کرد. به حساب‌کاربری دیگری بروید و دوباره "
-"امتحان کنید."
+msgid "The active profile cannot be deleted. Switch to a different profile and try again."
+msgstr "حساب‌کاربری فعال را نمی توان حذف کرد. به حساب‌کاربری دیگری بروید و دوباره امتحان کنید."
 
 #: packages/app-desktop/bridge.ts:603
-msgid ""
-"The app is now going to close. Please relaunch it to complete the process."
-msgstr ""
-"برنامه اکنون در حال بسته شدن است. لطفاً برای تکمیل مراحل آن را مجدداً راه "
-"اندازی کنید."
+msgid "The app is now going to close. Please relaunch it to complete the process."
+msgstr "برنامه اکنون در حال بسته شدن است. لطفاً برای تکمیل مراحل آن را مجدداً راه اندازی کنید."
 
 #: packages/lib/onedrive-api-node-utils.js:87
-msgid ""
-"The application has been authorised - you may now close this browser tab."
+msgid "The application has been authorised - you may now close this browser tab."
 msgstr "برنامه احراز هویت شده است - اکنون می توانید این برگه مرورگر را ببندید."
 
 #: packages/lib/components/shared/dropbox-login-shared.js:39
@@ -6378,9 +5839,7 @@ msgid "The application must be restarted for these changes to take effect."
 msgstr "برای اعمال این تغییرات، برنامه باید دوباره راه اندازی شود."
 
 #: packages/app-desktop/gui/NoteEditor/NoteEditor.tsx:583
-msgid ""
-"The attachments will no longer be watched when you switch to a different "
-"note."
+msgid "The attachments will no longer be watched when you switch to a different note."
 msgstr "وقتی به یادداشت دیگری بروید، پیوست‌ها دیگر مشاهده نخواهند شد."
 
 #: packages/app-cli/app/app.ts:288
@@ -6388,55 +5847,30 @@ msgid "The command \"%s\" is only available in GUI mode"
 msgstr "دستور «%s» فقط در حالت گرافیکی (GUI) کاربرد دارد"
 
 #: packages/server/src/middleware/notificationHandler.ts:25
-msgid ""
-"The default admin password is insecure and has not been changed! [Change it "
-"now](%s)"
-msgstr ""
-"رمز عبور پیشفرض مدیر امن نیست و تا کنون تغییر نکرده است! [اکنون آن را تغییر "
-"دهید] (%s)"
+msgid "The default admin password is insecure and has not been changed! [Change it now](%s)"
+msgstr "رمز عبور پیشفرض مدیر امن نیست و تا کنون تغییر نکرده است! [اکنون آن را تغییر دهید] (%s)"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:344
-msgid ""
-"The default encryption method has been changed to a more secure one and it "
-"is recommended that you apply it to your data."
-msgstr ""
-"روش پیش فرض رمزنگاری به یک روش امن‌تر تغییر پیدا کرده و پیشنهاد می‌شود که آن "
-"را بر داده خود اعمال کنید."
+msgid "The default encryption method has been changed to a more secure one and it is recommended that you apply it to your data."
+msgstr "روش پیش فرض رمزنگاری به یک روش امن‌تر تغییر پیدا کرده و پیشنهاد می‌شود که آن را بر داده خود اعمال کنید."
 
 #: packages/app-desktop/gui/MainScreen.tsx:554
-msgid ""
-"The default encryption method has been changed, you should re-encrypt your "
-"data."
-msgstr ""
-"روش رمزنگاری پیش فرض تغییر یافته است،‌ شما باید داده‌های خود را دوباره "
-"رمزنگاری کنید."
+msgid "The default encryption method has been changed, you should re-encrypt your data."
+msgstr "روش رمزنگاری پیش فرض تغییر یافته است،‌ شما باید داده‌های خود را دوباره رمزنگاری کنید."
 
 #: packages/lib/services/profileConfig/index.ts:105
 msgid "The default profile cannot be deleted"
 msgstr "حساب‌کاربری پیش فرض را نمی توان حذف نمود"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1433
-msgid ""
-"The editor command (may include arguments) that will be used to open a note. "
-"If none is provided it will try to auto-detect the default editor."
-msgstr ""
-"دستور ویرایشگر (ممکن است شامل آرگومان‌هایی نیز باشد) که برای باز کردن یادداشت "
-"استفاده می‌شود. اگر هیچ کدام ارائه نشده باشد، سعی می‌کند ویرایشگر پیش فرض را "
-"به طور خودکار شناسایی کند."
+msgid "The editor command (may include arguments) that will be used to open a note. If none is provided it will try to auto-detect the default editor."
+msgstr "دستور ویرایشگر (ممکن است شامل آرگومان‌هایی نیز باشد) که برای باز کردن یادداشت استفاده می‌شود. اگر هیچ کدام ارائه نشده باشد، سعی می‌کند ویرایشگر پیش فرض را به طور خودکار شناسایی کند."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1738
 #: packages/lib/models/settings/builtInMetadata.ts:1753
 #: packages/lib/models/settings/builtInMetadata.ts:1768
-msgid ""
-"The factor property sets how the item will grow or shrink to fit the "
-"available space in its container with respect to the other items. Thus an "
-"item with a factor of 2 will take twice as much space as an item with a "
-"factor of 1.Restart app to see changes."
-msgstr ""
-"ویژگی فاکتور نحوه رشد یا کوچک شدن آیتم را تعیین می‌کند تا فضای موجود در ظرف "
-"خود را با توجه به سایر موارد متناسب کند. بنابراین یک مورد با ضریب 2، دو "
-"برابر فضای بیشتری نسبت به یک مورد با ضریب 1 اشغال می‌کند. برای مشاهده "
-"تغییرات، برنامه را مجدد راه‌اندازی کنید."
+msgid "The factor property sets how the item will grow or shrink to fit the available space in its container with respect to the other items. Thus an item with a factor of 2 will take twice as much space as an item with a factor of 1.Restart app to see changes."
+msgstr "ویژگی فاکتور نحوه رشد یا کوچک شدن آیتم را تعیین می‌کند تا فضای موجود در ظرف خود را با توجه به سایر موارد متناسب کند. بنابراین یک مورد با ضریب 2، دو برابر فضای بیشتری نسبت به یک مورد با ضریب 1 اشغال می‌کند. برای مشاهده تغییرات، برنامه را مجدد راه‌اندازی کنید."
 
 #: packages/app-desktop/gui/NoteEditor/NoteEditor.tsx:598
 msgid "The following attachment matches your search query:"
@@ -6449,72 +5883,43 @@ msgid "The following attachments are being watched for changes:"
 msgstr "پیوست های زیر برای تغییرات در حال مشاهده هستند:"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:75
-msgid ""
-"The following keys use an out-dated encryption algorithm and it is "
-"recommended to upgrade them. The upgraded key will still be able to decrypt "
-"and encrypt your data as usual."
-msgstr ""
-"کلیدهای زیر از یک الگوریتم رمزنگاری قدیمی استفاده می کنند و توصیه می شود "
-"آنها را ارتقا دهید. کلید ارتقا یافته همچنان می‌تواند مانند همیشه داده‌های شما "
-"را رمزگشایی و رمزنگاری کند."
+msgid "The following keys use an out-dated encryption algorithm and it is recommended to upgrade them. The upgraded key will still be able to decrypt and encrypt your data as usual."
+msgstr "کلیدهای زیر از یک الگوریتم رمزنگاری قدیمی استفاده می کنند و توصیه می شود آنها را ارتقا دهید. کلید ارتقا یافته همچنان می‌تواند مانند همیشه داده‌های شما را رمزگشایی و رمزنگاری کند."
 
 #: packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx:76
 msgid "The following plugins may not support the current markdown editor:"
-msgstr ""
+msgstr "افزونه‌ های زیر ممکن است از ویرایشگر فعلی Markdown پشتیبانی نکنند:"
 
 #: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx:257
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/RecommendedBadge.tsx:49
-msgid ""
-"The Joplin team has vetted this plugin and it meets our standards for "
-"security and performance."
-msgstr ""
-"تیم joplin این افزونه را بررسی کرده است و استانداردهای ما را برای امنیت و "
-"عملکرد مطابقت دارد."
+msgid "The Joplin team has vetted this plugin and it meets our standards for security and performance."
+msgstr "تیم joplin این افزونه را بررسی کرده است و استانداردهای ما را برای امنیت و عملکرد مطابقت دارد."
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:321
-msgid ""
-"The keys with these IDs are used to encrypt some of your items, however the "
-"application does not currently have access to them. It is likely they will "
-"eventually be downloaded via synchronisation."
-msgstr ""
-"کلیدهای دارای این شناسه‌ها برای رمزگذاری برخی از آیتم‌های شما استفاده می‌شوند، "
-"اما برنامه در حال حاضر به آنها دسترسی ندارد. این احتمال وجود دارد که آنها در "
-"نهایت از طریق همگام سازی دانلود شوند."
+msgid "The keys with these IDs are used to encrypt some of your items, however the application does not currently have access to them. It is likely they will eventually be downloaded via synchronisation."
+msgstr "کلیدهای دارای این شناسه‌ها برای رمزنگاری برخی از آیتم‌های شما استفاده می‌شوند، اما برنامه در حال حاضر به آنها دسترسی ندارد. این احتمال وجود دارد که آنها در نهایت از طریق همگام سازی دانلود شوند."
 
 #: packages/app-desktop/gui/ErrorBoundary.tsx:56
-msgid ""
-"The legacy Markdown editor appears to have crashed due to an incompatibility "
-"with a plugin. We recommend using the new editor."
-msgstr ""
+msgid "The legacy Markdown editor appears to have crashed due to an incompatibility with a plugin. We recommend using the new editor."
+msgstr "به نظر می‌رسد ویرایشگر قدیمی Markdown به دلیل ناسازگاری با یکی از افزونه‌ها از کار افتاده است. توصیه می‌کنیم از ویرایشگر جدید استفاده کنید."
 
 #: packages/lib/components/EncryptionConfigScreen/utils.ts:222
 msgid "The master key has been upgraded successfully!"
 msgstr "کلید اصلی با موفقیت ارتقا یافت!"
 
 #: packages/app-mobile/components/screens/encryption-config.tsx:308
-msgid ""
-"The master keys with these IDs are used to encrypt some of your items, "
-"however the application does not currently have access to them. It is likely "
-"they will eventually be downloaded via synchronisation."
-msgstr ""
-"کلیدهای اصلی با این شناسه ها برای رمزگذاری برخی از موارد شما استفاده می‌شوند، "
-"اما برنامه در حال حاضر به آنها دسترسی ندارد. این احتمال وجود دارد که آنها در "
-"نهایت از طریق همگام سازی دانلود شوند."
+msgid "The master keys with these IDs are used to encrypt some of your items, however the application does not currently have access to them. It is likely they will eventually be downloaded via synchronisation."
+msgstr "کلیدهای اصلی با این شناسه ها برای رمزنگاری برخی از موارد شما استفاده می‌شوند، اما برنامه در حال حاضر به آنها دسترسی ندارد. این احتمال وجود دارد که آنها در نهایت از طریق همگام سازی دانلود شوند."
 
 #: packages/lib/services/RevisionService.ts:297
 msgid "The note \"%s\" has been successfully restored to the notebook \"%s\"."
 msgstr "یادداشت «%s» با موفقیت به دفترچه «%s» بازگردانده شد."
 
 #: packages/lib/commands/convertNoteToMarkdown.ts:64
-#, fuzzy
-msgid ""
-"The note has been converted to Markdown and the original note has been moved "
-"to the trash"
-msgid_plural ""
-"The notes have been converted to Markdown and the original notes have been "
-"moved to the trash"
-msgstr[0] "پوشه یادداشتها و محتوای آن با موفقیت به سطل زباله منتقل شد."
-msgstr[1] "پوشه یادداشتها و محتوای آن با موفقیت به سطل زباله منتقل شد."
+msgid "The note has been converted to Markdown and the original note has been moved to the trash"
+msgid_plural "The notes have been converted to Markdown and the original notes have been moved to the trash"
+msgstr[0] "یادداشت‌ها به Markdown تبدیل شدند و یادداشت‌های اصلی به سطل زباله منتقل شدند"
+msgstr[1] "یادداشت به Markdown تبدیل شد و یادداشت اصلی به سطل زباله منتقل شد"
 
 #: packages/app-desktop/gui/TrashNotification/TrashNotification.tsx:45
 msgid "The note was successfully moved to the trash."
@@ -6524,7 +5929,7 @@ msgstr[1] "یادداشت «%s» با موفقیت به دفترچه «%s» با
 
 #: packages/app-desktop/gui/TrashNotification/TrashNotification.tsx:43
 msgid "The notebook and its content was successfully moved to the trash."
-msgstr "پوشه یادداشتها و محتوای آن با موفقیت به سطل زباله منتقل شد."
+msgstr "دفترچه و محتوای آن با موفقیت به سطل زباله منتقل شد."
 
 #: packages/app-mobile/components/screens/folder.js:76
 msgid "The notebook could not be saved: %s"
@@ -6553,27 +5958,19 @@ msgstr ""
 msgid ""
 "The sync target cannot be changed for the following reason: %s\n"
 "\n"
-"If the issue cannot be resolved, you may need to clear your data first by "
-"following these instructions:\n"
+"If the issue cannot be resolved, you may need to clear your data first by following these instructions:\n"
 "\n"
 "%s"
 msgstr ""
 "هدف همگام سازی به دلایل زیر قابل تغییر نیست:%s\n"
 "\n"
-"اگر مشکل حل نشد، ممکن است لازم باشد ابتدا اطلاعات خود را با دنبال کردن این "
-"دستورالعمل ها پاک کنید:\n"
+"اگر مشکل حل نشد، ممکن است لازم باشد ابتدا اطلاعات خود را با دنبال کردن این دستورالعمل ها پاک کنید:\n"
 "\n"
 "%s"
 
 #: packages/app-desktop/gui/MainScreen.tsx:536
-msgid ""
-"The sync target needs to be upgraded before Joplin can sync. The operation "
-"may take a few minutes to complete and the app needs to be restarted. To "
-"proceed please click on the link."
-msgstr ""
-"قبل از اینکه joplin بتواند همگام‌سازی کند، هدف همگام‌سازی باید ارتقا یابد. "
-"ممکن است عملیات چند دقیقه طول بکشد و برنامه باید دوباره راه‌اندازی شود. برای "
-"ادامه لطفا روی لینک کلیک کنید."
+msgid "The sync target needs to be upgraded before Joplin can sync. The operation may take a few minutes to complete and the app needs to be restarted. To proceed please click on the link."
+msgstr "قبل از اینکه joplin بتواند همگام‌سازی کند، هدف همگام‌سازی باید ارتقا یابد. ممکن است عملیات چند دقیقه طول بکشد و برنامه باید دوباره راه‌اندازی شود. برای ادامه لطفا روی لینک کلیک کنید."
 
 #: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:46
 msgid "The sync target needs to be upgraded. Press this banner to proceed."
@@ -6588,29 +5985,26 @@ msgid "The tag \"%s\" already exists. Please choose a different name."
 msgstr "برچسب «%s» وجود دارد. لطفا نام دیگری انتخاب کنید."
 
 #: packages/lib/models/settings/builtInMetadata.ts:130
-msgid ""
-"The target to synchronise to. Each sync target may have additional "
-"parameters which are named as `sync.NUM.NAME` (all documented below)."
-msgstr ""
-"هدف برای همگام سازی. هر هدف همگام‌سازی ممکن است پارامترهای دیگری داشته باشد "
-"که به‌عنوان «sync.NUM.NAME» نام‌گذاری شده‌اند (همه در زیر مستند شده‌اند)."
+msgid "The target to synchronise to. Each sync target may have additional parameters which are named as `sync.NUM.NAME` (all documented below)."
+msgstr "هدف برای همگام سازی. هر هدف همگام‌سازی ممکن است پارامترهای دیگری داشته باشد که به‌عنوان «sync.NUM.NAME» نام‌گذاری شده‌اند (همه در زیر مستند شده‌اند)."
 
 #: packages/lib/services/share/invitationRespond.ts:22
 msgid ""
-"The web client does not support accepting encrypted shared notebooks. Please "
-"switch to the desktop or mobile app before accepting the share.\n"
+"The web client does not support accepting encrypted shared notebooks. Please switch to the desktop or mobile app before accepting the share.\n"
 "\n"
 "Error: \"%s\""
 msgstr ""
+"کلاینت تحت وب از پذیرش دفترچه‌های یادداشت مشترکِ رمزنگاری‌شده پشتیبانی نمی‌کند. لطفا پیش از پذیرش اشتراک، به برنامه دسکتاپ یا موبایل تغییر وضعیت دهید.\n"
+"\n"
+"خطا: «%s»"
 
 #: packages/app-desktop/gui/Root.tsx:129
 msgid "The Web Clipper needs your authorisation to access your data."
 msgstr "Web Clipper برای دسترسی به داده های شما به مجوز شما نیاز دارد."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:104
-#, fuzzy
 msgid "The web clipper service cannot be enabled in this instance of Joplin."
-msgstr "سرویس Web Clipper فعال شده و روی شروع خودکار تنظیم شده است."
+msgstr "سرویس Web Clipper در این نمونه از Joplin قابل فعال‌سازی نیست."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:79
 msgid "The web clipper service is enabled and set to auto-start."
@@ -6621,12 +6015,8 @@ msgid "The web clipper service is not enabled."
 msgstr "سرویس Web Clipper فعال نیست."
 
 #: packages/lib/utils/webDAVUtils.ts:28
-msgid ""
-"The WebDAV implementation of %s is incompatible with Joplin, and as such is "
-"no longer supported. Please use a different sync method."
-msgstr ""
-"نمونه‌سازی WebDAV با %s با joplin ناسازگار است و به همین دلیل دیگر پشتیبانی "
-"نمی‌شود. لطفاً از روش همگام‌سازی دیگری استفاده کنید."
+msgid "The WebDAV implementation of %s is incompatible with Joplin, and as such is no longer supported. Please use a different sync method."
+msgstr "نمونه‌سازی WebDAV با %s با joplin ناسازگار است و به همین دلیل دیگر پشتیبانی نمی‌شود. لطفاً از روش همگام‌سازی دیگری استفاده کنید."
 
 #: packages/lib/models/settings/builtInMetadata.ts:641
 msgid "Theme"
@@ -6667,53 +6057,20 @@ msgid "There was an error downloading this attachment:"
 msgstr "یک خطا در دانلود این پیوست بود:"
 
 #: packages/lib/services/ReportService.ts:237
-msgid ""
-"These items failed to sync, but have been marked as \"ignored\". They won't "
-"cause the sync warning to appear, but still aren't synced. To unignore, "
-"click \"retry\"."
-msgstr ""
-"این موارد همگام‌سازی نشدند، اما به‌عنوان «نادیده‌گرفته» علامت‌گذاری شدند. آنها "
-"باعث نمی شوند که هشدار همگام سازی ظاهر شود، اما همچنان همگام سازی نمی شوند. "
-"برای لغو نادیده گرفتن، روی «تلاش مجدد» کلیک کنید."
+msgid "These items failed to sync, but have been marked as \"ignored\". They won't cause the sync warning to appear, but still aren't synced. To unignore, click \"retry\"."
+msgstr "این موارد همگام‌سازی نشدند، اما به‌عنوان «نادیده‌گرفته» علامت‌گذاری شدند. آنها باعث نمی شوند که هشدار همگام سازی ظاهر شود، اما همچنان همگام سازی نمی شوند. برای لغو نادیده گرفتن، روی «تلاش مجدد» کلیک کنید."
 
 #: packages/lib/services/ReportService.ts:187
-msgid ""
-"These items will remain on the device but will not be uploaded to the sync "
-"target. In order to find these items, either search for the title or the ID "
-"(which is displayed in brackets above)."
-msgstr ""
-"این موارد در دستگاه باقی می‌مانند اما در هدف همگام‌سازی آپلود نمی‌شوند. برای "
-"یافتن این موارد، عنوان یا شناسه (که در پرانتز بالا نمایش داده شده است) را "
-"جستجو نمایید."
+msgid "These items will remain on the device but will not be uploaded to the sync target. In order to find these items, either search for the title or the ID (which is displayed in brackets above)."
+msgstr "این موارد در دستگاه باقی می‌مانند اما در هدف همگام‌سازی آپلود نمی‌شوند. برای یافتن این موارد، عنوان یا شناسه (که در پرانتز بالا نمایش داده شده است) را جستجو نمایید."
 
 #: packages/lib/models/Setting.ts:1376
-msgid ""
-"These plugins enhance the Markdown renderer with additional features. Please "
-"note that, while these features might be useful, they are not standard "
-"Markdown and thus most of them will only work in Joplin. Additionally, some "
-"of them are *incompatible* with the WYSIWYG editor. If you open a note that "
-"uses one of these plugins in that editor, you will lose the plugin "
-"formatting. It is indicated below which plugins are compatible or not with "
-"the WYSIWYG editor."
-msgstr ""
-"این افزونه ها رندر نشانه‌گذاری را با ویژگی های اضافی تقویت می کنند. لطفاً توجه "
-"داشته باشید که اگرچه این ویژگی‌ها ممکن است مفید باشند، اما نشانه‌گذاری "
-"استاندارد نیستند و بنابراین اکثر آنها فقط در joplin کار می‌کنند. علاوه بر "
-"این، برخی از آنها با ویرایشگر WYSIWYG *ناسازگار* هستند. اگر یادداشتی را باز "
-"کنید که از یکی از این افزونه ها در آن ویرایشگر استفاده می کند، قالب بندی "
-"افزونه را از دست خواهید داد. در زیر مشخص شده است که کدام افزونه ها با "
-"ویرایشگر WYSIWYG سازگار هستند یا خیر."
+msgid "These plugins enhance the Markdown renderer with additional features. Please note that, while these features might be useful, they are not standard Markdown and thus most of them will only work in Joplin. Additionally, some of them are *incompatible* with the WYSIWYG editor. If you open a note that uses one of these plugins in that editor, you will lose the plugin formatting. It is indicated below which plugins are compatible or not with the WYSIWYG editor."
+msgstr "این افزونه ها رندر Markdown را با ویژگی های اضافی تقویت می کنند. لطفاً توجه داشته باشید که اگرچه این ویژگی‌ها ممکن است مفید باشند، اما Markdown استاندارد نیستند و بنابراین اکثر آنها فقط در joplin کار می‌کنند. علاوه بر این، برخی از آنها با ویرایشگر WYSIWYG *ناسازگار* هستند. اگر یادداشتی را باز کنید که از یکی از این افزونه ها در آن ویرایشگر استفاده می کند، قالب بندی افزونه را از دست خواهید داد. در زیر مشخص شده است که کدام افزونه ها با ویرایشگر WYSIWYG سازگار هستند یا خیر."
 
 #: packages/lib/utils/joplinCloud/index.ts:185
-msgid ""
-"This allows another user to share a notebook with you, and you can then both "
-"collaborate on it. It does not however allow you to share a notebook with "
-"someone else, unless you have the feature \"%s\"."
-msgstr ""
-"این به کاربر دیگری اجازه می دهد تا یک دفترچه‌ را با شما به اشتراک بگذارد و "
-"سپس می توانید هر دو در آن همکاری کنید. با این حال به شما اجازه نمی‌دهد یک "
-"دفترچه را با شخص دیگری به اشتراک بگذارید، مگر اینکه ویژگی «%s» را داشته "
-"باشید."
+msgid "This allows another user to share a notebook with you, and you can then both collaborate on it. It does not however allow you to share a notebook with someone else, unless you have the feature \"%s\"."
+msgstr "این به کاربر دیگری اجازه می دهد تا یک دفترچه‌ را با شما به اشتراک بگذارد و سپس می توانید هر دو در آن همکاری کنید. با این حال به شما اجازه نمی‌دهد یک دفترچه را با شخص دیگری به اشتراک بگذارید، مگر اینکه ویژگی «%s» را داشته باشید."
 
 #: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:193
 msgid "This attachment does not have OCR data (Status: %s)"
@@ -6725,40 +6082,28 @@ msgid "This attachment is not downloaded or not decrypted yet"
 msgstr "این پیوست هنوز دانلود یا رمزگشایی نشده"
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:159
-msgid ""
-"This authorisation token is only needed to allow third-party applications to "
-"access Joplin."
-msgstr ""
-"این توکن مجوز تنها برای اجازه دادن به برنامه‌های شخص ثالث برای دسترسی به "
-"joplin مورد نیاز است."
+msgid "This authorisation token is only needed to allow third-party applications to access Joplin."
+msgstr "این توکن مجوز تنها برای اجازه دادن به برنامه‌های شخص ثالث برای دسترسی به joplin مورد نیاز است."
 
 #: packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx:44
 msgid "This drawing may have unsaved changes."
 msgstr "این طراحی ممکن است دارای تغییرات ذخیره نشده باشد."
 
 #: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:151
-msgid ""
-"This feature is disabled by default, you need to manually enable it by "
-"turning on the option to 'Enable handwritten transcription'."
-msgstr ""
+msgid "This feature is disabled by default, you need to manually enable it by turning on the option to 'Enable handwritten transcription'."
+msgstr "این ویژگی به طور پیشفرض غیر فعال است، شما می‌توانید با فعال کردن گزینه 'فعال‌ سازی رونویسی دست‌ نویس' آن را فعال کنید."
 
 #: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:146
 msgid "This feature is only available on Joplin Cloud and Joplin Server."
-msgstr ""
+msgstr "این ویژگی فقط بر روی Joplin Server و Joplin Cloud در دسترس است."
 
 #: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:158
 msgid "This image type is not supported by the recognition system."
-msgstr ""
+msgstr "این نوع تصویر توسط سیستم تشخیص پشتیبانی نمی‌شود."
 
 #: packages/app-desktop/gui/ResourceScreen.tsx:304
-msgid ""
-"This is an advanced tool to show the attachments that are linked to your "
-"notes. Please be careful when deleting one of them as they cannot be "
-"restored afterwards."
-msgstr ""
-"این یک ابزار پیشرفته برای نشان دادن پیوست‌هایی است که به یادداشت‌های شما پیوند "
-"داده شده‌اند. لطفاً هنگام حذف یکی از آنها مراقب باشید زیرا پس از آن قابل "
-"بازیابی نیستند."
+msgid "This is an advanced tool to show the attachments that are linked to your notes. Please be careful when deleting one of them as they cannot be restored afterwards."
+msgstr "این یک ابزار پیشرفته برای نشان دادن پیوست‌هایی است که به یادداشت‌های شما پیوند داده شده‌اند. لطفاً هنگام حذف یکی از آنها مراقب باشید زیرا پس از آن قابل بازیابی نیستند."
 
 #: packages/app-mobile/components/ScreenHeader/index.tsx:256
 msgid "This note could not be deleted: %s"
@@ -6788,21 +6133,16 @@ msgstr "این یادداشت تغییر یافته است:"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx:639
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx:213
-msgid ""
-"This note has no content. Click on \"%s\" to toggle the editor and edit the "
-"note."
-msgstr ""
-"این یادداشت هیچ محتوایی ندارد. برای تغییر وضعیت ویرایشگر و ویرایش یادداشت ، "
-"روی «%s» کلیک کنید."
+msgid "This note has no content. Click on \"%s\" to toggle the editor and edit the note."
+msgstr "این یادداشت هیچ محتوایی ندارد. برای تغییر وضعیت ویرایشگر و ویرایش یادداشت ، روی «%s» کلیک کنید."
 
 #: packages/app-desktop/gui/NoteRevisionViewer.tsx:72
 msgid "This note has no history"
 msgstr "این یادداشت هیچ تاریخچه ای ندارد"
 
 #: packages/app-desktop/gui/NoteEditor/NoteEditor.tsx:664
-msgid ""
-"This note is in HTML format. Convert it to Markdown to edit it more easily."
-msgstr ""
+msgid "This note is in HTML format. Convert it to Markdown to edit it more easily."
+msgstr "این یادداشت در فرمت HTML است. برای ویرایش راحت تر به Markdown تبدیل‌اش کنید."
 
 #: packages/lib/services/plugins/PluginService.ts:535
 msgid "This plugin doesn't support %s."
@@ -6810,36 +6150,20 @@ msgstr "این افزونه %s را پشتیبانی نمی کند."
 
 #: packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx:45
 #: packages/app-mobile/components/NoteEditor/WarningBanner.tsx:38
-msgid ""
-"This Rich Text editor has a number of limitations and it is recommended to "
-"be aware of them before using it."
-msgstr ""
-"ویرایشگر Rich Text دارای تعدادی محدودیت است و توصیه می شود قبل از استفاده از "
-"آن ها آگاه باشید."
+msgid "This Rich Text editor has a number of limitations and it is recommended to be aware of them before using it."
+msgstr "ویرایشگر Rich Text دارای تعدادی محدودیت است و توصیه می شود قبل از استفاده از آن ها آگاه باشید."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:137
-msgid ""
-"This service allows the browser extension to communicate with Joplin. When "
-"enabling it your firewall may ask you to give permission to Joplin to listen "
-"to a particular port."
-msgstr ""
-"این سرویس به افزونه مرورگر اجازه می دهد تا با joplin  ارتباط برقرار کند. "
-"هنگام فعال کردن آن، فایروال شما ممکن است از شما بخواهد که به joplin  اجازه "
-"دهید تا به یک پورت خاص در ارتباط باشد."
+msgid "This service allows the browser extension to communicate with Joplin. When enabling it your firewall may ask you to give permission to Joplin to listen to a particular port."
+msgstr "این سرویس به افزونه مرورگر اجازه می دهد تا با joplin  ارتباط برقرار کند. هنگام فعال کردن آن، فایروال شما ممکن است از شما بخواهد که به joplin  اجازه دهید تا به یک پورت خاص در ارتباط باشد."
 
 #: packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts:11
 msgid "This subfolder of the trash has no notes."
 msgstr "این زیرپوشه سطل زباله هیچ یادداشتی ندارد."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1135
-msgid ""
-"This will allow Joplin to run in the background. It is recommended to enable "
-"this setting so that your notes are constantly being synchronised, thus "
-"reducing the number of conflicts."
-msgstr ""
-"این به joplin اجازه می‌دهد تا در پس زمینه اجرا شود. توصیه می‌شود این تنظیم را "
-"فعال کنید تا یادداشت های شما دائماً همگام شوند و در نتیجه تعداد تداخل‌ها کاهش "
-"یابند."
+msgid "This will allow Joplin to run in the background. It is recommended to enable this setting so that your notes are constantly being synchronised, thus reducing the number of conflicts."
+msgstr "این به joplin اجازه می‌دهد تا در پس زمینه اجرا شود. توصیه می‌شود این تنظیم را فعال کنید تا یادداشت های شما دائماً همگام شوند و در نتیجه تعداد تداخل‌ها کاهش یابند."
 
 #: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:148
 msgid "This will open a new screen. Save your current changes?"
@@ -6848,18 +6172,12 @@ msgstr "این یک صفحه جدید باز می‌کند. تغییرات فع�
 #: packages/app-desktop/commands/emptyTrash.ts:14
 #: packages/app-mobile/components/side-menu-content.tsx:347
 msgid "This will permanently delete all items in the trash. Continue?"
-msgstr ""
-"با این کار همه موارد موجود در سطل زباله برای همیشه حذف می شوند. آیا ادامه "
-"هید؟"
+msgstr "با این کار همه موارد موجود در سطل زباله برای همیشه حذف می شوند. آیا ادامه هید؟"
 
 #: packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx:60
 #: packages/lib/commands/leaveSharedFolder.ts:22
-msgid ""
-"This will remove the notebook from your collection and you will no longer "
-"have access to its content. Do you wish to continue?"
-msgstr ""
-"با این کار، دفترچه از مجموعه شما حذف می شود و دیگر به محتوای آن دسترسی "
-"نخواهید داشت. آیا مایل هستید ادامه دهید؟"
+msgid "This will remove the notebook from your collection and you will no longer have access to its content. Do you wish to continue?"
+msgstr "با این کار، دفترچه از مجموعه شما حذف می شود و دیگر به محتوای آن دسترسی نخواهید داشت. آیا مایل هستید ادامه دهید؟"
 
 #: packages/lib/models/settings/builtInMetadata.ts:557
 msgid "Time format"
@@ -6879,30 +6197,19 @@ msgstr "عنوان"
 #: packages/app-cli/app/command-sync.ts:82
 #: packages/app-desktop/gui/DropboxLoginScreen.tsx:45
 #: packages/app-mobile/components/screens/dropbox-login.tsx:62
-msgid ""
-"To allow Joplin to synchronise with Dropbox, please follow the steps below:"
-msgstr ""
-"برای اینکه به joplin اجازه همگام‌سازی با Dropbox را بدهید، مراحل زیر را دنبال "
-"نمایید:"
+msgid "To allow Joplin to synchronise with Dropbox, please follow the steps below:"
+msgstr "برای اینکه به joplin اجازه همگام‌سازی با Dropbox را بدهید، مراحل زیر را دنبال نمایید:"
 
 #: packages/app-cli/app/command-sync.ts:111
 #: packages/app-desktop/gui/JoplinCloudLoginScreen.tsx:86
 #: packages/app-mobile/components/screens/JoplinCloudLoginScreen.tsx:153
-msgid ""
-"To allow Joplin to synchronise with Joplin Cloud, please login using this "
-"URL:"
-msgstr ""
-"برای اینکه به Joplin اجازه دهید با سرویس ابری Joplin همگام شود، لطفاً با "
-"استفاده از این URL وارد شوید:"
+msgid "To allow Joplin to synchronise with Joplin Cloud, please login using this URL:"
+msgstr "برای اینکه به Joplin اجازه دهید با سرویس ابری Joplin همگام شود، لطفاً با استفاده از این URL وارد شوید:"
 
 #: packages/app-desktop/gui/SsoLoginScreen/SsoLoginScreen.tsx:36
 #: packages/app-mobile/components/screens/SsoLoginScreen.tsx:64
-#, fuzzy
-msgid ""
-"To allow Joplin to synchronise with your account, please follow these steps:"
-msgstr ""
-"برای اینکه به joplin اجازه همگام‌سازی با Dropbox را بدهید، مراحل زیر را دنبال "
-"نمایید:"
+msgid "To allow Joplin to synchronise with your account, please follow these steps:"
+msgstr "برای اینکه به Joplin اجازه همگام‌سازی با حساب خود را بدهید، مراحل زیر را دنبال نمایید:"
 
 #: packages/lib/components/EncryptionConfigScreen/utils.ts:53
 msgid "To continue, please enter your master password below."
@@ -6910,7 +6217,7 @@ msgstr "برای ادامه، لطفاً گذرواژه اصلی خود را د�
 
 #: packages/app-mobile/components/ComboBox.tsx:581
 msgid "To create a new tag, type the name and press enter."
-msgstr ""
+msgstr "برای ساخت یک برچسب، نام را بنویسید و کلید enter را فشار دهید."
 
 #: packages/app-cli/app/app-gui.js:465
 msgid "To delete a tag, untag the associated notes."
@@ -6929,12 +6236,8 @@ msgid "To exit command line mode, press ESCAPE"
 msgstr "برای خروج از حالت خط فرمان، دکمه ی Esc را فشار دهید"
 
 #: packages/app-desktop/gui/NoteList/utils/canManuallySortNotes.ts:10
-msgid ""
-"To manually sort the notes, the sort order must be changed to \"%s\" in the "
-"menu \"%s\" > \"%s\""
-msgstr ""
-"برای مرتب‌سازی دستی یادداشت‌ها، ترتیب مرتب‌سازی باید به «%s» از منوی «%s» > "
-"«%s» تغییر پیدا کند"
+msgid "To manually sort the notes, the sort order must be changed to \"%s\" in the menu \"%s\" > \"%s\""
+msgstr "برای مرتب‌سازی دستی یادداشت‌ها، ترتیب مرتب‌سازی باید به «%s» از منوی «%s» > «%s» تغییر پیدا کند"
 
 #: packages/app-cli/app/command-help.ts:82
 msgid "To maximise/minimise the console, press \"tc\"."
@@ -6945,26 +6248,16 @@ msgid "To move from one pane to another, press Tab or Shift+Tab."
 msgstr "برای انتقال از یک پنجره به پنجره دیگر ، Tab یا Shift Tab را فشار دهید."
 
 #: packages/app-cli/app/command-status.js:44
-msgid ""
-"To retry decryption of these items. Run `e2ee decrypt --retry-failed-items`"
-msgstr ""
-"برای تلاش مجدد رمزگشایی این موارد «e2ee decrypt --retry-failed-items» را "
-"اجرا کنید"
+msgid "To retry decryption of these items. Run `e2ee decrypt --retry-failed-items`"
+msgstr "برای تلاش مجدد رمزگشایی این موارد «e2ee decrypt --retry-failed-items» را اجرا کنید"
 
 #: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:64
-msgid ""
-"To switch the profile, the app is going to close and you will need to "
-"restart it."
-msgstr ""
-"برای تغییر حساب‌کاربری، برنامه بسته می‌شود و باید آن را دوباره راه‌اندازی نماید."
+msgid "To switch the profile, the app is going to close and you will need to restart it."
+msgstr "برای تغییر حساب‌کاربری، برنامه بسته می‌شود و باید آن را دوباره راه‌اندازی نماید."
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:615
-msgid ""
-"To work correctly, the app needs the following permissions. Please enable "
-"them in your phone settings, in Apps > Joplin > Permissions"
-msgstr ""
-"برای کارکرد صحیح، برنامه به این دسترسی‌ها نیاز دارد. لطفا آن‌ها را در تنظیمات "
-"گوشی خود در برنامه‌ها > joplin > دسترسی‌ها فعال کنید"
+msgid "To work correctly, the app needs the following permissions. Please enable them in your phone settings, in Apps > Joplin > Permissions"
+msgstr "برای کارکرد صحیح، برنامه به این دسترسی‌ها نیاز دارد. لطفا آن‌ها را در تنظیمات گوشی خود در برنامه‌ها > joplin > دسترسی‌ها فعال کنید"
 
 #: packages/app-desktop/gui/NoteListControls/NoteListControls.tsx:120
 #: packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx:71
@@ -6980,9 +6273,8 @@ msgid "to-do: %s"
 msgstr "فهرست کار: %s"
 
 #: packages/lib/commands/toggleAllFolders.ts:8
-#, fuzzy
 msgid "Toggle all notebooks"
-msgstr "انتخاب دفترچه والد"
+msgstr "تغییر وضعیت نمایش همه دفترچه‌ها"
 
 #: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:134
 msgid "Toggle comment"
@@ -6997,14 +6289,12 @@ msgid "Toggle editor layout"
 msgstr "تغییر وضعیت چیدمان ویرایشگر"
 
 #: packages/lib/commands/toggleEditorPlugin.ts:11
-#, fuzzy
 msgid "Toggle editor plugin"
-msgstr "تغییر وضعیت چیدمان ویرایشگر"
+msgstr "تغییر وضعیت افزونه ویرایشگر"
 
 #: packages/app-desktop/commands/toggleTabMovesFocus.ts:8
-#, fuzzy
 msgid "Toggle editor tab key navigation"
-msgstr "تغییر وضعیت چیدمان ویرایشگر"
+msgstr "تغییر وضعیت پیمایش با کلید Tab در ویرایشگر"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleEditors.ts:8
 msgid "Toggle editors"
@@ -7031,9 +6321,8 @@ msgid "Toggle own sort order"
 msgstr "تغییر ترتیب مرتب‌سازی شخصی"
 
 #: packages/app-mobile/components/ScreenHeader/index.tsx:468
-#, fuzzy
 msgid "Toggle plugin editor"
-msgstr "تغییر وضعیت ویرایشگر"
+msgstr "تغییر وضعیت ویرایشگر افزونه"
 
 #: packages/app-desktop/commands/toggleSafeMode.ts:8
 msgid "Toggle safe mode"
@@ -7052,9 +6341,8 @@ msgid "Token has been copied to the clipboard!"
 msgstr "توکن در کلیپ‌بورد کپی شد!"
 
 #: packages/app-desktop/gui/NoteEditor/commands/focusElementToolbar.ts:8
-#, fuzzy
 msgid "Toolbar"
-msgstr "&ابزار‌ها"
+msgstr "نوار ابزار"
 
 #: packages/lib/models/Setting.ts:1365
 msgid "Tools"
@@ -7085,34 +6373,23 @@ msgstr "هم‌اکنون تلاش کن"
 
 #: packages/app-cli/app/command-keymap.ts:30
 msgid "TYPE"
-msgstr ""
+msgstr "نوع"
 
 #: packages/app-cli/app/command-help.ts:72
-msgid ""
-"Type `help [command]` for more information about a command; or type `help "
-"all` for the complete usage information."
-msgstr ""
-"برای اطلاعات بیشتر درباره یک فرمان، 'help [command]' را تایپ کنید. یا برای "
-"اطلاعات کامل استفاده، «help all» را تایپ کنید."
+msgid "Type `help [command]` for more information about a command; or type `help all` for the complete usage information."
+msgstr "برای اطلاعات بیشتر درباره یک فرمان، 'help [command]' را تایپ کنید. یا برای اطلاعات کامل استفاده، «help all» را تایپ کنید."
 
 #: packages/app-cli/app/main.js:105
 msgid "Type `joplin help` for usage information."
 msgstr "`joplin help` را برای راهنمای استفاده تایپ کنید."
 
 #: packages/app-desktop/plugins/GotoAnything.tsx:708
-msgid ""
-"Type a note title or part of its content to jump to it. Or type # followed "
-"by a tag name, or @ followed by a notebook name. Or type : to search for "
-"commands."
-msgstr ""
-"عنوان یادداشت یا بخشی از محتوای آن را تایپ کنید تا به آن بروید. یا # به "
-"دنبال نام برچسب یا @ و به دنبال آن نام دفترچه را تایپ کنید. یا برای جستجوی "
-"دستورات، دستور «:» تایپ نمایید."
+msgid "Type a note title or part of its content to jump to it. Or type # followed by a tag name, or @ followed by a notebook name. Or type : to search for commands."
+msgstr "عنوان یادداشت یا بخشی از محتوای آن را تایپ کنید تا به آن بروید. یا # به دنبال نام برچسب یا @ و به دنبال آن نام دفترچه را تایپ کنید. یا برای جستجوی دستورات، دستور «:» تایپ نمایید."
 
 #: packages/app-desktop/plugins/GotoAnything.tsx:706
-#, fuzzy
 msgid "Type a note title to search for it."
-msgstr "برچسب‌های جدید را تایپ کنید یا از لیست انتخاب کنید"
+msgstr "عنوان یادداشت را برای جستجوی آن تایپ کنید."
 
 #: packages/app-cli/app/help-utils.js:56
 msgid "Type: %s."
@@ -7127,13 +6404,12 @@ msgid "Unable to share log data. Reason: %s"
 msgstr "امکان اشتراک‌گذاری داده های لاگ وجود ندارد. دلیل: %s"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:1125
-#, fuzzy
 msgid "Unable to share note data. Reason: %s"
-msgstr "امکان اشتراک‌گذاری داده های لاگ وجود ندارد. دلیل: %s"
+msgstr "امکان اشتراک‌گذاری داده‌های یادداشت وجود ندارد. دلیل: %s"
 
 #: packages/app-mobile/components/Checkbox.tsx:51
 msgid "Unchecked"
-msgstr ""
+msgstr "بررسی نشده"
 
 #: packages/lib/models/settings/builtInMetadata.ts:714
 msgid "Uncompleted to-dos on top"
@@ -7147,13 +6423,8 @@ msgid "Undo"
 msgstr "بازگرد"
 
 #: packages/lib/models/settings/settingValidations.ts:32
-msgid ""
-"Uninstall and reinstall the application. Make sure you create a backup first "
-"by exporting all your notes as JEX from the desktop application."
-msgstr ""
-"برنامه را حذف و دوباره نصب کنید. اطمینان حاصل کنید که ابتدا با صادر کردن "
-"تمام یادداشت های خود به عنوان JEX از برنامه دسکتاپ، یک نسخه پشتیبان ایجاد "
-"کرده اید."
+msgid "Uninstall and reinstall the application. Make sure you create a backup first by exporting all your notes as JEX from the desktop application."
+msgstr "برنامه را حذف و دوباره نصب کنید. اطمینان حاصل کنید که ابتدا با صادر کردن تمام یادداشت های خود به عنوان JEX از برنامه دسکتاپ، یک نسخه پشتیبان ایجاد کرده اید."
 
 #: packages/app-mobile/utils/getVersionInfoText.ts:13
 #: packages/app-mobile/utils/getVersionInfoText.ts:14
@@ -7169,28 +6440,24 @@ msgid "Unknown flag: %s"
 msgstr "پرچم ناشناخته: %s"
 
 #: packages/lib/Synchronizer.ts:1182
-msgid ""
-"Unknown item type downloaded - please upgrade Joplin to the latest version"
+msgid "Unknown item type downloaded - please upgrade Joplin to the latest version"
 msgstr "نوع آیتم ناشناس دانلود شد - لطفاً joplin را به آخرین نسخه ارتقا دهید"
 
 #: packages/app-mobile/utils/getVersionInfoText.ts:28
-#, fuzzy
 msgid "Unknown platform"
-msgstr "پرچم ناشناخته: %s"
+msgstr "پلتفرم ناشناخته"
 
 #: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:108
 msgid "Unordered list"
 msgstr "لیست نامرتب"
 
 #: packages/app-mobile/components/screens/ShareNoteDialog.tsx:79
-#, fuzzy
 msgid "Unpublish"
-msgstr "لغو انتشار یادداشت"
+msgstr "لغو انتشار"
 
 #: packages/app-mobile/components/screens/ShareNoteDialog.tsx:74
-#, fuzzy
 msgid "Unpublish \"%s\""
-msgstr "لغو انتشار یادداشت"
+msgstr "لغو انتشار «%s»"
 
 #: packages/app-desktop/gui/ShareNoteDialog.tsx:72
 msgid "Unpublish note"
@@ -7201,18 +6468,12 @@ msgid "Unshare"
 msgstr "لغو اشتراک‌گذاری"
 
 #: packages/app-cli/app/command-share.ts:244
-msgid ""
-"Unshare notebook \"%s\"? This may cause other users to lose access to the "
-"notebook."
-msgstr ""
+msgid "Unshare notebook \"%s\"? This may cause other users to lose access to the notebook."
+msgstr "اشتراک دفترچه یادداشت «%s» لغو شود؟ این کار ممکن است باعث شود سایر کاربران دسترسی خود را به این دفترچه یادداشت از دست بدهند."
 
 #: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:377
-msgid ""
-"Unshare this notebook? The recipients will no longer have access to its "
-"content."
-msgstr ""
-"اشتراک‌گذاری این دفترچه لغو شود؟ گیرندگان دیگر به محتوای آن دسترسی نخواهند "
-"داشت."
+msgid "Unshare this notebook? The recipients will no longer have access to its content."
+msgstr "اشتراک‌گذاری این دفترچه لغو شود؟ گیرندگان دیگر به محتوای آن دسترسی نخواهند داشت."
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:959
 msgid "Unsupported image type: %s"
@@ -7224,11 +6485,12 @@ msgid "Unsupported link or message: %s"
 msgstr "پیوند یا پیام پشتیبانی نشده: %s"
 
 #: packages/app-mobile/commands/openItem.ts:60
-#, fuzzy
 msgid ""
 "Unsupported link or message: %s.\n"
 "Error: %s"
-msgstr "پیوند یا پیام پشتیبانی نشده: %s"
+msgstr ""
+"پیوند یا پیام پشتیبانی نشده: %s.\n"
+"خطا: %s"
 
 #: packages/app-desktop/gui/ProfileEditor.tsx:54
 #: packages/app-desktop/gui/ResourceScreen.tsx:129
@@ -7247,9 +6509,8 @@ msgid "Update available"
 msgstr "به روز رسانی موجود است"
 
 #: packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx:53
-#, fuzzy
 msgid "Update later"
-msgstr "تاریخ به‌روزرسانی"
+msgstr "به‌روزرسانی بعداً"
 
 #: packages/server/src/routes/admin/users.ts:257
 #: packages/server/src/routes/index/users.ts:91
@@ -7307,9 +6568,8 @@ msgid "Upgrade the sync target to the latest version."
 msgstr "هدف همگام‌سازی را به آخرین نسخه ارتقا دهید."
 
 #: packages/app-mobile/components/CameraView/CameraView.web.tsx:45
-#, fuzzy
 msgid "Upload photo"
-msgstr "عکس گرفتن"
+msgstr "بارگذاری عکس"
 
 #: packages/app-desktop/gui/NotePropertiesDialog.tsx:86
 #: packages/app-mobile/components/NoteEditor/EditLinkDialog.tsx:109
@@ -7328,74 +6588,44 @@ msgid "Use biometrics to secure access to the app"
 msgstr "از بیومتریک برای ایمن کردن دسترسی به برنامه استفاده کنید"
 
 #: packages/app-cli/app/command-ls.ts:33 packages/app-cli/app/command-tag.js:18
-msgid ""
-"Use long list format. Format is ID, NOTE_COUNT (for notebook), DATE, "
-"TODO_CHECKED (for to-dos), TITLE"
-msgstr ""
-"استفاده از فرمت لیست طولانی. فرمت به صورت ID (شناسه)، NOTE_COUNT (تعداد "
-"یادداشت (برای دفترچه))، DATE (تاریخ)، TODO_CHECKED (فهرست کار بررسی شده "
-"(برای فهرست کار‌ها))، TITLE (عنوان) می‌باشد"
+msgid "Use long list format. Format is ID, NOTE_COUNT (for notebook), DATE, TODO_CHECKED (for to-dos), TITLE"
+msgstr "استفاده از فرمت لیست طولانی. فرمت به صورت ID (شناسه)، NOTE_COUNT (تعداد یادداشت (برای دفترچه))، DATE (تاریخ)، TODO_CHECKED (فهرست کار بررسی شده (برای فهرست کار‌ها))، TITLE (عنوان) می‌باشد"
 
 #: packages/lib/services/spellChecker/SpellCheckerService.ts:185
 msgid "Use spell checker"
 msgstr "استفاده از بررسی کننده غلط املایی"
 
 #: packages/app-cli/app/command-help.ts:81
-msgid ""
-"Use the arrows and page up/down to scroll the lists and text areas "
-"(including this console)."
-msgstr ""
-"از فلش ها و صفحه به بالا/پایین برای پیمایش لیست ها و نواحی متن (از جمله این "
-"کنسول) استفاده کنید."
+msgid "Use the arrows and page up/down to scroll the lists and text areas (including this console)."
+msgstr "از فلش ها و صفحه به بالا/پایین برای پیمایش لیست ها و نواحی متن (از جمله این کنسول) استفاده کنید."
 
 #: packages/app-desktop/gui/MainScreen.tsx:794
 msgid "Use the arrows to move the layout items. Press \"Escape\" to exit."
-msgstr ""
-"از فلش ها برای جابجایی آیتم های چیدمان استفاده کنید. برای خروج، \"Esc\" را "
-"فشار دهید."
+msgstr "از فلش ها برای جابجایی آیتم های چیدمان استفاده کنید. برای خروج، \"Esc\" را فشار دهید."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1563
-#, fuzzy
 msgid "Use the legacy Markdown editor"
-msgstr "فعال‌سازی نوار ابزار نشانه‌گذاری"
+msgstr "استفاده از ویرایشگر قدیمی Markdown"
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:580
-msgid ""
-"Use this to rebuild the search index if there is a problem with search. It "
-"may take a long time depending on the number of notes."
-msgstr ""
-"اگر مشکلی در جستجو وجود دارد از این برای بازسازی فهرست جستجو استفاده کنید. "
-"بسته به تعداد یادداشت ها ممکن است زمان زیادی طول بکشد."
+msgid "Use this to rebuild the search index if there is a problem with search. It may take a long time depending on the number of notes."
+msgstr "اگر مشکلی در جستجو وجود دارد از این برای بازسازی فهرست جستجو استفاده کنید. بسته به تعداد یادداشت ها ممکن است زمان زیادی طول بکشد."
 
 #: packages/app-mobile/components/biometrics/BiometricPopup.tsx:83
-msgid ""
-"Use your biometrics to secure access to your application. You can always set "
-"it up later in Settings."
-msgstr ""
-"از بیومتریک خود برای دسترسی ایمن به برنامه خود استفاده کنید. همواره می‌توانید "
-"بعداً آن را در تنظیمات، تنظیم کنید."
+msgid "Use your biometrics to secure access to your application. You can always set it up later in Settings."
+msgstr "از بیومتریک خود برای دسترسی ایمن به برنامه خود استفاده کنید. همواره می‌توانید بعداً آن را در تنظیمات، تنظیم کنید."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1249
-msgid ""
-"Used for most text in the markdown editor. If not found, a generic "
-"proportional (variable width) font is used."
-msgstr ""
-"برای اکثر متن ها در ویرایشگر نشانه گذاری استفاده می شود. اگر یافت نشد، از یک "
-"فونت متناسب (یا عرض متغیر) عمومی استفاده می شود."
+msgid "Used for most text in the markdown editor. If not found, a generic proportional (variable width) font is used."
+msgstr "برای اکثر متن ها در ویرایشگر Markdown استفاده می شود. اگر یافت نشد، از یک فونت متناسب (یا عرض متغیر) عمومی استفاده می شود."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1262
-msgid ""
-"Used where a fixed width font is needed to lay out text legibly (e.g. "
-"tables, checkboxes, code). If not found, a generic monospace (fixed width) "
-"font is used."
-msgstr ""
-"در جاهایی استفاده می شود که برای چیدمان متن به صورت خوانا به یک فونت با عرض "
-"ثابت نیاز است (مانند جداول، چک باکس ها، کد). اگر پیدا نشد، از فونت تک فضایی "
-"(یا عرض ثابت) عمومی استفاده می شود."
+msgid "Used where a fixed width font is needed to lay out text legibly (e.g. tables, checkboxes, code). If not found, a generic monospace (fixed width) font is used."
+msgstr "در جاهایی استفاده می شود که برای چیدمان متن به صورت خوانا به یک فونت با عرض ثابت نیاز است (مانند جداول، چک باکس ها، کد). اگر پیدا نشد، از فونت تک فضایی (یا عرض ثابت) عمومی استفاده می شود."
 
 #: packages/app-mobile/components/FeedbackBanner.tsx:195
 msgid "Useful"
-msgstr ""
+msgstr "مفید"
 
 #: packages/server/src/services/MustacheService.ts:125
 msgid "User deletions"
@@ -7443,14 +6673,12 @@ msgid "Viewer"
 msgstr "بیننده"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1273
-#, fuzzy
 msgid "Viewer and Rich Text Editor font family"
-msgstr "خانواده فونت ویرایشگر"
+msgstr "خانواده فونت نمایشگر و ویرایشگر متن غنی"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1195
-#, fuzzy
 msgid "Viewer font size"
-msgstr "اندازه فونت ویرایشگر"
+msgstr "اندازه فونت نمایشگر"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1476
 msgid "Vim"
@@ -7458,16 +6686,15 @@ msgstr "Vim"
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:231
 msgid "Voice recorder"
-msgstr ""
+msgstr "ضبط کننده صدا"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1963
 msgid "Voice typing language files (URL)"
 msgstr "فایل های زبان تایپ صوتی (URL)"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1992
-#, fuzzy
 msgid "Voice typing: Glossary"
-msgstr "تایپ صوتی..."
+msgstr "تایپ صوتی: واژه‌نامه"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:1320
 #: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:198
@@ -7480,9 +6707,8 @@ msgid "Waiting for authorisation..."
 msgstr "در انتظار احراز هویت..."
 
 #: packages/app-cli/app/command-share.ts:175
-#, fuzzy
 msgid "Waiting: Notebook %s from %s"
-msgstr "دفترچه: %s (%s)"
+msgstr "در انتظار: دفترچه %s از %s"
 
 #: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:224
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:143
@@ -7499,12 +6725,8 @@ msgid "We have a system for reporting and removing problematic plugins."
 msgstr "ما سیستمی برای گزارش دهی و حذف افزونه های مشکل دار داریم."
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:114
-msgid ""
-"We mark plugins developed by trusted Joplin community members as "
-"\"recommended\"."
-msgstr ""
-"ما افزونه‌های توسعه‌یافته توسط اعضای مورد اعتماد جامعه Joplin را به‌عنوان "
-"«توصیه‌شده» علامت‌گذاری می‌کنیم."
+msgid "We mark plugins developed by trusted Joplin community members as \"recommended\"."
+msgstr "ما افزونه‌های توسعه‌یافته توسط اعضای مورد اعتماد جامعه Joplin را به‌عنوان «توصیه‌شده» علامت‌گذاری می‌کنیم."
 
 #: packages/lib/models/Setting.ts:1362
 msgid "Web Clipper"
@@ -7543,18 +6765,15 @@ msgstr "نسخه WebView: %s"
 msgid ""
 "Welcome to Joplin!\n"
 "\n"
-"Type `:help shortcuts` for the list of keyboard shortcuts, or just `:help` "
-"for usage information.\n"
+"Type `:help shortcuts` for the list of keyboard shortcuts, or just `:help` for usage information.\n"
 "\n"
 "For example, to create a notebook press `mb`; to create a note press `mn`."
 msgstr ""
 "به joplin خوش آمدید! \n"
 "\n"
-"برای فهرست میانبرهای صفحه‌کلید «:help shortcuts» یا برای اطلاعات نحوه استفاده "
-"فقط «:help» را تایپ کنید.\n"
+"برای فهرست میانبرهای صفحه‌کلید «:help shortcuts» یا برای اطلاعات نحوه استفاده فقط «:help» را تایپ کنید.\n"
 "\n"
-"به عنوان مثال ، برای ایجاد یکدفترچه `mb` را بفشارید؛ برای ایجاد یک یادداشت "
-"`mn` را فشار دهید."
+"به عنوان مثال ، برای ایجاد یکدفترچه `mb` را بفشارید؛ برای ایجاد یک یادداشت `mn` را فشار دهید."
 
 #: packages/lib/WelcomeUtils.ts:63
 msgid "Welcome!"
@@ -7573,19 +6792,12 @@ msgid "When creating a new to-do:"
 msgstr "زمان ساخت یک فهرست کار جدید:"
 
 #: packages/app-mobile/components/screens/DocumentScanner/NotePreview.tsx:167
-msgid ""
-"When enabled, requests that the images in the note be transcribed with a "
-"higher-quality on-server transcription service. Requires sync with a copy of "
-"the desktop app."
-msgstr ""
+msgid "When enabled, requests that the images in the note be transcribed with a higher-quality on-server transcription service. Requires sync with a copy of the desktop app."
+msgstr "در صورت فعال ‌سازی، درخواست می‌کند که متن تصاویر موجود در یادداشت با استفاده از سرویس رونویسیِ باکیفیتِ مستقر در سرور، استخراج شود. این قابلیت نیازمند همگام‌سازی با نسخه‌ای از برنامه دسکتاپ است."
 
 #: packages/lib/models/settings/builtInMetadata.ts:577
-msgid ""
-"When enabled, the application will scan your attachments and extract the "
-"text from it. This will allow you to search for text in these attachments."
-msgstr ""
-"وقتی فعال باشد، برنامه پیوست های شما را اسکن کرده و متن را از آن استخراج می "
-"کند. این به شما امکان می دهد متن را در این پیوست ها جستجو کنید."
+msgid "When enabled, the application will scan your attachments and extract the text from it. This will allow you to search for text in these attachments."
+msgstr "وقتی فعال باشد، برنامه پیوست های شما را اسکن کرده و متن را از آن استخراج می کند. این به شما امکان می دهد متن را در این پیوست ها جستجو کنید."
 
 #: packages/app-desktop/ElectronAppWrapper.ts:281
 msgid "Window unresponsive."
@@ -7618,32 +6830,25 @@ msgstr "بله"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:859
 #: packages/lib/shim-init-node.ts:277
-msgid ""
-"You are about to attach a large image (%dx%d pixels). Would you like to "
-"resize it down to %d pixels before attaching it?"
-msgstr ""
-"شما در شرف پیوست کردن یک تصویر بزرگ هستید (%dx%d پیکسل). آیا می خواهید "
-"اندازه آن را قبل از پیوست کردن به %d پیکسل تغییر دهید؟"
+msgid "You are about to attach a large image (%dx%d pixels). Would you like to resize it down to %d pixels before attaching it?"
+msgstr "شما در شرف پیوست کردن یک تصویر بزرگ هستید (%dx%d پیکسل). آیا می خواهید اندازه آن را قبل از پیوست کردن به %d پیکسل تغییر دهید؟"
 
 #: packages/lib/services/joplinCloudUtils.ts:45
 msgid "You are logged in into Joplin Cloud, you can leave this screen now."
-msgstr ""
-"شما به سرویس ابری Joplin وارد شده اید، اکنون می توانید این صفحه را ترک کنید."
+msgstr "شما به سرویس ابری Joplin وارد شده اید، اکنون می توانید این صفحه را ترک کنید."
 
 #: packages/app-desktop/gui/SsoLoginScreen/SsoLoginScreen.tsx:24
 #: packages/app-mobile/components/screens/SsoLoginScreen.tsx:48
 msgid "You are now logged into your account."
-msgstr ""
+msgstr "اکنون دیگر شما وارد حساب کاربری خود شده اید."
 
 #: packages/app-desktop/gui/ErrorBoundary.tsx:46
 msgid "You are now using the latest version of the Markdown editor."
-msgstr ""
+msgstr "اکنون شما از آخرین نسخه ویرایشگر Markdown استفاده می‌کنید."
 
 #: packages/app-desktop/gui/MainScreen.tsx:585
-msgid ""
-"You are running the Intel version of Joplin on an Apple Silicon processor. "
-"Download the Apple Silicon one for better performance."
-msgstr ""
+msgid "You are running the Intel version of Joplin on an Apple Silicon processor. Download the Apple Silicon one for better performance."
+msgstr "شما در حال اجرای نسخه Intel برنامه Joplin روی پردازنده Apple Silicon هستید. برای عملکرد بهتر، نسخه مخصوص Apple Silicon را دانلود کنید."
 
 #: packages/app-mobile/components/NoteList.tsx:98
 msgid "You currently have no notebooks."
@@ -7658,20 +6863,12 @@ msgid "You may also type `status` for more information."
 msgstr "شما همچنین می‌توانید `status` را برای اطلاعات بیشتر تایپ کنید."
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:344
-msgid ""
-"You may use the tool below to re-encrypt your data, for example if you know "
-"that some of your notes are encrypted with an obsolete encryption method."
-msgstr ""
-"می‌توانید از ابزار زیر برای رمزگذاری مجدد داده‌های خود استفاده کنید، برای مثال "
-"اگر می‌دانید برخی از یادداشت‌های شما با روش رمزگذاری منسوخ رمزگذاری شده‌اند."
+msgid "You may use the tool below to re-encrypt your data, for example if you know that some of your notes are encrypted with an obsolete encryption method."
+msgstr "می‌توانید از ابزار زیر برای رمزنگاری مجدد داده‌های خود استفاده کنید، برای مثال اگر می‌دانید برخی از یادداشت‌های شما با روش رمزنگاری منسوخ رمزنگاری شده‌اند."
 
 #: packages/lib/services/joplinCloudUtils.ts:53
-msgid ""
-"You were unable to connect to Joplin Cloud. Please check your credentials "
-"and try again. Error:"
-msgstr ""
-"شما نتوانستید به سرویس ابری Joplin متصل شوید. لطفا اعتبارات خود را بررسی "
-"نمایید و دوباره امتحان کنید. خطا:"
+msgid "You were unable to connect to Joplin Cloud. Please check your credentials and try again. Error:"
+msgstr "شما نتوانستید به سرویس ابری Joplin متصل شوید. لطفا اعتبارات خود را بررسی نمایید و دوباره امتحان کنید. خطا:"
 
 #: packages/app-desktop/gui/JoplinCloudConfigScreen.tsx:55
 #: packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.tsx:70
@@ -7689,19 +6886,15 @@ msgstr "داده‌های شما دوباره رمزنگاری و همگام‌�
 #: packages/app-desktop/gui/MainScreen.tsx:591
 #: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:55
 msgid "Your Joplin Cloud credentials are invalid, please login."
-msgstr ""
+msgstr "اطلاعات ورود شما به Joplin Cloud نامعتبر است؛ لطفاً وارد شوید."
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:259
 msgid "Your password is needed to decrypt some of your data."
 msgstr "گذرواژه شما برای رمزگشایی برخی از داده های شما مورد نیاز است."
 
 #: packages/app-cli/app/command-sync.ts:267
-msgid ""
-"Your password is needed to decrypt some of your data. Type `:e2ee decrypt` "
-"to set it."
-msgstr ""
-"گذرواژه شما برای رمزگشایی برخی از داده‌های شما مورد نیاز است. «:e2ee decrypt» "
-"را تایپ کنید تا آن را تنظیم کنید."
+msgid "Your password is needed to decrypt some of your data. Type `:e2ee decrypt` to set it."
+msgstr "گذرواژه شما برای رمزگشایی برخی از داده‌های شما مورد نیاز است. «:e2ee decrypt» را تایپ کنید تا آن را تنظیم کنید."
 
 #: packages/app-desktop/checkForUpdates.ts:108
 msgid "Your version: %s"
@@ -7721,13 +6914,11 @@ msgstr "کوچک نمایی"
 #~ msgstr "کد"
 
 #~ msgid ""
-#~ "In order to associate a geo-location with the note, the app needs your "
-#~ "permission to access your location.\n"
+#~ "In order to associate a geo-location with the note, the app needs your permission to access your location.\n"
 #~ "\n"
 #~ "You may turn off this option at any time in the Configuration screen."
 #~ msgstr ""
-#~ "برای مرتبط نمودن یک موقعیت جغرافیایی با یادداشت، برنامه برای دسترسی به "
-#~ "موقعیت مکانی، به اجازه شما نیاز دارد.\n"
+#~ "برای مرتبط نمودن یک موقعیت جغرافیایی با یادداشت، برنامه برای دسترسی به موقعیت مکانی، به اجازه شما نیاز دارد.\n"
 #~ "\n"
 #~ "شما می‌توانید این گزینه را در هر زمانی در صفحه تنظیمات غیرفعال نمایید."
 
@@ -7775,18 +6966,11 @@ msgstr "کوچک نمایی"
 #~ msgid "Type new tags or select from list"
 #~ msgstr "برچسب‌های جدید را تایپ کنید یا از لیست انتخاب کنید"
 
-#~ msgid ""
-#~ "The [Web Clipper](%s) is a browser extension that allows you to save web "
-#~ "pages and screenshots from your browser."
-#~ msgstr ""
-#~ "[Web Clipper](%s) یک افزونه مرورگر است که به شما امکان می دهد صفحات وب و "
-#~ "اسکرین شات ها را از مرورگر خود ذخیره کنید."
+#~ msgid "The [Web Clipper](%s) is a browser extension that allows you to save web pages and screenshots from your browser."
+#~ msgstr "[Web Clipper](%s) یک افزونه مرورگر است که به شما امکان می دهد صفحات وب و اسکرین شات ها را از مرورگر خود ذخیره کنید."
 
-#~ msgid ""
-#~ "The application did not close properly. Would you like to start in safe "
-#~ "mode?"
-#~ msgstr ""
-#~ "برنامه به درستی بسته نشد. آیا می خواهید در حالت ایمن شروع به کار کنید؟"
+#~ msgid "The application did not close properly. Would you like to start in safe mode?"
+#~ msgstr "برنامه به درستی بسته نشد. آیا می خواهید در حالت ایمن شروع به کار کنید؟"
 
 #~ msgid "%d hours"
 #~ msgstr "%d ساعت"
@@ -7806,14 +6990,8 @@ msgstr "کوچک نمایی"
 #~ msgid "Edit in..."
 #~ msgstr "ویرایش لینک"
 
-#~ msgid ""
-#~ "Biometric unlock is not setup on the device. Please set it up in order to "
-#~ "unlock Joplin. If the device is on lockout, consider switching it off and "
-#~ "on to reset biometrics scanning."
-#~ msgstr ""
-#~ "باز کردن قفل بیومتریک روی دستگاه تنظیم نشده است. لطفاً از آن را برای باز "
-#~ "کردن قفل joplin تنظیم کنید. اگر دستگاه در حالت قفل است، برای بازنشانی "
-#~ "اسکن بیومتریک، آن را خاموش و روشن کنید."
+#~ msgid "Biometric unlock is not setup on the device. Please set it up in order to unlock Joplin. If the device is on lockout, consider switching it off and on to reset biometrics scanning."
+#~ msgstr "باز کردن قفل بیومتریک روی دستگاه تنظیم نشده است. لطفاً از آن را برای باز کردن قفل joplin تنظیم کنید. اگر دستگاه در حالت قفل است، برای بازنشانی اسکن بیومتریک، آن را خاموش و روشن کنید."
 
 #~ msgid "Find and replace"
 #~ msgstr "جستجو و جایگزینی"
@@ -7845,10 +7023,8 @@ msgstr "کوچک نمایی"
 #~ msgid "Show more actions"
 #~ msgstr "نمایش اقدامات بیشتر"
 
-#~ msgid ""
-#~ "The Joplin mobile app does not currently support this type of link: %s"
-#~ msgstr ""
-#~ "برنامه موبایل joplin در حال حاضر از این نوع لینک پشتیبانی نمی‌کند: %s"
+#~ msgid "The Joplin mobile app does not currently support this type of link: %s"
+#~ msgstr "برنامه موبایل joplin در حال حاضر از این نوع لینک پشتیبانی نمی‌کند: %s"
 
 #~ msgid "This attachment is not downloaded or not decrypted yet."
 #~ msgstr "این پیوست هنوز دانلود یا رمزگشایی نشده."
@@ -7895,12 +7071,8 @@ msgstr "کوچک نمایی"
 #~ msgid "Database v%s"
 #~ msgstr "پایگاه داده، ورژن %s"
 
-#~ msgid ""
-#~ "There is currently no notebook. Create one by clicking on \"New "
-#~ "notebook\"."
-#~ msgstr ""
-#~ "در حال حاظر هیچ یادداشتی وجود ندارد. با کلیک بر روی «یادداشت جدید» یک "
-#~ "یادداشت جدید ایجاد کنید."
+#~ msgid "There is currently no notebook. Create one by clicking on \"New notebook\"."
+#~ msgstr "در حال حاظر هیچ یادداشتی وجود ندارد. با کلیک بر روی «یادداشت جدید» یک یادداشت جدید ایجاد کنید."
 
 #~ msgid "Unable to export or share data. Reason: %s"
 #~ msgstr "امکان صدور یا اشتراک‌گذاری داده وجود ندارد. دلیل: %s"
@@ -7911,12 +7083,8 @@ msgstr "کوچک نمایی"
 #~ msgstr "هشدارها: %s"
 
 #, fuzzy
-#~ msgid ""
-#~ "To allow Joplin to synchronise with Joplin Cloud, open this URL in your "
-#~ "browser to authorise the application:"
-#~ msgstr ""
-#~ "مرحله ۱: برای اجازه دادن به برنامه این آدرس اینترنتی را در مرورگر خود باز "
-#~ "نمایید:"
+#~ msgid "To allow Joplin to synchronise with Joplin Cloud, open this URL in your browser to authorise the application:"
+#~ msgstr "مرحله ۱: برای اجازه دادن به برنامه این آدرس اینترنتی را در مرورگر خود باز نمایید:"
 
 #~ msgid "Delete note?"
 #~ msgstr "یادداشت حذف شود؟"
@@ -7937,9 +7105,7 @@ msgstr "کوچک نمایی"
 #~ msgstr "یا ایحاد یک حساب‌کاربری."
 
 #~ msgid "Thank you! Your Joplin Cloud account is now setup and ready to use."
-#~ msgstr ""
-#~ "از شما سپاسگزاریم! حساب ابری joplin شما هم اکنون راه‌اندازی شده و آماده "
-#~ "استفاده است."
+#~ msgstr "از شما سپاسگزاریم! حساب ابری joplin شما هم اکنون راه‌اندازی شده و آماده استفاده است."
 
 #~ msgid "Logs"
 #~ msgstr "لاگ‌ها"
@@ -8000,14 +7166,8 @@ msgstr "کوچک نمایی"
 #~ msgid "Master keys that need upgrading"
 #~ msgstr "کلید‌های اصلی به ارتقا نیاز دارند"
 
-#~ msgid ""
-#~ "The following master keys use an out-dated encryption algorithm and it is "
-#~ "recommended to upgrade them. The upgraded master key will still be able "
-#~ "to decrypt and encrypt your data as usual."
-#~ msgstr ""
-#~ "این کلید‌های اصلی از یک الگوریتم رمزنگاری تاریخ گذشته استفاده می‌کنند و "
-#~ "پیشنهاد می‌شود که آن‌ها رو ارتقا دهید. کلید اصلی ارتقا یافته همچنان طبق "
-#~ "معمول قادر به رمزگشایی و رمزنگاری داده شما خواهد بود."
+#~ msgid "The following master keys use an out-dated encryption algorithm and it is recommended to upgrade them. The upgraded master key will still be able to decrypt and encrypt your data as usual."
+#~ msgstr "این کلید‌های اصلی از یک الگوریتم رمزنگاری تاریخ گذشته استفاده می‌کنند و پیشنهاد می‌شود که آن‌ها رو ارتقا دهید. کلید اصلی ارتقا یافته همچنان طبق معمول قادر به رمزگشایی و رمزنگاری داده شما خواهد بود."
 
 #, fuzzy
 #~ msgid "Master Keys"
@@ -8071,13 +7231,8 @@ msgstr "کوچک نمایی"
 #~ msgid "Check Status"
 #~ msgstr "بررسی وضعیت"
 
-#~ msgid ""
-#~ "Type a note title or part of its content to jump to it. Or type # "
-#~ "followed by a tag name, or @ followed by a notebook name."
-#~ msgstr ""
-#~ "عنوان یادداشت یا بخشی از محتوای آن را تایپ کنید تا به آن بروید. یا # و به "
-#~ "دنبال آن یک نام برچسب تایپ کنید ، یا @ و به دنبال آن یک نام دفترچه "
-#~ "یادداشت وارد کنید."
+#~ msgid "Type a note title or part of its content to jump to it. Or type # followed by a tag name, or @ followed by a notebook name."
+#~ msgstr "عنوان یادداشت یا بخشی از محتوای آن را تایپ کنید تا به آن بروید. یا # و به دنبال آن یک نام برچسب تایپ کنید ، یا @ و به دنبال آن یک نام دفترچه یادداشت وارد کنید."
 
 #~ msgid "Name"
 #~ msgstr "نام"
@@ -8118,12 +7273,8 @@ msgstr "کوچک نمایی"
 #~ msgid "Json Export Directory"
 #~ msgstr "پوشه استخراجی JSON"
 
-#~ msgid ""
-#~ "This item is currently encrypted: %s \"%s\". Please wait for all items to "
-#~ "be decrypted and try again."
-#~ msgstr ""
-#~ "این مورد در حال حاضر رمزنگاری شده است: %s «%s». لطفا تا رمزگشایی تمامی "
-#~ "موارد صبر کرده و سپس دوباره امتحان کنید."
+#~ msgid "This item is currently encrypted: %s \"%s\". Please wait for all items to be decrypted and try again."
+#~ msgstr "این مورد در حال حاضر رمزنگاری شده است: %s «%s». لطفا تا رمزگشایی تمامی موارد صبر کرده و سپس دوباره امتحان کنید."
 
 #~ msgid "Cannot move tag to this location."
 #~ msgstr "نمی‌توان برچسب را به این محل انتقال داد."
@@ -8180,11 +7331,8 @@ msgstr "کوچک نمایی"
 #~ msgid "Show metadata"
 #~ msgstr "نمایش متادیتا"
 
-#~ msgid ""
-#~ "You currently have no notebook. Create one by clicking on (+) button."
-#~ msgstr ""
-#~ "شما هیچ دفترچه ای ندارید. با کلیک کردن بر روی (+) یک دفترچه ی جدید ایجاد "
-#~ "کنید."
+#~ msgid "You currently have no notebook. Create one by clicking on (+) button."
+#~ msgstr "شما هیچ دفترچه ای ندارید. با کلیک کردن بر روی (+) یک دفترچه ی جدید ایجاد کنید."
 
 #~ msgid "Separate each tag by a comma."
 #~ msgstr "هر برچسب را با ویرگول شده کنید."


### PR DESCRIPTION
Update Persian (fa) translation.

- Filled in untranslated strings, bringing the locale from ~78% toward full coverage.
- Also corrected a number of existing strings (typos, inconsistent terminology, mistranslations).
- Single file change, no code.