### PR TITLE
Desktop: Chat panel: Support reading images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1621,6 +1621,7 @@ packages/lib/services/ai/tools/global/index.js
 packages/lib/services/ai/tools/global/listNotebooks.js
 packages/lib/services/ai/tools/global/listTags.js
 packages/lib/services/ai/tools/global/manageTags.js
+packages/lib/services/ai/tools/global/readImage.js
 packages/lib/services/ai/tools/global/readNote.js
 packages/lib/services/ai/tools/global/searchNotes.js
 packages/lib/services/ai/tools/global/semanticSearchNotes.js
@@ -1629,6 +1630,7 @@ packages/lib/services/ai/tools/types.js
 packages/lib/services/ai/tools/utils/applyNoteEdits.test.js
 packages/lib/services/ai/tools/utils/applyNoteEdits.js
 packages/lib/services/ai/tools/utils/buildTool.js
+packages/lib/services/ai/tools/utils/serializeToolOutput.js
 packages/lib/services/ai/tools/utils/settings.js
 packages/lib/services/ai/types.js
 packages/lib/services/ai/utils/findFencedBlock.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1647,6 +1647,7 @@ packages/lib/services/ai/tools/global/index.js
 packages/lib/services/ai/tools/global/listNotebooks.js
 packages/lib/services/ai/tools/global/listTags.js
 packages/lib/services/ai/tools/global/manageTags.js
+packages/lib/services/ai/tools/global/readImage.js
 packages/lib/services/ai/tools/global/readNote.js
 packages/lib/services/ai/tools/global/searchNotes.js
 packages/lib/services/ai/tools/global/semanticSearchNotes.js
@@ -1655,6 +1656,7 @@ packages/lib/services/ai/tools/types.js
 packages/lib/services/ai/tools/utils/applyNoteEdits.test.js
 packages/lib/services/ai/tools/utils/applyNoteEdits.js
 packages/lib/services/ai/tools/utils/buildTool.js
+packages/lib/services/ai/tools/utils/serializeToolOutput.js
 packages/lib/services/ai/tools/utils/settings.js
 packages/lib/services/ai/types.js
 packages/lib/services/ai/utils/findFencedBlock.js

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -901,6 +901,17 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			storage: SettingStorage.File,
 		},
 
