### PR TITLE
Chore: Fixes #15841: Fix "makeInlineReplaceExtension" CI failures

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts
@@ -42,7 +42,7 @@ const expandSelectionToFormattingCharacters = (decorations: DecorationSet, selec
 };
 
 export const makeInlineReplaceExtension = (extensionSpec: ReplacementExtension) => ViewPlugin.fromClass(class {
-	public decorations: DecorationSet;
+	public decorations: DecorationSet = Decoration.set([]);
 	private mouseSelectionInProgress = false;
 
 	public constructor(private view: EditorView) {


### PR DESCRIPTION
# Problem

The `makeInlineReplaceExtension` tests occasionally fail in CI with
```
[@***/editor]:   ● makeInlineReplaceExtension › should include Markdown syntax for bullet list item in a backward mouse selection
[@***/editor]: 
[@***/editor]:     TypeError: Cannot read properties of undefined (reading 'between')
[@***/editor]: 
[@***/editor]:       20 |
[@***/editor]:       21 | 	const hiddenRanges: { from: number; to: number }[] = [];
[@***/editor]:     > 22 | 	decorations.between(0, docLength, (from, to, decoration) => {
[@***/editor]:          | 	            ^
[@***/editor]:       23 | 		if (isHiddenDecoration(decoration)) hiddenRanges.push({ from, to });
[@***/editor]:       24 | 	});
[@***/editor]:       25 |
[@***/editor]: 
[@***/editor]:       at expandSelectionToFormattingCharacters (CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts:22:14)
[@***/editor]:       at Document.onMouseUp (CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts:68:56)
[@***/editor]:       at Document.callTheUserObjectsOperation (node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
[@***/editor]:       at innerInvokeEventListeners (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)
[@***/editor]:       at invokeEventListeners (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
[@***/editor]:       at DocumentImpl._dispatch (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
[@***/editor]:       at DocumentImpl.dispatchEvent (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
[@***/editor]:       at Document.dispatchEvent (node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
[@***/editor]:       at CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.test.ts:225:29
```

I've also observed similar errors locally while using the markdown editor (see #15841).

# Solution

Initialize `decorations` to an empty set when first creating the CodeMirror extension. With this change, if the mouse up handler is called before the first run of `updateDecorations`, `decorations` will not be `null`.

This should fix #15841.
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
