### PR TITLE
Desktop: Fixes #16099: Skip the note lock session effect on the first render

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
@@ -200,7 +200,7 @@ describe('useFormNote', () => {
 				is_conflict: 1,
 				title: testNote.title,
 			});
-		});
+		}, { timeout: 15_000 });
 
 		// Should preserve is_conflict after save.
 		expect(await formNoteToNote(formNote.result.current.formNote)).toMatchObject({

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
@@ -5,6 +5,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import useFormNote, { HookDependencies } from './useFormNote';
 import shim from '@joplin/lib/shim';
 import Resource from '@joplin/lib/models/Resource';
+import ItemChange from '@joplin/lib/models/ItemChange';
 import { join } from 'path';
 import { formNoteToNote } from '.';
 import NoteLockNote from '@joplin/lib/services/noteLock/NoteLockNote';
@@ -94,6 +95,8 @@ describe('useFormNote', () => {
 	it('should report a decryption failure instead of throwing, without producing a form note', async () => {
 		Setting.setValue('featureFlag.noteLock', true);
 		const testNote = await Note.save({ title: 'Locked note', body: 'ciphertext', is_locked: 1 });
+		// The save's own change event would otherwise reach the hook's listener and reload the note.
+		await ItemChange.waitForAllSaved();
 
 		const isUnlockedMock = jest.spyOn(NoteLockSession.instance(), 'isUnlocked').mockReturnValue(true);
 		const decryptBodyMock = jest.spyOn(NoteLockNote, 'decryptBody').mockRejectedValue(new Error('OperationError'));

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -97,7 +97,8 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 	// a new refresh.
 	const [formNoteRefreshScheduled, setFormNoteRefreshScheduled] = useState<number>(0);
 	const prevBuiltInEditorVisible = usePrevious<boolean>(builtInEditorVisible);
-	const prevNoteLockSessionUnlocked = usePrevious<boolean>(noteLockSessionUnlocked);
+	// Seeded because usePrevious defaults to null, which would read as a session change on mount.
+	const prevNoteLockSessionUnlocked = usePrevious<boolean>(noteLockSessionUnlocked, noteLockSessionUnlocked);
 
 	useQueuedAsyncEffect(async (event) => {
 		if (formNoteRefreshScheduled <= 0) return;
@@ -162,7 +163,7 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 	// Unlocking loads the note the panel was blocking (the form is then empty), locking must drop
 	// a locked note's plaintext - reload to recompute.
 	useEffect(() => {
-		if (isNoteLockEnabled() && prevNoteLockSessionUnlocked !== undefined && prevNoteLockSessionUnlocked !== noteLockSessionUnlocked && (formNoteRef.current.is_locked || formNoteRef.current.id !== noteId)) {
+		if (isNoteLockEnabled() && prevNoteLockSessionUnlocked !== noteLockSessionUnlocked && (formNoteRef.current.is_locked || formNoteRef.current.id !== noteId)) {
 			refreshFormNote();
 		}
 	}, [noteLockSessionUnlocked, prevNoteLockSessionUnlocked, noteId, formNoteRef, refreshFormNote]);


### PR DESCRIPTION
Fixes #16099

The session change effect in useFormNote checks the previous value against `undefined`, but usePrevious starts its ref at `null`, so it never skips the first render and refreshes the note on mount. Seeding usePrevious with the current value makes the first render compare equal, and the `undefined` check goes with it since there's no sentinel left to guard against. Real session changes still refresh as before.

The test also waits for its own setup save to flush, so that change event can't reach the hook's listener and reload the note mid-test.

Ran `yarn tsc` and the app-desktop suite. Note.load calls on mount went from 4 to 2 with note lock on and an editor plugin active.

I used AI tools on this PR for code suggestions and review, and reviewed and tested the changes myself.