### PR TITLE
Desktop: Prevent the remote version of a note being overwritten if typing while the sync changes the open note

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1246,6 +1246,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 	// https://github.com/facebook/react/issues/14010#issuecomment-433788147
 	const props_onChangeRef = useRef<NoteBodyEditorProps['onChange']>(null);
 	props_onChangeRef.current = props.onChange;
+	const editorNoteReloadTimeRequestRef = useRef(props.editorNoteReloadTimeRequest);
+	editorNoteReloadTimeRequestRef.current = props.editorNoteReloadTimeRequest;
 
 	const prop_htmlToMarkdownRef = useRef<HtmlToMarkdownHandler>(null);
 	prop_htmlToMarkdownRef.current = props.htmlToMarkdown;
@@ -1258,12 +1260,14 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 		if (!info) return;
 
 		nextOnChangeEventInfo.current = null;
+		if (info.editorNoteReloadTimeRequest !== editorNoteReloadTimeRequestRef.current) return;
 
 		resetLinkTooltips();
 		const contentMd = await prop_htmlToMarkdownRef.current(info.contentMarkupLanguage, info.editor.getContent(), info.contentOriginalCss);
 
 		lastOnChangeEventInfo.current.content = contentMd;
 		lastOnChangeEventInfo.current.resourceInfos = await attachedResources(contentMd);
