### PR TITLE
Desktop, Mobile: Resolves #15991: Disable reveal Markdown on mouseup behind a feature flag

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useEditorSettings.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useEditorSettings.ts
@@ -28,6 +28,7 @@ const useEditorSettings = (props: EditorSettingsProps) => {
 		automatchBraces: state.settings['editor.autoMatchingBraces'],
 		autocompleteMarkup: state.settings['editor.autocompleteMarkup'],
 		spellcheckEnabled: state.settings['editor.spellcheckBeta'],
+		featureFlagRevealMarkdownOnMouseup: state.settings['featureFlag.editor.revealMarkdownOnMouseup'],
 	});
 	type SelectedSettings = ReturnType<typeof stateToSettings>;
 	const settings = useSelector<AppState, SelectedSettings>(stateToSettings, isDeepStrictEqual);
@@ -52,6 +53,7 @@ const useEditorSettings = (props: EditorSettingsProps) => {
 			tableEditingEnabled: settings.tableEditing,
 			imageRenderingEnabled: settings.imageRendering,
 			highlightActiveLine: settings.highlightActiveLine,
+			featureFlagRevealMarkdownOnMouseup: settings.featureFlagRevealMarkdownOnMouseup,
 			themeData: {
 				...props.baseTheme,
 				marginLeft: 0,

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -301,6 +301,8 @@ const useEditorSettings = (props: Props) => {
 		ignoreModifiers: false,
 		autocompleteMarkup: Setting.value('editor.autocompleteMarkup'),
 
+		featureFlagRevealMarkdownOnMouseup: Setting.value('featureFlag.editor.revealMarkdownOnMouseup'),
+
 		// For now, mobile CodeMirror uses its built-in focus toggle shortcut.
 		tabMovesFocus: false,
 		indentWithTabs: true,

--- a/packages/editor/CodeMirror/configFromSettings.ts
+++ b/packages/editor/CodeMirror/configFromSettings.ts
@@ -19,6 +19,7 @@ import renderTables from './extensions/rendering/renderTables';
 import { RenderedContentContext } from './extensions/rendering/types';
 import highlightActiveLineExtension from './extensions/highlightActiveLineExtension';
 import renderBlockImages from './extensions/rendering/renderBlockImages';
+import { revealOnMouseupFacet } from './extensions/rendering/utils/makeInlineReplaceExtension';
 
 const closingFencedBlock = StateField.define<boolean>({
 	create: () => false,
@@ -126,6 +127,10 @@ const configFromSettings = (settings: EditorSettings, context: RenderedContentCo
 
 	if (settings.highlightActiveLine) {
 		extensions.push(highlightActiveLineExtension());
+	}
+
+	if (settings.featureFlagRevealMarkdownOnMouseup) {
+		extensions.push(revealOnMouseupFacet.of(true));
 	}
 
 	return extensions;

--- a/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.test.ts
@@ -5,6 +5,7 @@ import replaceBulletLists from '../replaceBulletLists';
 import replaceFormatCharacters from '../replaceFormatCharacters';
 import replaceInlineHtml from '../replaceInlineHtml';
 import replaceLinks from '../replaceLinks';
+import { revealOnMouseupFacet } from './makeInlineReplaceExtension';
 
 jest.retryTimes(2);
 
@@ -209,7 +210,7 @@ describe('makeInlineReplaceExtension', () => {
 			markdown,
 			EditorSelection.cursor(markdown.length),
 			expectedSyntaxTreeTags,
-			extensions,
+			[...extensions, revealOnMouseupFacet.of(true)],
 		);
 
 		try {
@@ -238,7 +239,7 @@ describe('makeInlineReplaceExtension', () => {
 			markdown,
 			EditorSelection.cursor(markdown.length),
 			expectedSyntaxTreeTags,
-			extensions,
+			[...extensions, revealOnMouseupFacet.of(true)],
 		);
 
 		try {

--- a/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/utils/makeInlineReplaceExtension.ts
@@ -4,7 +4,7 @@
 import { EditorView, Decoration, DecorationSet, WidgetType } from '@codemirror/view';
 import { ViewPlugin, ViewUpdate } from '@codemirror/view';
 import { syntaxTree } from '@codemirror/language';
-import { EditorSelection, Range, SelectionRange, StateEffect, TransactionSpec } from '@codemirror/state';
+import { EditorSelection, Facet, Range, SelectionRange, StateEffect, TransactionSpec } from '@codemirror/state';
 import { SyntaxNodeRef } from '@lezer/common';
 import { ReplacementExtension } from '../types';
 import nodeIntersectsSelection from './nodeIntersectsSelection';
@@ -41,6 +41,10 @@ const expandSelectionToFormattingCharacters = (decorations: DecorationSet, selec
 	return selection.anchor <= selection.head ? EditorSelection.single(from, to) : EditorSelection.single(to, from);
 };
 
+export const revealOnMouseupFacet = Facet.define<boolean, boolean>({
+	combine: values => values[0] ?? false,
+});
+
 export const makeInlineReplaceExtension = (extensionSpec: ReplacementExtension) => ViewPlugin.fromClass(class {
 	public decorations: DecorationSet = Decoration.set([]);
 	private mouseSelectionInProgress = false;
@@ -58,7 +62,7 @@ export const makeInlineReplaceExtension = (extensionSpec: ReplacementExtension) 
 
 	private onMouseDown = (event: MouseEvent) => {
 		if (event.button === 0) {
-			this.mouseSelectionInProgress = true;
+			this.mouseSelectionInProgress = this.view.state.facet(revealOnMouseupFacet);
 		}
 	};
 

--- a/packages/editor/testing/createEditorSettings.ts
+++ b/packages/editor/testing/createEditorSettings.ts
@@ -23,6 +23,8 @@ const createEditorSettings = (themeId: number) => {
 		language: EditorLanguageType.Markdown,
 		themeData,
 
+		featureFlagRevealMarkdownOnMouseup: false,
+
 		indentWithTabs: true,
 		editorLabel: 'Markdown editor',
 		imageRenderingEnabled: false,

--- a/packages/editor/types.ts
+++ b/packages/editor/types.ts
@@ -224,6 +224,8 @@ export interface EditorSettings {
 	readOnly: boolean;
 	highlightActiveLine: boolean;
 
+	featureFlagRevealMarkdownOnMouseup: boolean;
+
 	indentWithTabs: boolean;
 
 	editorLabel: string;

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -2352,6 +2352,17 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			isGlobal: true,
 		},
 
+		'featureFlag.editor.revealMarkdownOnMouseup': {
+			value: false,
+			public: true,
+			type: SettingItemType.Bool,
+			storage: SettingStorage.File,
+			appTypes: [AppType.Desktop, AppType.Mobile],
+			show: (settings) => settings['editor.inlineRendering'],
+			label: () => 'Editor: Reveal Markdown on mouse up',
+			isGlobal: true,
+		},
+
 		// 'featureFlag.syncAccurateTimestamps': {
 		// 	value: false,
 		// 	type: SettingItemType.Bool,


### PR DESCRIPTION
# Problem

- The v3.7 feature freeze is approaching.
- There are still unresolved regressions related to revealing Markdown on mouseup.

# Solution

- Restore the reveal Markdown on mousedown behavior.
- Add a feature flag to enable revealing Markdown on mouseup.

See also: https://github.com/laurent22/joplin/pull/16126, https://github.com/laurent22/joplin/issues/16070, https://github.com/laurent22/joplin/issues/15991.

# Screen recordings

## Desktop: Enabling and disabling the feature flag

https://github.com/user-attachments/assets/603c7289-62fa-46db-9f55-01ea2f1febfd


## Web: Editing with the feature flag disabled

https://github.com/user-attachments/assets/b7fd0627-477f-4b02-a87c-b80dacca9c2e

## Web: Enabling the feature flag and editing

https://github.com/user-attachments/assets/bd055913-a3ea-47ba-9583-9ebd290591e2

## iOS: Editing with the feature flag disabled

https://github.com/user-attachments/assets/87ff55cd-a90a-4bb1-96e5-0dbded628121

> [!NOTE]
>
> The React Native "unhandled promise rejection" warning seems to be unrelated to this change. The note in the iOS simulator contains a link to a non-existent image resource and `onResolveImageSrc` rejecting with:
> ```
> Error: (in RemoteMessenger, calling onResolveImageSrc):  TypeError: Cannot read property 'file_extension' of null
>    at resourceFilename (...)
> ```
> This seems unrelated to this pull request.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
