### PR TITLE
Desktop: Fixes #16007: Fix toggling the chat panel clears undo/redo history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -595,6 +595,7 @@ packages/app-desktop/gui/utils/convertToScreenCoordinates.js
 packages/app-desktop/gui/utils/dragAndDrop.js
 packages/app-desktop/gui/utils/loadScript.js
 packages/app-desktop/gulpfile.js
+packages/app-desktop/integration-tests/chatPanel.spec.js
 packages/app-desktop/integration-tests/goToAnything.spec.js
 packages/app-desktop/integration-tests/main.spec.js
 packages/app-desktop/integration-tests/markdownEditor.spec.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -620,6 +620,7 @@ packages/app-desktop/gui/utils/convertToScreenCoordinates.js
 packages/app-desktop/gui/utils/dragAndDrop.js
 packages/app-desktop/gui/utils/loadScript.js
 packages/app-desktop/gulpfile.js
+packages/app-desktop/integration-tests/chatPanel.spec.js
 packages/app-desktop/integration-tests/goToAnything.spec.js
 packages/app-desktop/integration-tests/main.spec.js
 packages/app-desktop/integration-tests/markdownEditor.spec.js

--- a/packages/app-desktop/gui/ResizableLayout/LayoutItemContainer.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/LayoutItemContainer.tsx
@@ -34,43 +34,35 @@ const LayoutItemContainer: React.FC<Props> = ({
 	const canResizeBottom = parentDir === LayoutItemDirection.Column && !isLastChild;
 
 	const className = `resizableLayoutItem rli-${item.key}`;
-	if (canResizeRight || canResizeBottom) {
-		const enable = {
-			top: false,
-			right: canResizeRight,
-			bottom: canResizeBottom,
-			left: false,
-			topRight: false,
-			bottomRight: false,
-			bottomLeft: false,
-			topLeft: false,
-		};
+	const enable = {
+		top: false,
+		right: canResizeRight,
+		bottom: canResizeBottom,
+		left: false,
+		topRight: false,
+		bottomRight: false,
+		bottomLeft: false,
+		topLeft: false,
+	};
 
-		return (
-			<Resizable
-				key={item.key}
-				className={className}
-				style={style}
-				size={size}
-				onResizeStart={onResizeStart}
-				onResize={onResize}
-				onResizeStop={onResizeStop}
-				enable={enable}
-				minWidth={'minWidth' in item ? item.minWidth : itemMinWidth}
-				minHeight={'minHeight' in item ? item.minHeight : itemMinHeight}
-				maxWidth={resizedItemMaxSize?.width}
-				maxHeight={resizedItemMaxSize?.height}
-			>
-				{children}
-			</Resizable>
-		);
-	} else {
-		return (
-			<div key={item.key} className={className} style={{ ...style, ...size }}>
-				{children}
-			</div>
-		);
-	}
+	return (
+		<Resizable
+			key={item.key}
+			className={className}
+			style={style}
+			size={size}
+			onResizeStart={onResizeStart}
+			onResize={onResize}
+			onResizeStop={onResizeStop}
+			enable={enable}
+			minWidth={'minWidth' in item ? item.minWidth : itemMinWidth}
+			minHeight={'minHeight' in item ? item.minHeight : itemMinHeight}
+			maxWidth={resizedItemMaxSize?.width}
+			maxHeight={resizedItemMaxSize?.height}
+		>
+			{children}
+		</Resizable>
+	);
 };
 
 export default LayoutItemContainer;

--- a/packages/app-desktop/integration-tests/chatPanel.spec.ts
+++ b/packages/app-desktop/integration-tests/chatPanel.spec.ts
@@ -1,0 +1,28 @@
+import { test } from './util/test';
+import MainScreen from './models/MainScreen';
+
+test.describe('chatPanel', () => {
+	test('should not clear undo history when opening/closing the chat panel', async ({ mainWindow, electronApp }) => {
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		await mainScreen.createNewNote('test');
+
+		const noteEditor = mainScreen.noteEditor;
+		await noteEditor.focusCodeMirrorEditor();
+		await mainWindow.keyboard.type('Testing');
+		await noteEditor.expectToHaveText('Testing');
+
+		await mainScreen.chatPanel.configure(electronApp);
+		await mainScreen.chatPanel.open(electronApp);
+		await mainScreen.chatPanel.close(electronApp);
+
+		// Should still have the correct content
+		await noteEditor.expectToHaveText('Testing');
+
+		// Should be possible to undo everything
+		for (let i = 0; i < 'Testing'.length; i++) {
+			await noteEditor.undo(electronApp);
+		}
+		await noteEditor.expectToHaveText(/^[\n]?$/);
+	});
+});
+

--- a/packages/app-desktop/integration-tests/models/ChatPanel.ts
+++ b/packages/app-desktop/integration-tests/models/ChatPanel.ts
@@ -23,6 +23,12 @@ export default class ChatPanel {
 		await this.container.waitFor();
 	}
 
+	public async close(electronApp: ElectronApplication) {
+		await this.container.waitFor();
+		await this.mainScreen_.goToAnything.runCommand(electronApp, 'toggleAiChat');
+		await expect(this.container).not.toBeVisible();
+	}
+
 	public async sendMessage(message: string) {
 		await this.textInput.fill(message);
 		await this.textInput.press('Enter');

--- a/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
+++ b/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
@@ -46,6 +46,10 @@ export default class NoteEditorScreen {
 		this.richTextCodeEditor = new EditorCodeDialog(page_);
 	}
 
+	public async undo(electronApp: ElectronApplication) {
+		await activateMainMenuItem(electronApp, 'Undo');
+	}
+
 	public toolbarButtonLocator(title: string) {
 		return this.containerLocator.getByRole('button', { name: title });
 	}


### PR DESCRIPTION
# Problem

Toggling the chat panel remounts the note editor, clearing its undo/redo history.

**Why this happened**: The rightmost component in the [`<ResizableLayout/>`](https://github.com/laurent22/joplin/blob/dev/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx) has a [different component hierarchy](https://github.com/laurent22/joplin/blob/ce449a5a50c8beb1e3255fe2b3fbba03603b3e1a/packages/app-desktop/gui/ResizableLayout/LayoutItemContainer.tsx#L69-L71). When the chat panel is hidden, the note editor transitions from being the second-to-right component to the rightmost. This changes the component hierarchy and rerenders the editor with its initial state.


# Solution

Remove the special case for the rightmost layout item. The resizable layout seems to work correctly even without this special case.

Fixes #16007.

# Testing
## Automated tests

This pull request adds a new automated regression test that:
- Makes some changes to a note
- Shows the chat panel
- Hides the chat panel
- Attempts to undo the changes
- Validates that the changes were undone

This should help prevent a similar issue from reoccurring in the future.

## Manual testing

| Case | Before | After |
|------|------|------|
| Toggling the chat panel and undoing/redoing changes | <video src="https://github.com/user-attachments/assets/fd413e38-dd83-4765-b457-c6bf7e9e0b3e"></video> | <video src="https://github.com/user-attachments/assets/55149fef-dca3-49f2-928a-a0bfaed85fd4"></video> |
| Resizing the chat panel | <video src="https://github.com/user-attachments/assets/81939e3a-f7d8-4c54-bd19-8820fb933713"></video> | <video src="https://github.com/user-attachments/assets/75430952-b9e0-44e3-bf08-024c24205f2b"></video> |
| Resizing the main window | <video src="https://github.com/user-attachments/assets/10064a09-48b0-481c-ae8f-6e516febf61b"></video> | <video src="https://github.com/user-attachments/assets/d884e30f-957c-44de-91b8-f20ab3adca3d"></video> |
| Opening a secondary window and resizing the chat panel and window | <video src="https://github.com/user-attachments/assets/1e072de4-17ee-4d4f-a32c-aa1c852f9700"></video> | <video src="https://github.com/user-attachments/assets/82857f4b-0821-4d14-ad29-350855ad0879"></video> |
| Changing application layout and resizing panels vertically | <video src="https://github.com/user-attachments/assets/5959cfdc-4e94-411e-9db4-ef7c39d2ab57"></video> | <video src="https://github.com/user-attachments/assets/98670835-5f0a-4fde-ac00-f73183a9a07c"></video> |
























<!--





Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
