### PR TITLE
Desktop, Mobile: Fixes #16047: Clearer error for bad OneNote property type

### DIFF
--- a/packages/onenote-converter/parser/src/shared/property.rs
+++ b/packages/onenote-converter/parser/src/shared/property.rs
@@ -158,7 +158,11 @@ impl PropertyValue {
 
             v => {
                 return Err(ErrorKind::MalformedOneStoreData(
-                    format!("unexpected property type: 0x{:x}", v).into(),
+                    format!(
+                        "section skipped: file contains an unsupported or invalid property type (0x{:x})",
+                        v
+                    )
+                    .into(),
                 )
                 .into());
             }


### PR DESCRIPTION
Fixes #16047

Before: import failed with a confusing error like "unexpected property type: 0xf".
Now: it says "section skipped: file contains an unsupported or invalid property type (0x...)".

This only changes the error text. Checked that it reaches the user (via onError) and only skips the one broken file, not the whole import.

cargo check passes.