### PR TITLE
Chore: Website: Fix build

### DIFF
--- a/readme/apps/ai_semantic_search.md
+++ b/readme/apps/ai_semantic_search.md
@@ -26,7 +26,7 @@ After the initial scan, new and edited notes are picked up within a few minutes.
 
 ## Using it
 
-When enabled, semantic search results are included in Joplin's built-in search UI. Semantic search results are mixed with the default [full-text search matches](./search.md).
+When enabled, semantic search results are included in Joplin's built-in search UI. Semantic search results are mixed with the default [full-text search matches](https://github.com/laurent22/joplin/blob/dev/readme/apps/search.md).
 
 Semantic search is also exposed to:
 


### PR DESCRIPTION
# Problem

The website build is failing for the French locale:
```
Exhaustive list of all broken links found:

- On source page path = /fr/help/apps/ai_semantic_search:
   -> linking to ./search.md (resolved as: /fr/help/apps/search.md)

    at throwError (/home/runner/work/***/***/packages/doc-builder/node_modules/@docusaurus/logger/lib/index.js:76:11)
    at handleBrokenLinks (/home/runner/work/***/***/packages/doc-builder/node_modules/@docusaurus/core/lib/server/brokenLinks.js:153:47)
    at async buildLocale (/home/runner/work/***/***/packages/doc-builder/node_modules/@docusaurus/core/lib/commands/build.js:186:5)
    at async tryToBuildLocale (/home/runner/work/***/***/packages/doc-builder/node_modules/@docusaurus/core/lib/commands/build.js:41:20)
    at async mapAsyncSequential (/home/runner/work/***/***/packages/doc-builder/node_modules/@docusaurus/utils/lib/jsUtils.js:34:24)
    at async Command.build (/home/runner/work/***/***/packages/doc-builder/node_modules/@docusaurus/core/lib/commands/build.js:76:21)
```

# Solution

Replace the relative Markdown link with an absolute GitHub link. This matches the other links in the same file.

# Testing plan

1. Build the website (`yarn buildWebsite`).
2. Serve the website and open the semantic search page (`/help/apps/ai_semantic_search`).
3. Click on the "full text search" link. Verify that this opens the standard search documentation.

https://github.com/user-attachments/assets/56820161-9e9c-44c8-a581-29fb6c001a20


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