+		'ai.tool.read_image.enabled': {
+			value: false,
+			type: SettingItemType.Bool,
+			public: true,
+			section: 'ai.tools',
+			appTypes: [AppType.Desktop],
+			show: showAiTools,
+			label: () => _('Allow reading images'),
+			storage: SettingStorage.File,
+		},
+
 		'ai.tool.list_notebooks.enabled': {
 			value: false,
 			type: SettingItemType.Bool,

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -116,7 +116,7 @@ const createHistory = (history: ChatMessage[], newMessage: string, context: Note
 const estimateTokens = (text: string|ToolImageResponse) => {
 	// In the case of images, this is a *very* rough estimate:
 	if (text instanceof ToolImageResponse) {
-		const approximateByteLength = text.base64Only.length * 4 / 3;
+		const approximateByteLength = text.base64Only.length * 3 / 4;
 		// Assuming a 50% compression ratio
 		const approximatePixelCount = approximateByteLength * 2;
 		// Assuming a patch size of 24

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -4,8 +4,9 @@ import JoplinError from '../../JoplinError';
 import Logger from '@joplin/utils/Logger';
 import { _ } from '../../locale';
 import { EditOp, isEditorToolCall } from './tools/buildEditorTools';
-import { NoteContext, ToolError } from './tools/types';
+import { NoteContext, ToolError, ToolOutput } from './tools/types';
 import ToolIndex from './tools/ToolIndex';
+import serializeToolOutput from './tools/utils/serializeToolOutput';
 
 const logger = Logger.create('noteChat');
 
@@ -112,7 +113,7 @@ const createHistory = (history: ChatMessage[], newMessage: string, context: Note
 	return history;
 };
 
-const estimateTokens = (text: string) => Math.ceil(text.length / charsPerToken);
+const estimateTokens = (text: { length: number }) => Math.ceil(text.length / charsPerToken);
 
 export interface ChatCommands {
 	replaceSelection: (text: string, originalText: string)=> Promise<void>;
@@ -294,7 +295,7 @@ const runTools = async (
 					role: ChatRole.Tool,
 					toolName: tool.id,
 					toolCallId: toolCall.callId,
-					content: typeof output === 'string' ? output : JSON.stringify(output),
+					content: serializeToolOutput(output as ToolOutput),
 					userDescription: tool.userDescription(toolCall.arguments, output),
 					isError: false,
 					isEdit: isEdit(tool.id),

--- a/packages/lib/services/ai/noteChat.ts
+++ b/packages/lib/services/ai/noteChat.ts
@@ -4,7 +4,7 @@ import JoplinError from '../../JoplinError';
 import Logger from '@joplin/utils/Logger';
 import { _ } from '../../locale';
 import { EditOp, isEditorToolCall } from './tools/buildEditorTools';
-import { NoteContext, ToolError, ToolOutput } from './tools/types';
+import { NoteContext, ToolError, ToolImageResponse, ToolOutput } from './tools/types';
 import ToolIndex from './tools/ToolIndex';
 import serializeToolOutput from './tools/utils/serializeToolOutput';
 
@@ -113,7 +113,19 @@ const createHistory = (history: ChatMessage[], newMessage: string, context: Note
 	return history;
 };
 
-const estimateTokens = (text: { length: number }) => Math.ceil(text.length / charsPerToken);
+const estimateTokens = (text: string|ToolImageResponse) => {
+	// In the case of images, this is a *very* rough estimate:
+	if (text instanceof ToolImageResponse) {
+		const approximateByteLength = text.base64Only.length * 4 / 3;
+		// Assuming a 50% compression ratio
+		const approximatePixelCount = approximateByteLength * 2;
+		// Assuming a patch size of 24
+		// See https://developers.openai.com/api/docs/guides/images-vision#patch-based-image-tokenization
+		const approximateTokens = Math.ceil(approximatePixelCount / 24 / 24);
+		return approximateTokens;
+	}
+	return Math.ceil(text.length / charsPerToken);
+};
 
 export interface ChatCommands {
 	replaceSelection: (text: string, originalText: string)=> Promise<void>;

--- a/packages/lib/services/ai/providers/Anthropic.ts
+++ b/packages/lib/services/ai/providers/Anthropic.ts
@@ -118,7 +118,7 @@ const convertMessages = (messages: ChatMessage[]) => {
 						source: {
 							type: 'base64' as const,
 							media_type: message.content.mimeType,
-							data: message.content.dataUrl,
+							data: message.content.base64Only,
 						},
 					}];
 				return {

--- a/packages/lib/services/ai/providers/Anthropic.ts
+++ b/packages/lib/services/ai/providers/Anthropic.ts
@@ -1,7 +1,7 @@
 import shim from '../../../shim';
 import JoplinError from '../../../JoplinError';
 import Logger from '@joplin/utils/Logger';
-import { ChatMessage, ChatOptions, ChatResult, ChatRole, ChatToolCall, ProviderClassification } from '../types';
+import { ChatMessage, ChatOptions, ChatResult, ChatRole, ChatToolCall, ChatToolMessage, ProviderClassification } from '../types';
 import ChatProviderBase from './ChatProviderBase';
 
 const logger = Logger.create('AnthropicProvider');
@@ -107,31 +107,39 @@ const convertMessages = (messages: ChatMessage[]) => {
 		};
 	};
 
+	const convertToolResponse = (message: ChatToolMessage): AnthropicMessage => {
+		let content;
+		if (typeof message.content === 'string') {
+			content = message.content;
+		} else {
+			content = [{
+				type: 'image' as const,
+				source: {
+					type: 'base64' as const,
+					media_type: message.content.mimeType,
+					data: message.content.base64Only,
+				},
+			}];
+		}
+
+		return {
+			role: 'user',
+			content: [
+				{
+					type: 'tool_result',
+					tool_use_id: message.toolCallId,
+					content,
+					...(message.isError ? { is_error: true } : {}),
+				},
+			],
+		};
+	};
+
 	const result = messages
 		.map((message): AnthropicMessage => {
 			if (message.role === ChatRole.System) return null;
 			if (message.role === ChatRole.Tool) {
-				const content = typeof message.content === 'string'
-					? message.content
-					: [{
-						type: 'image' as const,
-						source: {
-							type: 'base64' as const,
-							media_type: message.content.mimeType,
-							data: message.content.base64Only,
-						},
-					}];
-				return {
-					role: 'user',
-					content: [
-						{
-							type: 'tool_result',
-							tool_use_id: message.toolCallId,
-							content,
-							...(message.isError ? { is_error: true } : {}),
-						},
-					],
-				};
+				return convertToolResponse(message);
 			} else if (message.role === ChatRole.Assistant || message.role === ChatRole.User) {
 				return {
 					role: message.role,

--- a/packages/lib/services/ai/providers/Anthropic.ts
+++ b/packages/lib/services/ai/providers/Anthropic.ts
@@ -23,10 +23,19 @@ interface AnthropicToolUseContentBlock {
 	input: Record<string, unknown>;
 }
 
+interface AnthropicImageContent {
+	type: 'image';
+	source: {
+		type: 'base64';
+		media_type: string;
+		data: string;
+	};
+}
+
 interface AnthropicToolResultContentBlock {
 	type: 'tool_result';
 	tool_use_id: string;
-	content: string;
+	content: string|AnthropicImageContent[];
 }
 
 type AnthropicContentBlock = AnthropicToolUseContentBlock|AnthropicToolResultContentBlock|AnthropicTextContentBlock;
@@ -102,13 +111,23 @@ const convertMessages = (messages: ChatMessage[]) => {
 		.map((message): AnthropicMessage => {
 			if (message.role === ChatRole.System) return null;
 			if (message.role === ChatRole.Tool) {
+				const content = typeof message.content === 'string'
+					? message.content
+					: [{
+						type: 'image' as const,
+						source: {
+							type: 'base64' as const,
+							media_type: message.content.mimeType,
+							data: message.content.dataUrl,
+						},
+					}];
 				return {
 					role: 'user',
 					content: [
 						{
 							type: 'tool_result',
 							tool_use_id: message.toolCallId,
-							content: message.content,
+							content,
 							...(message.isError ? { is_error: true } : {}),
 						},
 					],

--- a/packages/lib/services/ai/providers/OpenAiCompatible.ts
+++ b/packages/lib/services/ai/providers/OpenAiCompatible.ts
@@ -73,7 +73,7 @@ const convertMessage = (message: ChatMessage) => {
 			return [{
 				role: 'tool',
 				name: message.toolName,
-				content: '[success: see next user message]',
+				content: `success: see next message for image ${content.id}`,
 				tool_call_id: message.toolCallId,
 			}, {
 				role: 'user',
@@ -82,7 +82,7 @@ const convertMessage = (message: ChatMessage) => {
 					image_url: {
 						url: content.dataUrl,
 					},
-				}],
+				}, { type: 'text', text: `[image ${content.id}]` }],
 			}];
 		}
 	} else {

--- a/packages/lib/services/ai/providers/OpenAiCompatible.ts
+++ b/packages/lib/services/ai/providers/OpenAiCompatible.ts
@@ -80,7 +80,7 @@ const convertMessage = (message: ChatMessage) => {
 				content: [
 					{
 						type: 'image_url',
-						image_url: content.dataUrl,
+						image_url: { url: content.dataUrl },
 					},
 				],
 			}];

--- a/packages/lib/services/ai/providers/OpenAiCompatible.ts
+++ b/packages/lib/services/ai/providers/OpenAiCompatible.ts
@@ -73,16 +73,16 @@ const convertMessage = (message: ChatMessage) => {
 			return [{
 				role: 'tool',
 				name: message.toolName,
-				content: `success: see next message for image ${content.id}`,
+				content: 'success: will be attached in user message',
 				tool_call_id: message.toolCallId,
 			}, {
 				role: 'user',
-				content: [{
-					type: 'image_url',
-					image_url: {
-						url: content.dataUrl,
+				content: [
+					{
+						type: 'image_url',
+						image_url: content.dataUrl,
 					},
-				}, { type: 'text', text: `[image ${content.id}]` }],
+				],
 			}];
 		}
 	} else {

--- a/packages/lib/services/ai/providers/OpenAiCompatible.ts
+++ b/packages/lib/services/ai/providers/OpenAiCompatible.ts
@@ -59,14 +59,34 @@ const convertTool = (tool: ToolSpec) => {
 
 const convertMessage = (message: ChatMessage) => {
 	if (message.role === 'tool') {
-		return {
-			role: 'tool',
-			name: message.toolName,
-			content: message.content,
-			tool_call_id: message.toolCallId,
-		};
+		const content = message.content;
+		if (typeof content === 'string') {
+			return [{
+				role: 'tool',
+				name: message.toolName,
+				content,
+				tool_call_id: message.toolCallId,
+			}];
+		} else {
+			// Joplin currently uses the older OpenAI chat responses API, which does not support
+			// images in tool results. Attach the image in a user message instead:
+			return [{
+				role: 'tool',
+				name: message.toolName,
+				content: '[uploaded image: see next message]',
+				tool_call_id: message.toolCallId,
+			}, {
+				role: 'user',
+				content: [{
+					type: 'image_url',
+					image_url: {
+						url: content.dataUrl,
+					},
+				}],
+			}];
+		}
 	} else {
-		return {
+		return [{
 			role: message.role,
 			content: message.content,
 			...(message.toolCalls ? {
@@ -81,7 +101,7 @@ const convertMessage = (message: ChatMessage) => {
 					};
 				}),
 			} : {}),
-		};
+		}];
 	}
 };
 
@@ -128,7 +148,7 @@ export default class OpenAiCompatibleProvider extends ChatProviderBase {
 
 		const body: Record<string, unknown> = {
 			model: this.model_,
-			messages: messages.map(convertMessage),
+			messages: messages.flatMap((message): unknown[] => convertMessage(message)),
 			stream: false,
 		};
 		if (options?.temperature !== undefined) body.temperature = options.temperature;

--- a/packages/lib/services/ai/providers/OpenAiCompatible.ts
+++ b/packages/lib/services/ai/providers/OpenAiCompatible.ts
@@ -73,7 +73,7 @@ const convertMessage = (message: ChatMessage) => {
 			return [{
 				role: 'tool',
 				name: message.toolName,
-				content: '[uploaded image: see next message]',
+				content: '[success: see next user message]',
 				tool_call_id: message.toolCallId,
 			}, {
 				role: 'user',

--- a/packages/lib/services/ai/providers/TestProvider.ts
+++ b/packages/lib/services/ai/providers/TestProvider.ts
@@ -1,8 +1,8 @@
 import { ToolSpec } from '../tools/types';
-import { ChatMessage, ChatOptions, ChatResult, ChatRole, ChatToolCall, ProviderClassification } from '../types';
+import { ChatMessage, ChatOptions, ChatResult, ChatRole, ChatStandardMessage, ChatToolCall, ProviderClassification } from '../types';
 import ChatProviderBase from './ChatProviderBase';
 
-const parseUserCommand = (message: ChatMessage, availableTools: ToolSpec[]) => {
+const parseUserCommand = (message: ChatStandardMessage, availableTools: ToolSpec[]) => {
 	const toolCalls: ChatToolCall[] = [];
 	const reply = [];
 	let repeat = 0;
@@ -61,11 +61,12 @@ export default class TestProvider extends ChatProviderBase {
 			let lastUserMessage;
 			let replyCount = 0;
 			for (let i = messages.length - 1; i >= 0; i--) {
-				if (messages[i].role === ChatRole.User) {
-					lastUserMessage = messages[i];
+				const message = messages[i];
+				if (message.role === ChatRole.User) {
+					lastUserMessage = message;
 					break;
 				}
-				if (messages[i].role === ChatRole.Assistant) {
+				if (message.role === ChatRole.Assistant) {
 					replyCount ++;
 				}
 			}
@@ -80,7 +81,7 @@ export default class TestProvider extends ChatProviderBase {
 		}
 
 		const output = content.join(' ');
-		const inputTokens = lastMessage.content.length;
+		const inputTokens = typeof lastMessage.content === 'string' ? lastMessage.content.length : lastMessage.content.length;
 		const outputTokens = output.length + toolCalls.length;
 		return { text: output, toolCalls, usage: { inputTokens, outputTokens } };
 	}

--- a/packages/lib/services/ai/providers/TestProvider.ts
+++ b/packages/lib/services/ai/providers/TestProvider.ts
@@ -81,7 +81,8 @@ export default class TestProvider extends ChatProviderBase {
 		}
 
 		const output = content.join(' ');
-		const inputTokens = typeof lastMessage.content === 'string' ? lastMessage.content.length : lastMessage.content.length;
+		const lastContent = lastMessage.content;
+		const inputTokens = typeof lastContent === 'string' ? lastContent.length : lastContent.dataUrl.length;
 		const outputTokens = output.length + toolCalls.length;
 		return { text: output, toolCalls, usage: { inputTokens, outputTokens } };
 	}

--- a/packages/lib/services/ai/tools/global/index.ts
+++ b/packages/lib/services/ai/tools/global/index.ts
@@ -8,6 +8,7 @@ import updateNote from './updateNote';
 import deleteNote from './deleteNote';
 import manageTags from './manageTags';
 import createNotebook from './createNotebook';
+import readImage from './readImage';
 
 export default [
 	searchNotes,
@@ -20,4 +21,5 @@ export default [
 	deleteNote,
 	manageTags,
 	createNotebook,
+	readImage,
 ];

--- a/packages/lib/services/ai/tools/global/readImage.ts
+++ b/packages/lib/services/ai/tools/global/readImage.ts
@@ -4,6 +4,7 @@ import { ToolError, ToolImageResponse } from '../types';
 import Resource from '../../../../models/Resource';
 import shim from '../../../../shim';
 import { ResourceEntity } from '@joplin/renderer/types';
+import isItemId from '../../../../models/utils/isItemId';
 
 interface Input {
 	id?: string;
@@ -20,7 +21,7 @@ class ReadImageResponse extends ToolImageResponse {
 const tool = buildTool({
 	id: 'read_image',
 	userDescription: (_input, output) => _('Read image: %s', output?.resource?.title ?? _('(untitled)')),
-	description: 'Read a single image attachment by id.',
+	description: 'View an image attachment. Use this to inspect the content of an image that\'s attached to a note. Returns the image data.',
 	inputSchema: {
 		type: 'object',
 		properties: {
@@ -30,13 +31,16 @@ const tool = buildTool({
 	},
 	handler: async (input: Input): Promise<ReadImageResponse> => {
 		if (!input.id) throw new ToolError('Missing "id" parameter');
+		// Models sometimes try to pass the full resource link. Handle this gracefully:
+		const id = input.id.replace(/^:?\//, '');
+		if (!isItemId(id)) throw new ToolError(`Invalid ID: ${id}`);
 
-		const resource = await Resource.load(input.id);
+		const resource = await Resource.load(id);
 		if (!resource || resource.is_locked) {
-			throw new ToolError(`Resource not found: ${input.id}`);
+			throw new ToolError(`Resource not found: ${id}`);
 		}
 		if (resource.encryption_applied) {
-			throw new ToolError(`Resource is encrypted: ${input.id}`);
+			throw new ToolError(`Resource is encrypted: ${id}`);
 		}
 		if (!resource.mime.startsWith('image/')) {
 			throw new ToolError(`Unsupported image MIME type: ${resource.mime}`);

--- a/packages/lib/services/ai/tools/global/readImage.ts
+++ b/packages/lib/services/ai/tools/global/readImage.ts
@@ -14,7 +14,11 @@ interface Input {
 
 class ReadImageResponse extends ToolImageResponse {
 	public constructor(dataUrl: string, public readonly resource: ResourceEntity) {
-		super(dataUrl, resource.mime);
+		super({
+			dataUrl,
+			mimeType: resource.mime,
+			id: resource.id,
+		});
 	}
 }
 

--- a/packages/lib/services/ai/tools/global/readImage.ts
+++ b/packages/lib/services/ai/tools/global/readImage.ts
@@ -26,7 +26,7 @@ const tool = buildTool({
 	userDescription: (_input, output) => {
 		return _('Read image: %s', output?.resource?.title ?? _('(untitled)'));
 	},
-	description: 'View an image attachment. Use this to inspect the content of an image that\'s attached to a note or to generate ALT text. Returns the image data.',
+	description: 'View an image attachment. Use this to describe image content or text. Returns the image data.',
 	inputSchema: {
 		type: 'object',
 		properties: {
@@ -65,7 +65,7 @@ const tool = buildTool({
 		if (input.resolution === 'medium') {
 			maximumSize = 256;
 		} else if (input.resolution === 'high') {
-			maximumSize = 400;
+			maximumSize = 512;
 		}
 
 		const fullPath = Resource.fullPath(resource);

--- a/packages/lib/services/ai/tools/global/readImage.ts
+++ b/packages/lib/services/ai/tools/global/readImage.ts
@@ -65,7 +65,7 @@ const tool = buildTool({
 		if (input.resolution === 'medium') {
 			maximumSize = 256;
 		} else if (input.resolution === 'high') {
-			maximumSize = 312;
+			maximumSize = 400;
 		}
 
 		const fullPath = Resource.fullPath(resource);

--- a/packages/lib/services/ai/tools/global/readImage.ts
+++ b/packages/lib/services/ai/tools/global/readImage.ts
@@ -47,6 +47,7 @@ const tool = buildTool({
 		}
 
 		const fullPath = Resource.fullPath(resource);
+		// Use a small default image size: Images can use a large number of tokens.
 		const url = await shim.imageToDataUrl(fullPath, 128);
 		return new ReadImageResponse(url, resource);
 	},

--- a/packages/lib/services/ai/tools/global/readImage.ts
+++ b/packages/lib/services/ai/tools/global/readImage.ts
@@ -31,7 +31,7 @@ const tool = buildTool({
 		properties: {
 			id: { type: 'string', description: 'The attachment id (32-character hex).' },
 		},
-		required: ['id'],
+		required: ['id', 'resolution'],
 	},
 	handler: async (input: Input): Promise<ReadImageResponse> => {
 		if (!input.id) throw new ToolError('Missing "id" parameter');
@@ -52,7 +52,7 @@ const tool = buildTool({
 
 		const fullPath = Resource.fullPath(resource);
 		// Use a small default image size: Images can use a large number of tokens.
-		const url = await shim.imageToDataUrl(fullPath, 128);
+		const url = await shim.imageToDataUrl(fullPath, 256);
 		return new ReadImageResponse(url, resource);
 	},
 });

--- a/packages/lib/services/ai/tools/global/readImage.ts
+++ b/packages/lib/services/ai/tools/global/readImage.ts
@@ -34,8 +34,8 @@ const tool = buildTool({
 			resolution: {
 				type: 'string',
 				enum: ['low', 'medium', 'high'],
-				default: 'low',
-				description: 'The quality of the image.',
+				default: 'medium',
+				description: 'The quality of the image. High resolution is better for OCR, but uses more tokens.',
 			},
 		},
 		required: ['id'],
@@ -57,14 +57,15 @@ const tool = buildTool({
 			throw new ToolError(`Unsupported image MIME type: ${resource.mime}`);
 		}
 
-		if (input.resolution && !['low', 'medium', 'high'].includes(input.resolution)) {
-			throw new ToolError(`Invalid resolution: ${JSON.stringify(input.resolution)}`);
+		const resolution = input.resolution ?? 'medium';
+		if (!['low', 'medium', 'high'].includes(resolution)) {
+			throw new ToolError(`Invalid resolution: ${JSON.stringify(resolution)}`);
 		}
 
 		let maximumSize = 128;
-		if (input.resolution === 'medium') {
+		if (resolution === 'medium') {
 			maximumSize = 256;
-		} else if (input.resolution === 'high') {
+		} else if (resolution === 'high') {
 			maximumSize = 512;
 		}
 

--- a/packages/lib/services/ai/tools/global/readImage.ts
+++ b/packages/lib/services/ai/tools/global/readImage.ts
@@ -8,8 +8,7 @@ import isItemId from '../../../../models/utils/isItemId';
 
 interface Input {
 	id?: string;
-	offset?: number;
-	max_chars?: number;
+	resolution?: 'low'|'medium'|'high';
 }
 
 class ReadImageResponse extends ToolImageResponse {
@@ -24,14 +23,22 @@ class ReadImageResponse extends ToolImageResponse {
 
 const tool = buildTool({
 	id: 'read_image',
-	userDescription: (_input, output) => _('Read image: %s', output?.resource?.title ?? _('(untitled)')),
+	userDescription: (_input, output) => {
+		return _('Read image: %s', output?.resource?.title ?? _('(untitled)'));
+	},
 	description: 'View an image attachment. Use this to inspect the content of an image that\'s attached to a note or to generate ALT text. Returns the image data.',
 	inputSchema: {
 		type: 'object',
 		properties: {
 			id: { type: 'string', description: 'The attachment id (32-character hex).' },
+			resolution: {
+				type: 'string',
+				enum: ['low', 'medium', 'high'],
+				default: 'low',
+				description: 'The quality of the image. Use low or medium resolution where possible. Higher quality images use more tokens, but are better for OCR.',
+			},
 		},
-		required: ['id', 'resolution'],
+		required: ['id'],
 	},
 	handler: async (input: Input): Promise<ReadImageResponse> => {
 		if (!input.id) throw new ToolError('Missing "id" parameter');
@@ -50,9 +57,21 @@ const tool = buildTool({
 			throw new ToolError(`Unsupported image MIME type: ${resource.mime}`);
 		}
 
+		if (input.resolution && !['low', 'medium', 'high'].includes(input.resolution)) {
+			throw new ToolError(`Invalid resolution: ${JSON.stringify(input.resolution)}`);
+		}
+
+		let maximumSize = 128;
+		if (input.resolution === 'medium') {
+			maximumSize = 256;
+		} else if (input.resolution === 'high') {
+			maximumSize = 512;
+		}
+
+
 		const fullPath = Resource.fullPath(resource);
 		// Use a small default image size: Images can use a large number of tokens.
-		const url = await shim.imageToDataUrl(fullPath, 256);
+		const url = await shim.imageToDataUrl(fullPath, maximumSize);
 		return new ReadImageResponse(url, resource);
 	},
 });

--- a/packages/lib/services/ai/tools/global/readImage.ts
+++ b/packages/lib/services/ai/tools/global/readImage.ts
@@ -47,7 +47,7 @@ const tool = buildTool({
 		}
 
 		const fullPath = Resource.fullPath(resource);
-		const url = await shim.imageToDataUrl(fullPath, 256);
+		const url = await shim.imageToDataUrl(fullPath, 128);
 		return new ReadImageResponse(url, resource);
 	},
 });

--- a/packages/lib/services/ai/tools/global/readImage.ts
+++ b/packages/lib/services/ai/tools/global/readImage.ts
@@ -11,11 +11,19 @@ interface Input {
 	resolution?: 'low'|'medium'|'high';
 }
 
+const dataUrlToMimeType = (url: string) => {
+	const dataUrlMatch = url.match(/^data:(.*);/);
+	if (!dataUrlMatch) throw new Error('Invalid data URL');
+	return dataUrlMatch[1];
+};
+
 class ReadImageResponse extends ToolImageResponse {
 	public constructor(dataUrl: string, public readonly resource: ResourceEntity) {
 		super({
 			dataUrl,
-			mimeType: resource.mime,
+			// Prefer the mime type from the data URL over the one in the resource, in case the
+			// resource was re-encoded while converting to a data URL:
+			mimeType: dataUrlToMimeType(dataUrl),
 			id: resource.id,
 		});
 	}

--- a/packages/lib/services/ai/tools/global/readImage.ts
+++ b/packages/lib/services/ai/tools/global/readImage.ts
@@ -1,0 +1,51 @@
+import { _ } from '../../../../locale';
+import buildTool from '../utils/buildTool';
+import { ToolError, ToolImageResponse } from '../types';
+import Resource from '../../../../models/Resource';
+import shim from '../../../../shim';
+import { ResourceEntity } from '@joplin/renderer/types';
+
+interface Input {
+	id?: string;
+	offset?: number;
+	max_chars?: number;
+}
+
+class ReadImageResponse extends ToolImageResponse {
+	public constructor(dataUrl: string, public readonly resource: ResourceEntity) {
+		super(dataUrl, resource.mime);
+	}
+}
+
+const tool = buildTool({
+	id: 'read_image',
+	userDescription: (_input, output) => _('Read image: %s', output?.resource?.title ?? _('(untitled)')),
+	description: 'Read a single image attachment by id.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			id: { type: 'string', description: 'The attachment id (32-character hex).' },
+		},
+		required: ['id'],
+	},
+	handler: async (input: Input): Promise<ReadImageResponse> => {
+		if (!input.id) throw new ToolError('Missing "id" parameter');
+
+		const resource = await Resource.load(input.id);
+		if (!resource || resource.is_locked) {
+			throw new ToolError(`Resource not found: ${input.id}`);
+		}
+		if (resource.encryption_applied) {
+			throw new ToolError(`Resource is encrypted: ${input.id}`);
+		}
+		if (!resource.mime.startsWith('image/')) {
+			throw new ToolError(`Unsupported image MIME type: ${resource.mime}`);
+		}
+
+		const fullPath = Resource.fullPath(resource);
+		const url = await shim.imageToDataUrl(fullPath, 256);
+		return new ReadImageResponse(url, resource);
+	},
+});
+
+export default tool;

--- a/packages/lib/services/ai/tools/global/readImage.ts
+++ b/packages/lib/services/ai/tools/global/readImage.ts
@@ -35,7 +35,7 @@ const tool = buildTool({
 				type: 'string',
 				enum: ['low', 'medium', 'high'],
 				default: 'low',
-				description: 'The quality of the image. Use low or medium resolution where possible. Higher quality images use more tokens, but are better for OCR.',
+				description: 'The quality of the image.',
 			},
 		},
 		required: ['id'],
@@ -65,9 +65,8 @@ const tool = buildTool({
 		if (input.resolution === 'medium') {
 			maximumSize = 256;
 		} else if (input.resolution === 'high') {
-			maximumSize = 512;
+			maximumSize = 312;
 		}
-
 
 		const fullPath = Resource.fullPath(resource);
 		// Use a small default image size: Images can use a large number of tokens.

--- a/packages/lib/services/ai/tools/global/readImage.ts
+++ b/packages/lib/services/ai/tools/global/readImage.ts
@@ -21,7 +21,7 @@ class ReadImageResponse extends ToolImageResponse {
 const tool = buildTool({
 	id: 'read_image',
 	userDescription: (_input, output) => _('Read image: %s', output?.resource?.title ?? _('(untitled)')),
-	description: 'View an image attachment. Use this to inspect the content of an image that\'s attached to a note. Returns the image data.',
+	description: 'View an image attachment. Use this to inspect the content of an image that\'s attached to a note or to generate ALT text. Returns the image data.',
 	inputSchema: {
 		type: 'object',
 		properties: {

--- a/packages/lib/services/ai/tools/types.ts
+++ b/packages/lib/services/ai/tools/types.ts
@@ -31,6 +31,10 @@ export class ToolImageResponse {
 	public get length() {
 		return this.dataUrl.length;
 	}
+
+	public get base64Only() {
+		return this.dataUrl.replace(/^data:[^;]+;base64,/, '');
+	}
 }
 
 export type ToolOutput = string|Record<string, unknown>|ToolImageResponse;

--- a/packages/lib/services/ai/tools/types.ts
+++ b/packages/lib/services/ai/tools/types.ts
@@ -1,3 +1,4 @@
+import isItemId from '../../../models/utils/isItemId';
 import { JsonSchema } from '../types';
 
 export interface EditorCommands {
@@ -25,8 +26,28 @@ export type ToolInput = Record<string, unknown>;
 // Plain Errors are treated as internal bugs.
 export class ToolError extends Error {}
 
+export interface ImageProperties {
+	dataUrl: string;
+	mimeType: string;
+	// A unique identifier, should be the same if the image is included in the chat
+	// transcript again.
+	id: string;
+}
+
 export class ToolImageResponse {
-	public constructor(public readonly dataUrl: string, public readonly mimeType: string) {}
+	public readonly dataUrl: string;
+	public readonly mimeType: string;
+	public readonly id: string;
+
+	public constructor(props: ImageProperties) {
+		if (!isItemId(props.id)) {
+			throw new Error('Invalid image ID: Must be compatible with Joplin IDs');
+		}
+
+		this.dataUrl = props.dataUrl;
+		this.mimeType = props.mimeType;
+		this.id = props.id;
+	}
 
 	public get length() {
 		return this.dataUrl.length;

--- a/packages/lib/services/ai/tools/types.ts
+++ b/packages/lib/services/ai/tools/types.ts
@@ -49,10 +49,6 @@ export class ToolImageResponse {
 		this.id = props.id;
 	}
 
-	public get length() {
-		return this.dataUrl.length;
-	}
-
 	public get base64Only() {
 		return this.dataUrl.replace(/^data:[^;]+;base64,/, '');
 	}

--- a/packages/lib/services/ai/tools/types.ts
+++ b/packages/lib/services/ai/tools/types.ts
@@ -25,7 +25,15 @@ export type ToolInput = Record<string, unknown>;
 // Plain Errors are treated as internal bugs.
 export class ToolError extends Error {}
 
-export type ToolOutput = string|Record<string, unknown>;
+export class ToolImageResponse {
+	public constructor(public readonly dataUrl: string, public readonly mimeType: string) {}
+
+	public get length() {
+		return this.dataUrl.length;
+	}
+}
+
+export type ToolOutput = string|Record<string, unknown>|ToolImageResponse;
 
 export interface ToolSpec {
 	id: string;

--- a/packages/lib/services/ai/tools/utils/serializeToolOutput.ts
+++ b/packages/lib/services/ai/tools/utils/serializeToolOutput.ts
@@ -1,0 +1,9 @@
+import { ToolImageResponse, ToolOutput } from '../types';
+
+const serializeToolOutput = (output: ToolOutput) => {
+	if (output instanceof ToolImageResponse) return output;
+	return typeof output === 'string' ? output : JSON.stringify(output);
+};
+
+export default serializeToolOutput;
+

--- a/packages/lib/services/ai/types.ts
+++ b/packages/lib/services/ai/types.ts
@@ -1,4 +1,4 @@
-import { ToolSpec } from './tools/types';
+import { ToolImageResponse, ToolSpec } from './tools/types';
 
 export enum ChatRole {
 	System = 'system',
@@ -8,17 +8,18 @@ export enum ChatRole {
 }
 
 interface ChatBaseMessage {
-	content: string;
 }
 
 export interface ChatStandardMessage extends ChatBaseMessage {
 	role: ChatRole.System | ChatRole.User | ChatRole.Assistant;
+	content: string;
 	hide?: boolean;
 	toolCalls?: ChatToolCall[];
 }
 
 export interface ChatToolMessage extends ChatBaseMessage {
 	role: ChatRole.Tool;
+	content: string|ToolImageResponse;
 	toolName: string;
 	toolCallId: string;
 	isError: boolean;

--- a/packages/lib/services/mcp/McpServer.test.ts
+++ b/packages/lib/services/mcp/McpServer.test.ts
@@ -3,9 +3,11 @@ import Note from '../../models/Note';
 import Folder from '../../models/Folder';
 import Tag from '../../models/Tag';
 import SearchEngine from '../search/SearchEngine';
-import { db, setupDatabaseAndSynchronizer, switchClient, withWarningSilenced } from '../../testing/test-utils';
+import { db, setupDatabaseAndSynchronizer, supportDir, switchClient, withWarningSilenced } from '../../testing/test-utils';
 import McpServer from './McpServer';
 import { McpProtocolVersion } from './types';
+import shim from '../../shim';
+import { join } from 'path';
 
 const allToolSettings = [
 	'ai.tool.search_notes.enabled',
@@ -13,6 +15,7 @@ const allToolSettings = [
 	'ai.tool.read_note.enabled',
 	'ai.tool.list_notebooks.enabled',
 	'ai.tool.list_tags.enabled',
+	'ai.tool.read_image.enabled',
 	'ai.tool.create_note.enabled',
 	'ai.tool.update_note.enabled',
 	'ai.tool.delete_note.enabled',
@@ -356,5 +359,23 @@ describe('McpServer', () => {
 		const updated = await Note.load(note.id);
 		expect(updated.title).toBe('New');
 		expect(updated.body).toBe('Keep');
+	});
+
+	test('read_image returns image data as base64', async () => {
+		const folder = await Folder.save({ title: 'Folder' });
+		let note = await Note.save({ title: 'Test', body: 'Test', parent_id: folder.id });
+		note = await shim.attachFileToNote(note, join(supportDir, 'photo.jpg'));
+		const resourceId = Note.linkedItemIds(note.body)[0];
+
+		const response = await McpServer.instance().handleRequest({
+			jsonrpc: '2.0', id: 1, method: 'tools/call',
+			params: { name: 'read_image', arguments: { id: resourceId, resolution: 'low' } },
+		});
+
+		expect(response.error).toBeFalsy();
+		const content = response.result.content[0];
+		expect(content.type).toBe('image');
+		expect(content.mimeType).toContain('image/');
+		expect(content.data).toBeTruthy();
 	});
 });

--- a/packages/lib/services/mcp/McpServer.ts
+++ b/packages/lib/services/mcp/McpServer.ts
@@ -139,7 +139,7 @@ const serialisePayload = (payload: unknown): ToolContent => {
 	if (payload instanceof ToolImageResponse) {
 		return {
 			type: 'image',
-			data: payload.dataUrl,
+			data: payload.base64Only,
 			mimeType: payload.mimeType,
 		};
 	}

--- a/packages/lib/services/mcp/McpServer.ts
+++ b/packages/lib/services/mcp/McpServer.ts
@@ -1,8 +1,8 @@
 import Logger from '@joplin/utils/Logger';
 import Setting from '../../models/Setting';
 import ToolIndex from '../ai/tools/ToolIndex';
-import { JsonRpcRequest, JsonRpcResponse, JsonRpcErrorCodes, McpProtocolVersion, ToolCallResult } from './types';
-import { ToolError } from '../ai/tools/types';
+import { JsonRpcRequest, JsonRpcResponse, JsonRpcErrorCodes, McpProtocolVersion, ToolCallResult, ToolContent, ToolTextContent } from './types';
+import { ToolError, ToolImageResponse, ToolOutput } from '../ai/tools/types';
 
 const logger = Logger.create('McpServer');
 
@@ -96,9 +96,10 @@ export default class McpServer {
 		}
 		const input = params.arguments ?? {};
 		try {
-			const payload = await tool.handler(input, {});
+			const payload = await tool.handler(input, {}) as ToolOutput;
+
 			return {
-				content: [{ type: 'text', text: serialisePayload(payload) }],
+				content: [serialisePayload(payload)],
 			};
 		} catch (error) {
 			if (error instanceof ToolError) {
@@ -129,8 +130,18 @@ const toolErrorResult = (message: string): ToolCallResult => ({
 
 // MCP content is always text, so we JSON-serialise objects/arrays and pass
 // strings through unchanged. null/undefined collapse to an empty string.
-const serialisePayload = (payload: unknown) => {
-	if (payload === null || payload === undefined) return '';
-	if (typeof payload === 'string') return payload;
-	return JSON.stringify(payload, null, 2);
+const serialisePayload = (payload: unknown): ToolContent => {
+	const textResponse = (text: string): ToolTextContent => ({
+		type: 'text', text,
+	});
+	if (payload === null || payload === undefined) return textResponse('');
+	if (typeof payload === 'string') return textResponse(payload);
+	if (payload instanceof ToolImageResponse) {
+		return {
+			type: 'image',
+			data: payload.dataUrl,
+			mimeType: payload.mimeType,
+		};
+	}
+	return textResponse(JSON.stringify(payload, null, 2));
 };

--- a/packages/lib/services/mcp/types.ts
+++ b/packages/lib/services/mcp/types.ts
@@ -5,8 +5,13 @@ export interface ToolTextContent {
 	text: string;
 }
 
-// MCP also allows image and resource content; v1 ships text only.
-export type ToolContent = ToolTextContent;
+export interface ToolImageContent {
+	type: 'image';
+	data: string;
+	mimeType: string;
+}
+
+export type ToolContent = ToolTextContent|ToolImageContent;
 
 export interface ToolCallResult {
 	content: ToolContent[];

--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -492,6 +492,19 @@ function shimInit(options: ShimInitOptions = null) {
 			}
 
 			return image.toDataURL();
+		} else if (shim.sharpEnabled()) {
+			let image = sharp(filePath);
+			const metadata = await image.metadata();
+
+			const maxDimensionIsWidth = metadata.width > metadata.height;
+			if (metadata.width > maxSize && maxDimensionIsWidth) {
+				image = image.resize({ width: maxSize });
+			} else if (metadata.height > maxSize) {
+				image = image.resize({ height: maxSize });
+			}
+
+			const base64 = (await image.png().toBuffer()).toString('base64');
+			return `data:image/png;base64,${base64}`;
 		} else {
 			throw new Error('Unsupported method');
 		}


### PR DESCRIPTION
# Summary

This pull request adds a `read_image` MCP tool that returns image attachments. This allows using MCP tools and the chat panel to:
- generate image ALT text
- categorize or tag notes based on the images they contain

# Notes

- For OpenAI-compatible servers, Joplin currently uses an older API (the chat completions API) that does not support images as tool responses. This pull request works around that by returning images as `user` messages. The `tool` responses point to the `user` messages.

# Screenshots

## Self-hosted `gemma4:e4b`


**Describing the Joplin logo**:
<img height="300" alt="The image you provided is a simple graphic, likely a logo. It consists of a blue square solid background with a single, prominent white capital letter 'J' placed in the center." src="https://github.com/user-attachments/assets/5de89a4c-18f4-432f-81ab-8367f45dac2b" />

**Transcribing a log screenshot, getting mostly-accurate results**:
<img height="300" alt="image" src="https://github.com/user-attachments/assets/40399c53-bdda-4b04-a51b-d541e41d00ad" />

**Transcribing a log screenshot, getting less-accurate results**:
<img height="300" alt="image" src="https://github.com/user-attachments/assets/a92d856a-9a78-4e13-81b5-91d8c9f7bc09" />




## Joplin Cloud AI

Transcribing a log screenshot:
<img width="700" alt="Prompt 'Convert the image to copyable text. Leave out the blue Logger.ts:316 lines, but keep everything else as-is.' results in a semi-accurate transcription of a log screenshot" src="https://github.com/user-attachments/assets/927a5345-aa98-41c6-9f11-c845000f5e96" />


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