+		if (info.editorNoteReloadTimeRequest !== editorNoteReloadTimeRequestRef.current) return;
 
 		props_onChangeRef.current({
 			changeId: info.changeId,
@@ -1304,6 +1308,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 				editor: editor,
 				contentMarkupLanguage: props.contentMarkupLanguage,
 				contentOriginalCss: props.contentOriginalCss,
+				editorNoteReloadTimeRequest: editorNoteReloadTimeRequestRef.current,
 			};
 
 			onChangeHandlerTimeoutRef.current = shim.setTimeout(async () => {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -33,7 +33,7 @@ import { DropHandler } from '../../utils/useDropHandler';
 import Logger from '@joplin/utils/Logger';
 import useWebViewApi from './utils/useWebViewApi';
 import useLinkTooltips from './utils/useLinkTooltips';
-import { focus } from '@joplin/lib/utils/focusHandler';
+import { blur, focus } from '@joplin/lib/utils/focusHandler';
 const md5 = require('md5');
 import { clipboard } from 'electron';
 const supportedLocales = require('./supportedLocales');
@@ -185,6 +185,9 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 			content: async () => {
 				if (!editorRef.current) return '';
 				return prop_htmlToMarkdownRef.current(props.contentMarkupLanguage, editorRef.current.getContent(), props.contentOriginalCss);
+			},
+			blurEditor: () => {
+				if (editor) blur('TinyMCE::reload', editor.getBody());
 			},
 			resetScroll: () => {
 				if (editor) editor.getWin().scrollTo(0, 0);

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -920,7 +920,7 @@ const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 		whiteboardForceMarkdown: windowState.whiteboardForceMarkdown ?? {},
 		noteLockSessionUnlocked: state.noteLockSessionUnlocked,
 		hasNoteLockKey: hasNoteLockKey(state.settings['syncInfoCache']),
-		editorNoteReloadTimeRequest: windowState.editorNoteReloadTimeRequest,
+		editorNoteReloadTimeRequest: windowState.windowEditorNoteReloadTimeRequest,
 	};
 };
 

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -66,6 +66,7 @@ import useConnectToEditorPlugin from './utils/useConnectToEditorPlugin';
 import getResourceBaseUrl from './utils/getResourceBaseUrl';
 import useInitialCursorLocation from './utils/useInitialCursorLocation';
 import NotePositionService, { EditorCursorLocations } from '@joplin/lib/services/NotePositionService';
+import { blur } from '@joplin/lib/utils/focusHandler';
 
 const debounce = require('debounce');
 
@@ -84,6 +85,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 	const [showRevisions, setShowRevisions] = useState(false);
 	const [titleHasBeenManuallyChanged, setTitleHasBeenManuallyChanged] = useState(false);
 	const [isReadOnly, setIsReadOnly] = useState<boolean>(false);
+	const [reloadInProgress, setReloadInProgress] = useState(false);
 
 	const editorRef = useRef<NoteBodyEditorRef|null>(null);
 	const titleInputRef = useRef<HTMLInputElement|null>(null);
@@ -99,6 +101,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 	const formNoteRef = useRef<FormNote>(null);
 	const { saveNoteIfWillChange, scheduleSaveNote } = useScheduleSaveCallbacks({
 		setFormNote: setFormNoteRef, formNote: formNoteRef, dispatch: props.dispatch, editorRef, editorId,
+		editorNoteReloadTimeRequest: props.editorNoteReloadTimeRequest,
 	});
 	const formNote_beforeLoad = useCallback(async (event: OnLoadEvent) => {
 		await saveNoteIfWillChange(event.formNote);
@@ -123,6 +126,10 @@ function NoteEditorContent(props: NoteEditorProps) {
 	const onDecryptFailedChange = useCallback((value: boolean) => {
 		props.dispatch({ type: 'SET_ACTIVE_NOTE_IS_UNDECRYPTABLE', value, windowId });
 	}, [props.dispatch, windowId]);
+	const onReloadInProgressChange = useCallback((value: boolean) => {
+		if (value && document.activeElement instanceof HTMLElement) blur('NoteEditor::reload', document.activeElement);
+		setReloadInProgress(value);
+	}, []);
 
 	const { formNote, setFormNote, isNewNote, resourceInfos, decryptFailed, loadBlocked } = useFormNote({
 		noteId: effectiveNoteId,
@@ -135,6 +142,8 @@ function NoteEditorContent(props: NoteEditorProps) {
 		editorId,
 		noteLockSessionUnlocked: props.noteLockSessionUnlocked,
 		onDecryptFailedChange,
+		onReloadInProgressChange,
+		editorNoteReloadTimeRequest: props.editorNoteReloadTimeRequest,
 	});
 	setFormNoteRef.current = setFormNote;
 	formNoteRef.current = { ...formNote };
@@ -258,6 +267,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 	}, [formNote.title, props.onTitleChange]);
 
 	const onFieldChange = useCallback(async (field: string, value: string, changeId = 0) => {
+		if (reloadInProgress) return;
 		if (!isMountedRef.current) {
 			// When the component is unmounted, various actions can happen which can
 			// trigger onChange events, for example the textarea might be cleared.
@@ -306,7 +316,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 			// - debounced because many calls to scheduleSaveNote can resolve at once
 			scheduleNoteListResort();
 		}
-	}, [handleProvisionalFlag, formNote, setFormNote, isNewNote, titleHasBeenManuallyChanged, scheduleNoteListResort, scheduleSaveNote]);
+	}, [reloadInProgress, handleProvisionalFlag, formNote, setFormNote, isNewNote, titleHasBeenManuallyChanged, scheduleNoteListResort, scheduleSaveNote]);
 
 	const onDrop = useDropHandler({ editorRef });
 
@@ -497,7 +507,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 		htmlToMarkdown: htmlToMarkdown,
 		markupToHtml: markupToHtml,
 		allAssets: allAssets,
-		disabled: isReadOnly,
+		disabled: isReadOnly || reloadInProgress,
 		themeId: props.themeId,
 		dispatch: props.dispatch,
 		noteToolbar: null,
@@ -793,7 +803,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 					noteTitle={formNote.title}
 					noteUserUpdatedTime={formNote.user_updated_time}
 					onTitleChange={onTitleChange}
-					disabled={isReadOnly}
+					disabled={isReadOnly || reloadInProgress}
 				/>
 				{renderSearchInfo()}
 				<div style={{ display: 'flex', flex: 1, paddingLeft: theme.editorPaddingLeft, maxHeight: '100%', minHeight: '0' }}>
@@ -888,6 +898,7 @@ const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 		whiteboardForceMarkdown: windowState.whiteboardForceMarkdown ?? {},
 		noteLockSessionUnlocked: state.noteLockSessionUnlocked,
 		hasNoteLockKey: hasNoteLockKey(state.settings['syncInfoCache']),
+		editorNoteReloadTimeRequest: windowState.editorNoteReloadTimeRequest,
 	};
 };
 

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -129,7 +129,16 @@ function NoteEditorContent(props: NoteEditorProps) {
 	const onReloadInProgressChange = useCallback((value: boolean) => {
 		if (value && document.activeElement instanceof HTMLElement) blur('NoteEditor::reload', document.activeElement);
 		setReloadInProgress(value);
-	}, []);
+		if (!value) {
+			// TinyMCE can report onWillChange before a reload, then have its delayed
+			// onChange rejected while the reload is in progress. Since no save is queued
+			// in that case, clear the saving status when the reload completes.
+			props.dispatch({
+				type: 'EDITOR_NOTE_STATUS_REMOVE',
+				id: effectiveNoteId,
+			});
+		}
+	}, [effectiveNoteId, props.dispatch]);
 
 	const { formNote, setFormNote, isNewNote, resourceInfos, decryptFailed, loadBlocked } = useFormNote({
 		noteId: effectiveNoteId,

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -127,7 +127,19 @@ function NoteEditorContent(props: NoteEditorProps) {
 		props.dispatch({ type: 'SET_ACTIVE_NOTE_IS_UNDECRYPTABLE', value, windowId });
 	}, [props.dispatch, windowId]);
 	const onReloadInProgressChange = useCallback((value: boolean) => {
-		if (value && document.activeElement instanceof HTMLElement) blur('NoteEditor::reload', document.activeElement);
+		if (value) {
+			// TinyMCE edits inside its own document. Blurring only the outer window does
+			// not reliably stop input when the editor is in a secondary window.
+			editorRef.current?.blurEditor?.();
+
+			// Blur only the window whose editor is being refreshed. A secondary window
+			// can refresh in response to a change saved by the main editor; blurring the
+			// global document here would incorrectly interrupt typing in the main window.
+			const editorWindowActiveElement = containerRef.current?.ownerDocument?.activeElement;
+			if (editorWindowActiveElement) {
+				blur('NoteEditor::reloadEditorWindow', editorWindowActiveElement);
+			}
+		}
 		setReloadInProgress(value);
 		if (!value) {
 			// TinyMCE can report onWillChange before a reload, then have its delayed

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -522,6 +522,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 		content: formNote.body,
 		contentMarkupLanguage: markupLanguage,
 		contentOriginalCss: formNote.originalCss,
+		editorNoteReloadTimeRequest: props.editorNoteReloadTimeRequest,
 		initialCursorLocation,
 		resourceInfos: resourceInfos,
 		resourceDirectory: Setting.value('resourceDir'),

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -118,6 +118,7 @@ export interface NoteBodyEditorProps {
 	contentKey: string;
 	contentMarkupLanguage: number;
 	contentOriginalCss: string;
+	editorNoteReloadTimeRequest: number;
 	initialCursorLocation: EditorCursorLocations;
 	onChange(event: OnChangeEvent): void;
 	onWillChange(event: { changeId: number }): void;

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -76,6 +76,7 @@ export interface NoteEditorProps {
 	whiteboardForceMarkdown: Record<string, boolean>;
 	noteLockSessionUnlocked: boolean;
 	hasNoteLockKey: boolean;
+	editorNoteReloadTimeRequest: number;
 }
 
 export interface NoteBodyEditorRef {

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -81,6 +81,7 @@ export interface NoteEditorProps {
 
 export interface NoteBodyEditorRef {
 	content(): string|Promise<string>;
+	blurEditor?(): void;
 	resetScroll(): void;
 	scrollTo(options: ScrollOptions): void;
 

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
@@ -267,6 +267,28 @@ describe('useFormNote', () => {
 		formNote.unmount();
 	});
 
+	it('should let the tokened reload handle sync changes', async () => {
+		const note = await Note.save({ title: 'Original', body: '...' });
+		const onReloadInProgressChange = jest.fn();
+		const props = { ...defaultFormNoteProps, noteId: note.id, editorNoteReloadTimeRequest: 0, onReloadInProgressChange };
+		const formNote = renderHook(hookProps => useFormNote(hookProps), { initialProps: props });
+		await waitFor(() => expect(formNote.result.current.formNote.title).toBe('Original'));
+
+		const loadMock = jest.spyOn(Note, 'load');
+		// A synchronizer save emits ItemChange before dispatching
+		// EDITOR_NOTE_NEEDS_RELOAD. Simulate that ordering here.
+		await Note.save({ id: note.id, title: 'Remote title' });
+		// Ignore Note.load calls internal to Note.save itself.
+		loadMock.mockClear();
+		formNote.rerender({ ...props, editorNoteReloadTimeRequest: 1 });
+		await waitFor(() => expect(loadMock).toHaveBeenCalledTimes(1));
+		await waitFor(() => expect(formNote.result.current.formNote.title).toBe('Remote title'));
+		await waitFor(() => expect(onReloadInProgressChange).toHaveBeenLastCalledWith(false));
+
+		loadMock.mockRestore();
+		formNote.unmount();
+	});
+
 	it('should clear reloadInProgress after overlapping reload requests', async () => {
 		const note = await Note.save({ title: 'Original', body: '...' });
 		const onReloadInProgressChange = jest.fn();

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
@@ -270,28 +270,6 @@ describe('useFormNote', () => {
 		formNote.unmount();
 	});
 
-	it('should let the tokened reload handle sync changes', async () => {
-		const note = await Note.save({ title: 'Original', body: '...' });
-		const onReloadInProgressChange = jest.fn();
-		const props = { ...defaultFormNoteProps, noteId: note.id, editorNoteReloadTimeRequest: 0, onReloadInProgressChange };
-		const formNote = renderHook(hookProps => useFormNote(hookProps), { initialProps: props });
-		await waitFor(() => expect(formNote.result.current.formNote.title).toBe('Original'));
-
-		const loadMock = jest.spyOn(Note, 'load');
-		// A synchronizer save emits ItemChange before dispatching
-		// EDITOR_NOTE_NEEDS_RELOAD. Simulate that ordering here.
-		await Note.save({ id: note.id, title: 'Remote title' });
-		// Ignore Note.load calls internal to Note.save itself.
-		loadMock.mockClear();
-		formNote.rerender({ ...props, editorNoteReloadTimeRequest: 1 });
-		await waitFor(() => expect(loadMock).toHaveBeenCalledTimes(1));
-		await waitFor(() => expect(formNote.result.current.formNote.title).toBe('Remote title'));
-		await waitFor(() => expect(onReloadInProgressChange).toHaveBeenLastCalledWith(false));
-
-		loadMock.mockRestore();
-		formNote.unmount();
-	});
-
 	it('should clear reloadInProgress after overlapping reload requests', async () => {
 		const note = await Note.save({ title: 'Original', body: '...' });
 		const onReloadInProgressChange = jest.fn();

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
@@ -24,6 +24,14 @@ const defaultFormNoteProps: HookDependencies = {
 	onDecryptFailedChange: () => {},
 };
 
+const deferred = <T>() => {
+	let resolve: (value: T)=> void;
+	const promise = new Promise<T>(resolvePromise => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve: resolve! };
+};
+
 describe('useFormNote', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
@@ -237,6 +245,54 @@ describe('useFormNote', () => {
 			expect(formNote.result.current.formNote.title).toBe('Modified');
 		});
 
+		formNote.unmount();
+	});
+
+	it('should force a reload when editorNoteReloadTimeRequest changes', async () => {
+		const note = await Note.save({ title: 'Original', body: '...' });
+		const onReloadInProgressChange = jest.fn();
+		const props = { ...defaultFormNoteProps, noteId: note.id, editorNoteReloadTimeRequest: 0, onReloadInProgressChange };
+		const formNote = renderHook(hookProps => useFormNote(hookProps), { initialProps: props });
+		await waitFor(() => expect(formNote.result.current.formNote.title).toBe('Original'));
+
+		act(() => {
+			formNote.result.current.setFormNote(previous => ({ ...previous, title: 'Unsaved local title', hasChanged: true }));
+		});
+		await Note.save({ id: note.id, title: 'Remote title' }, { changeId: 'test-editor' });
+		formNote.rerender({ ...props, editorNoteReloadTimeRequest: 1 });
+
+		await waitFor(() => expect(onReloadInProgressChange).toHaveBeenCalledWith(true));
+		await waitFor(() => expect(formNote.result.current.formNote.title).toBe('Remote title'));
+		await waitFor(() => expect(onReloadInProgressChange).toHaveBeenLastCalledWith(false));
+		formNote.unmount();
+	});
+
+	it('should clear reloadInProgress after overlapping reload requests', async () => {
+		const note = await Note.save({ title: 'Original', body: '...' });
+		const onReloadInProgressChange = jest.fn();
+		const props = { ...defaultFormNoteProps, noteId: note.id, editorNoteReloadTimeRequest: 0, onReloadInProgressChange };
+		const formNote = renderHook(hookProps => useFormNote(hookProps), { initialProps: props });
+		await waitFor(() => expect(formNote.result.current.formNote.title).toBe('Original'));
+
+		const firstLoad = deferred<typeof note>();
+		const lastLoad = deferred<typeof note>();
+		const loadMock = jest.spyOn(Note, 'load')
+			.mockImplementationOnce(() => firstLoad.promise)
+			.mockImplementationOnce(() => lastLoad.promise);
+
+		formNote.rerender({ ...props, editorNoteReloadTimeRequest: 1 });
+		await waitFor(() => expect(loadMock).toHaveBeenCalledTimes(1));
+		formNote.rerender({ ...props, editorNoteReloadTimeRequest: 2 });
+
+		firstLoad.resolve({ ...note, title: 'First reload' });
+		await waitFor(() => expect(loadMock).toHaveBeenCalledTimes(2));
+		expect(onReloadInProgressChange).toHaveBeenLastCalledWith(true);
+
+		lastLoad.resolve({ ...note, title: 'Last reload' });
+		await waitFor(() => expect(formNote.result.current.formNote.title).toBe('Last reload'));
+		await waitFor(() => expect(onReloadInProgressChange).toHaveBeenLastCalledWith(false));
+
+		loadMock.mockRestore();
 		formNote.unmount();
 	});
 

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
@@ -222,10 +222,12 @@ describe('useFormNote', () => {
 
 	it('should reload the note when it is changed outside of the editor', async () => {
 		const note = await Note.save({ title: 'Test Note!', body: '...' });
+		const onReloadInProgressChange = jest.fn();
 
 		const props = {
 			...defaultFormNoteProps,
 			noteId: note.id,
+			onReloadInProgressChange,
 		};
 
 		const formNote = renderHook(props => useFormNote(props), {
@@ -244,6 +246,7 @@ describe('useFormNote', () => {
 		await waitFor(() => {
 			expect(formNote.result.current.formNote.title).toBe('Modified');
 		});
+		expect(onReloadInProgressChange).not.toHaveBeenCalled();
 
 		formNote.unmount();
 	});

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -99,6 +99,8 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 	// a new refresh.
 	const [formNoteRefreshRequest, setFormNoteRefreshRequest] = useState({ counter: 0, force: false });
 	const previousEditorNoteReloadTimeRequestRef = useRef(editorNoteReloadTimeRequest);
+	const editorNoteReloadTimeRequestRef = useRef(editorNoteReloadTimeRequest);
+	editorNoteReloadTimeRequestRef.current = editorNoteReloadTimeRequest;
 	const prevBuiltInEditorVisible = usePrevious<boolean>(builtInEditorVisible);
 	// Seeded because usePrevious defaults to null, which would read as a session change on mount.
 	const prevNoteLockSessionUnlocked = usePrevious<boolean>(noteLockSessionUnlocked, noteLockSessionUnlocked);
@@ -189,6 +191,7 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 		if (!noteId) return ()=>{};
 
 		let cancelled = false;
+		let itemChangeRefreshTimeout: ReturnType<typeof setTimeout>|null = null;
 
 		type ChangeEventSlice = { itemId: string; changeId: string };
 		const listener = ({ itemId, changeId }: ChangeEventSlice) => {
@@ -197,16 +200,27 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 			// aren't ignored, most user-activated note changes (e.g. a keypress)
 			// cause the note to refresh. (Undesired refreshes can cause the cursor to jump).
 			const isExternalChange = !(changeId ?? 'unknown').endsWith(editorId);
-			if (itemId === noteId && !cancelled && isExternalChange) {
+			if (itemId !== noteId || cancelled || !isExternalChange) return;
+
+			const reloadRequestAtChange = editorNoteReloadTimeRequestRef.current;
+			if (itemChangeRefreshTimeout) clearTimeout(itemChangeRefreshTimeout);
+			// A sync save emits ItemChange just before it dispatches EDITOR_NOTE_NEEDS_RELOAD.
+			// Yield one task so the reload request can reach this editor first. If its token
+			// changes, the tokened reload handles the update and this generic refresh is skipped.
+			// For other external changes the token remains unchanged, so the refresh proceeds.
+			itemChangeRefreshTimeout = setTimeout(() => {
+				itemChangeRefreshTimeout = null;
+				if (cancelled || editorNoteReloadTimeRequestRef.current !== reloadRequestAtChange) return;
 				if (formNoteRef.current.hasChanged) return;
 				refreshFormNote();
-			}
+			}, 0);
 		};
 		eventManager.on(EventName.ItemChange, listener);
 
 		return () => {
 			eventManager.off(EventName.ItemChange, listener);
 			cancelled = true;
+			if (itemChangeRefreshTimeout) clearTimeout(itemChangeRefreshTimeout);
 		};
 	}, [formNoteRef, noteId, editorId, refreshFormNote]);
 };

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -99,8 +99,6 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 	// a new refresh.
 	const [formNoteRefreshRequest, setFormNoteRefreshRequest] = useState({ counter: 0, force: false });
 	const previousEditorNoteReloadTimeRequestRef = useRef(editorNoteReloadTimeRequest);
-	const editorNoteReloadTimeRequestRef = useRef(editorNoteReloadTimeRequest);
-	editorNoteReloadTimeRequestRef.current = editorNoteReloadTimeRequest;
 	const prevBuiltInEditorVisible = usePrevious<boolean>(builtInEditorVisible);
 	// Seeded because usePrevious defaults to null, which would read as a session change on mount.
 	const prevNoteLockSessionUnlocked = usePrevious<boolean>(noteLockSessionUnlocked, noteLockSessionUnlocked);
@@ -191,7 +189,6 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 		if (!noteId) return ()=>{};
 
 		let cancelled = false;
-		let itemChangeRefreshTimeout: ReturnType<typeof setTimeout>|null = null;
 
 		type ChangeEventSlice = { itemId: string; changeId: string };
 		const listener = ({ itemId, changeId }: ChangeEventSlice) => {
@@ -200,27 +197,16 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 			// aren't ignored, most user-activated note changes (e.g. a keypress)
 			// cause the note to refresh. (Undesired refreshes can cause the cursor to jump).
 			const isExternalChange = !(changeId ?? 'unknown').endsWith(editorId);
-			if (itemId !== noteId || cancelled || !isExternalChange) return;
-
-			const reloadRequestAtChange = editorNoteReloadTimeRequestRef.current;
-			if (itemChangeRefreshTimeout) clearTimeout(itemChangeRefreshTimeout);
-			// A sync save emits ItemChange just before it dispatches EDITOR_NOTE_NEEDS_RELOAD.
-			// Yield one task so the reload request can reach this editor first. If its token
-			// changes, the tokened reload handles the update and this generic refresh is skipped.
-			// For other external changes the token remains unchanged, so the refresh proceeds.
-			itemChangeRefreshTimeout = setTimeout(() => {
-				itemChangeRefreshTimeout = null;
-				if (cancelled || editorNoteReloadTimeRequestRef.current !== reloadRequestAtChange) return;
+			if (itemId === noteId && !cancelled && isExternalChange) {
 				if (formNoteRef.current.hasChanged) return;
 				refreshFormNote();
-			}, 0);
+			}
 		};
 		eventManager.on(EventName.ItemChange, listener);
 
 		return () => {
 			eventManager.off(EventName.ItemChange, listener);
 			cancelled = true;
-			if (itemChangeRefreshTimeout) clearTimeout(itemChangeRefreshTimeout);
 		};
 	}, [formNoteRef, noteId, editorId, refreshFormNote]);
 };

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -106,6 +106,7 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 	const prevNoteLockSessionUnlocked = usePrevious<boolean>(noteLockSessionUnlocked, noteLockSessionUnlocked);
 
 	useQueuedAsyncEffect(async (event) => {
+		if (event.cancelled) return;
 		if (formNoteRefreshRequest.counter <= 0) return;
 		const forceRefresh = formNoteRefreshRequest.force;
 		if (formNoteRef.current.hasChanged && !forceRefresh) {

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -36,6 +36,8 @@ export interface HookDependencies {
 	builtInEditorVisible: boolean;
 	noteLockSessionUnlocked: boolean;
 	onDecryptFailedChange(value: boolean): void;
+	onReloadInProgressChange?(value: boolean): void;
+	editorNoteReloadTimeRequest?: number;
 }
 
 type MapFormNoteCallback = (previousFormNote: FormNote)=> FormNote;
@@ -91,19 +93,22 @@ const loadNoteForForm = async (noteId: string): Promise<{ note: NoteEntity|null;
 	return { note: await Note.load(noteId), blocked: false, decryptFailed: false };
 };
 
-type InitNoteStateCallback = (note: NoteEntity, isNew: boolean)=> Promise<FormNote>;
-const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: string, noteId: string, initNoteState: InitNoteStateCallback, clearFormNote: ()=> void, builtInEditorVisible: boolean, noteLockSessionUnlocked: boolean, setDecryptFailed: (value: boolean)=> void, setLoadBlocked: (value: boolean)=> void) => {
+type InitNoteStateCallback = (note: NoteEntity, isNew: boolean, force?: boolean)=> Promise<FormNote>;
+const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: string, noteId: string, initNoteState: InitNoteStateCallback, clearFormNote: ()=> void, builtInEditorVisible: boolean, noteLockSessionUnlocked: boolean, setDecryptFailed: (value: boolean)=> void, setLoadBlocked: (value: boolean)=> void, onReloadInProgressChange: (value: boolean)=> void, editorNoteReloadTimeRequest: number) => {
 	// Increasing the value of this counter cancels any ongoing note refreshes and starts
 	// a new refresh.
-	const [formNoteRefreshScheduled, setFormNoteRefreshScheduled] = useState<number>(0);
+	const [formNoteRefreshRequest, setFormNoteRefreshRequest] = useState({ counter: 0, force: false });
+	const previousEditorNoteReloadTimeRequestRef = useRef(editorNoteReloadTimeRequest);
 	const prevBuiltInEditorVisible = usePrevious<boolean>(builtInEditorVisible);
 	// Seeded because usePrevious defaults to null, which would read as a session change on mount.
 	const prevNoteLockSessionUnlocked = usePrevious<boolean>(noteLockSessionUnlocked, noteLockSessionUnlocked);
 
 	useQueuedAsyncEffect(async (event) => {
-		if (formNoteRefreshScheduled <= 0) return;
-		if (formNoteRef.current.hasChanged) {
+		if (formNoteRefreshRequest.counter <= 0) return;
+		const forceRefresh = formNoteRefreshRequest.force;
+		if (formNoteRef.current.hasChanged && !forceRefresh) {
 			logger.info('Form note changed between scheduling a refresh and the refresh itself. Cancelling the refresh.');
+			onReloadInProgressChange(false);
 			return;
 		}
 
@@ -112,7 +117,7 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 		const loadNote = async () => {
 			setDecryptFailed(false);
 			const { note: n, blocked, decryptFailed } = await loadNoteForForm(noteId);
-			if (event.cancelled || formNoteRef.current.hasChanged) return;
+			if (event.cancelled || (formNoteRef.current.hasChanged && !forceRefresh)) return;
 
 			setLoadBlocked(blocked);
 			setDecryptFailed(decryptFailed);
@@ -129,28 +134,39 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 					return;
 				}
 
-				await initNoteState(n, false);
+				await initNoteState(n, false, forceRefresh);
 				if (event.cancelled) return;
 			}
-			setFormNoteRefreshScheduled(oldValue => {
+			setFormNoteRefreshRequest(oldValue => {
 				// If a new refresh was scheduled between initNoteState
 				// and now:
-				if (oldValue !== formNoteRefreshScheduled) {
+				if (oldValue.counter !== formNoteRefreshRequest.counter) {
 					return oldValue;
 				}
 				// A refresh is no longer scheduled
-				return 0;
+				return { counter: 0, force: false };
 			});
 		};
 
-		await loadNote();
-	}, [formNoteRefreshScheduled, noteId, editorId, initNoteState, clearFormNote, setDecryptFailed]);
+		try {
+			await loadNote();
+		} finally {
+			if (!event.cancelled) onReloadInProgressChange(false);
+		}
+	}, [formNoteRefreshRequest, noteId, editorId, initNoteState, clearFormNote, setDecryptFailed, onReloadInProgressChange]);
 
-	const refreshFormNote = useCallback(() => {
+	const refreshFormNote = useCallback((force = false) => {
 		// Increase the counter to cancel any ongoing refresh attempts
 		// and start a new one.
-		setFormNoteRefreshScheduled(count => count + 1);
-	}, []);
+		onReloadInProgressChange(true);
+		setFormNoteRefreshRequest(previous => ({ counter: previous.counter + 1, force: previous.force || force }));
+	}, [onReloadInProgressChange]);
+
+	useEffect(() => {
+		if (editorNoteReloadTimeRequest === previousEditorNoteReloadTimeRequestRef.current) return;
+		previousEditorNoteReloadTimeRequestRef.current = editorNoteReloadTimeRequest;
+		refreshFormNote(true);
+	}, [editorNoteReloadTimeRequest, refreshFormNote]);
 
 	// When switching from the plugin editor to the built-in editor, we refresh the note since the
 	// plugin may have modified it via the data API.
@@ -199,6 +215,8 @@ export default function useFormNote(dependencies: HookDependencies) {
 	const {
 		noteId, isProvisional, titleInputRef, editorRef, onBeforeLoad, onAfterLoad, builtInEditorVisible, editorId, noteLockSessionUnlocked, onDecryptFailedChange,
 	} = dependencies;
+	const onReloadInProgressChange = dependencies.onReloadInProgressChange ?? (() => {});
+	const editorNoteReloadTimeRequest = dependencies.editorNoteReloadTimeRequest ?? 0;
 
 	const [formNote, setFormNote] = useState<FormNote>(defaultFormNote());
 	const [isNewNote, setIsNewNote] = useState(false);
@@ -216,7 +234,7 @@ export default function useFormNote(dependencies: HookDependencies) {
 	const formNoteRef = useRef(formNote);
 	formNoteRef.current = formNote;
 
-	const initNoteState: InitNoteStateCallback = useCallback(async (n, isNewNote) => {
+	const initNoteState: InitNoteStateCallback = useCallback(async (n, isNewNote, force = false) => {
 		let noteLockKey = null;
 		if (isNoteLockEnabled() && NoteLockNote.isLocked(n)) {
 			// The session can lock between the gated load and here (e.g. lock-on-switch) - drop
@@ -265,7 +283,7 @@ export default function useFormNote(dependencies: HookDependencies) {
 
 		// If the user changes the note while resources are loading, this can lead to
 		// a note being incorrectly marked as "unchanged".
-		if (!isNewNote && formNoteRef.current?.hasChanged) {
+		if (!isNewNote && formNoteRef.current?.hasChanged && !force) {
 			logger.info('Cancelled note refresh -- form note changed while loading attached resources.');
 			return null;
 		}
@@ -285,7 +303,7 @@ export default function useFormNote(dependencies: HookDependencies) {
 		setFormNote(formNoteRef.current);
 	}, []);
 
-	useRefreshFormNoteOnChange(formNoteRef, editorId, noteId, initNoteState, clearFormNote, builtInEditorVisible, noteLockSessionUnlocked, setDecryptFailed, setLoadBlocked);
+	useRefreshFormNoteOnChange(formNoteRef, editorId, noteId, initNoteState, clearFormNote, builtInEditorVisible, noteLockSessionUnlocked, setDecryptFailed, setLoadBlocked, onReloadInProgressChange, editorNoteReloadTimeRequest);
 
 	useEffect(() => {
 		if (!noteId) {

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -111,7 +111,6 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 		const forceRefresh = formNoteRefreshRequest.force;
 		if (formNoteRef.current.hasChanged && !forceRefresh) {
 			logger.info('Form note changed between scheduling a refresh and the refresh itself. Cancelling the refresh.');
-			onReloadInProgressChange(false);
 			return;
 		}
 
@@ -154,14 +153,14 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 		try {
 			await loadNote();
 		} finally {
-			if (!event.cancelled) onReloadInProgressChange(false);
+			if (forceRefresh && !event.cancelled) onReloadInProgressChange(false);
 		}
 	}, [formNoteRefreshRequest, noteId, editorId, initNoteState, clearFormNote, setDecryptFailed, onReloadInProgressChange]);
 
 	const refreshFormNote = useCallback((force = false) => {
 		// Increase the counter to cancel any ongoing refresh attempts
 		// and start a new one.
-		onReloadInProgressChange(true);
+		if (force) onReloadInProgressChange(true);
 		setFormNoteRefreshRequest(previous => ({ counter: previous.counter + 1, force: previous.force || force }));
 	}, [onReloadInProgressChange]);
 

--- a/packages/app-desktop/gui/NoteEditor/utils/useScheduleSaveCallbacks.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useScheduleSaveCallbacks.ts
@@ -32,16 +32,7 @@ const useScheduleSaveCallbacks = (props: Props) => {
 		const editorNoteReloadTimeRequest = editorNoteReloadTimeRequestRef.current;
 		const makeAction = (formNote: FormNote) => {
 			return async function() {
-				if (editorNoteReloadTimeRequestRef.current > editorNoteReloadTimeRequest) {
-					// onWillChange marks the note as saving before this action is queued. If a
-					// reload makes the action stale, no later part of the action will clear that
-					// status, leaving commands such as the RTE/MDE toggle disabled.
-					props.dispatch({
-						type: 'EDITOR_NOTE_STATUS_REMOVE',
-						id: formNote.id,
-					});
-					return;
-				}
+				if (editorNoteReloadTimeRequestRef.current > editorNoteReloadTimeRequest) return;
 
 				// The lock state may change between scheduling and execution (e.g. encryption enabled
 				// from the note list menu), so the save uses the latest form state for this note.

--- a/packages/app-desktop/gui/NoteEditor/utils/useScheduleSaveCallbacks.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useScheduleSaveCallbacks.ts
@@ -1,5 +1,5 @@
 import Logger from '@joplin/utils/Logger';
-import { RefObject, useCallback } from 'react';
+import { RefObject, useCallback, useRef } from 'react';
 import { FormNote, NoteBodyEditorRef } from './types';
 import { formNoteToNote } from '.';
 import ExternalEditWatcher from '@joplin/lib/services/ExternalEditWatcher';
@@ -17,16 +17,23 @@ interface Props {
 	editorId: string;
 	dispatch: Dispatch;
 	editorRef: RefObject<NoteBodyEditorRef>;
+	editorNoteReloadTimeRequest: number;
 }
 
 const useScheduleSaveCallbacks = (props: Props) => {
+	const editorNoteReloadTimeRequestRef = useRef(props.editorNoteReloadTimeRequest);
+	editorNoteReloadTimeRequestRef.current = props.editorNoteReloadTimeRequest;
+
 	const scheduleSaveNote = useCallback((formNote: FormNote) => {
 		if (!formNote.saveActionQueue) throw new Error('saveActionQueue is not set!!'); // Sanity check
 
 		// reg.logger().debug('Scheduling...', formNote);
 
+		const editorNoteReloadTimeRequest = editorNoteReloadTimeRequestRef.current;
 		const makeAction = (formNote: FormNote) => {
 			return async function() {
+				if (editorNoteReloadTimeRequestRef.current > editorNoteReloadTimeRequest) return;
+
 				// The lock state may change between scheduling and execution (e.g. encryption enabled
 				// from the note list menu), so the save uses the latest form state for this note.
 				const latestFormNote = props.formNote.current?.id === formNote.id ? props.formNote.current : formNote;

--- a/packages/app-desktop/gui/NoteEditor/utils/useScheduleSaveCallbacks.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useScheduleSaveCallbacks.ts
@@ -32,7 +32,16 @@ const useScheduleSaveCallbacks = (props: Props) => {
 		const editorNoteReloadTimeRequest = editorNoteReloadTimeRequestRef.current;
 		const makeAction = (formNote: FormNote) => {
 			return async function() {
-				if (editorNoteReloadTimeRequestRef.current > editorNoteReloadTimeRequest) return;
+				if (editorNoteReloadTimeRequestRef.current > editorNoteReloadTimeRequest) {
+					// onWillChange marks the note as saving before this action is queued. If a
+					// reload makes the action stale, no later part of the action will clear that
+					// status, leaving commands such as the RTE/MDE toggle disabled.
+					props.dispatch({
+						type: 'EDITOR_NOTE_STATUS_REMOVE',
+						id: formNote.id,
+					});
+					return;
+				}
 
 				// The lock state may change between scheduling and execution (e.g. encryption enabled
 				// from the note list menu), so the save uses the latest form state for this note.

--- a/packages/lib/reducer.test.ts
+++ b/packages/lib/reducer.test.ts
@@ -1063,6 +1063,7 @@ describe('reducer', () => {
 		let state = initTestState(folders, 0, notes, [0]);
 
 		const previousReloadTime = state.editorNoteReloadTimeRequest;
+		const previousWindowReloadTime = state.windowEditorNoteReloadTimeRequest;
 		const now = Date.now();
 
 		state = reducer(state, {
@@ -1072,6 +1073,9 @@ describe('reducer', () => {
 
 		expect(state.editorNoteReloadTimeRequest).toBe(
 			shouldReload ? now : previousReloadTime,
+		);
+		expect(state.windowEditorNoteReloadTimeRequest).toBe(
+			noteIndex === 0 ? now : previousWindowReloadTime,
 		);
 
 		jest.useRealTimers();
@@ -1083,7 +1087,7 @@ describe('reducer', () => {
 		const notes = await createNTestNotes(2, folders[0]);
 		let state = initTestState(folders, 0, notes, [0]);
 		state = createBackgroundWindow(state, 'secondary', notes[1], notes);
-		const previousPrimaryReloadTime = state.editorNoteReloadTimeRequest;
+		const previousPrimaryReloadTime = state.windowEditorNoteReloadTimeRequest;
 		const now = Date.now();
 
 		state = reducer(state, {
@@ -1091,8 +1095,8 @@ describe('reducer', () => {
 			noteId: notes[1].id,
 		});
 
-		expect(state.editorNoteReloadTimeRequest).toBe(previousPrimaryReloadTime);
-		expect(state.backgroundWindows.secondary.editorNoteReloadTimeRequest).toBe(now);
+		expect(state.windowEditorNoteReloadTimeRequest).toBe(previousPrimaryReloadTime);
+		expect(state.backgroundWindows.secondary.windowEditorNoteReloadTimeRequest).toBe(now);
 		jest.useRealTimers();
 	});
 
@@ -1105,9 +1109,11 @@ describe('reducer', () => {
 
 		state = reducer(state, { type: 'EDITOR_NOTE_NEEDS_RELOAD', noteId: notes[0].id });
 		expect(state.editorNoteReloadTimeRequest).toBe(now);
+		expect(state.windowEditorNoteReloadTimeRequest).toBe(now);
 
 		state = reducer(state, { type: 'EDITOR_NOTE_NEEDS_RELOAD', noteId: notes[0].id });
 		expect(state.editorNoteReloadTimeRequest).toBe(now + 1);
+		expect(state.windowEditorNoteReloadTimeRequest).toBe(now + 1);
 
 		jest.useRealTimers();
 	});

--- a/packages/lib/reducer.test.ts
+++ b/packages/lib/reducer.test.ts
@@ -1095,4 +1095,20 @@ describe('reducer', () => {
 		expect(state.backgroundWindows.secondary.editorNoteReloadTimeRequest).toBe(now);
 		jest.useRealTimers();
 	});
+
+	it('should generate unique reload tokens within the same millisecond', async () => {
+		jest.useFakeTimers();
+		const folders = await createNTestFolders(1);
+		const notes = await createNTestNotes(1, folders[0]);
+		let state = initTestState(folders, 0, notes, [0]);
+		const now = Date.now();
+
+		state = reducer(state, { type: 'EDITOR_NOTE_NEEDS_RELOAD', noteId: notes[0].id });
+		expect(state.editorNoteReloadTimeRequest).toBe(now);
+
+		state = reducer(state, { type: 'EDITOR_NOTE_NEEDS_RELOAD', noteId: notes[0].id });
+		expect(state.editorNoteReloadTimeRequest).toBe(now + 1);
+
+		jest.useRealTimers();
+	});
 });

--- a/packages/lib/reducer.test.ts
+++ b/packages/lib/reducer.test.ts
@@ -1076,4 +1076,23 @@ describe('reducer', () => {
 
 		jest.useRealTimers();
 	});
+
+	it('should request reload only in windows displaying the specified note', async () => {
+		jest.useFakeTimers();
+		const folders = await createNTestFolders(1);
+		const notes = await createNTestNotes(2, folders[0]);
+		let state = initTestState(folders, 0, notes, [0]);
+		state = createBackgroundWindow(state, 'secondary', notes[1], notes);
+		const previousPrimaryReloadTime = state.editorNoteReloadTimeRequest;
+		const now = Date.now();
+
+		state = reducer(state, {
+			type: 'EDITOR_NOTE_NEEDS_RELOAD',
+			noteId: notes[1].id,
+		});
+
+		expect(state.editorNoteReloadTimeRequest).toBe(previousPrimaryReloadTime);
+		expect(state.backgroundWindows.secondary.editorNoteReloadTimeRequest).toBe(now);
+		jest.useRealTimers();
+	});
 });

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -1620,7 +1620,7 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 			{
 				for (const windowState of stateUtils.allWindowStates(draft)) {
 					if (!action.noteId || stateUtils.selectedNoteId(windowState) === action.noteId) {
-						windowState.editorNoteReloadTimeRequest = Date.now();
+						windowState.editorNoteReloadTimeRequest = Math.max(Date.now(), windowState.editorNoteReloadTimeRequest + 1);
 					}
 				}
 			}

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -119,6 +119,7 @@ export interface WindowState {
 	backwardHistoryNotes: NoteEntity[];
 	forwardHistoryNotes: NoteEntity[];
 	lastSelectedNotesIds: StateLastSelectedNotesIds;
+	editorNoteReloadTimeRequest: number;
 }
 
 export const defaultWindowId = 'default';
@@ -147,6 +148,7 @@ export const defaultWindowState: WindowState = {
 		Tag: {},
 		Search: {},
 	},
+	editorNoteReloadTimeRequest: 0,
 };
 
 export interface EditorNoteStatuses {
@@ -198,8 +200,6 @@ export interface State extends WindowState {
 	mustUpgradeAppMessage: string;
 	mustAuthenticate: boolean;
 	toast: Toast | null;
-	editorNoteReloadTimeRequest: number;
-
 	allowSelectionInOtherFolders: boolean;
 	noteHtmlToMarkdownDone: string;
 
@@ -274,7 +274,6 @@ export const defaultState: State = {
 	mustUpgradeAppMessage: '',
 	mustAuthenticate: false,
 	allowSelectionInOtherFolders: false,
-	editorNoteReloadTimeRequest: 0,
 	noteHtmlToMarkdownDone: '',
 
 	pluginService: pluginServiceDefaultState,
@@ -1619,8 +1618,10 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 
 		case 'EDITOR_NOTE_NEEDS_RELOAD':
 			{
-				if (!action.noteId || (draft.selectedNoteIds.length && draft.selectedNoteIds[0] === action.noteId)) {
-					draft.editorNoteReloadTimeRequest = Date.now();
+				for (const windowState of stateUtils.allWindowStates(draft)) {
+					if (!action.noteId || stateUtils.selectedNoteId(windowState) === action.noteId) {
+						windowState.editorNoteReloadTimeRequest = Date.now();
+					}
 				}
 			}
 			break;

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -119,7 +119,7 @@ export interface WindowState {
 	backwardHistoryNotes: NoteEntity[];
 	forwardHistoryNotes: NoteEntity[];
 	lastSelectedNotesIds: StateLastSelectedNotesIds;
-	editorNoteReloadTimeRequest: number;
+	windowEditorNoteReloadTimeRequest: number;
 }
 
 export const defaultWindowId = 'default';
@@ -148,7 +148,7 @@ export const defaultWindowState: WindowState = {
 		Tag: {},
 		Search: {},
 	},
-	editorNoteReloadTimeRequest: 0,
+	windowEditorNoteReloadTimeRequest: 0,
 };
 
 export interface EditorNoteStatuses {
@@ -200,6 +200,7 @@ export interface State extends WindowState {
 	mustUpgradeAppMessage: string;
 	mustAuthenticate: boolean;
 	toast: Toast | null;
+	editorNoteReloadTimeRequest: number;
 	allowSelectionInOtherFolders: boolean;
 	noteHtmlToMarkdownDone: string;
 
@@ -273,6 +274,7 @@ export const defaultState: State = {
 	lastDeletionNotificationTime: 0,
 	mustUpgradeAppMessage: '',
 	mustAuthenticate: false,
+	editorNoteReloadTimeRequest: 0,
 	allowSelectionInOtherFolders: false,
 	noteHtmlToMarkdownDone: '',
 
@@ -1618,9 +1620,20 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 
 		case 'EDITOR_NOTE_NEEDS_RELOAD':
 			{
-				for (const windowState of stateUtils.allWindowStates(draft)) {
-					if (!action.noteId || stateUtils.selectedNoteId(windowState) === action.noteId) {
-						windowState.editorNoteReloadTimeRequest = Math.max(Date.now(), windowState.editorNoteReloadTimeRequest + 1);
+				const nextReloadRequest = (previous: number) => Math.max(Date.now(), previous + 1);
+
+				// Mobile uses the root field and supports reload requests without a note ID.
+				if (!action.noteId || stateUtils.selectedNoteId(draft) === action.noteId) {
+					draft.editorNoteReloadTimeRequest = nextReloadRequest(draft.editorNoteReloadTimeRequest);
+				}
+
+				// Desktop reload requests must identify the note so that only windows
+				// displaying that note are invalidated.
+				if (action.noteId) {
+					for (const windowState of stateUtils.allWindowStates(draft)) {
+						if (stateUtils.selectedNoteId(windowState) === action.noteId) {
+							windowState.windowEditorNoteReloadTimeRequest = nextReloadRequest(windowState.windowEditorNoteReloadTimeRequest);
+						}
 					}
 				}
 			}

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -341,3 +341,4 @@ Socialboom
 AABB
 Koofr
 undecryptable
+tokened

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -341,4 +341,3 @@ Socialboom
 AABB
 Koofr
 undecryptable
-tokened


### PR DESCRIPTION
This PR fixes equivalent issues to PR https://github.com/laurent22/joplin/pull/16193 which are present in the desktop app.

Changing the note contents within about 0.5 seconds before the note is reloaded via an update by the sync, can cause the remote version to be overwritten with the local contents in the current editor. This can be a serious data integrity issue, particularly with the upcoming introduction of automatically resolved conflicts, where the resolved version could also get lost as a result of multiple possible race conditions.

This PR addresses the issue by implementing the following for the mobile note editor:
1. **Block saves scheduled before reload:** Scheduled saves will now set the value of the editorNoteReloadTimeRequest prop at the point of enqueuing, and when the save is executed, it will be rejected if the editorNoteReloadTimeRequest value has since been moved on. This value is incremented by the reducer handling of the EDITOR_NOTE_NEEDS_RELOAD event, which is triggered immediately when the sync or a conflict updates a note. The EDITOR_NOTE_NEEDS_RELOAD handling in the reducer has been amended to support holding a separate windowEditorNoteReloadTimeRequest state per window, while remaining compatible with mobile
2. **Block scheduling new changes during reload:** This is implemented by populating a reloadInProgress prop when a reload is triggered, and marking it as completed only once the editor has completed the reload. With this state established, the NoteEditor.onFieldChange function is blocked while true. Various places are also rejected when the editorNoteReloadTimeRequest value has changed since an action was triggered (including the execOnChangeEvent() function of the TinyMCE editor, which triggers after a 1 second debounce). This covers changes to the title, MDE, RTE and plain text editor. Additionally, the editor and title components are marked as disabled during this transition in all cases
3. **Blur the editor and title field while a reload is in progress:** This is done to immediately reject user input and dismiss the on screen keyboard, as continuous typing can prevent the editor from being able to refresh. This applies to any note window which is currently in focus

Note that when typing really fast, it is possible to lose some of the text typed in the last second or so, but this is much better than losing the entire changes from remote versions or auto merged conflicts.

### Testing

Manual testing covered the following scenarios:
- Verified very fast typing while sync updates the current note is halted when the refresh occurs, and nothing is overwritten
- Verified for the MDE / RTE / plain text editor and title field, that the refresh while typing causes a blur, which breaks the flow of the constant typing
- Verified when exiting switching note after the above scenarios, that the new state shown is what was saved, where nothing else was changed post reload
- Verified normal note changes are saved and persisted
- Verified external editing behaviour is unaffected
- Verified the fix works with and without E2EE enabled
- Verified note refresh works as per existing behaviour on mobile
- Verified after making a change to a whiteboard in the editor view, that toggling the editor view refreshes the note content with the latest source, as per existing behaviour

Original behaviour:

https://github.com/user-attachments/assets/9c1971ed-a337-477c-98e0-1e4e879f444c

New behaviour, demonstrating no content overwritten for the title, MDE, RTE and plain text editor without encryption enabled (note I accidentally used the legacy markdown editor for most of the MDE tests, but I did a thorough test with CM6 too):

https://github.com/user-attachments/assets/c2757022-8585-4e37-b2a6-c1457cddfa09

New behaviour showing a few tests with E2EE enabled:

https://github.com/user-attachments/assets/13915e84-5c93-44ef-acb3-f3702961d9cc