### PR TITLE
Mobile: Fixes #15604: Fix long press on the note list cancelling multi select immediately after switching on Web

### DIFF
--- a/packages/app-mobile/components/NoteItem.tsx
+++ b/packages/app-mobile/components/NoteItem.tsx
@@ -125,6 +125,7 @@ const NoteItemComponent: React.FC<Props> = memo(props => {
 	}, [props.note, props.dispatch]);
 
 	const onPress = useCallback(() => {
+		// Suppress touch release triggers during interval, to avoid conflicting with right click event handling on web
 		if (Date.now() < suppressPressUntilRef.current) return;
 		if (!props.note) return;
 		if (props.note.encryption_applied) return;
@@ -145,6 +146,7 @@ const NoteItemComponent: React.FC<Props> = memo(props => {
 
 	const onLongPress = useCallback(() => {
 		const now = Date.now();
+		// Suppress duplicate long press triggers during interval, to avoid conflicting with right click event handling on web
 		if (now < suppressPressUntilRef.current) return;
 		suppressPressUntilRef.current = now + 500;
 

--- a/packages/app-mobile/components/NoteItem.tsx
+++ b/packages/app-mobile/components/NoteItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
 import { connect } from 'react-redux';
 import { Text, StyleSheet, TextStyle, View, ViewStyle, AccessibilityInfo } from 'react-native';
 import Checkbox from './Checkbox';
@@ -102,6 +102,7 @@ const useStyles = (themeId: number, showTopBorder: boolean) => {
 
 const NoteItemComponent: React.FC<Props> = memo(props => {
 	const styles = useStyles(props.themeId, props.index !== 0);
+	const suppressPressUntilRef = useRef(0);
 
 	const todoCheckbox_change = useCallback(async (checked: boolean) => {
 		if (!props.note) return;
@@ -124,6 +125,7 @@ const NoteItemComponent: React.FC<Props> = memo(props => {
 	}, [props.note, props.dispatch]);
 
 	const onPress = useCallback(() => {
+		if (Date.now() < suppressPressUntilRef.current) return;
 		if (!props.note) return;
 		if (props.note.encryption_applied) return;
 
@@ -142,6 +144,10 @@ const NoteItemComponent: React.FC<Props> = memo(props => {
 	}, [props.note, props.noteSelectionEnabled, props.dispatch]);
 
 	const onLongPress = useCallback(() => {
+		const now = Date.now();
+		if (now < suppressPressUntilRef.current) return;
+		suppressPressUntilRef.current = now + 500;
+
 		if (!props.note) return;
 
 		if (!props.noteSelectionEnabled) {


### PR DESCRIPTION
When long pressing a note in the note list on the web app via an Android device (tested in Chrome and Firefox), it will switch to multiselect mode for a split second, and then deselect, which prevents any multiselect actions from being possible without an external input device. This is caused by a conflict between event handlers to allow entering multi select mode both via long press with a touch or click, or via right click on a mouse. This PR fixes the issue by adding a 500 ms suppression window after a long press. During that window, duplicate long-press triggers and trailing onPress events are ignored. This is needed because on touch/web, a long press is often followed by a release-generated press/click event that can immediately undo the selection change.

This fixes https://github.com/laurent22/joplin/issues/15604

### Testing

I verified that both long press and right clicking with a mouse on note list items will trigger the multi select mode, when using the web app via an Android device. Additionally, I verified when using the native app that long press still works correctly. See video on web:

https://github.com/user-attachments/assets/5460268c-65ec-4f52-935c-7ac99035bf88

