### PR TITLE
Mobile: Fixes #15923: Prevent scrolling the cursor into view on the markdown editor when unnecessary to do so

### DIFF
--- a/packages/app-mobile/contentScripts/markdownEditorBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/markdownEditorBundle/useWebViewSetup.ts
@@ -78,7 +78,22 @@ const useWebViewSetup = ({
 				${setInitialSelectionJs}
 				${setInitialSearchJs}
 
+				let pendingScroll = false;
+				let pendingTimeout;
+
+				window.onclick = () => {
+					pendingScroll = true;
+
+					clearTimeout(pendingTimeout);
+					pendingTimeout = setTimeout(() => {
+						pendingScroll = false;
+					}, 1000);
+				};
+
 				window.onresize = () => {
+					if (!pendingScroll) return;
+					// Do not reset pendingScroll here, let pendingTimeout do it, because multiple resize events fire on keyboard open,
+					// so scroll should not be suppressed after the first one
 					cm.execCommand('scrollSelectionIntoView');
 				};
 			} else if (parentClassName) {

--- a/packages/app-mobile/contentScripts/markdownEditorBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/markdownEditorBundle/useWebViewSetup.ts
@@ -78,21 +78,26 @@ const useWebViewSetup = ({
 				${setInitialSelectionJs}
 				${setInitialSearchJs}
 
-				let pendingScroll = false;
-				let pendingTimeout;
+				let scrollAllowed = false;
+				let scrollAllowedTimeout;
 
 				window.onclick = () => {
-					pendingScroll = true;
+					scrollAllowed = true;
 
-					clearTimeout(pendingTimeout);
-					pendingTimeout = setTimeout(() => {
-						pendingScroll = false;
+					// Allow scrolling into view for a brief period after clicking / tapping the editor, which is what triggers opening
+					// the on-screen keyboard. A 1 second delay is needed to give time for the onresize event to trigger, then disallow
+					// the scroll so that other actions which trigger resize events will not cause unwanted scrolling. A small caveat is
+					// that dismissing the keyboard within 1 second of tapping may still cause a scroll, but this is acceptable given a
+					// user would be unable to scroll away much from the cursor position in just 1 second.
+					clearTimeout(scrollAllowedTimeout);
+					scrollAllowedTimeout = setTimeout(() => {
+						scrollAllowed = false;
 					}, 1000);
 				};
 
 				window.onresize = () => {
-					if (!pendingScroll) return;
-					// Do not reset pendingScroll here, let pendingTimeout do it, because multiple resize events fire on keyboard open,
+					if (!scrollAllowed) return;
+					// Do not reset scrollAllowed here, let scrollAllowedTimeout do it, because multiple resize events fire on keyboard open,
 					// so scroll should not be suppressed after the first one
 					cm.execCommand('scrollSelectionIntoView');
 				};

--- a/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
@@ -93,6 +93,8 @@ const replaceCheckboxes = [
 		mousedown: (event) => {
 			const target = event.target as Element;
 			if (target.nodeName === 'INPUT' && target.parentElement?.classList?.contains(checkboxClassName)) {
+				// Prevent the keyboard from opening
+				event.preventDefault();
 				// Let the checkbox handle the event
 				return true;
 			}

--- a/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
@@ -93,8 +93,6 @@ const replaceCheckboxes = [
 		mousedown: (event) => {
 			const target = event.target as Element;
 			if (target.nodeName === 'INPUT' && target.parentElement?.classList?.contains(checkboxClassName)) {
-				// Prevent the keyboard from opening
-				event.preventDefault();
 				// Let the checkbox handle the event
 				return true;
 			}

--- a/packages/editor/CodeMirror/extensions/searchExtension.ts
+++ b/packages/editor/CodeMirror/extensions/searchExtension.ts
@@ -77,7 +77,7 @@ const autoScrollToMatchPlugin = ViewPlugin.fromClass(class {
 		startState: EditorState,
 		cancelEvent: CancelEvent,
 	) {
-		const isOpenSearchPanelEvent = () => searchPanelOpen(startState) && !searchPanelOpen(state);
+		const isOpenSearchPanelEvent = () => !searchPanelOpen(startState) && searchPanelOpen(state);
 		if (
 			!query || query.search.length === 0
 			// Avoid auto-scrolling to the search result when first opening the search panel


### PR DESCRIPTION
When dismissing the on screen keyboard on the markdown editor on a mobile device, when the cursor is at a position which is currently off screen, this results in the editor scrolling to the position of the cursor, which can be frustrating when searching or editing a large note.

This is caused by the following code:
https://github.com/laurent22/joplin/blob/5df269104ef233d78c535e9df8abd1061c49233c/packages/app-mobile/contentScripts/markdownEditorBundle/useWebViewSetup.ts#L81-L83

This code is only necessary for a single scenario, which is when a user taps the markdown editor at a position they wish to edit from, the keyboard (when docked) should avoid covering the tapped position, so should therefore scroll the cursor into view when this would happen. This scroll on resize behaviour is problematic however, because in addition to the issue detailed in a first paragraph, this causes unwanted scrolls in multiple other scenarios (see testing section). Originally I thought that scrolling into view was also required upon opening the search panel when a query is prefilled, however this behaviour turned out to be a bug and was not intentional (based on the code comment around it, and the naming of the variable).

This PR addresses the majority of scrolling issues by essentially making the scroll on resize opt out by default, and only opt in for the specific scenario where it is required (tapping the markdown editor body), and additionally addresses the incorrect logic regarding auto scrolling upon opening the search panel (I have changed it so it will not scroll upon opening, but scrolling to the match while typing the search term still applies). As the markdown editor fills the entire container webview and the title and editor toolbar are outside of the webview, handling click events globally within the webview handles the issues sufficiently. This event handler also would avoid receiving touch events while scrolling via swiping.

The only related issue this does not address is https://github.com/laurent22/joplin/issues/15920. That is because toggling a checkbox initiates a click event, which will therefore opt in for being eligible to scroll, and tapping the checkbox will also cause the keyboard to open if it is not currently showing (therefore triggering a resize event). It is a possible to stop propagation for the tap checkbox event (on toggle in the replaceChecklists extension) specifically, however this still would not prevent the keyboard opening, which could cover the checkbox which was tapped. This issue therefore may need to be handled differently, and separately.

EDIT: In addition, I found there is another scenario where it could be useful to scroll into view. With these changes, long pressing some text to select it (when the cursor is not already nearby) in the markdown editor will no longer trigger the scroll into view, which means it is possible that the selected text may get covered by the keyboard in this case. However, this seems like an edge case, and is a much rarer interaction than tapping a position in the text to start editing there. A minor annoyance there seems a reasonable compromise compared to all the other annoying issues which this PR addresses. For comparison, the Notesnook app also does not scroll into view when long pressing text, but it does when tapping the editor text.

This fixes https://github.com/laurent22/joplin/issues/15923 and supersedes https://github.com/laurent22/joplin/pull/16046

### Testing

The changes in the PR enforce the following behaviours (changes shown in bold):
1. Tapping the markdown editor at the bottom of the screen, will scroll the cursor position into view if the keyboard is docked and covers the cursor position (no change in behaviour)
2. Dismissing the keyboard will not change the scroll position of the editor **(existing behaviour scrolls to the cursor position)**
3. Tapping the title input will not change the scroll position in the markdown editor **(existing behaviour scrolls to the cursor position)**
4. When the search panel is open, typing in the search input will automatically scroll while typing, and the matched result is always visible. The same applies when using find next / previous buttons (no change in behaviour)
5. When opening the search panel with a prefilled query (and when closing it), the search will not automatically scroll to the first match, and the scroll position will not change at all, which how search usually works in web browsers **(existing behaviour scrolls to the first match immediately upon opening the search panel. It also scrolls when closing the search panel)**
6. When re-opening a note in the markdown editor, it will automatically scroll upon opening to the last position where the cursor was (no change in behaviour)
7. When switching to another app and then switching back, the scroll position will not change **(existing behaviour scrolls to the cursor position)**

I have tested these on a real Android device, on Android emulator and on the web app accessed via a real Android device. I also tested with a long note as well, and there were no issues with any missed scrolling when expected, or applied scrolling when not expected, so the only race condition likely to happen is if the user dismisses the keyboard within 1 second of opening it, but as mentioned in the code comment, this seems an acceptable compromise.

See video demonstrating the test scenarios on Android emulator:

https://github.com/user-attachments/assets/9ac4b4c7-2562-419e-97bf-b3464ca408c1


