### PR TITLE
Desktop: Fixes #16196: Fix note editor pane collapsing when search query returns no results

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -232,6 +232,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 	// const waitingToSaveNote = props.noteId && formNote.id !== props.noteId && props.editorNoteStatuses[props.noteId] === 'saving';
 
 	const styles = styles_(props);
+	const theme = themeStyle(props.themeId);
 
 	const whiteBackgroundNoteRendering = formNote.markup_language === MarkupLanguage.Html;
 
@@ -488,12 +489,23 @@ function NoteEditorContent(props: NoteEditorProps) {
 	}, [windowId]);
 
 	function renderNoNotes(rootStyle: React.CSSProperties) {
-		const emptyDivStyle = {
-			backgroundColor: 'black',
-			opacity: 0.1,
+		const emptyDivStyle: React.CSSProperties = {
 			...rootStyle,
+			backgroundColor: theme.backgroundColor,
+			display: 'flex',
+			alignItems: 'center',
+			justifyContent: 'center',
 		};
-		return <div style={emptyDivStyle} ref={containerRef}></div>;
+
+		return (
+			<div style={emptyDivStyle} ref={containerRef}>
+				{props.notesParentType === 'Search' ? (
+					<div style={{ ...theme.textStyle, color: theme.colorFaded, textAlign: 'center' }}>
+						{_('No notes match the search query.')}
+					</div>
+				) : null}
+			</div>
+		);
 	}
 
 	const searchMarkers = useSearchMarkers({
@@ -790,8 +802,6 @@ function NoteEditorContent(props: NoteEditorProps) {
 	if (formNote.encryption_applied || !formNote.id || !effectiveNoteId) {
 		return renderNoNotes(styles.root);
 	}
-
-	const theme = themeStyle(props.themeId);
 
 	function renderConvertHtmlToMarkdown(): React.ReactNode {
 		if (!props.enableHtmlToMarkdownBanner) return null;


### PR DESCRIPTION
## Summary

When typing a search query in the search bar that returns no results, `selectedNoteId` becomes `null` and `notes` becomes empty (`[]`). Previously, `NoteEditor` rendered a semi-transparent black overlay (`opacity: 0.1`), causing the note editor pane to collapse or look like a broken/closed window.

This PR updates `NoteEditor.tsx` so that when search yields 0 results:
1. The note editor pane maintains its proper background matching the application theme (`theme.backgroundColor`).
2. Displays a clean empty state message (*"No notes match the search query."*) while in search mode.

## Testing

1. Open Joplin Desktop app.
2. Enter a search query in the search bar that has no matching notes (e.g., `girls` or `xyz999nonexistent`).
3. Verify that the Note Editor pane does not collapse/disappear, but displays a centered empty message (*"No notes match the search query."*) matching the active theme.

## Screenshots

Empty Search State Result:

<img width="1520" height="800" alt="Screenshot 2026-08-19 002650" src="https://github.com/user-attachments/assets/a90115ff-7c1c-40f9-b793-fe8de1a6f4c5" />

