### PR TITLE
Desktop, Mobile, Cli: Fix note screen is not properly refreshed when updated by the sync, when E2EE is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1404,6 +1404,7 @@ packages/lib/components/shared/config/plugins/useOnInstallHandler.js
 packages/lib/components/shared/config/shouldShowMissingPasswordWarning.test.js
 packages/lib/components/shared/config/shouldShowMissingPasswordWarning.js
 packages/lib/components/shared/dropbox-login-shared.js
+packages/lib/components/shared/note-screen-shared.test.js
 packages/lib/components/shared/note-screen-shared.js
 packages/lib/components/shared/reduxSharedMiddleware.js
 packages/lib/components/shared/side-menu-shared.test.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1430,6 +1430,7 @@ packages/lib/components/shared/config/plugins/useOnInstallHandler.js
 packages/lib/components/shared/config/shouldShowMissingPasswordWarning.test.js
 packages/lib/components/shared/config/shouldShowMissingPasswordWarning.js
 packages/lib/components/shared/dropbox-login-shared.js
+packages/lib/components/shared/note-screen-shared.test.js
 packages/lib/components/shared/note-screen-shared.js
 packages/lib/components/shared/reduxSharedMiddleware.js
 packages/lib/components/shared/side-menu-shared.test.js

--- a/packages/lib/components/shared/note-screen-shared.test.ts
+++ b/packages/lib/components/shared/note-screen-shared.test.ts
@@ -1,0 +1,53 @@
+import Note from '../../models/Note';
+import { setupDatabaseAndSynchronizer, switchClient } from '../../testing/test-utils';
+import shared, { BaseNoteScreenComponent } from './note-screen-shared';
+
+const newComponent = () => ({
+	props: {
+		provisionalNoteIds: [],
+		noteId: 'note-id',
+		folders: [],
+		sharedData: undefined,
+		noteVisiblePanes: ['editor'],
+	},
+	state: { mode: 'edit' },
+	setState: jest.fn(),
+	scheduleFocusUpdate: jest.fn(),
+}) as unknown as BaseNoteScreenComponent;
+
+describe('note-screen-shared', () => {
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+		jest.spyOn(shared, 'attachedResources').mockResolvedValue({});
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('should reload an encrypted note after decrypting it', async () => {
+		const encryptedNote = { id: 'note-id', encryption_cipher_text: 'cipher text', deleted_time: 0 };
+		const decryptedNote = { ...encryptedNote, encryption_cipher_text: '', title: 'Title', body: 'Body' };
+		jest.spyOn(Note, 'load').mockResolvedValue(encryptedNote as never);
+		jest.spyOn(Note, 'decrypt').mockResolvedValue(decryptedNote as never);
+		const component = newComponent();
+
+		await shared.reloadNote(component);
+
+		expect(component.setState).toHaveBeenCalledWith(expect.objectContaining({ note: decryptedNote }));
+	});
+
+	it('should use the empty-note branch when the master key is not loaded', async () => {
+		const encryptedNote = { id: 'note-id', encryption_cipher_text: 'cipher text' };
+		const error = Object.assign(new Error('Master key is not loaded'), { code: 'masterKeyNotLoaded' });
+		jest.spyOn(Note, 'load').mockResolvedValue(encryptedNote as never);
+		jest.spyOn(Note, 'decrypt').mockRejectedValue(error);
+		const component = newComponent();
+
+		const result = await shared.reloadNote(component);
+
+		expect(result).toBeNull();
+		expect(component.setState).toHaveBeenCalledWith(expect.objectContaining({ note: {}, isLoading: true }));
+	});
+});

--- a/packages/lib/components/shared/note-screen-shared.test.ts
+++ b/packages/lib/components/shared/note-screen-shared.test.ts
@@ -2,6 +2,14 @@ import Note from '../../models/Note';
 import { setupDatabaseAndSynchronizer, switchClient } from '../../testing/test-utils';
 import shared, { BaseNoteScreenComponent } from './note-screen-shared';
 
