### PR TITLE
Desktop: Fixes #16219: Fix semantic search availability check

### DIFF
--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -19,8 +19,8 @@ const { sprintf } = require('sprintf-js');
 import { pregQuote, scriptType, removeDiacritics } from '../../string-utils';
 import PerformanceLogger from '../../PerformanceLogger';
 import SearchService from '../ai/SearchService';
-import AiService from '../ai/AiService';
 import { unique } from '../../ArrayUtils';
+import { embeddingAvailability } from '../ai/availability';
 
 const perfLogger = PerformanceLogger.create();
 
@@ -754,9 +754,7 @@ export default class SearchEngine {
 		}
 
 		return Setting.value('featureFlag.enableSemanticSearch')
-			&& Setting.value('ai.enabled')
-			&& Setting.value('ai.embedding.enabled')
-			&& !!AiService.instance().getActiveEmbeddingProvider();
+			&& embeddingAvailability().available;
 	}
 
 	private async searchFromItemIds(searchString: string): Promise<ProcessResultsRow[]> {

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -754,6 +754,7 @@ export default class SearchEngine {
 		}
 
 		return Setting.value('featureFlag.enableSemanticSearch')
+			&& Setting.value('ai.enabled')
 			&& Setting.value('ai.embedding.enabled')
 			&& !!AiService.instance().getActiveEmbeddingProvider();
 	}

--- a/packages/lib/testing/ai/semanticSearch.ts
+++ b/packages/lib/testing/ai/semanticSearch.ts
@@ -7,6 +7,7 @@ import SearchEngine from '../../services/search/SearchEngine';
 export const setUpSemanticSearch = async () => {
 	AiService.instance().setEmbeddingProvider(new TestEmbeddingProvider());
 	Setting.setValue('featureFlag.enableSemanticSearch', true);
+	Setting.setValue('ai.enabled', true);
 };
 
 export const tearDownSemanticSearch = async () => {


### PR DESCRIPTION
# Problem

Searching for content in the search panel would attempt to download the semantic search embedding model, even if AI features had not been enabled in settings.

**Why**: The semantic search availability check added in https://github.com/laurent22/joplin/pull/16118 checked `ai.embedding.enabled` without checking `ai.enabled`:

https://github.com/laurent22/joplin/blob/a43e772c85f3c7547952b967e2fc26c71a9dd675/packages/lib/services/search/SearchEngine.ts#L756-L758

With the default app configuration, `ai.embedding.enabled` is `true` and `ai.enabled` is `false`. However, `ai.embedding.enabled` is treated as `false` in other parts of the app until `ai.enabled` is `true`.

# Solution

Use the existing `embeddingAvailability().available` logic to determine whether semantic search is available.

Fixes #16219.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
