### PR TITLE
Mobile, Desktop, Cli: Fixes #16145: Release the save mutex when a save fails validation

### DIFF
--- a/packages/lib/BaseModel.ts
+++ b/packages/lib/BaseModel.ts
@@ -644,41 +644,43 @@ class BaseModel {
 
 		const mutexRelease = await this.saveMutex(o).acquire();
 
-		options = this.modOptions(options);
-		const isNew = this.isNew(o, options);
-		options.isNew = isNew;
-
-		// Diff saving is an optimisation which takes a new version of the item and an old one,
-		// do a diff and save only this diff. IMPORTANT: When using this make sure that both
-		// models have been normalised using ItemClass.filter()
-		const isDiffSaving = options && options.oldItem && !options.isNew;
-
-		if (isDiffSaving) {
-			const newObject = BaseModel.diffObjects(options.oldItem, o);
-			newObject.type_ = o.type_;
-			newObject.id = o.id;
-			o = newObject;
-		}
-
-		o = this.filter(o);
-
-		if (options.userSideValidation) {
-			this.userSideValidation(o);
-		}
-
-		let queries = [];
-		const saveQuery = this.saveQuery(o, options);
-		const modelId = saveQuery.id;
-
-		queries.push(saveQuery);
-
-		if (options.nextQueries && options.nextQueries.length) {
-			queries = queries.concat(options.nextQueries);
-		}
-
 		let output = null;
 
+		// The try must cover everything after the mutex acquire: a throw from userSideValidation
+		// or saveQuery would otherwise leak the mutex and hang every later save of the same item.
 		try {
+			options = this.modOptions(options);
+			const isNew = this.isNew(o, options);
+			options.isNew = isNew;
+
+			// Diff saving is an optimisation which takes a new version of the item and an old one,
+			// do a diff and save only this diff. IMPORTANT: When using this make sure that both
+			// models have been normalised using ItemClass.filter()
+			const isDiffSaving = options && options.oldItem && !options.isNew;
+
+			if (isDiffSaving) {
+				const newObject = BaseModel.diffObjects(options.oldItem, o);
+				newObject.type_ = o.type_;
+				newObject.id = o.id;
+				o = newObject;
+			}
+
+			o = this.filter(o);
+
+			if (options.userSideValidation) {
+				this.userSideValidation(o);
+			}
+
+			let queries = [];
+			const saveQuery = this.saveQuery(o, options);
+			const modelId = saveQuery.id;
+
+			queries.push(saveQuery);
+
+			if (options.nextQueries && options.nextQueries.length) {
+				queries = queries.concat(options.nextQueries);
+			}
+
 			await this.db().transactionExecBatch(queries);
 
 			o = { ...o };

--- a/packages/lib/models/Note.test.ts
+++ b/packages/lib/models/Note.test.ts
@@ -197,6 +197,14 @@ describe('models/Note', () => {
 		expect(!!changedNote.is_todo).toBe(false);
 	}));
 
+	it('should still save a note after a save was rejected by validation', (async () => {
+		const note = await Note.save({ title: 'ok' });
+		await expect(Note.save({ id: note.id, title: `bad${String.fromCharCode(0)}title` }, { userSideValidation: true })).rejects.toThrow(/null byte/);
+		// Deadlocks on the note's save mutex if the rejected save above failed to release it.
+		const saved = await Note.save({ id: note.id, title: 'fixed' });
+		expect(saved.title).toBe('fixed');
+	}));
+
 	it('should serialize and unserialize without modifying data', (async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const testCases = [


### PR DESCRIPTION
A save rejected by `userSideValidation` (for example the null byte check from #15485) left the per-id save mutex acquired forever, so every later save of the same item silently hung until restart. Full repro and impact in #16145.

`BaseModel.save()` acquires the mutex at the top of the function, but the `try/finally` that releases it only wrapped the database transaction. `userSideValidation` and `saveQuery` run between the two, so a throw from either leaked the mutex.

The fix moves the `try` up so the `finally` covers everything after the acquire.

Tested with a new regression test in `Note.test.ts` (a second save after a rejected save, which hangs without this fix), the full `models/Note` and `BaseModel` suites, and the curl reproduction from #16145 run against a build of this branch.

EDIT:
This fix is also needed for local note encryption project: bulk encrypt/decrypt feature requires enable/disable to be re-runnable after a partial failure, which the leaked mutex blocks.