### PR TITLE
Mobile, Desktop: Resolves #16169: Decrypt a note on demand when it is selected

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -333,6 +333,13 @@ export default function useFormNote(dependencies: HookDependencies) {
 			if (!n) throw new Error(`Cannot find note with ID: ${noteId}`);
 			logger.debug('Loaded note:', n);
 
+			// If the note is still encrypted, decrypt it on demand so that it can be
+			// displayed without waiting for the whole decryption queue to be processed.
+			// The ItemChange event emitted on decryption triggers a refresh of the note.
+			if (n.encryption_applied) {
+				void DecryptionWorker.instance().decryptItem(n.id);
+			}
+
 			await onBeforeLoad({ formNote });
 
 			const newFormNote = await initNoteState(n, true);

--- a/packages/app-mobile/components/NoteItem.tsx
+++ b/packages/app-mobile/components/NoteItem.tsx
@@ -128,7 +128,6 @@ const NoteItemComponent: React.FC<Props> = memo(props => {
 		// Suppress touch release triggers during interval, to avoid conflicting with right click event handling on web
 		if (Date.now() < suppressPressUntilRef.current) return;
 		if (!props.note) return;
-		if (props.note.encryption_applied) return;
 
 		if (props.noteSelectionEnabled) {
 			props.dispatch({

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -32,6 +32,7 @@ import ResourceFetcher from '@joplin/lib/services/ResourceFetcher';
 import { BaseScreenComponent } from '../../base-screen';
 import { themeStyle, editorFont } from '../../global-style';
 import shared, { BaseNoteScreenComponent, Props as BaseProps } from '@joplin/lib/components/shared/note-screen-shared';
+import DecryptionWorker from '@joplin/lib/services/DecryptionWorker';
 import SelectDateTimeDialog from '../../SelectDateTimeDialog';
 import ShareExtension from '../../../utils/ShareExtension.js';
 import { FolderEntity, NoteEntity, ResourceEntity } from '@joplin/lib/services/database/types';
@@ -596,6 +597,10 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 
 		await shared.initState(this);
 
+		// If the note is still encrypted, decrypt it on demand so that it can be
+		// displayed without waiting for the whole decryption queue to be processed.
+		void this.decryptNoteOnDemand();
+
 		this.undoRedoService_ = new UndoRedoService();
 		this.undoRedoService_.on('stackChange', this.undoRedoService_stackChange);
 
@@ -767,6 +772,16 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	private async reloadNoteAndUpdateRefreshKey() {
 		await shared.reloadNote(this);
 		this.refreshKey = this.props.editorNoteReloadTimeRequest;
+	}
+
+	private async decryptNoteOnDemand() {
+		const note = this.state.note;
+		if (!note?.id || !note.encryption_applied) return;
+
+		const wasDecrypted = await DecryptionWorker.instance().decryptItem(note.id);
+		if (wasDecrypted) {
+			this.props.dispatch({ type: 'EDITOR_NOTE_NEEDS_RELOAD' });
+		}
 	}
 
 	private title_changeText(text: string) {

--- a/packages/lib/services/DecryptionWorker.test.ts
+++ b/packages/lib/services/DecryptionWorker.test.ts
@@ -1,9 +1,14 @@
-import { setupDatabaseAndSynchronizer, switchClient, decryptionWorker } from '../testing/test-utils';
+import { setupDatabaseAndSynchronizer, switchClient, decryptionWorker, encryptionService, loadEncryptionMasterKey, synchronizerStart } from '../testing/test-utils';
+import { setEncryptionEnabled } from './synchronizer/syncInfoUtils';
+import Note from '../models/Note';
+import Folder from '../models/Folder';
+import MasterKey from '../models/MasterKey';
 
 describe('services/DecryptionWorker', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
+		await setupDatabaseAndSynchronizer(2);
 		await switchClient(1);
 	});
 
@@ -22,5 +27,60 @@ describe('services/DecryptionWorker', () => {
 			expect(result === undefined).toBe(false);
 			expect(result).toHaveProperty('error');
 		}
+	});
+
+	it('should decrypt a single item on demand, without decrypting the rest of the queue', async () => {
+		setEncryptionEnabled(true);
+		await loadEncryptionMasterKey();
+
+		const folder = await Folder.save({ title: 'folder' });
+		const notes = [];
+		for (let i = 0; i < 5; i++) {
+			notes.push(await Note.save({ title: `note${i}`, body: `body${i}`, parent_id: folder.id }));
+		}
+		await synchronizerStart();
+
+		// On the second client the notes are received encrypted.
+		await switchClient(2);
+		await synchronizerStart();
+
+		for (const note of notes) {
+			expect((await Note.load(note.id)).encryption_applied).toBe(1);
+		}
+
+		await encryptionService().loadMasterKey((await MasterKey.all())[0], '123456', true);
+
+		const targetNote = notes[2];
+		const result = await decryptionWorker().decryptItem(targetNote.id);
+		expect(result).toBe(true);
+
+		const decryptedNote = await Note.load(targetNote.id);
+		expect(decryptedNote.encryption_applied).toBe(0);
+		expect(decryptedNote.title).toBe('note2');
+		expect(decryptedNote.body).toBe('body2');
+
+		// The other notes remain encrypted - only the requested one has been decrypted.
+		for (const note of notes) {
+			if (note.id === targetNote.id) continue;
+			expect((await Note.load(note.id)).encryption_applied).toBe(1);
+		}
+	});
+
+	it('should return false when the item is not encrypted', async () => {
+		setEncryptionEnabled(true);
+		await loadEncryptionMasterKey();
+
+		const folder = await Folder.save({ title: 'folder' });
+		const note = await Note.save({ title: 'note', body: 'body', parent_id: folder.id });
+		await synchronizerStart();
+
+		await switchClient(2);
+		await synchronizerStart();
+
+		await encryptionService().loadMasterKey((await MasterKey.all())[0], '123456', true);
+
+		expect(await decryptionWorker().decryptItem(note.id)).toBe(true);
+		// Once the note has been decrypted, calling decryptItem again returns false.
+		expect(await decryptionWorker().decryptItem(note.id)).toBe(false);
 	});
 });

--- a/packages/lib/services/DecryptionWorker.ts
+++ b/packages/lib/services/DecryptionWorker.ts
@@ -48,6 +48,9 @@ export default class DecryptionWorker {
 	private maxDecryptionAttempts_ = 2;
 	private taskQueue_: AsyncActionQueue = new AsyncActionQueue();
 	private encryptionService_: EncryptionService = null;
+	// IDs of items that are currently being decrypted on demand (via decryptItem()).
+	// The main decryption loop skips these items to avoid decrypting them twice.
+	private decryptingItemIds_: Set<string> = new Set();
 
 	public constructor() {
 		this.state_ = 'idle';
@@ -204,6 +207,14 @@ export default class DecryptionWorker {
 
 					const ItemClass = BaseItem.itemClass(item);
 
+					// The item might be being decrypted on demand (or have just been
+					// decrypted that way), so skip it - the on-demand decryption is
+					// responsible for updating the UI in that case.
+					if (this.decryptingItemIds_.has(item.id)) {
+						excludedIds.push(item.id);
+						continue;
+					}
+
 					this.dispatchReport({
 						itemIndex: i,
 						itemCount: items.length,
@@ -323,6 +334,52 @@ export default class DecryptionWorker {
 		}
 
 		return finalReport;
+	}
+
+	// Decrypt a single item immediately, without waiting for the whole decryption
+	// queue to be processed. This is used for example when the user selects an
+	// encrypted note and wants to view it right away.
+	//
+	// Returns true if the item has been decrypted, false otherwise - for example if
+	// the item doesn't exist, is not encrypted, is already being decrypted, or if a
+	// master key needs to be loaded first (in which case a MASTERKEY_ADD_NOT_LOADED
+	// action is dispatched, so that the UI can ask the user to enter the password).
+	public async decryptItem(itemId: string): Promise<boolean> {
+		// Add the item to the set before any await so that concurrent calls for the
+		// same item are rejected right away instead of both proceeding to decrypt.
+		if (this.decryptingItemIds_.has(itemId)) return false;
+		this.decryptingItemIds_.add(itemId);
+
+		try {
+			const item = await BaseItem.loadItemById(itemId);
+			if (!item || item.encryption_applied !== 1) return false;
+
+			const ItemClass = BaseItem.itemClass(item);
+			const decryptedItem = await ItemClass.decrypt(item);
+
+			// Keep the events in sync with the ones emitted by the main decryption
+			// loop in start_().
+			if (decryptedItem.type_ === Resource.modelType() && !!decryptedItem.encryption_blob_encrypted) {
+				this.eventEmitter_.emit('resourceMetadataButNotBlobDecrypted', { id: decryptedItem.id });
+			} else if (decryptedItem.type_ === Resource.modelType() && !decryptedItem.encryption_blob_encrypted) {
+				this.eventEmitter_.emit('resourceDecrypted', { id: decryptedItem.id });
+			}
+
+			return true;
+		} catch (error) {
+			if (error.code === 'masterKeyNotLoaded' && error.masterKeyId) {
+				this.dispatch({
+					type: 'MASTERKEY_ADD_NOT_LOADED',
+					id: error.masterKeyId,
+				});
+			} else {
+				this.logger().warn(`DecryptionWorker: could not decrypt item on demand: ${itemId}`, error);
+			}
+
+			return false;
+		} finally {
+			this.decryptingItemIds_.delete(itemId);
+		}
 	}
 
 	public async start(options: DecryptionWorkerStartOptions = {}): Promise<DecryptionResult> {


### PR DESCRIPTION
## Summary

When E2EE is enabled and a large number of encrypted items are queued for decryption (e.g. after the first sync of a large notebook), clicking an encrypted note only shows a placeholder until the DecryptionWorker reaches that note in the queue. With thousands of items this can take a very long time.

This PR decrypts the selected note immediately:

- New `DecryptionWorker.decryptItem(itemId)` decrypts a single item right away, bypassing the queue. It is guarded with an in-progress set so the item is not decrypted twice (the main loop skips items currently being decrypted on demand).
- Desktop: `useFormNote` triggers it when an encrypted note is loaded; the existing ItemChange refresh flow updates the editor.
- Mobile: encrypted notes can now be opened, and the note screen decrypts them on demand and reloads via `EDITOR_NOTE_NEEDS_RELOAD`.

## Tests

- `services/DecryptionWorker`: new tests for decrypting a single item without decrypting the rest of the queue, and for returning false when the item is already decrypted.
- `Synchronizer.e2ee`: 17/17 pass.

## Platforms

Mobile, Desktop

Resolves #16169