### PR TITLE
Desktop: Fixes #15947: Disable link to note button when note is readonly

### DIFF
--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.ts
@@ -34,6 +34,6 @@ export const runtime = (): CommandRuntime => {
 			return result;
 		},
 
-		enabledCondition: 'markdownEditorPaneVisible || richTextEditorVisible',
+		enabledCondition: '(markdownEditorPaneVisible || richTextEditorVisible) && !noteIsReadOnly && !noteIsDeleted',
 	};
 };


### PR DESCRIPTION
The "Link to note..." button on the desktop app currently is always enabled, even when the note is readonly. This PR makes the button disabled when the note is readonly or deleted.

This fixes https://github.com/laurent22/joplin/issues/15947

### Testing

**See video:**

https://github.com/user-attachments/assets/225e01f2-63a9-4a1a-b55a-8f8cc6f90bf5