### PR TITLE
Desktop: Fixes #16174: Fix Find-in-Note focus loss and disappearing dialog in Rich Text Editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -687,6 +687,7 @@ packages/app-desktop/utils/layout/layoutKeyToLabel.js
 packages/app-desktop/utils/restartInSafeModeFromMain.test.js
 packages/app-desktop/utils/restartInSafeModeFromMain.js
 packages/app-desktop/utils/sourceMapSetup.js
+packages/app-desktop/utils/window/eventHandlerOverrides.test.js
 packages/app-desktop/utils/window/types.js
 packages/app-mobile/PluginAssetsLoader.js
 packages/app-mobile/commands/dismissPluginPanels.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -713,6 +713,7 @@ packages/app-desktop/utils/layout/layoutKeyToLabel.js
 packages/app-desktop/utils/restartInSafeModeFromMain.test.js
 packages/app-desktop/utils/restartInSafeModeFromMain.js
 packages/app-desktop/utils/sourceMapSetup.js
+packages/app-desktop/utils/window/eventHandlerOverrides.test.js
 packages/app-desktop/utils/window/types.js
 packages/app-mobile/PluginAssetsLoader.js
 packages/app-mobile/commands/dismissPluginPanels.js

--- a/packages/app-desktop/utils/window/eventHandlerOverrides.js
+++ b/packages/app-desktop/utils/window/eventHandlerOverrides.js
@@ -19,5 +19,10 @@ document.addEventListener('click', (event) => {
 	// https://github.com/facebook/react/issues/13477#issuecomment-489274045
 	if (['LABEL', 'INPUT'].includes(event.target.nodeName)) return;
 
+	// Do not prevent default click events on TinyMCE elements (like dialog buttons, toolbars, menus, etc.)
+	// because preventing default behavior breaks focus transitions/selection inside modeless dialogs
+	// (such as the searchreplace find box).
+	if (typeof event.target.closest === 'function' && event.target.closest('.tox')) return;
+
 	event.preventDefault();
 });

--- a/packages/app-desktop/utils/window/eventHandlerOverrides.test.ts
+++ b/packages/app-desktop/utils/window/eventHandlerOverrides.test.ts
@@ -1,0 +1,84 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('eventHandlerOverrides', () => {
+	let clickHandler: (event: unknown)=> void;
+
+	beforeAll(() => {
+		// Mock document.addEventListener
+		const originalAddEventListener = document.addEventListener;
+		document.addEventListener = jest.fn((event, handler) => {
+			if (event === 'click') {
+				clickHandler = handler as (event: unknown)=> void;
+			}
+		}) as unknown as typeof document.addEventListener;
+
+		// Load and execute the script
+		const scriptPath = path.join(__dirname, 'eventHandlerOverrides.js');
+		const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+		// Run in global scope
+		eval(scriptContent);
+
+		// Restore original addEventListener
+		document.addEventListener = originalAddEventListener;
+	});
+
+	it('should register click handler', () => {
+		expect(clickHandler).toBeDefined();
+	});
+
+	it('should preventDefault for standard elements like buttons or divs', () => {
+		const preventDefault = jest.fn();
+		const event = {
+			target: {
+				nodeName: 'DIV',
+			},
+			preventDefault,
+		};
+
+		clickHandler(event);
+		expect(preventDefault).toHaveBeenCalled();
+	});
+
+	it('should not preventDefault for INPUT or LABEL elements', () => {
+		const preventDefault = jest.fn();
+
+		const eventInput = {
+			target: {
+				nodeName: 'INPUT',
+			},
+			preventDefault,
+		};
+		clickHandler(eventInput);
+		expect(preventDefault).not.toHaveBeenCalled();
+
+		const eventLabel = {
+			target: {
+				nodeName: 'LABEL',
+			},
+			preventDefault,
+		};
+		clickHandler(eventLabel);
+		expect(preventDefault).not.toHaveBeenCalled();
+	});
+
+	it('should not preventDefault for elements within TinyMCE container (.tox)', () => {
+		const preventDefault = jest.fn();
+
+		const container = document.createElement('div');
+		container.className = 'tox';
+		const button = document.createElement('button');
+		container.appendChild(button);
+		document.body.appendChild(container);
+
+		const eventTox = {
+			target: button,
+			preventDefault,
+		};
+
+		clickHandler(eventTox);
+		expect(preventDefault).not.toHaveBeenCalled();
+
+		document.body.removeChild(container);
+	});
+});


### PR DESCRIPTION
---

### **Pull Request Description**

#### **Summary**
This PR resolves GitHub issue **#16174: "CTRL+F Find in Note Focus issues"** in the Desktop Rich Text (TinyMCE) Editor.

When the Find & Replace dialog is open in the Rich Text Editor, interacting with the dialog buttons (e.g. clicking "Next", "Replace", or "Close") after typing or clicking in the editor causes the dialog to immediately close/disappear, losing the search term and the editor selection.

---

#### **Root Cause**
Joplin registers a global click listener in `packages/app-desktop/utils/window/eventHandlerOverrides.js` to block default browser click behaviors (like middle-clicking a link to open a browser window) on all elements except `LABEL` and `INPUT` tags:
```javascript
document.addEventListener('click', (event) => {
	if (['LABEL', 'INPUT'].includes(event.target.nodeName)) return;
	event.preventDefault();
});
```

* TinyMCE's Find and Replace dialog is a modeless (inline) dialog rendered inside the main document. 
* Dialog control buttons (like "Next" / "Previous") are rendered as `BUTTON`, `SPAN`, or `SVG` elements. 
* When clicked, the global listener intercepts the event, fails the node name checks, and calls `event.preventDefault()`. 
* Calling `preventDefault()` stops browser focus shifting and button activation on the modeless dialog, corrupting the focus state and triggering TinyMCE to automatically close the dialog.

---

#### **Solution**
We modify `eventHandlerOverrides.js` to bypass `event.preventDefault()` if the click target is within a TinyMCE container. 
All TinyMCE components (dialogs, toolbars, dropdowns, statusbars) are wrapped inside the `.tox` namespace. Checking `event.target.closest('.tox')` ensures click events bubble and focus normally for all editor UI components:

```javascript
if (typeof event.target.closest === 'function' && event.target.closest('.tox')) return;
```

This restores normal browser click and focus transitions to TinyMCE dialog buttons without affecting any Markdown editor behaviors or general Joplin navigation.

---

#### **Tests Added**
Added a dedicated unit test file: **`packages/app-desktop/utils/window/eventHandlerOverrides.test.ts`** that uses Jest/jsdom to verify click intercept logic:
1. `should register click handler` - Verifies that the global click listener is attached.
2. `should preventDefault for standard elements like buttons or divs` - Verifies the default interception behavior.
3. `should not preventDefault for INPUT or LABEL elements` - Verifies standard exclusions.
4. `should not preventDefault for elements within TinyMCE container (.tox)` - Verifies the new TinyMCE exclusion using a real DOM element tree.

All lint checks and tests pass successfully:
```text
PASS utils/window/eventHandlerOverrides.test.ts
  eventHandlerOverrides
    √ should register click handler (110 ms)
    √ should preventDefault for standard elements like buttons or divs (109 ms)
    √ should not preventDefault for INPUT or LABEL elements (110 ms)
    √ should not preventDefault for elements within TinyMCE container (.tox) (109 ms)
```