### PR TITLE
Desktop: Fixes #16016: Chat panel: Allow closing the chat panel in small windows

### DIFF
--- a/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
@@ -322,6 +322,10 @@ const ChatPanel: React.FC<Props> = (props) => {
 		dispatch({ type: 'AI_CHAT_RESET', windowId: windowId });
 	}, [dispatch, windowId, cancelRequest]);
 
+	const handleClose = useCallback(() => {
+		void CommandService.instance().executeInWindow('toggleAiChat', { windowId: windowId, args: [] });
+	}, [windowId]);
+
 	const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
 		// Don't send while an IME composition is in flight — Enter commits
 		// the composition for CJK / accented input.
@@ -415,10 +419,12 @@ const ChatPanel: React.FC<Props> = (props) => {
 			onFocus={onFocus}
 			onBlur={onBlur}
 		>
-			<div className='header'>
+			<div className='header chat-panel-header'>
 				<h1 className='title' id={headerId}>{_('AI Chat')}</h1>
-				{showingMessages && (
+				{showingMessages ? (
 					<button type='button' className='reset' onClick={handleReset}>{_('Reset')}</button>
+				) : (
+					<button type='button' className='close' onClick={handleClose}>{_('Close')}</button>
 				)}
 			</div>
 			{content}

--- a/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
+++ b/packages/app-desktop/gui/ChatPanel/ChatPanel.tsx
@@ -411,6 +411,21 @@ const ChatPanel: React.FC<Props> = (props) => {
 	const headerId = useId();
 	const { content, showingMessages } = renderContent();
 
+	const renderHeaderActions = () => {
+		if (showingMessages) {
+			return <button type='button' className='reset' onClick={handleReset}>{_('Reset')}</button>;
+		}
+
+		const closeLabel = _('Close');
+		return <button
+			type='button'
+			className='close'
+			onClick={handleClose}
+			title={closeLabel}
+			aria-label={closeLabel}
+		><i className='fas fa-times' role='img' aria-hidden={true}/></button>;
+	};
+
 	return (
 		<div
 			className='chat-panel'
@@ -421,11 +436,7 @@ const ChatPanel: React.FC<Props> = (props) => {
 		>
 			<div className='header chat-panel-header'>
 				<h1 className='title' id={headerId}>{_('AI Chat')}</h1>
-				{showingMessages ? (
-					<button type='button' className='reset' onClick={handleReset}>{_('Reset')}</button>
-				) : (
-					<button type='button' className='close' onClick={handleClose}>{_('Close')}</button>
-				)}
+				{renderHeaderActions()}
 			</div>
 			{content}
 		</div>

--- a/packages/app-desktop/gui/ChatPanel/style.scss
+++ b/packages/app-desktop/gui/ChatPanel/style.scss
@@ -19,23 +19,25 @@
 	font-weight: 600;
 }
 
-.chat-panel > .header > .title {
-	flex: 1;
-	font-size: inherit;
-	margin: 0;
-}
+.chat-panel-header {
+	> .title {
+		flex: 1;
+		font-size: inherit;
+		margin: 0;
+	}
 
-.chat-panel > .header > .reset {
-	background: none;
-	border: none;
-	color: var(--joplin-color-faded);
-	cursor: pointer;
-	font-size: 0.85em;
-	padding: 2px 6px;
-}
+	> .reset, > .close {
+		background: none;
+		border: none;
+		color: var(--joplin-color-faded);
+		cursor: pointer;
+		font-size: 0.85em;
+		padding: 2px 6px;
 
-.chat-panel > .header > .reset:hover {
-	color: var(--joplin-color);
+		&:hover {
+			color: var(--joplin-color);
+		}
+	}
 }
 
 .chat-panel > .degraded-status {


### PR DESCRIPTION
# Problem

The chat panel cannot be closed in small windows.

# Solution

Replace "reset" with a "close" button, when the chat panel is empty.

This is similar to the approach taken by @Gysum in https://github.com/laurent22/joplin/pull/16139. Unlike #16139, the close button is shown only in an empty chat.

Fixes #16016.

# Screenshots

| Comment | Screenshot/recording |
|---|---|
| An empty chat | <img width="1956" height="1686" alt="screenshot: empty chat, a close button is now present at top right" src="https://github.com/user-attachments/assets/8e1b14c8-bbbb-4058-a82e-53b0fa534d3b" /> |
| An in-progress chat | <img width="1956" height="1686" alt="screenshot: full chat, close button has been replaced with 'reset'" src="https://github.com/user-attachments/assets/bb8a2b82-531e-4797-aacb-a5e001128ab8" /> |
| Opening and closing the panel | <video src="https://github.com/user-attachments/assets/fed4ae29-a521-463f-8477-6f335106f6b7"></video> |



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
