### PR TITLE
Desktop: Resolves #16156: add support for unpublishing notebooks

### DIFF
--- a/packages/app-desktop/gui/PublishFolderDialog.tsx
+++ b/packages/app-desktop/gui/PublishFolderDialog.tsx
@@ -15,6 +15,7 @@ import { clipboard } from 'electron';
 import useOnPublishFolderLinkClick from '@joplin/lib/components/shared/PublishFolderDialog/useOnPublishFolderLinkClick';
 import useShareStatusMessage from '@joplin/lib/components/shared/ShareNoteDialog/useShareStatusMessage';
 import { SharingStatus } from '@joplin/lib/components/shared/ShareNoteDialog/types';
+import Button from './Button/Button';
 
 interface Props {
 	themeId: number;
@@ -28,6 +29,7 @@ export function PublishFolderDialog(props: Props) {
 	const [folder, setFolder] = useState<FolderEntity>(null);
 	const [noteCount, setNoteCount] = useState<number>(0);
 	const [publishFolderStatus, setPublishFolderStatus] = useState<SharingStatus>(SharingStatus.Unknown);
+	const [isUnpublishing, setIsUnpublishing] = useState(false);
 
 	const encryptionWarning = useEncryptionWarningMessage();
 	const publishedShare = useMemo(() => {
@@ -68,19 +70,35 @@ export function PublishFolderDialog(props: Props) {
 		props.onClose();
 	}, [props]);
 
+	const onUnpublishFolderClick = useCallback(async () => {
+		setIsUnpublishing(true);
+		try {
+			await ShareService.instance().unpublishFolder(props.folderId);
+		} finally {
+			setIsUnpublishing(false);
+		}
+	}, [props.folderId]);
+
 	const statusMessage = useShareStatusMessage({ sharesState: publishFolderStatus, noteCount: 1 });
 
 	return (
 		<Dialog>
 			<div className="form share-note-dialog">
 				<DialogTitle title={_('Publish Notebook')}/>
-				<div className="folder-info">
-					<p>{_('Notebook: %s', folder ? folder.title : '...')}</p>
-					<p>{_('Status: %s', publishedShare ? _('Published') : _('Not published'))}</p>
-					<p>{_n('%d note in notebook', '%d notes in notebook', noteCount, noteCount)}</p>
+				<div className="shared-note-list-item">
+					<div className="title">
+						<div className="folder-info">
+							<p>{_('Notebook: %s', folder ? folder.title : '...')}</p>
+							<p>{_('Status: %s', publishedShare ? _('Published') : _('Not published'))}</p>
+							<p>{_n('%d note in notebook', '%d notes in notebook', noteCount, noteCount)}</p>
+						</div>
+					</div>
+					{publishedShare && (
+						<Button disabled={isUnpublishing} tooltip={_('Unpublish notebook')} iconName="fas fa-share-alt" onClick={onUnpublishFolderClick}/>
+					)}
 				</div>
 				<button
-					disabled={!folder || [SharingStatus.Creating, SharingStatus.Synchronizing].indexOf(publishFolderStatus) >= 0}
+					disabled={isUnpublishing || !folder || [SharingStatus.Creating, SharingStatus.Synchronizing].indexOf(publishFolderStatus) >= 0}
 					className="share"
 					onClick={publishFolderLinkButton_click}
 				>{publishedShare ? _('Copy Shareable Link') : _('Publish notebook')}</button>

--- a/packages/app-desktop/gui/PublishFolderDialog.tsx
+++ b/packages/app-desktop/gui/PublishFolderDialog.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import JoplinServerApi from '@joplin/lib/JoplinServerApi';
 import { _, _n } from '@joplin/lib/locale';
 import Folder from '@joplin/lib/models/Folder';
+import shim from '@joplin/lib/shim';
 import DialogButtonRow, { ClickEvent } from './DialogButtonRow';
 import Dialog from '@joplin/lib/components/Dialog';
 import DialogTitle from './DialogTitle';
@@ -74,6 +76,8 @@ export function PublishFolderDialog(props: Props) {
 		setIsUnpublishing(true);
 		try {
 			await ShareService.instance().unpublishFolder(props.folderId);
+		} catch (error) {
+			void shim.showErrorDialog(JoplinServerApi.connectionErrorMessage(error as Error));
 		} finally {
 			setIsUnpublishing(false);
 		}

--- a/packages/lib/services/share/ShareService.test.ts
+++ b/packages/lib/services/share/ShareService.test.ts
@@ -1,7 +1,7 @@
 import Note from '../../models/Note';
 import { createFolderTree, encryptionService, loadEncryptionMasterKey, msleep, resourceService, setupDatabaseAndSynchronizer, simulateReadOnlyShareEnv, supportDir, switchClient, synchronizerStart } from '../../testing/test-utils';
 import ShareService, { ApiShare } from './ShareService';
-import { ShareType } from './reducer';
+import { ShareType, StateShare } from './reducer';
 import { NoteEntity, ResourceEntity } from '../database/types';
 import Folder from '../../models/Folder';
 import { localSyncInfo, setEncryptionEnabled, setPpk } from '../synchronizer/syncInfoUtils';
@@ -427,6 +427,80 @@ describe('ShareService', () => {
 		await service.refreshShares();
 
 		expect(service.folderShare('folder1')).toBeUndefined();
+	});
+
+	it('should unpublish a folder and all its children', async () => {
+		const folderA = await Folder.save({ title: 'folder A' });
+		const folderB = await Folder.save({ title: 'folder B', parent_id: folderA.id });
+		const noteA = await Note.save({ title: 'note A', parent_id: folderA.id });
+		const noteB = await Note.save({ title: 'note B', parent_id: folderB.id });
+
+		let serverShares: StateShare[] = [];
+		const deletedShareIds: string[] = [];
+		const service = mockShareService({
+			onExec: async (method, path) => {
+				if (method === 'GET' && path === 'api/shares') {
+					return { items: serverShares };
+				}
+				if (method === 'POST' && path === 'api/shares') {
+					const share: StateShare = {
+						id: 'published-folder-a',
+						type: ShareType.PublishedFolder,
+						folder_id: folderA.id,
+						note_id: '',
+						master_key_id: '',
+					};
+					serverShares.push(share);
+					return share;
+				}
+				if (method === 'DELETE' && path.startsWith('api/shares/')) {
+					const shareId = path.substring('api/shares/'.length);
+					deletedShareIds.push(shareId);
+					serverShares = serverShares.filter(share => share.id !== shareId);
+					return null;
+				}
+				throw new Error(`Unhandled: ${method} ${path}`);
+			},
+		});
+
+		await service.publishFolder(folderA.id);
+		await Folder.updateAllShareIds(resourceService(), service.shares);
+
+		expect((await Folder.load(folderA.id)).is_shared).toBe(1);
+		expect((await Folder.load(folderB.id)).is_shared).toBe(1);
+		expect((await Note.load(noteA.id)).is_shared).toBe(1);
+		expect((await Note.load(noteB.id)).is_shared).toBe(1);
+
+		await service.unpublishFolder(folderA.id);
+
+		expect(deletedShareIds).toEqual(['published-folder-a']);
+		expect((await Folder.load(folderA.id)).is_shared).toBe(0);
+		expect((await Folder.load(folderB.id)).is_shared).toBe(0);
+		expect((await Note.load(noteA.id)).is_shared).toBe(0);
+		expect((await Note.load(noteB.id)).is_shared).toBe(0);
+	});
+
+	it('should throw when the folder or its published share does not exist', async () => {
+		const folderA = await Folder.save({ title: 'folder A' });
+		let deleteCallCount = 0;
+		const service = mockShareService({
+			onExec: async (method, path) => {
+				if (method === 'GET' && path === 'api/shares') {
+					return { items: [] };
+				}
+				if (method === 'DELETE') {
+					deleteCallCount++;
+					return null;
+				}
+				throw new Error(`Unhandled: ${method} ${path}`);
+			},
+		});
+
+		await service.refreshShares();
+
+		await expect(service.unpublishFolder('000000000000000000000000000000F9')).rejects.toThrow('No such folder: 000000000000000000000000000000F9');
+		await expect(service.unpublishFolder(folderA.id)).rejects.toThrow(`No published share for folder: ${folderA.id}`);
+		expect(deleteCallCount).toBe(0);
 	});
 
 	it('should throw when publishing a folder that does not exist', async () => {

--- a/packages/lib/services/share/ShareService.test.ts
+++ b/packages/lib/services/share/ShareService.test.ts
@@ -464,7 +464,10 @@ describe('ShareService', () => {
 		});
 
 		await service.publishFolder(folderA.id);
-		await Folder.updateAllShareIds(resourceService(), service.shares);
+		await Folder.save({ id: folderA.id, is_shared: 1 });
+		await Folder.save({ id: folderB.id, is_shared: 1 });
+		await Note.save({ id: noteA.id, parent_id: folderA.id, is_shared: 1 });
+		await Note.save({ id: noteB.id, parent_id: folderB.id, is_shared: 1 });
 
 		expect((await Folder.load(folderA.id)).is_shared).toBe(1);
 		expect((await Folder.load(folderB.id)).is_shared).toBe(1);

--- a/packages/lib/services/share/ShareService.test.ts
+++ b/packages/lib/services/share/ShareService.test.ts
@@ -483,6 +483,38 @@ describe('ShareService', () => {
 		expect((await Note.load(noteB.id)).is_shared).toBe(0);
 	});
 
+	it('should keep a separately published child folder published', async () => {
+		const folderA = await Folder.save({ title: 'folder A' });
+		const folderB = await Folder.save({ title: 'folder B', parent_id: folderA.id });
+		const publishedFolderAShare = {
+			id: 'published-folder-a',
+			type: ShareType.PublishedFolder,
+			folder_id: folderA.id,
+		};
+		const publishedFolderBShare = {
+			id: 'published-folder-b',
+			type: ShareType.PublishedFolder,
+			folder_id: folderB.id,
+		};
+		let sharesReturnedByServer = [publishedFolderAShare, publishedFolderBShare];
+		const service = mockShareService({
+			getShares: async () => ({ items: sharesReturnedByServer }),
+			postShares: async () => null,
+			getShareInvitations: async () => ({ items: [] }),
+		});
+
+		await service.refreshShares();
+		await Folder.save({ id: folderA.id, is_shared: 1 });
+		await Folder.save({ id: folderB.id, is_shared: 1 });
+		sharesReturnedByServer = [publishedFolderBShare];
+
+		await service.unpublishFolder(folderA.id);
+
+		expect(service.shares).toEqual([publishedFolderBShare]);
+		expect((await Folder.load(folderA.id)).is_shared).toBe(0);
+		expect((await Folder.load(folderB.id)).is_shared).toBe(1);
+	});
+
 	it('should throw when the folder or its published share does not exist', async () => {
 		const folderA = await Folder.save({ title: 'folder A' });
 		let deleteCallCount = 0;

--- a/packages/lib/services/share/ShareService.test.ts
+++ b/packages/lib/services/share/ShareService.test.ts
@@ -483,9 +483,10 @@ describe('ShareService', () => {
 		expect((await Note.load(noteB.id)).is_shared).toBe(0);
 	});
 
-	it('should keep a separately published child folder published', async () => {
+	it('should keep a separately published child folder and child note published', async () => {
 		const folderA = await Folder.save({ title: 'folder A' });
 		const folderB = await Folder.save({ title: 'folder B', parent_id: folderA.id });
+		const noteA = await Note.save({ title: 'note A', parent_id: folderA.id });
 		const publishedFolderAShare = {
 			id: 'published-folder-a',
 			type: ShareType.PublishedFolder,
@@ -496,7 +497,12 @@ describe('ShareService', () => {
 			type: ShareType.PublishedFolder,
 			folder_id: folderB.id,
 		};
-		let sharesReturnedByServer = [publishedFolderAShare, publishedFolderBShare];
+		const publishedNoteAShare = {
+			id: 'published-note-a',
+			type: ShareType.Note,
+			note_id: noteA.id,
+		};
+		let sharesReturnedByServer = [publishedFolderAShare, publishedFolderBShare, publishedNoteAShare];
 		const service = mockShareService({
 			getShares: async () => ({ items: sharesReturnedByServer }),
 			postShares: async () => null,
@@ -506,13 +512,15 @@ describe('ShareService', () => {
 		await service.refreshShares();
 		await Folder.save({ id: folderA.id, is_shared: 1 });
 		await Folder.save({ id: folderB.id, is_shared: 1 });
-		sharesReturnedByServer = [publishedFolderBShare];
+		await Note.save({ id: noteA.id, parent_id: folderA.id, is_shared: 1 });
+		sharesReturnedByServer = [publishedFolderBShare, publishedNoteAShare];
 
 		await service.unpublishFolder(folderA.id);
 
-		expect(service.shares).toEqual([publishedFolderBShare]);
+		expect(service.shares).toEqual([publishedFolderBShare, publishedNoteAShare]);
 		expect((await Folder.load(folderA.id)).is_shared).toBe(0);
 		expect((await Folder.load(folderB.id)).is_shared).toBe(1);
+		expect((await Note.load(noteA.id)).is_shared).toBe(1);
 	});
 
 	it('should throw when the folder or its published share does not exist', async () => {

--- a/packages/lib/services/share/ShareService.test.ts
+++ b/packages/lib/services/share/ShareService.test.ts
@@ -483,6 +483,54 @@ describe('ShareService', () => {
 		expect((await Note.load(noteB.id)).is_shared).toBe(0);
 	});
 
+	it('should recover if app closes while unpublishing a folder', async () => {
+		const folder = await Folder.save({ title: 'folder' });
+		const note = await Note.save({ title: 'note', parent_id: folder.id });
+		const share = {
+			id: 'published-folder',
+			type: ShareType.PublishedFolder,
+			folder_id: folder.id,
+		};
+		let serverShares = [share];
+		const service = mockShareService({
+			onExec: async (method, path) => {
+				if (method === 'GET' && path === 'api/shares') return { items: serverShares };
+				if (method === 'DELETE' && path === `api/shares/${share.id}`) {
+					serverShares = [];
+					return null;
+				}
+				throw new Error(`Unhandled: ${method} ${path}`);
+			},
+		});
+
+		await service.refreshShares();
+		await Folder.save({ id: folder.id, is_shared: 1 });
+		await Note.save({ id: note.id, parent_id: folder.id, is_shared: 1 });
+
+		const updateShareStatusSpy = jest.spyOn(Folder, 'updateShareStatus').mockImplementationOnce(async (item, isShared) => {
+			await BaseItem.updateShareStatus(item, isShared);
+			throw new Error('App closed');
+		});
+		try {
+			await expect(service.unpublishFolder(folder.id)).rejects.toThrow('App closed');
+		} finally {
+			updateShareStatusSpy.mockRestore();
+		}
+
+		expect(serverShares).toEqual([share]);
+
+		const restartedService = mockShareService({
+			getShares: async () => ({ items: serverShares }),
+			postShares: async () => null,
+			getShareInvitations: async () => ({ items: [] }),
+		});
+		await restartedService.refreshShares();
+		await Folder.updateAllShareIds(resourceService(), restartedService.shares);
+
+		expect((await Folder.load(folder.id)).is_shared).toBe(1);
+		expect((await Note.load(note.id)).is_shared).toBe(1);
+	});
+
 	it('should keep a separately published child folder and child note published', async () => {
 		const folderA = await Folder.save({ title: 'folder A' });
 		const folderB = await Folder.save({ title: 'folder B', parent_id: folderA.id });

--- a/packages/lib/services/share/ShareService.ts
+++ b/packages/lib/services/share/ShareService.ts
@@ -336,13 +336,16 @@ export default class ShareService {
 		const folders = await Folder.loadItemsByIds(folderIds) as FolderEntity[];
 		const noteIds = (await Promise.all(folderIds.map(id => Folder.noteIds(id, { includeConflicts: true, includeDeleted: true })))).flat();
 		const notes = await Note.loadItemsByIds(noteIds) as NoteEntity[];
+		const directlyPublishedNoteIds = new Set(remainingShares
+			.filter(s => s.type === ShareType.Note && !!s.note_id)
+			.map(s => s.note_id));
 
 		for (const folderItem of folders) {
 			await Folder.updateShareStatus({ ...folderItem, type_: ModelType.Folder }, false);
 		}
 
 		for (const note of notes) {
-			await Note.updateShareStatus({ ...note, type_: ModelType.Note }, false);
+			await Note.updateShareStatus({ ...note, type_: ModelType.Note }, directlyPublishedNoteIds.has(note.id));
 		}
 
 		await Folder.updateAllShareIds(ResourceService.instance(), remainingShares);

--- a/packages/lib/services/share/ShareService.ts
+++ b/packages/lib/services/share/ShareService.ts
@@ -329,9 +329,7 @@ export default class ShareService {
 		const share = this.shares.find(s => s.type === ShareType.PublishedFolder && s.folder_id === folderId);
 		if (!share) throw new Error(`No published share for folder: ${folderId}`);
 
-		await this.deleteShare(share.id);
-
-		const remainingShares = await this.refreshShares();
+		const remainingShares = this.shares.filter(s => s.id !== share.id);
 		const folderIds = [folderId, ...(await Folder.allChildrenFolders(folderId)).map(f => f.id)];
 		const folders = await Folder.loadItemsByIds(folderIds) as FolderEntity[];
 		const noteIds = (await Promise.all(folderIds.map(id => Folder.noteIds(id, { includeConflicts: true, includeDeleted: true })))).flat();
@@ -349,6 +347,10 @@ export default class ShareService {
 		}
 
 		await Folder.updateAllShareIds(ResourceService.instance(), remainingShares);
+
+		// Clean local state first so next sync can recover if deletion stops midway
+		await this.deleteShare(share.id);
+		await this.refreshShares();
 	}
 
 	public async unshareNote(noteId: string) {

--- a/packages/lib/services/share/ShareService.ts
+++ b/packages/lib/services/share/ShareService.ts
@@ -1,4 +1,5 @@
 import { Store } from 'redux';
+import { ModelType } from '../../BaseModel';
 import JoplinServerApi from '../../JoplinServerApi';
 import { _ } from '../../locale';
 import Logger from '@joplin/utils/Logger';
@@ -6,7 +7,7 @@ import Folder from '../../models/Folder';
 import MasterKey from '../../models/MasterKey';
 import Note from '../../models/Note';
 import Setting from '../../models/Setting';
-import { FolderEntity } from '../database/types';
+import { FolderEntity, NoteEntity } from '../database/types';
 import EncryptionService from '../e2ee/EncryptionService';
 import { PublicPrivateKeyPair, mkReencryptFromPasswordToPublicKey, mkReencryptFromPublicKeyToPassword, supportsPpkAlgorithm } from '../e2ee/ppk/ppk';
 import { MasterKeyEntity } from '../e2ee/types';
@@ -319,6 +320,32 @@ export default class ShareService {
 		await this.refreshShares();
 
 		return share;
+	}
+
+	public async unpublishFolder(folderId: string): Promise<void> {
+		const folder = await Folder.load(folderId);
+		if (!folder) throw new Error(`No such folder: ${folderId}`);
+
+		const share = this.shares.find(s => s.type === ShareType.PublishedFolder && s.folder_id === folderId);
+		if (!share) throw new Error(`No published share for folder: ${folderId}`);
+
+		await this.deleteShare(share.id);
+
+		const remainingShares = await this.refreshShares();
+		const folderIds = [folderId, ...(await Folder.allChildrenFolders(folderId)).map(f => f.id)];
+		const folders = await Folder.loadItemsByIds(folderIds) as FolderEntity[];
+		const noteIds = (await Promise.all(folderIds.map(id => Folder.noteIds(id, { includeConflicts: true, includeDeleted: true })))).flat();
+		const notes = await Note.loadItemsByIds(noteIds) as NoteEntity[];
+
+		for (const folderItem of folders) {
+			await Folder.updateShareStatus({ ...folderItem, type_: ModelType.Folder }, false);
+		}
+
+		for (const note of notes) {
+			await Note.updateShareStatus({ ...note, type_: ModelType.Note }, false);
+		}
+
+		await Folder.updateAllShareIds(ResourceService.instance(), remainingShares);
 	}
 
 	public async unshareNote(noteId: string) {


### PR DESCRIPTION
Resolves #16156

I added unpublish button similar to the one used for published notes and it's disable while unpublishing is in progress. Unpublishing removes the notebook’s public share while other notebooks and notes published separately stay published.

Added tests to check that a notebook and everything inside it are unpublished correctly. Also tested trying to unpublish a notebook that is not published