### PR TITLE
Desktop, Mobile, Cli: Prevent race which allows changes to be lost, during a long delta step

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -1017,14 +1017,18 @@ export default class Synchronizer {
 										// Nothing to do, and no need to fetch the content
 									} else {
 										content = await loadContent();
-										if (content && content.updated_time > local.updated_time) {
+										// Load the latest updated_time, otherwise a change made during a long delta step could overwrite the remote version without making a conflict
+										const latestLocalState = await ItemClass.load(remoteId, { fields: ['updated_time'] });
+										const localUpdatedTime = latestLocalState ? latestLocalState.updated_time : local.updated_time;
+										if (content && content.updated_time > localUpdatedTime) {
 											action = SyncAction.UpdateLocal;
 											reason = 'remote is more recent than local';
 										} else if (enableEnhancedBasicDeltaAlgorithm()) {
+											const syncItem = await BaseItem.syncItem(syncTargetId, local.id, { fields: ['sync_time'] });
 											// When the enhanced basic delta algorithm is first used, all items are rescanned and we need to persist the remoteItemUpdatedTime
 											// to set up the initial synced state. This also catches the case if content.updated_time < local.updated_time due to manual manipulation
 											// of the md files, to prevent these items being continually fetched on every sync
-											await ItemClass.saveSyncTime(syncTargetId, local, local.updated_time, remote.updated_time);
+											await ItemClass.saveSyncTime(syncTargetId, local, syncItem.sync_time, remote.updated_time);
 										}
 									}
 								}

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -1017,7 +1017,7 @@ export default class Synchronizer {
 										// Nothing to do, and no need to fetch the content
 									} else {
 										content = await loadContent();
-										// Load the latest updated_time, otherwise a change made during a long delta step could overwrite the remote version without making a conflict
+										// Load the latest updated_time, otherwise a change made during a long delta step could overwrite the local version without making a conflict
 										const latestLocalState = await ItemClass.load(remoteId, { fields: ['updated_time'] });
 										const localUpdatedTime = latestLocalState ? latestLocalState.updated_time : local.updated_time;
 										if (content && content.updated_time > localUpdatedTime) {

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -5,7 +5,7 @@ import shim from './shim';
 import MigrationHandler from './services/synchronizer/MigrationHandler';
 import eventManager, { EventName } from './eventManager';
 import { _ } from './locale';
-import BaseItem from './models/BaseItem';
+import BaseItem, { RemoteItemMetadata } from './models/BaseItem';
 import Folder from './models/Folder';
 import Note from './models/Note';
 import Resource from './models/Resource';
@@ -903,6 +903,7 @@ export default class Synchronizer {
 				while (true) {
 					if (this.cancelling() || hasCancelled) break;
 
+					let localItemMetadata: Map<string, RemoteItemMetadata> = null;
 					const listResult: PaginatedList = await this.apiCall('delta', '', {
 						context: context,
 
@@ -917,7 +918,8 @@ export default class Synchronizer {
 
 						// This is only used by the basic delta
 						allItemMetadataHandler: async () => {
-							return BaseItem.remoteItemMetadata(syncTargetId);
+							localItemMetadata = await BaseItem.remoteItemMetadata(syncTargetId);
+							return localItemMetadata;
 						},
 
 						wipeOutFailSafe: Setting.value('sync.wipeOutFailSafe'),
@@ -1023,12 +1025,12 @@ export default class Synchronizer {
 										if (content && content.updated_time > localUpdatedTime) {
 											action = SyncAction.UpdateLocal;
 											reason = 'remote is more recent than local';
-										} else if (enableEnhancedBasicDeltaAlgorithm()) {
-											const syncItem = await BaseItem.syncItem(syncTargetId, local.id, { fields: ['sync_time'] });
+										} else if (content && enableEnhancedBasicDeltaAlgorithm()) {
 											// When the enhanced basic delta algorithm is first used, all items are rescanned and we need to persist the remoteItemUpdatedTime
 											// to set up the initial synced state. This also catches the case if content.updated_time < local.updated_time due to manual manipulation
 											// of the md files, to prevent these items being continually fetched on every sync
-											await ItemClass.saveSyncTime(syncTargetId, local, syncItem.sync_time, remote.updated_time);
+											const syncTime = localItemMetadata.get(local.id)?.sync_time ?? 0;
+											await ItemClass.saveSyncTime(syncTargetId, local, syncTime, remote.updated_time);
 										}
 									}
 								}

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -1025,7 +1025,7 @@ export default class Synchronizer {
 										if (content && content.updated_time > localUpdatedTime) {
 											action = SyncAction.UpdateLocal;
 											reason = 'remote is more recent than local';
-										} else if (content && enableEnhancedBasicDeltaAlgorithm()) {
+										} else if (enableEnhancedBasicDeltaAlgorithm()) {
 											// When the enhanced basic delta algorithm is first used, all items are rescanned and we need to persist the remoteItemUpdatedTime
 											// to set up the initial synced state. This also catches the case if content.updated_time < local.updated_time due to manual manipulation
 											// of the md files, to prevent these items being continually fetched on every sync

--- a/packages/lib/file-api.test.ts
+++ b/packages/lib/file-api.test.ts
@@ -61,6 +61,7 @@ const syncOptions = (noteId: string, localUpdatedTime: number, contextTimestamp:
 	const metadata = {
 		item_id: noteId,
 		updated_time: localUpdatedTime,
+		sync_time: localUpdatedTime,
 	};
 
 	if (noteId) {

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -45,6 +45,7 @@ export interface ItemsThatNeedSyncResult {
 export interface RemoteItemMetadata {
 	item_id: string;
 	updated_time: number;
+	sync_time: number;
 }
 
 export interface EncryptedItemsStats {
@@ -209,12 +210,13 @@ export default class BaseItem extends BaseModel {
 
 	public static async remoteItemMetadata(syncTarget: number): Promise<Map<string, RemoteItemMetadata>> {
 		if (!syncTarget) throw new Error('No syncTarget specified');
-		const temp = await this.db().selectAll('SELECT item_id, remote_item_updated_time FROM sync_items WHERE sync_time > 0 AND sync_target = ?', [syncTarget]);
+		const temp = await this.db().selectAll('SELECT item_id, remote_item_updated_time, sync_time FROM sync_items WHERE sync_time > 0 AND sync_target = ?', [syncTarget]);
 		const output = new Map<string, RemoteItemMetadata>();
 		for (let i = 0; i < temp.length; i++) {
 			const metadata: RemoteItemMetadata = {
 				item_id: temp[i].item_id,
 				updated_time: temp[i].remote_item_updated_time,
+				sync_time: temp[i].sync_time,
 			};
 			output.set(temp[i].item_id, metadata);
 		}

--- a/packages/lib/services/synchronizer/Synchronizer.conflicts.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.conflicts.test.ts
@@ -78,6 +78,35 @@ describe('Synchronizer.conflicts', () => {
 		expect(syncItem.sync_time).toBeLessThan(note1.updated_time);
 	}));
 
+	it('should leave changes made after the upload phase for the next sync', (async () => {
+		const folder = await Folder.save({ title: 'folder' });
+		const note = await Note.save({ title: 'original', parent_id: folder.id });
+		await synchronizerStart();
+
+		await switchClient(2);
+		await synchronizerStart();
+		await sleep(0.1);
+		await Note.save({ id: note.id, title: 'remote change' });
+		await synchronizerStart();
+
+		await switchClient(1);
+		await sleep(0.1);
+		const localChange = await Note.save({ id: note.id, title: 'local change' });
+
+		// Simulate an edit made after this sync's upload phase but before the
+		// remotely changed note is processed by delta.
+		await synchronizerStart(null, { syncSteps: ['delta'] });
+		expect((await Note.load(note.id)).title).toBe('local change');
+		const syncItem = await BaseItem.syncItem(syncTargetId(), note.id, { fields: ['sync_time'] });
+		expect(syncItem.sync_time).toBeLessThan(localChange.updated_time);
+
+		// The following upload phase sees both changes and uses the existing
+		// conflict handling path.
+		await synchronizerStart();
+		expect((await Note.load(note.id)).title).toBe('remote change');
+		expect((await Note.conflictedNotes()).map(note => note.title)).toContain('local change');
+	}));
+
 	it('should resolve folders conflicts', (async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		await Note.save({ title: 'un', parent_id: folder1.id });

--- a/packages/lib/services/synchronizer/Synchronizer.conflicts.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.conflicts.test.ts
@@ -90,12 +90,20 @@ describe('Synchronizer.conflicts', () => {
 		await synchronizerStart();
 
 		await switchClient(1);
-		await sleep(0.1);
-		const localChange = await Note.save({ id: note.id, title: 'local change' });
+		let localChange: NoteEntity = null;
+		const loadItemsByIds = BaseItem.loadItemsByIds.bind(BaseItem);
+		const loadItemsByIdsMock = jest.spyOn(BaseItem, 'loadItemsByIds').mockImplementation(async ids => {
+			const items = await loadItemsByIds(ids);
+			if (ids.includes(note.id)) {
+				await sleep(0.1);
+				localChange = await Note.save({ id: note.id, title: 'local change' });
+			}
+			return items;
+		});
 
-		// Simulate an edit made after this sync's upload phase but before the
-		// remotely changed note is processed by delta.
 		await synchronizerStart(null, { syncSteps: ['delta'] });
+		loadItemsByIdsMock.mockRestore();
+
 		expect((await Note.load(note.id)).title).toBe('local change');
 		const syncItem = await BaseItem.syncItem(syncTargetId(), note.id, { fields: ['sync_time'] });
 		expect(syncItem.sync_time).toBeLessThan(localChange.updated_time);


### PR DESCRIPTION
In the Synchronizer, the sync process assumes that conflicts do not need to be handled in the delta step, because the upload step always runs before it. Most of the time this assumption is true. However, in the event that a lot of incoming changes are being synced at one time, if a local note becomes 'dirty' only while the delta step is running, if the delta downloads an incoming change to this same note only after the local change has been made, this may result in the local change being lost. In the case of using a slow sync target, this could potentially be minutes of changes lost, rather than just a few seconds. This is because the local object in memory may still use the outdated version at that point during the delta loop, and therefore the sync would assume the remote is more recent than local and will overwrite the local version

This PR addresses the issue by loaded the latest updated_time value from the local item immediately before comparing the timestamp in the delta step. Additionally, due to the changes in https://github.com/laurent22/joplin/pull/13054 for making file system sync work properly with distributed sync targets, this introduced an update to the sync_items entry when a local update is not applied. Updating the sync time at this point would prevent a conflict being created when the upload step next runs, and could also allow remote changes to be overwritten due to no editor refresh happening in this scenario (see first video). This PR also changes this logic to only update the remoteItemUpdatedTime, not the sync_time on the sync_item entry in this scenario.

Note that changes made during a long delta step will automatically trigger another sync after the sync completes, due to the 'There are more outgoing changes to sync, schedule the sync again' logic at the end of the synchronizer logic. This does mean the conflict will not be created until after the original sync completes, but a deferred conflict is certainly better than losing changes.

### Testing

I verified the scenario using file system sync, by duplicating a large amount of notes, then making a change to note A and triggering the sync, on client A. Then on client B (which was fully synced previously), I triggered a sync, and after the first few items have changed I made some changes to note B until the sync completed. When clicking sync again, the note then created a conflict, and the original note was replaced with the remote contents which were originally synced on client B. I also verified that the file sync will still fetch an item where the modification time of the file has been changed to a time in the past.

**Video examples before changes:**

https://github.com/user-attachments/assets/34bf240a-c305-4c40-9076-a296fc4ee846

https://github.com/user-attachments/assets/54cbf777-5bb8-4606-a755-2b515ebe8c5c

**Video after changes:**

https://github.com/user-attachments/assets/705dc2ab-747d-4719-be17-00cbffa0e319

