### PR TITLE
Mobile: Prevent the remote version of a note being overwritten if typing while the sync changes the open note

### DIFF
--- a/packages/app-mobile/components/NoteEditor/MarkdownEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/MarkdownEditor.tsx
@@ -169,6 +169,10 @@ const MarkdownEditor: React.FC<EditorProps> = props => {
 
 		editorWebViewSetup.webViewEventHandlers.onMessage(event);
 	}, [editorWebViewSetup]);
+	const onLoadEnd = useCallback(() => {
+		editorWebViewSetup.webViewEventHandlers.onLoadEnd();
+		props.onLoadEnd?.();
+	}, [editorWebViewSetup, props.onLoadEnd]);
 
 	const onError = useCallback((event: NativeSyntheticEvent<WebViewErrorEvent>) => {
 		logger.error(`Load error: Code ${event.nativeEvent.code}: ${event.nativeEvent.description}`);
@@ -185,7 +189,7 @@ const MarkdownEditor: React.FC<EditorProps> = props => {
 			css={css}
 			hasPluginScripts={editorWebViewSetup.hasPlugins}
 			onMessage={onMessage}
-			onLoadEnd={editorWebViewSetup.webViewEventHandlers.onLoadEnd}
+			onLoadEnd={onLoadEnd}
 			onError={onError}
 		/>
 	);

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -75,6 +75,7 @@ interface Props {
 	onUndoRedoDepthChange: OnUndoRedoDepthChange;
 	onAttach: OnAttach;
 	refreshKey?: number;
+	onLoadEnd?: ()=> void;
 }
 
 function fontFamilyFromSettings() {
@@ -493,6 +494,7 @@ function NoteEditor(props: Props) {
 					noteResources={props.noteResources}
 					plugins={props.plugins}
 					onAttach={onAttach}
+					onLoadEnd={props.onLoadEnd}
 				/>
 			</View>
 

--- a/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
@@ -144,6 +144,10 @@ const RichTextEditor: React.FC<EditorProps> = props => {
 
 		editorWebViewSetup.webViewEventHandlers.onMessage(event);
 	}, [editorWebViewSetup]);
+	const onLoadEnd = useCallback(() => {
+		editorWebViewSetup.webViewEventHandlers.onLoadEnd();
+		props.onLoadEnd?.();
+	}, [editorWebViewSetup, props.onLoadEnd]);
 
 	const onError = useCallback((event: NativeSyntheticEvent<WebViewErrorEvent>) => {
 		logger.error(`Load error: Code ${event.nativeEvent.code}: ${event.nativeEvent.description}`);
@@ -160,7 +164,7 @@ const RichTextEditor: React.FC<EditorProps> = props => {
 			css={css}
 			hasPluginScripts={false}
 			onMessage={onMessage}
-			onLoadEnd={editorWebViewSetup.webViewEventHandlers.onLoadEnd}
+			onLoadEnd={onLoadEnd}
 			onError={onError}
 		/>
 	);

--- a/packages/app-mobile/components/NoteEditor/types.ts
+++ b/packages/app-mobile/components/NoteEditor/types.ts
@@ -68,6 +68,7 @@ export interface EditorProps {
 	plugins: PluginStates;
 
 	onAttach: OnAttachCallback;
+	onLoadEnd?: ()=> void;
 	onEditorEvent: (event: EditorEvent)=> void;
 }
 

--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -221,6 +221,24 @@ describe('screens/Note', () => {
 		unmount();
 	});
 
+	it('should discard a queued save when the reload time has moved on', async () => {
+		const noteId = await openNewNote({ title: 'Original title', body: 'Body' });
+		const { unmount } = render(<WrappedNoteScreen />);
+		const titleInput = await screen.findByDisplayValue('Original title');
+
+		await act(async () => {
+			fireEvent.changeText(titleInput, 'Stale local title');
+			const remotelyUpdatedNote = await Note.load(noteId);
+			remotelyUpdatedNote.title = 'Remote title';
+			await Note.save(remotelyUpdatedNote);
+			store.dispatch({ type: 'EDITOR_NOTE_NEEDS_RELOAD', noteId });
+		});
+
+		await waitForNoteToMatch(noteId, { title: 'Remote title' });
+		unmount();
+		await waitForNoteToMatch(noteId, { title: 'Remote title' });
+	});
+
 	it('changing the note body in the editor should update the note\'s body', async () => {
 		const defaultBody = 'Change me!';
 		const noteId = await openNewNote({ title: 'Unchanged title', body: defaultBody });

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -49,7 +49,7 @@ import restoreItems from '@joplin/lib/services/trash/restoreItems';
 import { getDisplayParentTitle } from '@joplin/lib/services/trash';
 import { PluginHtmlContents, PluginStates, utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
 import debounce from '../../../utils/debounce';
-import { focus } from '@joplin/lib/utils/focusHandler';
+import { blur, focus } from '@joplin/lib/utils/focusHandler';
 import CommandService, { RegisteredRuntime } from '@joplin/lib/services/CommandService';
 import { ResourceInfo } from '../../NoteBodyViewer/hooks/useRerenderHandler';
 import getImageDimensions from '../../../utils/image/getImageDimensions';
@@ -154,6 +154,7 @@ interface State {
 	noteResources: Record<string, ResourceInfo>;
 	newAndNoTitleChangeNoteId: boolean|null;
 	noteLastLoadTime: number;
+	reloadInProgress: boolean;
 
 	undoRedoButtonState: {
 		canUndo: boolean;
@@ -194,6 +195,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		return shared.noteComponent_change(this, 'body', saveEvent.body);
 	});
 	private refreshKey: number | undefined;
+	private reloadInProgress_ = false;
 
 	public static navigationOptions(): { header: null } {
 		return { header: null };
@@ -226,6 +228,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			imageEditorResourceFilepath: null,
 			newAndNoTitleChangeNoteId: null,
 			noteLastLoadTime: Date.now(),
+			reloadInProgress: false,
 
 			undoRedoButtonState: {
 				canUndo: false,
@@ -709,6 +712,11 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			const explicitReloadRequired = !editorPlugin && this.props.editorNoteReloadTimeRequest > this.state.noteLastLoadTime;
 
 			if (explicitReloadRequired) {
+				this.reloadInProgress_ = true;
+				Keyboard.dismiss();
+				this.editorRef.current?.hideKeyboard();
+				blur('Note::reload', this.titleTextFieldRef.current);
+				this.setState({ reloadInProgress: true });
 				void this.reloadNoteAndUpdateRefreshKey();
 			}
 
@@ -765,11 +773,24 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	}
 
 	private async reloadNoteAndUpdateRefreshKey() {
+		const refreshKey = this.props.editorNoteReloadTimeRequest;
 		await shared.reloadNote(this);
-		this.refreshKey = this.props.editorNoteReloadTimeRequest;
+		this.refreshKey = refreshKey;
+		if (this.useEditorBeta() && this.state.mode === 'edit') {
+			this.forceUpdate();
+		} else {
+			this.setState({}, () => this.editorReloadComplete(refreshKey));
+		}
 	}
 
+	private editorReloadComplete = (refreshKey: number|undefined) => {
+		if (!this.reloadInProgress_ || refreshKey !== this.props.editorNoteReloadTimeRequest) return;
+		this.reloadInProgress_ = false;
+		this.setState({ reloadInProgress: false });
+	};
+
 	private title_changeText(text: string) {
+		if (this.reloadInProgress_) return;
 		let newText = text;
 		newText = text.replace(/(\r\n|\n|\r)/gm, ' ');
 		shared.noteComponent_change(this, 'title', newText);
@@ -784,6 +805,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	}
 
 	private onPlainEditorTextChange = (text: string) => {
+		if (this.reloadInProgress_) return;
 		if (!this.undoRedoService_.canUndo) {
 			this.undoRedoService_.push(this.undoState());
 		} else {
@@ -798,6 +820,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	//
 	// See https://github.com/laurent22/joplin/issues/10130
 	private onMarkdownEditorTextChange = debounce((event: EditorChangeEvent) => {
+		if (this.reloadInProgress_) return;
 		shared.noteComponent_change(this, 'body', event.value);
 	}, 100);
 
@@ -813,9 +836,12 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		);
 	};
 
-	public makeSaveAction(state: State) {
+	public makeSaveAction(state: State, editorNoteReloadTimeRequest: number) {
 		return async () => {
-			return shared.saveNoteButton_press(this, state, null, null);
+			return shared.saveNoteButton_press(this, state, null, {
+				editorNoteReloadTimeRequest,
+				getEditorNoteReloadTimeRequest: () => this.props.editorNoteReloadTimeRequest,
+			});
 		};
 	}
 
@@ -827,7 +853,9 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	}
 
 	public scheduleSave(state: State) {
-		this.saveActionQueue(state.note.id).push(this.makeSaveAction(state));
+		if (this.reloadInProgress_) return;
+		const editorNoteReloadTimeRequest = this.props.editorNoteReloadTimeRequest;
+		this.saveActionQueue(state.note.id).push(this.makeSaveAction(state, editorNoteReloadTimeRequest));
 	}
 
 	private async saveNoteButton_press(folderId: string = null) {
@@ -1732,6 +1760,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 							keyboardAppearance={theme.keyboardAppearance}
 							placeholder={_('Add body')}
 							placeholderTextColor={theme.colorFaded}
+							editable={!this.state.readOnly && !this.state.reloadInProgress}
 							// need some extra padding for iOS so that the keyboard won't cover last line of the note
 							// see https://github.com/laurent22/joplin/issues/3607
 							// Property is gone as of RN 0.72?
@@ -1757,7 +1786,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 						onSearchVisibleChange={this.onSearchVisibleChange_}
 						onAttach={this.onAttach}
 						noteResources={this.state.noteResources}
-						readOnly={this.state.readOnly}
+						readOnly={this.state.readOnly || this.state.reloadInProgress}
 						plugins={this.props.plugins}
 						style={{
 							...editorStyle,
@@ -1776,6 +1805,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 
 						mode={this.props.editorType}
 						refreshKey={this.refreshKey}
+						onLoadEnd={() => this.editorReloadComplete(this.refreshKey)}
 					/>;
 				}
 			}
@@ -1836,7 +1866,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 					keyboardAppearance={theme.keyboardAppearance}
 					placeholder={_('Add title')}
 					placeholderTextColor={theme.colorFaded}
-					editable={!this.state.readOnly}
+					editable={!this.state.readOnly && !this.state.reloadInProgress}
 					multiline={this.state.multiline}
 					submitBehavior = "blurAndSubmit"
 				/>

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -820,10 +820,15 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	// and updating this.state.note immediately causes slow rerenders.
 	//
 	// See https://github.com/laurent22/joplin/issues/10130
-	private onMarkdownEditorTextChange = debounce((event: EditorChangeEvent) => {
-		if (this.reloadInProgress_) return;
+	private debouncedMarkdownEditorTextChange_ = debounce((event: EditorChangeEvent, reloadRequest: number) => {
+		if (this.reloadInProgress_ || reloadRequest !== this.props.editorNoteReloadTimeRequest) return;
 		shared.noteComponent_change(this, 'body', event.value);
 	}, 100);
+
+	private onMarkdownEditorTextChange = (event: EditorChangeEvent) => {
+		if (this.reloadInProgress_) return;
+		this.debouncedMarkdownEditorTextChange_(event, this.props.editorNoteReloadTimeRequest);
+	};
 
 	private onPlainEditorSelectionChange = (event: NativeSyntheticEvent<{ selection: SelectionRange }>) => {
 		this.selection = event.nativeEvent.selection;

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -773,10 +773,9 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	}
 
 	private async reloadNoteAndUpdateRefreshKey() {
-		const refreshKey = this.props.editorNoteReloadTimeRequest;
 		await shared.reloadNote(this);
-		if (refreshKey !== this.props.editorNoteReloadTimeRequest) return;
 
+		const refreshKey = this.props.editorNoteReloadTimeRequest;
 		this.refreshKey = refreshKey;
 		if (this.useEditorBeta() && this.state.mode === 'edit') {
 			this.forceUpdate();

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -775,6 +775,8 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	private async reloadNoteAndUpdateRefreshKey() {
 		const refreshKey = this.props.editorNoteReloadTimeRequest;
 		await shared.reloadNote(this);
+		if (refreshKey !== this.props.editorNoteReloadTimeRequest) return;
+
 		this.refreshKey = refreshKey;
 		if (this.useEditorBeta() && this.state.mode === 'edit') {
 			this.forceUpdate();

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -41,6 +41,8 @@ export type AttachedResources = Record<string, AttachedResource>;
 
 export interface SaveNoteOptions {
 	autoTitle?: boolean;
+	editorNoteReloadTimeRequest?: number;
+	getEditorNoteReloadTimeRequest?: ()=> number;
 }
 
 export interface BaseState {
@@ -158,6 +160,17 @@ shared.saveNoteButton_press = async function(comp: BaseNoteScreenComponent, stat
 	if (hasAutoTitle && options.autoTitle) {
 		note.title = Note.defaultTitle(note.body);
 		if (saveOptions.fields && saveOptions.fields.indexOf('title') < 0) saveOptions.fields.push('title');
+	}
+
+	// This check is intentionally immediately before Note.save. The action may
+	// have been queued, or waiting for the save mutex, when the reload was
+	// requested. In that case its note snapshot is stale and must be discarded.
+	if (
+		options.editorNoteReloadTimeRequest !== undefined &&
+		options.getEditorNoteReloadTimeRequest &&
+		options.getEditorNoteReloadTimeRequest() > options.editorNoteReloadTimeRequest
+	) {
+		return releaseMutex();
 	}
 
 	const savedNote = 'fields' in saveOptions && !saveOptions.fields.length ? { ...note } : await Note.save(note, saveOptions);


### PR DESCRIPTION
This PR fixes the remaining race condition mentioned in the PR description of https://github.com/laurent22/joplin/pull/16150. As it turns out, the race condition is not as rare as it might seem. Changing the note contents within about 0.5 seconds before the note is reloaded via an update by the sync, can cause the remote version to be overwritten with the local contents in the current editor. This can be a serious data integrity issue, particularly on mobile where changing a note triggers a sync almost immediately, and particularly with the upcoming introduction of automatically resolved conflicts, where the resolved version could also get lost as a result of multiple possible race conditions.

This PR addresses the issue by implementing the following for the mobile note editor:
1. **Block saves scheduled before reload:** Scheduled saves will now set the value of the editorNoteReloadTimeRequest prop at the point of enqueuing, and when the save is executed, it will be rejected if the editorNoteReloadTimeRequest value has since been moved on. This value is incremented by the reducer handling of the EDITOR_NOTE_NEEDS_RELOAD event, which is triggered immediately when the sync or a conflict updates a note
2. **Block scheduling new changes during reload:** This is implemented by populating a reloadInProgress prop when a reload is triggered, and marking it as completed only once the web view for the note editor has completed onLoad, with the exception of the plain text editor, which resets reloadInProgress immediately, and relies solely on the read only state to prevent changes instead. With this state established, the title_changeText, onPlainEditorTextChange and onMarkdownEditorTextChange functions are blocked while true. This covers changes to the title, MDE, RTE and plain text editor. Additionally, the editor and title components are marked as read only during this transition in all cases
3. **Blur the editor and title field while a reload is in progress:** This is done to immediately reject user input and dismiss the on screen keyboard, as continuous typing can prevent the editor from being able to refresh

Note that when typing really fast, it is possible to lose some of the text typed in the last second or so, but this is much better than losing the entire changes from remote versions or auto merged conflicts.

### Testing

Manual testing covered the following scenarios:
- Verified very fast typing while sync updates the current note is halted when the refresh occurs, and nothing is overwritten
- Verified for the MDE / RTE / plain text editor and title field, that the refresh while typing causes a blur, which dismisses the keyboard and breaks the flow of the constant typing
- Verified using a real keyboard on an Android device loses blur on the editor when typing fast, breaking the flow of the constant typing
- Verified when exiting and leaving the note after the above scenarios, that the new state shown is what was saved, where nothing else was changed post reload
- Verified normal note changes are saved and persisted
- Verified the fix works with and without E2EE enabled

Note that all testing was done with the changes in https://github.com/laurent22/joplin/pull/16179 applied, which are required when E2EE is enabled.

Original behaviour:

https://github.com/user-attachments/assets/c1dc25af-f712-489c-880c-b1a0ea6bff95

New behaviour, demonstrating no content overwritten for the title, MDE, RTE and plain text editor without encryption enabled:

https://github.com/user-attachments/assets/cdb37de8-39a7-431d-86c8-839911bc05b8

