### PR TITLE
Desktop: Fix All Notes showing trashed note after switching from Trash (#16229)

### DIFF
--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -548,7 +548,6 @@ export default class BaseApplication {
 
 		if (action.type === 'SMART_FILTER_SELECT') {
 			refreshNotes = true;
-			refreshNotesUseSelectedNoteId = true;
 		}
 
 		// Switching windows can also change which note(s) and which note parent type is selected.

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -1094,6 +1094,7 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 		case 'SMART_FILTER_SELECT':
 			draft.notesParentType = 'SmartFilter';
 			draft.selectedSmartFilterId = action.id;
+			draft.selectedNoteIds = [];
 			break;
 
 		case 'FOLDER_SELECT_ADD':


### PR DESCRIPTION
## Summary

When switching from the **Trash** folder to the **All Notes** smart filter, the previously-selected trashed note remained visible in the editor, and nothing was selected in the note list.

## Root Cause

Two interrelated bugs in `SMART_FILTER_SELECT` handling:

**1. Reducer (`packages/lib/reducer.ts`) — `selectedNoteIds` not cleared**

The `SMART_FILTER_SELECT` case did not clear `selectedNoteIds`, leaving the trashed note's ID in state. In contrast, `FOLDER_SELECT` and `TAG_SELECT` both clear `selectedNoteIds` when the parent context changes.

**2. Middleware (`packages/lib/BaseApplication.ts`) — stale note re-selected after refresh**

`refreshNotesUseSelectedNoteId = true` caused `refreshNotes()` to dispatch `NOTE_SELECT` with the old `selectedNoteIds[0]` (the trashed note ID). Since trashed notes do not appear in All Notes, the note list showed no selection while the editor still rendered the old trashed note content.

## Fix

- Clear `selectedNoteIds` in the `SMART_FILTER_SELECT` reducer case, consistent with `FOLDER_SELECT` and `TAG_SELECT` behaviour.
- Remove `refreshNotesUseSelectedNoteId = true` so the note refresh falls through to the `lastSelectedNoteIds` / first-note logic, also consistent with `FOLDER_SELECT` behaviour.

## Testing

1. Create a notebook with at least one note
2. Trash one of the notes
3. Go to **Trash** in the sidebar and open the trashed note
4. Click **All Notes** in the sidebar
5. ✅ A non-trashed note is now selected in the list and shown in the editor (previously: no note selected, trashed note still shown)

Fixes #16229
