### PR TITLE
Desktop: Sync: Apply changes to proxy settings immediately

### DIFF
--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -456,8 +456,8 @@ export default class BaseApplication {
 		sideEffects['encryption.passwordCache'] = sideEffects['syncInfoCache'];
 		sideEffects['encryption.masterPassword'] = sideEffects['syncInfoCache'];
 		sideEffects['sync.maxConcurrentConnections'] = sideEffects['net.proxyEnabled'];
-		sideEffects['sync.proxyTimeout'] = sideEffects['net.proxyEnabled'];
-		sideEffects['sync.proxyUrl'] = sideEffects['net.proxyEnabled'];
+		sideEffects['net.proxyTimeout'] = sideEffects['net.proxyEnabled'];
+		sideEffects['net.proxyUrl'] = sideEffects['net.proxyEnabled'];
 		sideEffects['ai.chat.baseUrl'] = sideEffects['ai.chat.providerType'];
 		sideEffects['ai.chat.apiKey'] = sideEffects['ai.chat.providerType'];
 		sideEffects['ai.chat.model'] = sideEffects['ai.chat.providerType'];

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -76,6 +76,7 @@ import NoteLockKey from './services/noteLock/NoteLockKey';
 import isNoteLockEnabled from './services/noteLock/isNoteLockEnabled';
 import NoteLockSession from './services/noteLock/NoteLockSession';
 import NoteLockService from './services/noteLock/NoteLockService';
+import { BuiltInMetadataKeys } from './models/settings/builtInMetadata';
 
 const appLogger: LoggerWrapper = Logger.create('App');
 const perfLogger = PerformanceLogger.create();
@@ -373,7 +374,8 @@ export default class BaseApplication {
 	}
 
 	protected async applySettingsSideEffects(action: { type?: string; key?: string; keys?: string[] } = null) {
-		const sideEffects: Record<string, ()=> Promise<void>> = {
+		type SideEffects = Partial<Record<BuiltInMetadataKeys, ()=> Promise<void>>>;
+		const sideEffects: SideEffects = {
 			'dateFormat': async () => {
 				time.setLocale(Setting.value('locale'));
 				setTimeLocale(Setting.value('locale'));
@@ -463,11 +465,11 @@ export default class BaseApplication {
 		sideEffects['ai.chat.model'] = sideEffects['ai.chat.providerType'];
 
 		if (action) {
-			const effect = sideEffects[action.key];
+			const effect = sideEffects[action.key as keyof SideEffects];
 			if (effect) await effect();
 		} else {
 			for (const key in sideEffects) {
-				await sideEffects[key]();
+				await sideEffects[key as keyof SideEffects]();
 			}
 		}
 	}


### PR DESCRIPTION
# Problem

Changing the proxy timeout and/or URL does not reload the proxy configuration. As a result, it was necessary to either restart the app or disable, then re-enable the proxy in settings.

This was caused by an incorrect setting name in `BaseApplication.ts`.

# Solution

- Reload the proxy configuration when the proxy timeout and/or URL changes.
- Help TypeScript catch similar errors in the future by improving type safety.

# Screen recording

| Before | After |
|----|----|
| <video src="https://github.com/user-attachments/assets/342b4c5c-99af-44ba-abba-d4d7b6fea25d"></video> | <video src="https://github.com/user-attachments/assets/1dd9879c-7e08-4501-a60f-3ec009f397f5"></video> |

The above screen recordings show fixing the password component in a Proxy URL. In the before case, it was necessary to disable, then re-enable the proxy before the URL change would take effect.





<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