+const deferred = <T>() => {
+	let resolve: (value: T)=> void;
+	const promise = new Promise<T>(resolvePromise => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve: resolve! };
+};
+
 const newComponent = () => ({
 	props: {
 		provisionalNoteIds: [],
@@ -29,18 +37,30 @@ describe('note-screen-shared', () => {
 	it('should reload an encrypted note after decrypting it', async () => {
 		const encryptedNote = { id: 'note-id', encryption_cipher_text: 'cipher text', deleted_time: 0 };
 		const decryptedNote = { ...encryptedNote, encryption_cipher_text: '', title: 'Title', body: 'Body' };
+		const decryptStarted = deferred<void>();
+		const decryption = deferred<typeof decryptedNote>();
 		jest.spyOn(Note, 'load').mockResolvedValue(encryptedNote as never);
-		jest.spyOn(Note, 'decrypt').mockResolvedValue(decryptedNote as never);
+		jest.spyOn(Note, 'decrypt').mockImplementation(() => {
+			decryptStarted.resolve();
+			return decryption.promise as never;
+		});
 		const component = newComponent();
 
-		await shared.reloadNote(component);
+		const reloadPromise = shared.reloadNote(component);
+		await decryptStarted.promise;
+		expect(component.setState).not.toHaveBeenCalled();
+
+		decryption.resolve(decryptedNote);
+		await reloadPromise;
 
 		expect(component.setState).toHaveBeenCalledWith(expect.objectContaining({ note: decryptedNote }));
 	});
 
-	it('should use the empty-note branch when the master key is not loaded', async () => {
+	it.each([
+		['the master key is not loaded', Object.assign(new Error('Master key is not loaded'), { code: 'masterKeyNotLoaded' })],
+		['decryption otherwise fails', new Error('Invalid ciphertext')],
+	])('should use the empty-note branch when %s', async (_description, error) => {
 		const encryptedNote = { id: 'note-id', encryption_cipher_text: 'cipher text' };
-		const error = Object.assign(new Error('Master key is not loaded'), { code: 'masterKeyNotLoaded' });
 		jest.spyOn(Note, 'load').mockResolvedValue(encryptedNote as never);
 		jest.spyOn(Note, 'decrypt').mockRejectedValue(error);
 		const component = newComponent();

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -298,7 +298,15 @@ shared.isModified = function(comp: BaseNoteScreenComponent) {
 shared.reloadNote = async (comp: BaseNoteScreenComponent, useDefaultEditorState = false) => {
 	const isProvisionalNote = comp.props.provisionalNoteIds.includes(comp.props.noteId);
 
-	const note = await Note.load(comp.props.noteId);
+	let note = await Note.load(comp.props.noteId);
+	if (note.encryption_cipher_text) {
+		try {
+			note = await Note.decrypt(note);
+		} catch (error) {
+			reg.logger().info(`Could not decrypt note ${note.id}, note could not be refreshed:`, error.message);
+			note = null; // fall into the non existent note handling
+		}
+	}
 	let mode = comp.state.mode;
 
 	if (useDefaultEditorState) {

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -299,7 +299,7 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent, useDefaultEditorState 
 	const isProvisionalNote = comp.props.provisionalNoteIds.includes(comp.props.noteId);
 
 	let note = await Note.load(comp.props.noteId);
-	if (note.encryption_cipher_text) {
+	if (note?.encryption_cipher_text) {
 		try {
 			note = await Note.decrypt(note);
 		} catch (error) {

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -304,7 +304,11 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent, useDefaultEditorState 
 			note = await Note.decrypt(note);
 		} catch (error) {
 			reg.logger().info(`Could not decrypt note ${note.id}, note could not be refreshed:`, error.message);
-			note = null; // fall into the non existent note handling
+			// All decryption errors, including masterKeyNotLoaded, intentionally use the non-existent note branch below.
+			// A forced reload must not retain the previously loaded plaintext, as it presents a risk of data loss if the
+			// user is typing during the reload. Aside from certain edge cases, a user cannot directly open a note which
+			// is still encrypted, so normally would not see this.
+			note = null;
 		}
 	}
 	let mode = comp.state.mode;

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -20,7 +20,6 @@ import { checkObjectHasProperties } from '@joplin/utils/object';
 
 const { sprintf } = require('sprintf-js');
 import moment = require('moment');
-import Note from './Note';
 
 export interface ItemsThatNeedDecryptionResult {
 	hasMore: boolean;
@@ -572,13 +571,6 @@ export default class BaseItem extends BaseModel {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- item is a BaseItemEntity subclass with encryption_cipher_text/encryption_applied; saved back via ItemClass.save which is per-subclass
 	public static async decrypt(item: any) {
-		if (item.type_ === ModelType.Note) {
-			// Validate if still eligible to decrypt using the latest encryption_applied value, as notes may be decrypted on demand while the decryption worker is running.
-			// If it has been decrypted already, avoid decrypting it again to avoid potentially overwriting it with an outdated version
-			const encryptionApplied = (await Note.load(item.id, { fields: ['encryption_applied'] }))?.encryption_applied;
-			if (!encryptionApplied) throw new Error(`Note has already been decrypted: ${item.id}`);
-		}
-
 		if (!item.encryption_cipher_text) throw new Error(`Item is not encrypted: ${item.id}`);
 
 		const ItemClass = this.itemClass(item);

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -20,6 +20,7 @@ import { checkObjectHasProperties } from '@joplin/utils/object';
 
 const { sprintf } = require('sprintf-js');
 import moment = require('moment');
+import Note from './Note';
 
 export interface ItemsThatNeedDecryptionResult {
 	hasMore: boolean;
@@ -571,6 +572,13 @@ export default class BaseItem extends BaseModel {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- item is a BaseItemEntity subclass with encryption_cipher_text/encryption_applied; saved back via ItemClass.save which is per-subclass
 	public static async decrypt(item: any) {
+		if (item.type_ === ModelType.Note) {
+			// Validate if still eligible to decrypt using the latest encryption_applied value, as notes may be decrypted on demand while the decryption worker is running.
+			// If it has been decrypted already, avoid decrypting it again to avoid potentially overwriting it with an outdated version
+			const encryptionApplied = (await Note.load(item.id, { fields: ['encryption_applied'] }))?.encryption_applied;
+			if (!encryptionApplied) throw new Error(`Note has already been decrypted: ${item.id}`);
+		}
+
 		if (!item.encryption_cipher_text) throw new Error(`Item is not encrypted: ${item.id}`);
 
 		const ItemClass = this.itemClass(item);

--- a/packages/lib/services/DecryptionWorker.test.ts
+++ b/packages/lib/services/DecryptionWorker.test.ts
@@ -1,10 +1,16 @@
 import { setupDatabaseAndSynchronizer, switchClient, decryptionWorker } from '../testing/test-utils';
+import BaseItem from '../models/BaseItem';
+import Note from '../models/Note';
 
 describe('services/DecryptionWorker', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
 	});
 
 	it('should not return null when a call to .start is cancelled', async () => {
@@ -22,5 +28,23 @@ describe('services/DecryptionWorker', () => {
 			expect(result === undefined).toBe(false);
 			expect(result).toHaveProperty('error');
 		}
+	});
+
+	it('should skip a note that was decrypted on demand after the worker loaded it', async () => {
+		const note = await Note.save({ title: 'Test note', body: 'Test body' });
+		const encryptedSnapshot = { ...note, encryption_applied: 1, encryption_cipher_text: 'cipher text' };
+		const worker = decryptionWorker();
+
+		jest.spyOn(worker.encryptionService(), 'loadedMasterKeysCount').mockReturnValue(1);
+		jest.spyOn(BaseItem, 'itemsThatNeedDecryption').mockResolvedValue({
+			items: [encryptedSnapshot],
+			hasMore: false,
+		});
+		const decryptSpy = jest.spyOn(Note, 'decrypt');
+
+		const result = await worker.start();
+
+		expect(decryptSpy).not.toHaveBeenCalled();
+		expect(result.decryptedItemCount).toBe(1);
 	});
 });

--- a/packages/lib/services/DecryptionWorker.ts
+++ b/packages/lib/services/DecryptionWorker.ts
@@ -242,6 +242,7 @@ export default class DecryptionWorker {
 							// If it has been decrypted already, avoid decrypting it again to avoid potentially overwriting it with an outdated version
 							const encryptionApplied = (await ItemClass.load(item.id, { fields: ['encryption_applied'] }))?.encryption_applied;
 							if (!encryptionApplied) {
+								this.logger().info(`DecryptionWorker: Skipping decryption for note ${item.id} as it was already decrypted on demand`);
 								await markSuccessfulDecryption(item.type_);
 								continue;
 							}

--- a/packages/lib/services/DecryptionWorker.ts
+++ b/packages/lib/services/DecryptionWorker.ts
@@ -1,5 +1,5 @@
 import BaseItem, { ItemsThatNeedDecryptionResult } from '../models/BaseItem';
-import BaseModel from '../BaseModel';
+import BaseModel, { ModelType } from '../BaseModel';
 import MasterKey from '../models/MasterKey';
 import Resource from '../models/Resource';
 import ResourceService from './ResourceService';
@@ -219,6 +219,12 @@ export default class DecryptionWorker {
 						await this.kvStore().deleteValue(errorKey);
 					};
 
+					const markSuccessfulDecryption = async (decryptedItemType: number) => {
+						await clearDecryptionCounter();
+						if (!decryptedItemCounts[decryptedItemType]) decryptedItemCounts[decryptedItemType] = 0;
+						decryptedItemCounts[decryptedItemType]++;
+					};
+
 					// Don't log in production as it results in many messages when importing many items
 					// this.logger().debug('DecryptionWorker: decrypting: ' + item.id + ' (' + ItemClass.tableName() + ')');
 					try {
@@ -231,13 +237,18 @@ export default class DecryptionWorker {
 							continue;
 						}
 
+						if (item.type_ === ModelType.Note) {
+							// Validate if still eligible to decrypt using the latest encryption_applied value, as notes may be decrypted on demand while the decryption worker is running.
+							// If it has been decrypted already, avoid decrypting it again to avoid potentially overwriting it with an outdated version
+							const encryptionApplied = (await ItemClass.load(item.id, { fields: ['encryption_applied'] }))?.encryption_applied;
+							if (!encryptionApplied) {
+								await markSuccessfulDecryption(item.type_);
+								continue;
+							}
+						}
+
 						const decryptedItem = await ItemClass.decrypt(item);
-
-						await clearDecryptionCounter();
-
-						if (!decryptedItemCounts[decryptedItem.type_]) decryptedItemCounts[decryptedItem.type_] = 0;
-
-						decryptedItemCounts[decryptedItem.type_]++;
+						await markSuccessfulDecryption(decryptedItem.type_);
 
 						if (decryptedItem.type_ === Resource.modelType() && !!decryptedItem.encryption_blob_encrypted) {
 							// itemsThatNeedDecryption() will return the resource again if the blob has not been decrypted,


### PR DESCRIPTION
PR https://github.com/laurent22/joplin/pull/16150 fixed an issue whereby the note viewer / editor on mobile does not get refreshed upon the open note being updated via the sync. However, this caused a regression, as it turns out the existing shared.reloadNote function does not actually work properly with notes which still have E2EE applied (which is the case immediately after a change is synced), and it simply displays a blank note viewer / editor if refreshed immediately after syncing an update to the note, where E2EE is enabled.

This PR addresses the issue by decrypting the note immediately upon reloading the note, and waiting for the decryption to complete before updating the screen. Additionally, the DecryptionWorker has been amended to avoid decrypting and re-saving the note if the latest version of the note has the encryption removed, since decrypting other items in the decryption loop. This is in order to prevent a race condition which could cause content in the editor to be lost, if the decryption worker is running slowly and takes a while to reach the note which was already decrypted. This also aids PR https://github.com/laurent22/joplin/pull/16023 which also makes use of on demand decryption of E2EE encrypted notes, which will prevent the decryption worker from potentially overwriting an automatically resolved conflict.

### Testing

In order to test the DecryptionWorker change, I artifically added delays for both the on demand decryption and before starting the inner loop of the DecryptionWorker after selecting the items for decryption. Using these changes locally, I could produce this race condition which I verified from the log that this occurred and did not cause any issues.

Video demonstrating the issue when a conflict refreshes the note with E2EE enabled, before the change:

https://github.com/user-attachments/assets/1bf1637b-2eb4-4664-8dd6-ca771dd8b593

Demonstrating the issue resolved, after the change:

https://github.com/user-attachments/assets/6c25bdb7-05be-4259-a0d0-ce3e2e9c5147

I also added an artificial decryption delay of 30 seconds, to verify the readonly state is enforced for each editor when a refresh is triggered, but decryption has not completed yet. The MDE prevents typing in this scenario, the plain text editor prevents both typing and focus, and the RTE does not prevent typing at all due to not supporting a readonly mode currently (but that can be addressed separately), though all saves are rejected during this period. See video of the MDE in the readonly state:

https://github.com/user-attachments/assets/a23d922e-9224-4d65-b979-c85284ee1abe



