### PR TITLE
Desktop: MCP: Return correct API response type

### DIFF
--- a/packages/lib/ClipperServer.ts
+++ b/packages/lib/ClipperServer.ts
@@ -150,7 +150,7 @@ export default class ClipperServer {
 			};
 
 			const writeResponseJson = (code: number, object: unknown) => {
-				writeCorsHeaders(code);
+				writeCorsHeaders(code, 'application/json');
 				response.write(JSON.stringify(object));
 				response.end();
 			};


### PR DESCRIPTION
# Problem

Many MCP clients (e.g. Android Studio, VSCode, etc) expect JSON output to have `Content-Type: application/json`.

# Solution

Specify `application/json` as the `Content-Type` for JSON output.

# Testing

## Web clipper regression testing

Chrome:
1. Add the web clipper as a development extension.
2. Clip a Wikipedia article. Verify that the article is created successfully.

## MCP server testing

1. Set up VSCode's chat panel to use a local `gemma4:e4b` model.
2. Add Joplin as an HTTP MCP server to VSCode.
3. Open VSCode's chat panel.
4. Remove access to all tools except "create note".
5. Prompt "create a new Joplin note about any topic".
6. Verify that the chat panel prompts to create a note.
7. Accept.
8. Verify that a note has been created in Joplin.
