### PR TITLE
Desktop: Fixes #16167: Fix conflict created when syncing a just-published note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1479,6 +1479,7 @@ packages/lib/models/Alarm.js
 packages/lib/models/BaseItem.test.js
 packages/lib/models/BaseItem.js
 packages/lib/models/ConflictNoteState.js
+packages/lib/models/Folder.publishing.test.js
 packages/lib/models/Folder.sharing.test.js
 packages/lib/models/Folder.test.js
 packages/lib/models/Folder.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1505,6 +1505,7 @@ packages/lib/models/Alarm.js
 packages/lib/models/BaseItem.test.js
 packages/lib/models/BaseItem.js
 packages/lib/models/ConflictNoteState.js
+packages/lib/models/Folder.publishing.test.js
 packages/lib/models/Folder.sharing.test.js
 packages/lib/models/Folder.test.js
 packages/lib/models/Folder.js

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -1251,7 +1251,7 @@ export default class Synchronizer {
 		try {
 			// Update published/unpublished status after the main sync to avoid conflicts.
 			// See https://github.com/laurent22/joplin/issues/16167.
-			await Folder.updateNotePublicationStatus(this.shareService_ ? this.shareService_.shares : [], true);
+			await Folder.updateNotePublicationStatus(this.shareService_ ? this.shareService_.shares : [], { publishedFoldersOnly: false });
 		} catch (error) {
 			logger.error('Failed to save note publication status', error);
 		}

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -1251,7 +1251,7 @@ export default class Synchronizer {
 		try {
 			// Update published/unpublished status after the main sync to avoid conflicts.
 			// See https://github.com/laurent22/joplin/issues/16167.
-			await Folder.updateNotePublicationStatus(this.shareService_ ? this.shareService_.shares : [], { publishedFoldersOnly: false });
+			await Note.updatePublishedNotes(this.shareService_ ? this.shareService_.shares : []);
 		} catch (error) {
 			logger.error('Failed to save note publication status', error);
 		}

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -1248,6 +1248,14 @@ export default class Synchronizer {
 			}
 		}
 
+		try {
+			// Update published/unpublished status after the main sync to avoid conflicts.
+			// See https://github.com/laurent22/joplin/issues/16167.
+			await Folder.updateNotePublicationStatus(this.shareService_ ? this.shareService_.shares : [], true);
+		} catch (error) {
+			logger.error('Failed to save note publication status', error);
+		}
+
 		if (syncLock) {
 			this.lockHandler().stopAutoLockRefresh(syncLock);
 			await this.lockHandler().releaseLock(LockType.Sync, this.lockClientType(), this.clientId_);

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -1251,9 +1251,12 @@ export default class Synchronizer {
 		try {
 			// Update published/unpublished status after the main sync to avoid conflicts.
 			// See https://github.com/laurent22/joplin/issues/16167.
-			await Note.updatePublishedNotes(this.shareService_ ? this.shareService_.shares : []);
+			if (!hasCaughtError && !this.cancelling()) {
+				await Note.updatePublishedNotes(this.shareService_ ? this.shareService_.shares : []);
+			}
 		} catch (error) {
 			logger.error('Failed to save note publication status', error);
+			this.progressReport_.errors.push(error);
 		}
 
 		if (syncLock) {

--- a/packages/lib/models/Folder.publishing.test.ts
+++ b/packages/lib/models/Folder.publishing.test.ts
@@ -1,7 +1,23 @@
 import { setupDatabaseAndSynchronizer, switchClient, resourceService } from '../testing/test-utils';
 import Folder from '../models/Folder';
 import { ShareType, StateShare } from '../services/share/reducer';
+import BaseItem from './BaseItem';
 
+const publishedFolderShareState = (folderId: string): StateShare => ({
+	id: `share-${folderId}`,
+	type: ShareType.PublishedFolder,
+	folder_id: folderId,
+	note_id: '',
+	master_key_id: '',
+});
+
+const expectPublished = async (id: string, published = true) => {
+	expect(await BaseItem.loadItemsByIds([id])).toMatchObject([{
+		is_shared: published ? 1 : 0,
+	}]);
+};
+
+const expectUnpublished = (id: string) => expectPublished(id, false);
 
 describe('models/Folder.publishing', () => {
 
@@ -31,13 +47,7 @@ describe('models/Folder.publishing', () => {
 		});
 
 		const shareState: StateShare[] = [
-			{
-				id: 'share-1',
-				type: ShareType.PublishedFolder,
-				folder_id: root.id,
-				note_id: '',
-				master_key_id: '',
-			},
+			publishedFolderShareState(root.id),
 		];
 
 		await Folder.updateAllShareIds(
@@ -45,20 +55,10 @@ describe('models/Folder.publishing', () => {
 			shareState,
 		);
 
-		const expectPublished = async (id: string) => {
-			expect(await Folder.load(id)).toMatchObject({
-				is_shared: 1,
-			});
-		};
-
 		await expectPublished(root.id);
 		await expectPublished(child1.id);
 		await expectPublished(child2.id);
 		await expectPublished(grandChild1.id);
-
-		expect(await Folder.load(unpublished.id)).toMatchObject({
-			title: unpublished.title,
-			is_shared: 0,
-		});
+		await expectUnpublished(unpublished.id);
 	});
 });

--- a/packages/lib/models/Folder.publishing.test.ts
+++ b/packages/lib/models/Folder.publishing.test.ts
@@ -1,7 +1,6 @@
 import { setupDatabaseAndSynchronizer, switchClient, resourceService, createFolderTree } from '../testing/test-utils';
 import Folder from '../models/Folder';
 import { ShareType, StateShare } from '../services/share/reducer';
-import BaseItem from './BaseItem';
 import Note from './Note';
 
 const publishedFolderShareState = (folderId: string): StateShare => ({
@@ -12,13 +11,19 @@ const publishedFolderShareState = (folderId: string): StateShare => ({
 	master_key_id: '',
 });
 
-const expectPublished = async (id: string, published = true) => {
-	expect(await BaseItem.loadItemsByIds([id])).toMatchObject([{
-		is_shared: published ? 1 : 0,
-	}]);
+type ItemSlice = { title: string };
+
+const expectPublished = async (items: ItemSlice[], published = true) => {
+	for (let item of items) {
+		item = (await Folder.loadByTitle(item.title)) ?? await Note.loadByTitle(item.title);
+		expect(item).toMatchObject({
+			title: item.title,
+			is_shared: published ? 1 : 0,
+		});
+	}
 };
 
-const expectUnpublished = (id: string) => expectPublished(id, false);
+const expectUnpublished = (items: ItemSlice[]) => expectPublished(items, false);
 
 describe('models/Folder.publishing', () => {
 
@@ -64,26 +69,36 @@ describe('models/Folder.publishing', () => {
 			shareState,
 		);
 
-		for (const title of [
+		// After the first round, only folders should have is_shared=1
+		await expectPublished([
 			'root',
 			'sub-folder 1',
 			'sub-folder 2',
 			'sub-sub-folder',
-		]) {
-			const id = (await Folder.loadByTitle(title)).id;
-			await expectPublished(id);
-		}
-		for (const title of [
+		].map(title => ({ title })));
+		await expectUnpublished([
 			'published note 1',
 			'published note 2',
 			'published note 3',
-		]) {
-			const id = (await Note.loadByTitle(title)).id;
-			await expectPublished(id);
-		}
+			'unpublished folder',
+			'unpublished note',
+		].map(title => ({ title })));
 
-		// Items that are not descendants of root should not be published
-		await expectUnpublished((await Folder.loadByTitle('unpublished folder')).id);
-		await expectUnpublished((await Note.loadByTitle('unpublished note')).id);
+		// Should update published notes when calling Note.updateNotePublicationStatus
+		await Note.updatePublishedNotes(shareState);
+
+		await expectPublished([
+			'root',
+			'sub-folder 1',
+			'sub-folder 2',
+			'sub-sub-folder',
+			'published note 1',
+			'published note 2',
+			'published note 3',
+		].map(title => ({ title })));
+		await expectUnpublished([
+			'unpublished folder',
+			'unpublished note',
+		].map(title => ({ title })));
 	});
 });

--- a/packages/lib/models/Folder.publishing.test.ts
+++ b/packages/lib/models/Folder.publishing.test.ts
@@ -1,0 +1,64 @@
+import { setupDatabaseAndSynchronizer, switchClient, resourceService } from '../testing/test-utils';
+import Folder from '../models/Folder';
+import { ShareType, StateShare } from '../services/share/reducer';
+
+
+describe('models/Folder.publishing', () => {
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+	});
+
+	it('should set is_shared=1 for descendants of a published folder', async () => {
+		const root = await Folder.save({
+			title: 'root',
+		});
+		const child1 = await Folder.save({
+			title: 'sub-folder-1',
+			parent_id: root.id,
+		});
+		const child2 = await Folder.save({
+			title: 'sub-folder-2',
+			parent_id: root.id,
+		});
+		const grandChild1 = await Folder.save({
+			title: 'sub-sub-folder',
+			parent_id: child1.id,
+		});
+		const unpublished = await Folder.save({
+			title: 'not published',
+		});
+
+		const shareState: StateShare[] = [
+			{
+				id: 'share-1',
+				type: ShareType.PublishedFolder,
+				folder_id: root.id,
+				note_id: '',
+				master_key_id: '',
+			},
+		];
+
+		await Folder.updateAllShareIds(
+			resourceService(),
+			shareState,
+		);
+
+		const expectPublished = async (id: string) => {
+			expect(await Folder.load(id)).toMatchObject({
+				is_shared: 1,
+			});
+		};
+
+		await expectPublished(root.id);
+		await expectPublished(child1.id);
+		await expectPublished(child2.id);
+		await expectPublished(grandChild1.id);
+
+		expect(await Folder.load(unpublished.id)).toMatchObject({
+			title: unpublished.title,
+			is_shared: 0,
+		});
+	});
+});

--- a/packages/lib/models/Folder.publishing.test.ts
+++ b/packages/lib/models/Folder.publishing.test.ts
@@ -27,7 +27,7 @@ describe('models/Folder.publishing', () => {
 		await switchClient(1);
 	});
 
-	it('should set is_shared=1 for descendants of a published folder', async () => {
+	it('should set is_shared=1 on descendants of a published folder', async () => {
 		const root = await createFolderTree('', [
 			{
 				title: 'root',

--- a/packages/lib/models/Folder.publishing.test.ts
+++ b/packages/lib/models/Folder.publishing.test.ts
@@ -1,7 +1,8 @@
-import { setupDatabaseAndSynchronizer, switchClient, resourceService } from '../testing/test-utils';
+import { setupDatabaseAndSynchronizer, switchClient, resourceService, createFolderTree } from '../testing/test-utils';
 import Folder from '../models/Folder';
 import { ShareType, StateShare } from '../services/share/reducer';
 import BaseItem from './BaseItem';
+import Note from './Note';
 
 const publishedFolderShareState = (folderId: string): StateShare => ({
 	id: `share-${folderId}`,
@@ -27,24 +28,32 @@ describe('models/Folder.publishing', () => {
 	});
 
 	it('should set is_shared=1 for descendants of a published folder', async () => {
-		const root = await Folder.save({
-			title: 'root',
-		});
-		const child1 = await Folder.save({
-			title: 'sub-folder-1',
-			parent_id: root.id,
-		});
-		const child2 = await Folder.save({
-			title: 'sub-folder-2',
-			parent_id: root.id,
-		});
-		const grandChild1 = await Folder.save({
-			title: 'sub-sub-folder',
-			parent_id: child1.id,
-		});
-		const unpublished = await Folder.save({
-			title: 'not published',
-		});
+		const root = await createFolderTree('', [
+			{
+				title: 'root',
+				children: [
+					{
+						title: 'sub-folder 1',
+						children: [],
+					},
+					{
+						title: 'sub-folder 2',
+						children: [
+							{ title: 'sub-sub-folder', children: [] },
+							{ title: 'published note 1' },
+							{ title: 'published note 2' },
+						],
+					},
+					{ title: 'published note 3' },
+				],
+			},
+			{
+				title: 'unpublished folder',
+				children: [
+					{ title: 'unpublished note' },
+				],
+			},
+		]);
 
 		const shareState: StateShare[] = [
 			publishedFolderShareState(root.id),
@@ -55,10 +64,26 @@ describe('models/Folder.publishing', () => {
 			shareState,
 		);
 
-		await expectPublished(root.id);
-		await expectPublished(child1.id);
-		await expectPublished(child2.id);
-		await expectPublished(grandChild1.id);
-		await expectUnpublished(unpublished.id);
+		for (const title of [
+			'root',
+			'sub-folder 1',
+			'sub-folder 2',
+			'sub-sub-folder',
+		]) {
+			const id = (await Folder.loadByTitle(title)).id;
+			await expectPublished(id);
+		}
+		for (const title of [
+			'published note 1',
+			'published note 2',
+			'published note 3',
+		]) {
+			const id = (await Note.loadByTitle(title)).id;
+			await expectPublished(id);
+		}
+
+		// Items that are not descendants of root should not be published
+		await expectUnpublished((await Folder.loadByTitle('unpublished folder')).id);
+		await expectUnpublished((await Note.loadByTitle('unpublished note')).id);
 	});
 });

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -797,7 +797,9 @@ export default class Folder extends BaseItem {
 			.filter(share => share.type === ShareType.PublishedFolder && !!share.folder_id)
 			.map(share => share.folder_id);
 		const publishedFolderIds = unique(publishedFolderRootIds.concat(
-			...(await Promise.all(publishedFolderRootIds.map(id => this.allChildrenFolders(id)))).map(folders => folders.map(f => f.id)),
+			(await Promise.all(
+				publishedFolderRootIds.map(id => this.allChildrenFolders(id)),
+			)).flatMap(folders => folders.map(f => f.id)),
 		));
 
 		const publishedFolderIdSet = new Set(publishedFolderIds);

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -781,19 +781,22 @@ export default class Folder extends BaseItem {
 	public static async updateAllShareIds(resourceService: ResourceService, activeShares: StateShare[]) {
 		await this.updateFolderShareIds(activeShares);
 		await this.updateNoteShareIds();
+		await this.updateResourceShareIds(resourceService);
 
+		await this.updateFolderPublishStatus_(activeShares);
+		// Don't update directly published notes to avoid unexpected conflicts
+		await this.updateNotePublicationStatus(activeShares, false);
+	}
+
+	private static async updateFolderPublishStatus_(activeShares: StateShare[]) {
 		const publishedFolderRootIds = activeShares
 			.filter(share => share.type === ShareType.PublishedFolder && !!share.folder_id)
 			.map(share => share.folder_id);
-		const directlyPublishedNoteIds = activeShares
-			.filter(share => share.type === ShareType.Note && !!share.note_id)
-			.map(share => share.note_id);
 		const publishedFolderIds = unique(publishedFolderRootIds.concat(
 			...(await Promise.all(publishedFolderRootIds.map(id => this.allChildrenFolders(id)))).map(folders => folders.map(f => f.id)),
 		));
 
 		const publishedFolderIdSet = new Set(publishedFolderIds);
-		const directlyPublishedNoteIdSet = new Set(directlyPublishedNoteIds);
 
 		if (publishedFolderIds.length) {
 			for (const folder of await this.all({ fields: ['id', 'is_shared'] })) {
@@ -801,29 +804,34 @@ export default class Folder extends BaseItem {
 				await this.updateShareStatus({ ...folder, type_: BaseModel.TYPE_FOLDER }, true);
 			}
 		}
+	}
 
-		const noteIsSharedSql = [
-			directlyPublishedNoteIds.length ? `id IN (${this.escapeIdsForSql(directlyPublishedNoteIds)})` : '',
-			publishedFolderIds.length ? `parent_id IN (${this.escapeIdsForSql(publishedFolderIds)})` : '',
-		].filter(v => !!v).join(' OR ');
+	public static async updateNotePublicationStatus(activeShares: StateShare[], includeDirectlyPublished: boolean) {
+		const directlyPublishedNoteIds = activeShares
+			.filter(share => share.type === ShareType.Note && !!share.note_id)
+			.map(share => share.note_id);
 
-		let notesToUpdate: NoteEntity[] = [];
-		if (noteIsSharedSql) {
-			notesToUpdate = await this.db().selectAll(`
-				SELECT id, parent_id, is_shared
-				FROM notes
-				WHERE is_shared = 0 AND (${noteIsSharedSql})
-			`);
-		}
+		const locallyUnpublishedNotesWithShares: NoteEntity[] = directlyPublishedNoteIds.length > 0 && includeDirectlyPublished ? (
+			await this.db().selectAll(`
+					SELECT id, parent_id, is_shared
+					FROM notes
+					WHERE is_shared = 0 AND id IN (${this.escapeIdsForSql(directlyPublishedNoteIds)})
+				`)
+		) : [];
+		const unpublishedNotesInPublishedFolders: NoteEntity[] = await this.db().selectAll(`
+			SELECT notes.id, notes.parent_id, notes.is_shared
+			FROM notes
+			JOIN folders ON notes.parent_id = folders.id
+			WHERE notes.is_shared = 0 AND folders.is_shared = 1
+		`);
 
-		for (const note of notesToUpdate) {
+		const notesToPublish = locallyUnpublishedNotesWithShares.concat(unpublishedNotesInPublishedFolders);
+		for (const note of notesToPublish) {
 			await this.updateShareStatus(
 				{ ...note, type_: BaseModel.TYPE_NOTE },
-				directlyPublishedNoteIdSet.has(note.id) || publishedFolderIdSet.has(note.parent_id),
+				true,
 			);
 		}
-
-		await this.updateResourceShareIds(resourceService);
 	}
 
 	// Clear the "share_id" property for the items that are associated with a

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -34,10 +34,6 @@ export interface SortFolderOptions {
 	includeDeleted?: boolean;
 }
 
-interface UpdateNotePublicationStatusOptions {
-	publishedFoldersOnly: boolean;
-}
-
 export default class Folder extends BaseItem {
 	public static tableName() {
 		return 'folders';
@@ -787,9 +783,9 @@ export default class Folder extends BaseItem {
 		await this.updateNoteShareIds();
 		await this.updateResourceShareIds(resourceService);
 
+		// Don't update note publication status here: Doing so can cause conflicts if updateAllShareIds
+		// is called just before sync
 		await this.updateFolderPublishStatus_(activeShares);
-		// Don't update directly published notes to avoid unexpected conflicts
-		await this.updateNotePublicationStatus(activeShares, { publishedFoldersOnly: true });
 	}
 
 	private static async updateFolderPublishStatus_(activeShares: StateShare[]) {
@@ -809,36 +805,6 @@ export default class Folder extends BaseItem {
 				if (!publishedFolderIdSet.has(folder.id)) continue;
 				await this.updateShareStatus({ ...folder, type_: BaseModel.TYPE_FOLDER }, true);
 			}
-		}
-	}
-
-	public static async updateNotePublicationStatus(activeShares: StateShare[], { publishedFoldersOnly }: UpdateNotePublicationStatusOptions) {
-		const directlyPublishedNoteIds = activeShares
-			.filter(share => share.type === ShareType.Note && !!share.note_id)
-			.map(share => share.note_id);
-
-		const loadUnpublishedWithDirectShare = async (): Promise<NoteEntity[]> => {
-			if (directlyPublishedNoteIds.length === 0 || publishedFoldersOnly) return [];
-
-			return await this.db().selectAll(`
-				SELECT id, parent_id, is_shared
-				FROM notes
-				WHERE is_shared = 0 AND id IN (${this.escapeIdsForSql(directlyPublishedNoteIds)})
-			`);
-		};
-		const unpublishedNotesInPublishedFolders: NoteEntity[] = await this.db().selectAll(`
-			SELECT notes.id, notes.parent_id, notes.is_shared
-			FROM notes
-			JOIN folders ON notes.parent_id = folders.id
-			WHERE notes.is_shared = 0 AND folders.is_shared = 1
-		`);
-
-		const notesToPublish = unpublishedNotesInPublishedFolders.concat(await loadUnpublishedWithDirectShare());
-		for (const note of notesToPublish) {
-			await this.updateShareStatus(
-				{ ...note, type_: BaseModel.TYPE_NOTE },
-				true,
-			);
 		}
 	}
 

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -34,6 +34,10 @@ export interface SortFolderOptions {
 	includeDeleted?: boolean;
 }
 
+interface UpdateNotePublicationStatusOptions {
+	publishedFoldersOnly: boolean;
+}
+
 export default class Folder extends BaseItem {
 	public static tableName() {
 		return 'folders';
@@ -785,7 +789,7 @@ export default class Folder extends BaseItem {
 
 		await this.updateFolderPublishStatus_(activeShares);
 		// Don't update directly published notes to avoid unexpected conflicts
-		await this.updateNotePublicationStatus(activeShares, false);
+		await this.updateNotePublicationStatus(activeShares, { publishedFoldersOnly: true });
 	}
 
 	private static async updateFolderPublishStatus_(activeShares: StateShare[]) {
@@ -806,18 +810,20 @@ export default class Folder extends BaseItem {
 		}
 	}
 
-	public static async updateNotePublicationStatus(activeShares: StateShare[], includeDirectlyPublished: boolean) {
+	public static async updateNotePublicationStatus(activeShares: StateShare[], { publishedFoldersOnly }: UpdateNotePublicationStatusOptions) {
 		const directlyPublishedNoteIds = activeShares
 			.filter(share => share.type === ShareType.Note && !!share.note_id)
 			.map(share => share.note_id);
 
-		const locallyUnpublishedNotesWithShares: NoteEntity[] = directlyPublishedNoteIds.length > 0 && includeDirectlyPublished ? (
-			await this.db().selectAll(`
-					SELECT id, parent_id, is_shared
-					FROM notes
-					WHERE is_shared = 0 AND id IN (${this.escapeIdsForSql(directlyPublishedNoteIds)})
-				`)
-		) : [];
+		const loadUnpublishedWithDirectShare = async (): Promise<NoteEntity[]> => {
+			if (directlyPublishedNoteIds.length === 0 || publishedFoldersOnly) return [];
+
+			return await this.db().selectAll(`
+				SELECT id, parent_id, is_shared
+				FROM notes
+				WHERE is_shared = 0 AND id IN (${this.escapeIdsForSql(directlyPublishedNoteIds)})
+			`);
+		};
 		const unpublishedNotesInPublishedFolders: NoteEntity[] = await this.db().selectAll(`
 			SELECT notes.id, notes.parent_id, notes.is_shared
 			FROM notes
@@ -825,7 +831,7 @@ export default class Folder extends BaseItem {
 			WHERE notes.is_shared = 0 AND folders.is_shared = 1
 		`);
 
-		const notesToPublish = locallyUnpublishedNotesWithShares.concat(unpublishedNotesInPublishedFolders);
+		const notesToPublish = unpublishedNotesInPublishedFolders.concat(await loadUnpublishedWithDirectShare());
 		for (const note of notesToPublish) {
 			await this.updateShareStatus(
 				{ ...note, type_: BaseModel.TYPE_NOTE },

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -29,6 +29,7 @@ import { ALL_NOTES_FILTER_ID } from '../reserved-ids';
 import NoteLockNote from '../services/noteLock/NoteLockNote';
 import isNoteLockEnabled from '../services/noteLock/isNoteLockEnabled';
 import isItemId from './utils/isItemId';
+import { ShareType, StateShare } from '../services/share/reducer';
 
 export interface PreviewsOrder {
 	by: string;
@@ -597,6 +598,36 @@ export default class Note extends BaseItem {
 
 	public static unconflictedNotes() {
 		return this.modelSelectAll('SELECT * FROM notes WHERE is_conflict = 0');
+	}
+
+	public static async updatePublishedNotes(activeShares: StateShare[]) {
+		const directlyPublishedNoteIds = activeShares
+			.filter(share => share.type === ShareType.Note && !!share.note_id)
+			.map(share => share.note_id);
+
+		const loadUnpublishedWithDirectShare = async (): Promise<NoteEntity[]> => {
+			if (directlyPublishedNoteIds.length === 0) return [];
+
+			return await this.db().selectAll(`
+				SELECT id, parent_id, is_shared
+				FROM notes
+				WHERE is_shared = 0 AND id IN (${this.escapeIdsForSql(directlyPublishedNoteIds)})
+			`);
+		};
+		const unpublishedNotesInPublishedFolders: NoteEntity[] = await this.db().selectAll(`
+			SELECT notes.id, notes.parent_id, notes.is_shared
+			FROM notes
+			JOIN folders ON notes.parent_id = folders.id
+			WHERE notes.is_shared = 0 AND folders.is_shared = 1
+		`);
+
+		const notesToPublish = unpublishedNotesInPublishedFolders.concat(await loadUnpublishedWithDirectShare());
+		for (const note of notesToPublish) {
+			await this.updateShareStatus(
+				{ ...note, type_: BaseModel.TYPE_NOTE },
+				true,
+			);
+		}
 	}
 
 	public static async updateGeolocation(noteId: string): Promise<NoteEntity | null> {

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -619,6 +619,8 @@ export default class Note extends BaseItem {
 			FROM notes
 			JOIN folders ON notes.parent_id = folders.id
 			WHERE notes.is_shared = 0 AND folders.is_shared = 1
+				AND notes.is_conflict = 0
+				AND notes.deleted_time = 0
 		`);
 
 		const notesToPublish = unpublishedNotesInPublishedFolders.concat(await loadUnpublishedWithDirectShare());

--- a/packages/tools/fuzzer/sample-fuzzer-setup.json
+++ b/packages/tools/fuzzer/sample-fuzzer-setup.json
@@ -1,16 +1,35 @@
 {
-	"clientCount": 1,
-	"description": "Changes a note, then publishes it",
+	"clientCount": 2,
+	"description": "Sample fuzzer setup: Reproduces the case where (at least historically) a large number of conflicts are created after adding a new client to an account",
 	"actions": [
-		"// Setup: Start with two clients on the same account",
 		["switchClient", { "id": 0 }],
-		["newNote", { "id": "11111111111111111111111111111110" }],
-		["newClientOnSameAccount", { "welcomeNoteCount": 0 }],
+		"sync",
+
+		"// Switch to the second client & share a folder",
+		["switchClient", { "id": 1 }],
+		["newToplevelFolder", { "id": "11111111111111111111111111111112" }],
+		["newNote", { "id": "11111111111111111111111111111113", "parentId": "11111111111111111111111111111112" }],
+		["shareFolder", { "folderId": "11111111111111111111111111111112", "otherClientId": 0, "readOnly": false }],
 		"syncAndCheckState",
 
-		"// Change a note, then publish it",
-		["updateNoteBody", { "id": "11111111111111111111111111111110"}],
-		["publishNote", { "id": "11111111111111111111111111111110" }],
+		"// Switch to the first client and do a large number of actions",
+		["switchClient", { "id": 0 }],
+		"syncAndCheckState",
+		["createOrUpdateMany", { "deleteProbability": 0, "count": 400 }],
+		"syncAndCheckState",
+
+		"// Switch back to the second client. Unshare the folder and do a large number of actions",
+		["switchClient", { "id": 1 }],
+		["unshareFolder", { "folderId": "11111111111111111111111111111112", "clientId": 0 }],
+		["createOrUpdateMany", { "deleteProbability": 0, "count": 300 }],
+
+		"// ...then share it again...",
+		["shareFolder", { "folderId": "11111111111111111111111111111112", "otherClientId": 0, "readOnly": false }],
+		"syncAndCheckState",
+
+		"// Switch back to the first client and add a new client to the same account",
+		["switchClient", { "id": 0 }],
+		["newClientOnSameAccount", { "welcomeNoteCount": 10 }],
 		"syncAndCheckState"
 	]
 }

--- a/packages/tools/fuzzer/sample-fuzzer-setup.json
+++ b/packages/tools/fuzzer/sample-fuzzer-setup.json
@@ -1,35 +1,16 @@
 {
-	"clientCount": 2,
-	"description": "Sample fuzzer setup: Reproduces the case where (at least historically) a large number of conflicts are created after adding a new client to an account",
+	"clientCount": 1,
+	"description": "Changes a note, then publishes it",
 	"actions": [
+		"// Setup: Start with two clients on the same account",
 		["switchClient", { "id": 0 }],
-		"sync",
-
-		"// Switch to the second client & share a folder",
-		["switchClient", { "id": 1 }],
-		["newToplevelFolder", { "id": "11111111111111111111111111111112" }],
-		["newNote", { "id": "11111111111111111111111111111113", "parentId": "11111111111111111111111111111112" }],
-		["shareFolder", { "folderId": "11111111111111111111111111111112", "otherClientId": 0, "readOnly": false }],
+		["newNote", { "id": "11111111111111111111111111111110" }],
+		["newClientOnSameAccount", { "welcomeNoteCount": 0 }],
 		"syncAndCheckState",
 
-		"// Switch to the first client and do a large number of actions",
-		["switchClient", { "id": 0 }],
-		"syncAndCheckState",
-		["createOrUpdateMany", { "deleteProbability": 0, "count": 400 }],
-		"syncAndCheckState",
-
-		"// Switch back to the second client. Unshare the folder and do a large number of actions",
-		["switchClient", { "id": 1 }],
-		["unshareFolder", { "folderId": "11111111111111111111111111111112", "clientId": 0 }],
-		["createOrUpdateMany", { "deleteProbability": 0, "count": 300 }],
-
-		"// ...then share it again...",
-		["shareFolder", { "folderId": "11111111111111111111111111111112", "otherClientId": 0, "readOnly": false }],
-		"syncAndCheckState",
-
-		"// Switch back to the first client and add a new client to the same account",
-		["switchClient", { "id": 0 }],
-		["newClientOnSameAccount", { "welcomeNoteCount": 10 }],
+		"// Change a note, then publish it",
+		["updateNoteBody", { "id": "11111111111111111111111111111110"}],
+		["publishNote", { "id": "11111111111111111111111111111110" }],
 		"syncAndCheckState"
 	]
 }


### PR DESCRIPTION
# Problem

Currently, downloading a newly-published note (with remote changes to the title or body) creates a conflict. This happens even if the note has no local changes.

Currently, when an existing note has been changed and published remotely:
1. [`Folder::updateAllShareIds`](https://github.com/laurent22/joplin/blob/4942bccd1e6ca0f5abd7d247099e2defac144594/packages/lib/models/Folder.ts#L781) is called at the beginning of sync, with the new share state from the server.
2. The new share state indicates that an existing note has been published.
3. `Folder::updateAllShareIds` [sets `is_shared = 1`](https://github.com/laurent22/joplin/blob/4942bccd1e6ca0f5abd7d247099e2defac144594/packages/lib/models/BaseItem.ts#L985) on the note.
  - This marks the note as changed.
4. Sync continues, downloading the remote changes to the item.
5. Both the local and remote have changes (the local change is from step 3). As such, a conflict is created.

This seems to be a regression from https://github.com/laurent22/joplin/pull/15276.


# Solution

Change what happens in `updateAllShareIds`:
- Continue to set `is_shared` for folders and sub-folders.
- Delay changing `is_shared` for notes until after the sync upload/delta+download steps have completed. The ["resync if there are changes" logic](https://github.com/laurent22/joplin/blob/2654b33620775080d1d59c552259d41e33dad3d2/packages/lib/Synchronizer.ts#L1296) should handle uploading new `is_shared` changes (if any).

Fixes #16167.

# Testing
## Sync fuzzer

1. Set `sample-fuzzer-setup.json` to:
    ```json
    {
	    "clientCount": 1,
	    "description": "Changes a note, then publishes it",
	    "actions": [
		    "// Setup: Start with two clients on the same account",
		    ["switchClient", { "id": 0 }],
		    ["newNote", { "id": "11111111111111111111111111111110" }],
		    ["newClientOnSameAccount", { "welcomeNoteCount": 0 }],
		    "syncAndCheckState",
    
		    "// Change a note, then publish it",
		    ["updateNoteBody", { "id": "11111111111111111111111111111110"}],
		    ["publishNote", { "id": "11111111111111111111111111111110" }],
		    "syncAndCheckState"
	    ]
    }
    ```
2. Run the sync fuzzer with `yarn syncFuzzer start --setup packages/tools/fuzzer/sample-fuzzer-setup.json`.
3. Verify that the sync fuzzer runs the setup steps from the JSON file successfully.
   - Previously, the fuzzer failed with unexpected conflicts in the last `syncAndCheckState` step.

## Manual

**Publishing and changing a single note no longer creates a conflict** (compare with #16167):

https://github.com/user-attachments/assets/cf76028a-2103-41e1-b6f4-cdefaf8d20e5

**Publishing a notebook is still possible**:

https://github.com/user-attachments/assets/2a303552-4b20-454a-b689-dea0121fbb30



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
