### PR TITLE
Mobile: Remove single-word titles from error/warning dialogs

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/TaskButton.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/TaskButton.tsx
@@ -70,10 +70,7 @@ const TaskButton: FunctionComponent<Props> = props => {
 			}
 		} catch (error) {
 			logger.error(`Task ${props.taskName} failed`, error);
-			await shim.showMessageBox(_('Task "%s" failed with error: %s', props.taskName, error.toString()), {
-				title: _('Error'),
-				buttons: [_('OK')],
-			});
+			await shim.showErrorDialog(_('Task "%s" failed with error: %s', props.taskName, error.toString()));
 		} finally {
 			if (!completedSuccessfully) {
 				setTaskStatus(TaskStatus.NotStarted);

--- a/packages/lib/components/shared/NoteRevisionViewer/useDeleteHistoryClick.ts
+++ b/packages/lib/components/shared/NoteRevisionViewer/useDeleteHistoryClick.ts
@@ -15,7 +15,6 @@ const useDeleteHistoryClick = ({
 	return useCallback(async () => {
 		if (!noteId) return;
 		const response = await shim.showMessageBox(_('Are you sure you want to delete all history for this note? This cannot be undone.'), {
-			title: _('Warning'),
 			buttons: [_('Yes'), _('No')],
 			type: MessageBoxType.Confirm,
 		});


### PR DESCRIPTION
# Summary

This pull request removes two single-word "Warning" and "Error" titles from dialogs on mobile, as per [comment](https://github.com/laurent22/joplin/pull/15970#issuecomment-5008340824).

Related to https://github.com/laurent22/joplin/issues/15958.

# Screenshots

|Dialog| Before | After |
|------|--------|-------|
| Importing an invalid JEX file | <img width="877" height="453" src="https://github.com/user-attachments/assets/a0aab82b-33b4-4bba-9365-9bb866211be6" /> | <img width="877" height="453" alt="image" src="https://github.com/user-attachments/assets/ac5f1b45-8722-43a3-a4d8-7088f6a0cf30" /> |
| Deleting note history | <img width="877" height="453" alt="image" src="https://github.com/user-attachments/assets/561e998b-1884-4d24-9703-f869722f27fa" />| <img width="877" height="453" src="https://github.com/user-attachments/assets/b8004e87-f675-4d4a-9eee-f7d8889b1e54" /> |

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
