### PR TITLE
Mobile: Fixes #15920: Mobile: When toggling a checkbox which is not at the cursor position, it will scroll away from the checkbox back to the cursor position

### DIFF
--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -127,8 +127,7 @@ const createEditor = (
 	};
 
 	const notifySelectionChange = (viewUpdate: ViewUpdate) => {
-		const isCheckboxSelection = viewUpdate.transactions.some(transaction => transaction.isUserEvent('select.checkbox'));
-		if (!viewUpdate.state.selection.eq(viewUpdate.startState.selection) && !isCheckboxSelection) {
+		if (!viewUpdate.state.selection.eq(viewUpdate.startState.selection)) {
 			const mainRange = viewUpdate.state.selection.main;
 			const event: SelectionRangeChangeEvent = {
 				kind: EditorEventType.SelectionRangeChange,

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -127,7 +127,8 @@ const createEditor = (
 	};
 
 	const notifySelectionChange = (viewUpdate: ViewUpdate) => {
-		if (!viewUpdate.state.selection.eq(viewUpdate.startState.selection)) {
+		const isCheckboxSelection = viewUpdate.transactions.some(transaction => transaction.isUserEvent('select.checkbox'));
+		if (!viewUpdate.state.selection.eq(viewUpdate.startState.selection) && !isCheckboxSelection) {
 			const mainRange = viewUpdate.state.selection.main;
 			const event: SelectionRangeChangeEvent = {
 				kind: EditorEventType.SelectionRangeChange,

--- a/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
@@ -38,7 +38,12 @@ class CheckboxWidget extends WidgetType {
 		container.appendChild(checkbox);
 
 		checkbox.oninput = () => {
-			toggleCheckboxAt(view.posAtDOM(container))(view);
+			const checkboxPosition = view.posAtDOM(container);
+			view.dispatch({
+				selection: { anchor: view.state.doc.lineAt(checkboxPosition).from },
+				userEvent: 'select.checkbox',
+			});
+			toggleCheckboxAt(checkboxPosition)(view);
 		};
 
 		this.applyContainerClasses(container);
@@ -90,13 +95,9 @@ const replaceCheckboxes = [
 		},
 	}),
 	EditorView.domEventHandlers({
-		mousedown: (event, view) => {
+		mousedown: (event) => {
 			const target = event.target as Element;
 			if (target.nodeName === 'INPUT' && target.parentElement?.classList?.contains(checkboxClassName)) {
-				view.dispatch({
-					selection: { anchor: view.state.doc.lineAt(view.posAtDOM(target.parentElement)).from },
-					userEvent: 'select.checkbox',
-				});
 				// Let the checkbox handle the event
 				return true;
 			}

--- a/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
@@ -90,9 +90,13 @@ const replaceCheckboxes = [
 		},
 	}),
 	EditorView.domEventHandlers({
-		mousedown: (event) => {
+		mousedown: (event, view) => {
 			const target = event.target as Element;
 			if (target.nodeName === 'INPUT' && target.parentElement?.classList?.contains(checkboxClassName)) {
+				view.dispatch({
+					selection: { anchor: view.state.doc.lineAt(view.posAtDOM(target.parentElement)).from },
+					userEvent: 'select.checkbox',
+				});
 				// Let the checkbox handle the event
 				return true;
 			}
@@ -110,6 +114,7 @@ const replaceCheckboxes = [
 				const rangeFrom = listMarker ? listMarker.from : node.from;
 				const rangeTo = node.to;
 
+				if (selection.empty && selection.from === rangeFrom) return false;
 				const rangeContains = (point: number) => point >= rangeFrom && point <= rangeTo;
 				const selectionContains = (point: number) => point >= selection.from && point <= selection.to;
 


### PR DESCRIPTION
Fixes #15920

I tried different ways to find the real issue, but I could not find one clear cause. I had to force the correct behavior instead.

I added code that overrides the old cursor position and moves the cursor to the checkbox you clicked. This stops the page from jumping to the old cursor

For the note not to open at the last clicked checkbox, we stop this checkbox cursor move from being saved. Normal cursor positions still save

https://github.com/user-attachments/assets/cbeb5ec7-2ead-4a7f-8b69-74c5c84d741a

