### PR TITLE
Desktop: Fixes #16016: Fix chat panel closing and layout calculations in small windows

### DIFF
--- a/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
@@ -322,6 +322,10 @@ const ChatPanel: React.FC<Props> = (props) => {
 		dispatch({ type: 'AI_CHAT_RESET', windowId: windowId });
 	}, [dispatch, windowId, cancelRequest]);
 
+	const handleClose = useCallback(() => {
+		void CommandService.instance().execute('toggleAiChat');
+	}, []);
+
 	const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
 		// Don't send while an IME composition is in flight — Enter commits
 		// the composition for CJK / accented input.
@@ -420,6 +424,15 @@ const ChatPanel: React.FC<Props> = (props) => {
 				{showingMessages && (
 					<button type='button' className='reset' onClick={handleReset}>{_('Reset')}</button>
 				)}
+				<button
+					type='button'
+					className='close'
+					onClick={handleClose}
+					aria-label={_('Close')}
+					title={_('Close')}
+				>
+					<i className='fas fa-times' aria-hidden='true' />
+				</button>
 			</div>
 			{content}
 		</div>

--- a/packages/app-desktop/gui/ChatPanel/style.scss
+++ b/packages/app-desktop/gui/ChatPanel/style.scss
@@ -25,7 +25,8 @@
 	margin: 0;
 }
 
-.chat-panel > .header > .reset {
+.chat-panel > .header > .reset,
+.chat-panel > .header > .close {
 	background: none;
 	border: none;
 	color: var(--joplin-color-faded);
@@ -34,7 +35,8 @@
 	padding: 2px 6px;
 }
 
-.chat-panel > .header > .reset:hover {
+.chat-panel > .header > .reset:hover,
+.chat-panel > .header > .close:hover {
 	color: var(--joplin-color);
 }
 

--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
@@ -514,4 +514,23 @@ describe('useLayoutItemSizes', () => {
 		expect(col3).not.toHaveProperty('width');
 	});
 
+	test('should not assign negative sizes to hidden first siblings in small windows', () => {
+		const layout: LayoutItem = validateLayout({
+			key: 'root',
+			width: 200,
+			height: 100,
+			direction: LayoutItemDirection.Row,
+			children: [
+				{ key: 'sideBar', width: 250, visible: false },
+				{ key: 'editor', flexible: true },
+				{ key: 'chatPanel', width: 340 },
+			],
+		});
+
+		const { result } = renderHook(() => useLayoutItemSizes(layout));
+		const sizes = result.current;
+		expect(sizes.sideBar.width).toBeGreaterThanOrEqual(0);
+		expect(sizes.chatPanel.width).toBeGreaterThanOrEqual(0);
+	});
+
 });

--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.ts
@@ -93,12 +93,13 @@ function calculateChildrenSizes(item: LayoutItem, parent: LayoutItem | null, siz
 	}
 
 	while (remainingSize.width < noWidthChildrenMinWidth) {
-		// There is not enough space, the widest item will be made smaller
-		let widestChild = item.children[0].key;
+		// There is not enough space, the widest visible item will be made smaller
+		let widestChild: string | null = null;
 		for (const child of item.children) {
-			if (!child.visible) continue;
-			if (sizes[child.key].width > sizes[widestChild].width) widestChild = child.key;
+			if (!child.visible || sizes[child.key].width === null) continue;
+			if (widestChild === null || sizes[child.key].width > sizes[widestChild].width) widestChild = child.key;
 		}
+		if (!widestChild) break;
 
 		const dw = Math.abs(remainingSize.width - noWidthChildrenMinWidth);
 		sizes[widestChild].width -= dw;
@@ -106,12 +107,13 @@ function calculateChildrenSizes(item: LayoutItem, parent: LayoutItem | null, siz
 	}
 
 	while (remainingSize.height < noHeightChildrenMinHeight) {
-		// There is not enough space, the tallest item will be made smaller
-		let tallestChild = item.children[0].key;
+		// There is not enough space, the tallest visible item will be made smaller
+		let tallestChild: string | null = null;
 		for (const child of item.children) {
-			if (!child.visible) continue;
-			if (sizes[child.key].height > sizes[tallestChild].height) tallestChild = child.key;
+			if (!child.visible || sizes[child.key].height === null) continue;
+			if (tallestChild === null || sizes[child.key].height > sizes[tallestChild].height) tallestChild = child.key;
 		}
+		if (!tallestChild) break;
 
 		const dh = Math.abs(remainingSize.height - noHeightChildrenMinHeight);
 		sizes[tallestChild].height -= dh;

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleAiChat.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleAiChat.ts
@@ -21,8 +21,6 @@ export const runtime = (control: WindowControl): CommandRuntime => {
 			const visible = !layoutItemProp(layout, 'chatPanel', 'visible');
 			control.announcePanelVisibility(_('AI Chat'), visible);
 
-			window.dispatchEvent(new Event('resize'));
-
 			context.dispatch({
 				type: 'WINDOW_LAYOUT_SET_ITEM_PROP',
 				windowId: context.state.windowId,
@@ -30,6 +28,8 @@ export const runtime = (control: WindowControl): CommandRuntime => {
 				propName: 'visible',
 				propValue: visible,
 			});
+
+			window.dispatchEvent(new Event('resize'));
 		},
 	};
 };


### PR DESCRIPTION
## Summary

This PR fixes layout calculation errors when closing/toggling the AI Chat panel in small application windows (which previously assigned negative dimensions to hidden layout items) and adds a Close (`✕`) button to the AI Chat panel header.

## Details of Changes

1. **Layout Calculations (`useLayoutItemSizes.ts`)**:
   - Updated candidate selection for `widestChild` and `tallestChild` in `calculateChildrenSizes()` to skip hidden (`!child.visible`) and unsized (`width === null`) items.
   - Prevents `widestChild` from defaulting to an invisible first sibling (e.g. `sideBar`), which previously resulted in negative pixel dimensions (`0 - dw`) being assigned when total child minimum widths exceeded window container width.

2. **Event Dispatch Order (`toggleAiChat.ts`)**:
   - Reordered `toggleAiChat` execution so `context.dispatch({ type: 'WINDOW_LAYOUT_SET_ITEM_PROP', ... })` updates Redux layout state *before* `window.dispatchEvent(new Event('resize'))` triggers window resize handlers.

3. **Chat Panel Header Close Button (`ChatPanel.tsx` & `style.scss`)**:
   - Added a Close button (`✕`) directly to the top-right header of the AI Chat panel to invoke `toggleAiChat`.

4. **Regression Unit Tests (`useLayoutItemSizes.test.ts`)**:
   - Added a test case (`should not assign negative sizes to hidden first siblings in small windows`) verifying layout calculations when container width is small and initial siblings are hidden.

## Testing

https://github.com/user-attachments/assets/fe17a187-d544-48c0-9270-ce4994a50703


- **Automated Unit Tests**:
  ```bash
  yarn workspace @joplin/app-desktop test useLayoutItemSizes.test.ts
