### PR TITLE
Desktop: Resolves #15935: Escape square brackets in ENEX note link text

### DIFF
--- a/packages/app-cli/tests/enex_to_md/links-brackets/notebook.enex
+++ b/packages/app-cli/tests/enex_to_md/links-brackets/notebook.enex
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export4.dtd">
+<en-export export-date="20260808T000000Z" application="Evernote" version="11.28.2">
+  <note>
+    <title>Linker note</title>
+    <created>20260805T185318Z</created>
+    <updated>20260805T200333Z</updated>
+    <note-attributes>
+      <author>author</author>
+    </note-attributes>
+    <content>
+      <![CDATA[<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div style="display:none;"> </div><div>Link to a note whose title contains square brackets: <a type="inline-richlink" rev="{&quot;isCached&quot;:false}" href="https://share.evernote.com/note/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee">simple note version [1]</a></div></en-note>      ]]>
+    </content>
+  </note>
+  <note>
+    <title>simple note version [1]</title>
+    <created>20260805T200313Z</created>
+    <updated>20260805T200320Z</updated>
+    <note-attributes>
+      <author>author</author>
+    </note-attributes>
+    <content>
+      <![CDATA[<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div style="display:none;"> </div><div>Target note body.</div></en-note>      ]]>
+    </content>
+  </note>
+</en-export>

--- a/packages/app-cli/tests/enex_to_md/links-dollar/notebook.enex
+++ b/packages/app-cli/tests/enex_to_md/links-dollar/notebook.enex
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export4.dtd">
+<en-export export-date="20260808T000000Z" application="Evernote" version="11.28.2">
+  <note>
+    <title>Linker note</title>
+    <created>20260805T185318Z</created>
+    <updated>20260805T200333Z</updated>
+    <note-attributes>
+      <author>author</author>
+    </note-attributes>
+    <content>
+      <![CDATA[<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div style="display:none;"> </div><div>Link to a note whose title contains dollar signs: <a type="inline-richlink" rev="{&quot;isCached&quot;:false}" href="https://share.evernote.com/note/11111111-2222-3333-4444-555555555555">Cost $$ total</a></div></en-note>      ]]>
+    </content>
+  </note>
+  <note>
+    <title>Cost $$ total</title>
+    <created>20260805T200313Z</created>
+    <updated>20260805T200320Z</updated>
+    <note-attributes>
+      <author>author</author>
+    </note-attributes>
+    <content>
+      <![CDATA[<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div style="display:none;"> </div><div>Target note body.</div></en-note>      ]]>
+    </content>
+  </note>
+</en-export>

--- a/packages/lib/import-enex.ts
+++ b/packages/lib/import-enex.ts
@@ -12,6 +12,7 @@ import { extractUrls as extractUrlsFromHtml } from '@joplin/utils/html';
 import { extractUrls as extractUrlsFromMarkdown } from '@joplin/utils/markdown';
 import moment from 'moment';
 import { wrapError } from './errorUtils';
+import markdownUtils from './markdownUtils';
 const { enexXmlToHtml } = require('./import-enex-html-gen.js');
 const md5 = require('md5');
 const { Base64Decode } = require('base64-stream');
@@ -337,7 +338,20 @@ export const restoreEnexNoteLinks = async (notes: AsyncIterable<SavedNote>, note
 
 			const matchingNoteIds = await noteTitlesToIds(link.title);
 			if (matchingNoteIds.length === 1) {
-				note.body = note.body.replace(link.url, `:/${matchingNoteIds[0]}`);
+				const noteId = matchingNoteIds[0];
+				// Escape brackets in the note title so they don't prematurely
+				// close the Markdown link (#15935). HTML output swaps the URL only.
+				const markdownLink = `[${link.title}](${link.url})`;
+				if (importOptions.outputFormat !== 'html' && note.body.includes(markdownLink)) {
+					// A replacer function is used so "$$" / "$&" etc. in the title are
+					// inserted literally — a plain string replacement would interpret them.
+					note.body = note.body.replace(
+						markdownLink,
+						() => `[${markdownUtils.escapeTitleText(link.title)}](:/${noteId})`,
+					);
+				} else {
+					note.body = note.body.replace(link.url, `:/${noteId}`);
+				}
 				noteChanged = true;
 			} else {
 				hasUnresolvedLink = true;

--- a/packages/lib/services/interop/InteropService_Importer_EnexToMd.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_EnexToMd.test.ts
@@ -54,4 +54,34 @@ describe('InteropService_Importer_EnexToMd', () => {
 		expect(notes[2].body).toContain(`[Test note](:/${notes[3].id})`);
 		expect(notes[4].body).toContain(`[Test](:/${notes[2].id})`);
 	});
+
+	it('should escape square brackets in note link text', async () => {
+		await importTestFile('links-brackets/');
+
+		const notes = await Note.all();
+		const linkerNote = notes.find(note => note.title === 'Linker note');
+		const targetNote = notes.find(note => note.title === 'simple note version [1]');
+
+		expect(targetNote).toBeTruthy();
+
+		// Brackets in the link text must be backslash-escaped so the inner "]"
+		// does not prematurely close the link. See #15935.
+		expect(linkerNote.body).toContain(`[simple note version \\[1\\]](:/${targetNote.id})`);
+		expect(linkerNote.body).not.toContain(`[simple note version [1]](:/${targetNote.id})`);
+	});
+
+	it('should not mangle dollar signs in note link text', async () => {
+		await importTestFile('links-dollar/');
+
+		const notes = await Note.all();
+		const linkerNote = notes.find(note => note.title === 'Linker note');
+		const targetNote = notes.find(note => note.title === 'Cost $$ total');
+
+		expect(targetNote).toBeTruthy();
+
+		// "$$" in the title must be preserved verbatim. A plain string replacement
+		// would interpret it and collapse it to a single "$".
+		expect(linkerNote.body).toContain(`[Cost $$ total](:/${targetNote.id})`);
+		expect(linkerNote.body).not.toContain(`[Cost $ total](:/${targetNote.id})`);
+	});
 });


### PR DESCRIPTION
Resolves #15935.

## Root cause
When an Evernote ENEX file is imported, internal note links are converted to Joplin `[:/<id>]` links in `restoreEnexNoteLinks` (`packages/lib/import-enex.ts`). The **URL** half was rewritten, but the **link-text** half (the target note's title) was never escaped. A link to a note titled `simple note version [1]` was emitted as `[simple note version [1]](:/<id>)`, where the inner `]` prematurely closes the link text — exactly the broken rendering in the issue.

Every other place that builds a `[:/<id>]` link already escapes the title with the existing helper `markdownUtils.escapeTitleText` (`linkToNote.ts`, `BaseItem.ts`); the ENEX importer was simply missing that one call.

## Changes
- `packages/lib/import-enex.ts`: for Markdown output, rebuild the whole `[title](url)` construct with the title escaped via `markdownUtils.escapeTitleText`; fall back to the previous URL-only swap for HTML output (brackets in `<a>` text need no escaping) or non-literal link shapes — so a previously-resolving link can never regress. The replacement uses a **replacer function** so `$`-substitutions in a user-controlled title are inserted verbatim (a string replacement would corrupt `Cost $$` → `Cost $`).
- Two regression tests + fixtures (`links-brackets`, `links-dollar`): bracket-escaping, and `$$` preserved (proves the replacer-function choice).

## Test plan
`yarn workspace @joplin/lib test` — the two new cases pass (red before the fix, green after); existing `InteropService_Importer_EnexToMd` cases unchanged. Scope is `@joplin/lib` only (headless Jest).