### PR TITLE
Mobile: Fix empty navigation when navigating to settings from the conflicts folder after it was removed

### DIFF
--- a/packages/app-mobile/utils/appReducer.test.ts
+++ b/packages/app-mobile/utils/appReducer.test.ts
@@ -1,5 +1,6 @@
 import appReducer from './appReducer';
 import appDefaultState, { DEFAULT_ROUTE } from './appDefaultState';
+import Folder from '@joplin/lib/models/Folder';
 
 const notesRoute = { type: 'NAV_GO', routeName: 'Notes', folderId: 'folder1' };
 const settingsRoute = { type: 'NAV_GO', routeName: 'Config' };
@@ -41,6 +42,25 @@ describe('appReducer', () => {
 		state = appReducer(state, settingsRoute);
 
 		// Go back
+		state = appReducer(state, { type: 'NAV_BACK' });
+
+		expect(state.route).toEqual(DEFAULT_ROUTE);
+	});
+
+	test('removes the conflicts folder from navigation when it disappears', () => {
+		const conflictFolderId = Folder.conflictFolderId();
+		let state = appReducer({
+			...appDefaultState,
+			folders: [{ ...Folder.conflictFolder(), id: conflictFolderId }],
+		}, {
+			type: 'NAV_GO',
+			routeName: 'Notes',
+			folderId: conflictFolderId,
+			clearHistory: true,
+		});
+
+		state = appReducer(state, { type: 'FOLDER_UPDATE_ALL', items: [] });
+		state = appReducer(state, settingsRoute);
 		state = appReducer(state, { type: 'NAV_BACK' });
 
 		expect(state.route).toEqual(DEFAULT_ROUTE);

--- a/packages/app-mobile/utils/appReducer.ts
+++ b/packages/app-mobile/utils/appReducer.ts
@@ -4,6 +4,7 @@ import appDefaultState, { DEFAULT_ROUTE } from './appDefaultState';
 import fastDeepEqual = require('fast-deep-equal');
 import Logger from '@joplin/utils/Logger';
 import { TagsWithNoteCountEntity } from '@joplin/lib/services/database/types';
+import getConflictFolderId from '@joplin/lib/models/utils/getConflictFolderId';
 
 const logger = Logger.create('appReducer');
 
@@ -186,6 +187,32 @@ const appReducer = (state = appDefaultState, action: any) => {
 						isDeleted: true,
 					},
 				};
+			}
+			break;
+
+		case 'FOLDER_UPDATE_ALL':
+
+			{
+				const conflictFolderId = getConflictFolderId();
+				const conflictFolderRemoved = state.folders.some(folder => folder.id === conflictFolderId) &&
+					!action.items.some((folder: { id: string }) => folder.id === conflictFolderId);
+
+				if (conflictFolderRemoved) {
+					let newNavHistory = navHistory.filter(route => !(route.routeName === 'Notes' && route.folderId === conflictFolderId));
+					newNavHistory = removeAdjacentFolderDuplicates(newNavHistory);
+					removeLatestFolderIfSelected(newNavHistory, state.route);
+					navHistory.splice(0, navHistory.length, ...newNavHistory);
+
+					if (state.route.routeName === 'Notes' && state.route.folderId === conflictFolderId) {
+						newState = {
+							...state,
+							route: {
+								...state.route,
+								isDeleted: true,
+							},
+						};
+					}
+				}
 			}
 			break;
 

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -94,6 +94,7 @@ import { Platform } from 'react-native';
 import VoiceTyping from '../services/voiceTyping/VoiceTyping';
 import whisper from '../services/voiceTyping/whisper';
 import PerFolderSortOrderService from '@joplin/lib/services/sortOrder/PerFolderSortOrderService';
+import getConflictFolderId from '@joplin/lib/models/utils/getConflictFolderId';
 const { runStartupTests } = require('@joplin/mobile-config');
 
 
@@ -402,7 +403,12 @@ const buildStartupTasks = (
 
 		const notesParent = await getNotesParent();
 
-		if (notesParent && notesParent.type === 'SmartFilter') {
+		// Do not navigate to the conflicts folder if stored, because it has special behaviour and will disappear when the last note
+		// is removed from it, without being purged from notesParent and activeFolderId
+		if (notesParent.selectedItemId === getConflictFolderId() || folder.id === getConflictFolderId()) {
+			reg.logger().info(`JCC: ${notesParent.selectedItemId} ${folder.id}`);
+			dispatch(DEFAULT_ROUTE);
+		} else if (notesParent && notesParent.type === 'SmartFilter') {
 			dispatch({
 				type: 'NAV_GO',
 				routeName: 'Notes',

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -407,7 +407,6 @@ const buildStartupTasks = (
 		// is removed from it, without being purged from notesParent and activeFolderId
 		const conflictFolderId = getConflictFolderId();
 		if (notesParent?.selectedItemId === conflictFolderId || folder?.id === conflictFolderId) {
-			reg.logger().info(`JCC: ${notesParent.selectedItemId} ${folder.id}`);
 			dispatch(DEFAULT_ROUTE);
 		} else if (notesParent && notesParent.type === 'SmartFilter') {
 			dispatch({

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -405,7 +405,8 @@ const buildStartupTasks = (
 
 		// Do not navigate to the conflicts folder if stored, because it has special behaviour and will disappear when the last note
 		// is removed from it, without being purged from notesParent and activeFolderId
-		if (notesParent.selectedItemId === getConflictFolderId() || folder.id === getConflictFolderId()) {
+		const conflictFolderId = getConflictFolderId();
+		if (notesParent?.selectedItemId === conflictFolderId || folder?.id === conflictFolderId) {
 			reg.logger().info(`JCC: ${notesParent.selectedItemId} ${folder.id}`);
 			dispatch(DEFAULT_ROUTE);
 		} else if (notesParent && notesParent.type === 'SmartFilter') {


### PR DESCRIPTION
When the conflicts folder is present on mobile, if this is the last folder which has been navigated to, this can cause blank navigations when the folder is removed, due to automatically disappearing when the last conflict is deleted, instead of via a folder delete action. You will get a blank navigation if going to the settings screen and back, or simply restarting the app without navigating elsewhere first.

This PR addresses the issue by removing the conflict folder from the mobile navigation history when a FOLDER_UPDATE_ALL event is handled in the appReducer, where the previous folder list contained the conflicts notesbook, but the new list does not. Additionally, in the logic which navigates to the last notebook / tag / smart filter on app startup, this has been amended to go directly to the All Notes notebook if the last navigation was the conflicts folder, to avoid a blank navigation showing initially there.

### Testing

Verified that the blank navigation is no longer present for the above reproduction steps, and that the all notebooks notebook is shown when restarting the app where the last notebook navigation was to the conflicts notebook.

**Video before the fix:**

https://github.com/user-attachments/assets/4ebf4e5f-1f40-47cd-9468-b2a5b3461563

**Video after the fix:**

https://github.com/user-attachments/assets/65ab49be-2a30-439f-bf46-c84684b5edc7

