### PR TITLE
Desktop, Mobile: Implement readonly state for mobile RTE and disable the MDE interactive table editor for readonly notes

### DIFF
--- a/packages/app-mobile/components/NoteEditor/RichTextEditor.test.tsx
+++ b/packages/app-mobile/components/NoteEditor/RichTextEditor.test.tsx
@@ -178,19 +178,25 @@ describe('RichTextEditor', () => {
 	});
 
 	it('should become non-editable when set to read-only', async () => {
+		const table = '| A | B |\n| --- | --- |\n| C | D |';
 		const component = render(<WrappedEditor
-			noteBody='Test'
+			noteBody={table}
 			onBodyChange={jest.fn()}
 		/>);
 		const editor = await findElement('.prosemirror-editor');
 		expect(editor.getAttribute('contenteditable')).toBe('true');
+		mockSelectionMovement(await getEditorWindow(), 4);
+		const tableToolbar = await findElement('.floating-button-bar:not(.-hidden)');
 
 		component.rerender(<WrappedEditor
-			noteBody='Test'
+			noteBody={table}
 			onBodyChange={jest.fn()}
 			readOnly={true}
 		/>);
-		await waitFor(() => expect(editor.getAttribute('contenteditable')).toBe('false'));
+		await waitFor(() => {
+			expect(editor.getAttribute('contenteditable')).toBe('false');
+			expect(tableToolbar.classList).toContain('-hidden');
+		});
 	});
 
 	it('should save repeated spaces using nonbreaking spaces', async () => {

--- a/packages/app-mobile/components/NoteEditor/RichTextEditor.test.tsx
+++ b/packages/app-mobile/components/NoteEditor/RichTextEditor.test.tsx
@@ -33,6 +33,7 @@ interface WrapperProps {
 	onLinkClick?: (link: string)=> void;
 	note?: NoteEntity;
 	noteBody: string;
+	readOnly?: boolean;
 }
 
 const defaultEditorProps = createTestEditorProps();
@@ -45,6 +46,7 @@ const WrappedEditor: React.FC<WrapperProps> = (
 		onLinkClick,
 		noteResources,
 		ref,
+		readOnly = false,
 	}: WrapperProps,
 ) => {
 	const onEvent = useCallback((event: EditorEvent) => {
@@ -63,9 +65,10 @@ const WrappedEditor: React.FC<WrapperProps> = (
 		const isHtml = note?.markup_language === MarkupLanguage.Html;
 		return {
 			...defaultEditorProps.editorSettings,
+			readOnly,
 			language: isHtml ? EditorLanguageType.Html : EditorLanguageType.Markdown,
 		};
-	}, [note]);
+	}, [note, readOnly]);
 
 	return <TestProviderStack store={testStore}>
 		<RichTextEditor
@@ -172,6 +175,22 @@ describe('RichTextEditor', () => {
 		await waitFor(async () => {
 			expect(body.trim()).toBe('**bold** normal test');
 		});
+	});
+
+	it('should become non-editable when set to read-only', async () => {
+		const component = render(<WrappedEditor
+			noteBody='Test'
+			onBodyChange={jest.fn()}
+		/>);
+		const editor = await findElement('.prosemirror-editor');
+		expect(editor.getAttribute('contenteditable')).toBe('true');
+
+		component.rerender(<WrappedEditor
+			noteBody='Test'
+			onBodyChange={jest.fn()}
+			readOnly={true}
+		/>);
+		await waitFor(() => expect(editor.getAttribute('contenteditable')).toBe('false'));
 	});
 
 	it('should save repeated spaces using nonbreaking spaces', async () => {

--- a/packages/editor/CodeMirror/extensions/rendering/renderTables.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderTables.test.ts
@@ -1,10 +1,10 @@
-import { EditorSelection } from '@codemirror/state';
+import { EditorSelection, EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import createTestEditor from '../../testing/createTestEditor';
 import renderTables, { renderInlineMarkdown } from './renderTables';
 import { RenderedContentContext } from './types';
 
-const createEditor = async (initialMarkdown: string, context?: Partial<RenderedContentContext>) => {
+const createEditor = async (initialMarkdown: string, context?: Partial<RenderedContentContext>, readOnly = false) => {
 	const fullContext: RenderedContentContext = {
 		resolveImageSrc: async () => '',
 		openLink: () => {},
@@ -14,7 +14,7 @@ const createEditor = async (initialMarkdown: string, context?: Partial<RenderedC
 		initialMarkdown,
 		EditorSelection.cursor(0),
 		['TableHeader'],
-		[renderTables(fullContext)],
+		[EditorState.readOnly.of(readOnly), renderTables(fullContext)],
 	);
 };
 
@@ -111,6 +111,16 @@ describe('renderTables', () => {
 		expect(cells[1].querySelector('em')?.textContent).toBe('italic');
 		expect(cells[2].querySelector('code')?.textContent).toBe('code');
 		expect(cells[3].textContent).toBe('plain');
+	});
+
+	test('table editing controls should be hidden when read-only', async () => {
+		const editor = await createEditor('| A | B |\n|---|---|\n| C | D |', undefined, true);
+		const cells = findCellTextDivs(editor);
+		expect([...cells].every(cell => cell.contentEditable === 'false')).toBe(true);
+		expect(editor.dom.querySelector('.cm-tw-ac-wrap, .cm-tw-ar-wrap')).toBeNull();
+
+		cells[0].dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
+		expect(editor.dom.querySelector('.cm-tw-ctx')).toBeNull();
 	});
 
 	test('focusing a cell should swap rendered DOM for raw markdown source', async () => {

--- a/packages/editor/CodeMirror/extensions/rendering/renderTables.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderTables.ts
@@ -104,6 +104,7 @@ class TableWidget extends WidgetType {
 		private from: number,
 		private to: number,
 		private context: RenderedContentContext,
+		private readOnly: boolean,
 	) {
 		super();
 		this.cacheKey_ = `table_${from}_${to}_${tableText.length}`;
@@ -114,7 +115,8 @@ class TableWidget extends WidgetType {
 	public eq(other: TableWidget) {
 		return this.tableText === other.tableText
 			&& this.from === other.from
-			&& this.to === other.to;
+			&& this.to === other.to
+			&& this.readOnly === other.readOnly;
 	}
 
 	public get estimatedHeight() {
@@ -242,7 +244,7 @@ class TableWidget extends WidgetType {
 			// Editable text lives in its own div — cell itself is NOT editable
 			const textDiv = doc.createElement('div');
 			textDiv.classList.add('cm-tw-text');
-			textDiv.contentEditable = 'true';
+			textDiv.contentEditable = this.readOnly ? 'false' : 'true';
 			textDiv.spellcheck = false;
 			// When not focused, show rendered inline markdown. On focus we
 			// swap to the raw source so the user edits the markdown text.
@@ -506,13 +508,13 @@ class TableWidget extends WidgetType {
 			el.appendChild(textDiv);
 			// Clicking anywhere in the cell (including empty space in tall rows)
 			// should activate the text editor
-			el.onmousedown = (e) => {
+			el.onmousedown = this.readOnly ? null : (e) => {
 				if (e.target === el) {
 					e.preventDefault();
 					focus('TableWidget', textDiv);
 				}
 			};
-			el.oncontextmenu = (e) => showCtx(e, r, c);
+			if (!this.readOnly) el.oncontextmenu = (e) => showCtx(e, r, c);
 
 			return el;
 		};
@@ -587,9 +589,9 @@ class TableWidget extends WidgetType {
 		for (let c = 0; c < numCols; c++) {
 			const cell = mkCell(table.header.cells[c].content, 0, c, true);
 			// "+" on right edge of every header cell → add column
-			mkAddColBtn(c, cell);
+			if (!this.readOnly) mkAddColBtn(c, cell);
 			// "+" on bottom edge of first header cell → add row below header
-			if (c === 0) mkAddRowBtn(-1, cell);
+			if (!this.readOnly && c === 0) mkAddRowBtn(-1, cell);
 			allCells[0].push(cell);
 			headerTr.appendChild(cell);
 		}
@@ -605,7 +607,7 @@ class TableWidget extends WidgetType {
 				const content = c < table.body[r].cells.length ? table.body[r].cells[c].content : '';
 				const cell = mkCell(content, r + 1, c, false);
 				// "+" on bottom edge of first column cell → add row
-				if (c === 0) mkAddRowBtn(r, cell);
+				if (!this.readOnly && c === 0) mkAddRowBtn(r, cell);
 				allCells[r + 1].push(cell);
 				tr.appendChild(cell);
 			}
@@ -1139,8 +1141,9 @@ const renderTables = (context: RenderedContentContext) => [
 			}
 			const text = state.doc.sliceString(startLine.from, endLine.to);
 			if (!parseTable(text)) return null;
-			return new TableWidget(text, startLine.from, endLine.to, context);
+			return new TableWidget(text, startLine.from, endLine.to, context, state.readOnly);
 		},
+		shouldFullReRender: transaction => transaction.startState.readOnly !== transaction.state.readOnly,
 		getDecorationRange: (node: SyntaxNodeRef, state: EditorState) => {
 			if (node.name !== 'TableHeader') return null;
 			const startLine = state.doc.lineAt(node.from);

--- a/packages/editor/ProseMirror/createEditor.ts
+++ b/packages/editor/ProseMirror/createEditor.ts
@@ -147,6 +147,7 @@ const createEditor = async (
 
 	const view = new EditorView(parentElement, {
 		state: await createInitialState(props.initialText),
+		editable: () => !settings.readOnly,
 		dispatchTransaction: transaction => {
 			const newState = view.state.apply(transaction);
 
@@ -224,6 +225,9 @@ const createEditor = async (
 		updateSettings: async (newSettings: EditorSettings) => {
 			const oldSettings = settings;
 			settings = newSettings;
+			if (oldSettings.readOnly !== newSettings.readOnly) {
+				view.setProps({ editable: () => !settings.readOnly });
+			}
 
 			if (oldSettings.themeData.themeId !== newSettings.themeData.themeId) {
 				// Refresh global CSS when the theme changes -- render the full document

--- a/packages/editor/ProseMirror/plugins/utils/createFloatingButtonPlugin.ts
+++ b/packages/editor/ProseMirror/plugins/utils/createFloatingButtonPlugin.ts
@@ -39,6 +39,7 @@ class FloatingButtonBar implements PluginView {
 
 	private currentTarget_: TargetNode|null = null;
 	private observer_: ElementObserver;
+	private editable_: boolean|null = null;
 
 	public constructor(
 		private view_: EditorView,
@@ -152,11 +153,19 @@ class FloatingButtonBar implements PluginView {
 
 	public update(view: EditorView, lastState: EditorState|null) {
 		this.view_ = view;
+		const editableChanged = this.editable_ !== view.editable;
+		this.editable_ = view.editable;
+		if (!view.editable) {
+			this.observer_.setElement(null);
+			this.currentTarget_ = null;
+			this.container_.classList.add('-hidden');
+			return;
+		}
 
 		const state = view.state;
 		const sameSelection = lastState && state.selection.eq(lastState.selection);
 		const sameDoc = lastState && state.doc.eq(lastState.doc);
-		if (sameSelection && sameDoc) {
+		if (!editableChanged && sameSelection && sameDoc) {
 			return;
 		}
 


### PR DESCRIPTION
Currently, the mobile Rich Text editor does not implement the readonly prop, and therefore allows typing freely in the editor for readonly notes. This was apparent in the Joplin Android 3.6.13 release, where trashed notes were opened in the editor mode by default. This PR addresses the issue by implementing a readonly mode in the ProseMirror editor, which includes suppressing the table editor UI when a note is set to readonly: true, as this would allow making changes even when the text cannot be changed directly.

Additionally, the new interactive table editing feature of the Markdown editor also allows making changes to readonly notes on both the desktop and mobile apps, so the PR also suppresses this functionality when the note is set to readonly: true.

Note that inline checkboxes can still be toggled in editors and viewers in both the desktop and mobile apps in readonly mode, but this is historic behaviour and would be a bigger change to address with lesser benefit, as any potential data loss would be minimal, due to the inability to enter free text for this action.

### Testing

I verified the fixes by removing the code locally which overrides the mode to view mode when opening trashed notes on mobile, so that I can test the readonly mode easily.

**Video of existing behaviour in Joplin Android 3.6.13:**

https://github.com/user-attachments/assets/1504cee0-8fb2-48d8-949b-67c728e37798

**Video of fixes to mobile:**

https://github.com/user-attachments/assets/bbea6aa3-0d49-4b5c-a817-92d1eb460f51

**Video of fixes to desktop:**

https://github.com/user-attachments/assets/18875674-5b75-412a-9845-567eac4a8e77