### PR TITLE
Web, Android: Resolves #16107: Dialogs: Bold and add margin below titles

### DIFF
--- a/packages/app-mobile/components/DialogManager/PromptDialog.tsx
+++ b/packages/app-mobile/components/DialogManager/PromptDialog.tsx
@@ -39,6 +39,10 @@ const useStyles = (themeId: number, isMenu: boolean) => {
 			dialogLabel: isMenu ? {
 				textAlign: 'center',
 			} : {},
+			dialogTitle: isMenu ? {} : {
+				fontWeight: 'bold',
+				marginBottom: theme.margin,
+			},
 		});
 	}, [isMenu, themeId]);
 };
@@ -58,7 +62,7 @@ const PromptDialog: React.FC<Props> = ({ dialog, containerStyle, themeId }) => {
 	const titleComponent = <Text
 		variant='titleMedium'
 		accessibilityRole='header'
-		style={styles.dialogLabel}
+		style={[styles.dialogLabel, styles.dialogTitle]}
 	>{dialog.title}</Text>;
 
 	return (

--- a/packages/app-mobile/components/screens/tags.tsx
+++ b/packages/app-mobile/components/screens/tags.tsx
@@ -155,21 +155,27 @@ const TagsScreenComponent: React.FC<Props> = props => {
 		const menuItems: PromptButtonSpec[] = [];
 
 		const generateTagDeletion = () => {
+			const options = [
+				{
+					text: _('Cancel'),
+					onPress: () => { },
+					style: 'cancel' as const,
+				},
+				{
+					text: _('OK'),
+					onPress: async () => {
+						await Tag.delete(tag.id, { sourceDescription: 'tags-screen (long-press)' });
+						setRefreshTrigger(prev => prev + 1);
+					},
+				},
+
+			];
 			return () => {
-				dialogs.prompt('', _('Delete tag "%s"?\n\nAll notes associated with this tag will remain, but the tag will be removed from all notes.', substrWithEllipsis(tag.title, 0, 32)), [
-					{
-						text: _('Cancel'),
-						onPress: () => { },
-						style: 'cancel',
-					},
-					{
-						text: _('OK'),
-						onPress: async () => {
-							await Tag.delete(tag.id, { sourceDescription: 'tags-screen (long-press)' });
-							setRefreshTrigger(prev => prev + 1);
-						},
-					},
-				]);
+				dialogs.prompt(
+					_('Delete tag "%s"?', substrWithEllipsis(tag.title, 0, 32)),
+					_('All notes associated with this tag will remain, but the tag will be removed from all notes.'),
+					options,
+				);
 			};
 		};
 


### PR DESCRIPTION
# Summary

This pull request:
- Updates dialogs to bold and add space below titles.
- Converts the "Delete tag ..." title to a proper title (rather than part of the alert body).

Resolves #16107.

# Screenshots

|| Before | After |
|----|----|----|
|Save geolocation dialog| <img width="1006" height="954" alt="image" src="https://github.com/user-attachments/assets/c1cff6d7-4b73-49d8-9c7a-53e8184f59fe" />| <img width="1006" height="954" alt="screenshot: 'save geolocation' title is now bolded and has roughly 1 line height of space below" src="https://github.com/user-attachments/assets/d72f9d65-376c-4ade-ba2a-ba2d69be7e00" /> |
|Delete tag confirmation| <img width="1006" height="954" alt="image" src="https://github.com/user-attachments/assets/4a4d0a7f-cd57-416d-a208-75725448d540" />| <img width="1006" height="954" alt="screenshot: delete tag header has slightly less space below and is bolded" src="https://github.com/user-attachments/assets/99fc6a5b-455e-4646-9038-823779d29345" /> |

**Note**: The above screenshots are from the web app, with modifications to show the geolocation dialog.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
