### PR TITLE
Server: Fixes #15226: Fix SQLite database getting permanently locked

### DIFF
--- a/packages/server/src/services/TaskService.ts
+++ b/packages/server/src/services/TaskService.ts
@@ -81,7 +81,7 @@ export default class TaskService extends BaseService {
 	}
 
 	// Null when task state is managed through the main connection pool.
-	public get taskStateDb(): DbConnection {
+	public get taskStateDb() {
 		return this.taskStateDb_;
 	}
 

--- a/packages/server/src/services/TaskService.ts
+++ b/packages/server/src/services/TaskService.ts
@@ -80,6 +80,11 @@ export default class TaskService extends BaseService {
 		this.taskStateModels_ = taskStateDb ? newModelFactory(taskStateDb, taskStateDb, config) : models;
 	}
 
+	// Null when task state is managed through the main connection pool.
+	public get taskStateDb(): DbConnection {
+		return this.taskStateDb_;
+	}
+
 	public async destroy() {
 		this.taskServiceDestroyed_ = true;
 		for (const handle of this.scheduledHandles_) {

--- a/packages/server/src/utils/setupTaskService.test.ts
+++ b/packages/server/src/utils/setupTaskService.test.ts
@@ -1,8 +1,7 @@
 import config from '../config';
-import { TaskId } from '../services/database/types';
 import { Services } from '../services/types';
 import setupTaskService from './setupTaskService';
-import { afterAllTests, beforeAllDb, beforeEachDb, db, getDatabaseClientType, models, msleep } from './testing/testUtils';
+import { afterAllTests, beforeAllDb, beforeEachDb, getDatabaseClientType, models } from './testing/testUtils';
 import { DatabaseConfigClient, Env } from './types';
 
 const newServices = (): Services => {
@@ -42,40 +41,6 @@ describe('setupTaskService', () => {
 		} finally {
 			await taskService.destroy();
 		}
-	});
-
-	test('should serialise task state writes with the main connection when using SQLite', async () => {
-		if (!isSqlite()) return;
-
-		const taskService = await setupTaskService(Env.Prod, models(), config(), newServices());
-
-		// An open transaction holds the only connection of the SQLite pool. The
-		// task state write must queue behind it - if it goes through on its own
-		// connection, the two writers race for the file lock and eventually
-		// leave one of them stuck inside a transaction.
-		const trx = await db().transaction();
-
-		let completed = false;
-		let writeError: Error = null;
-		const writePromise = (async () => {
-			try {
-				await taskService.enableTask(TaskId.ProcessShares, false);
-			} catch (error) {
-				writeError = error;
-			}
-			completed = true;
-		})();
-
-		try {
-			await msleep(500);
-			expect(completed).toBe(false);
-		} finally {
-			await trx.commit();
-			await writePromise;
-			await taskService.destroy();
-		}
-
-		expect(writeError).toBeNull();
 	});
 
 });

--- a/packages/server/src/utils/setupTaskService.test.ts
+++ b/packages/server/src/utils/setupTaskService.test.ts
@@ -1,0 +1,81 @@
+import config from '../config';
+import { TaskId } from '../services/database/types';
+import { Services } from '../services/types';
+import setupTaskService from './setupTaskService';
+import { afterAllTests, beforeAllDb, beforeEachDb, db, getDatabaseClientType, models, msleep } from './testing/testUtils';
+import { DatabaseConfigClient, Env } from './types';
+
+const newServices = (): Services => {
+	return {
+		email: null,
+		mustache: null,
+		tasks: null,
+		userDeletion: null,
+	};
+};
+
+const isSqlite = () => getDatabaseClientType() === DatabaseConfigClient.SQLite;
+
+describe('setupTaskService', () => {
+
+	beforeAll(async () => {
+		await beforeAllDb('setupTaskService');
+	});
+
+	afterAll(async () => {
+		await afterAllTests();
+	});
+
+	beforeEach(async () => {
+		await beforeEachDb();
+	});
+
+	test('should not open a separate connection pool when using SQLite', async () => {
+		const taskService = await setupTaskService(Env.Prod, models(), config(), newServices());
+
+		try {
+			if (isSqlite()) {
+				expect(taskService.taskStateDb).toBeNull();
+			} else {
+				expect(taskService.taskStateDb).toBeTruthy();
+			}
+		} finally {
+			await taskService.destroy();
+		}
+	});
+
+	test('should serialise task state writes with the main connection when using SQLite', async () => {
+		if (!isSqlite()) return;
+
+		const taskService = await setupTaskService(Env.Prod, models(), config(), newServices());
+
+		// An open transaction holds the only connection of the SQLite pool. The
+		// task state write must queue behind it - if it goes through on its own
+		// connection, the two writers race for the file lock and eventually
+		// leave one of them stuck inside a transaction.
+		const trx = await db().transaction();
+
+		let completed = false;
+		let writeError: Error = null;
+		const writePromise = (async () => {
+			try {
+				await taskService.enableTask(TaskId.ProcessShares, false);
+			} catch (error) {
+				writeError = error;
+			}
+			completed = true;
+		})();
+
+		try {
+			await msleep(500);
+			expect(completed).toBe(false);
+		} finally {
+			await trx.commit();
+			await writePromise;
+			await taskService.destroy();
+		}
+
+		expect(writeError).toBeNull();
+	});
+
+});

--- a/packages/server/src/utils/setupTaskService.ts
+++ b/packages/server/src/utils/setupTaskService.ts
@@ -4,7 +4,7 @@ import { TaskId } from '../services/database/types';
 import TaskService, { Task, taskIdToLabel } from '../services/TaskService';
 import { Services } from '../services/types';
 import { logHeartbeat as logHeartbeatMessage } from './metrics';
-import { Config, Env } from './types';
+import { Config, DatabaseConfigClient, Env } from './types';
 import { Day } from './time';
 
 export default async function(env: Env, models: Models, config: Config, services: Services): Promise<TaskService> {
@@ -12,7 +12,15 @@ export default async function(env: Env, models: Models, config: Config, services
 	// management so that it is not affected by failed transactions in the
 	// main connection pool. In dev/test, we reuse the main connection to
 	// avoid exhausting Postgres connection slots in CI.
-	const taskStateDb = env === Env.Prod ? await connectDb({ ...config.database, maxConnections: 1 }) : null;
+	//
+	// SQLite is excluded because it only allows one writer per database file. A
+	// second pool makes concurrent writes fail with "SQLITE_BUSY: database is
+	// locked", and a COMMIT that fails that way leaves the connection inside a
+	// transaction, so every later BEGIN fails with "cannot start a transaction
+	// within a transaction" until the server is restarted.
+	// https://github.com/laurent22/joplin/issues/15226
+	const useSeparateTaskStateDb = env === Env.Prod && config.database.client !== DatabaseConfigClient.SQLite;
+	const taskStateDb = useSeparateTaskStateDb ? await connectDb({ ...config.database, maxConnections: 1 }) : null;
 	const taskService = new TaskService(env, models, config, services, taskStateDb);
 
 	let tasks: Task[] = [


### PR DESCRIPTION
# Server: Fixes #15226: Fix SQLite database getting permanently locked

Fixes #15226. Also explains the intermittent `SQLITE_BUSY` failures reported in
[marph91/joppy#37](https://github.com/marph91/joppy/issues/37).

## Problem

On SQLite backends, Joplin Server eventually reaches a state where **every** database
transaction fails, permanently, until the container is restarted:

```
[error] db: COMMIT; - SQLITE_BUSY: database is locked
[error] db: BEGIN;  - SQLITE_ERROR: cannot start a transaction within a transaction
[error] TaskService: Failed running task #11 (Process shared items)
        Error: Transaction query already complete, run with DEBUG=knex:tx for more info
[warn]  TaskService: Tried to start #12 (Process emails) but it was already running
```

Desktop, Android and Linux clients then fail to sync with `SQLITE_BUSY: database is locked`
or `502 Bad Gateway`, and the admin UI stops loading. Multiple users have confirmed it on
3.6.1 and 3.7.1; 3.5.2 is unaffected.

## Root cause

`d7f701c8d` (#15137, "Fix tasks getting permanently stuck after database errors") introduced
a **second knex connection pool** for task-state bookkeeping:

```ts
const taskStateDb = env === Env.Prod ? await connectDb({ ...config.database, maxConnections: 1 }) : null;
```

For Postgres this does exactly what it was designed to do. For SQLite it is fatal, because
SQLite permits only one writer per database file:

1. **Two OS-level connections open the same file.** `makeKnexConfig()` deliberately leaves
   `pool` undefined for `sqlite3`, so knex applies its SQLite dialect default of
   [`{ min: 1, max: 1 }`](https://github.com/knex/knex/blob/master/lib/dialects/sqlite3/index.js).
   One pool is safe; two pools mean two competing writers.
2. **A `COMMIT` fails with `SQLITE_BUSY`.** Connection A (main pool) sits in a transaction
   holding `SHARED`. Connection B (task-state pool) holds `RESERVED` and its `COMMIT` needs
   `EXCLUSIVE` — blocked by A.
3. **The failed `COMMIT` does not end the transaction.** SQLite leaves it open on B, but knex
   marks its transaction object complete and returns the connection to the pool anyway.
4. **The poison is permanent.** The pool holds exactly one connection, so every later
   `db.transaction()` gets that same connection back. Its `BEGIN` fails, knex rejects the
   transaction, and the first query against the completed object throws
   `Transaction query already complete`. Nothing short of a restart recovers.
5. **Everything downstream stops.** `TaskStateModel.stop()` can never write, so
   `task_states.running` stays `1` and every task is skipped as *already running* — including
   `ProcessShares`. Meanwhile the two pools keep colliding, which reaches clients as
   `SQLITE_BUSY` on ordinary sync writes (`changes_2` inserts, per joppy#37).

The reporter's log in #15226 shows steps 2 and 4 back-to-back, one second apart, which is what
pinned the diagnosis.

Two related notes:

- The guard is `env === Env.Prod`, so the second pool never exists in dev or under the test
  suite. That is why CI never caught this and it only surfaces in user deployments.
- `e7631bc34` ("Fix database connection pool corruption after transaction failures", in 3.7.1)
  already attempts a rollback when a commit fails — but it swallows rollback errors, and under
  SQLite that `ROLLBACK` hits the same lock. That is why 3.7.1 is still affected.

## Fix

Skip the separate pool when the backend is SQLite:

```ts
const useSeparateTaskStateDb = env === Env.Prod && config.database.client !== DatabaseConfigClient.SQLite;
const taskStateDb = useSeparateTaskStateDb ? await connectDb({ ...config.database, maxConnections: 1 }) : null;
```

With a single pool of one connection, knex's pool queue serialises every writer in the
process, so `SQLITE_BUSY` cannot arise from Joplin Server itself.

Postgres keeps the isolated pool and the #15137 behaviour it was written for. SQLite gives
that isolation up — which is the right trade, since the resilience it buys is worth less than
the correctness guarantee it breaks.

`TaskService` also gains a `taskStateDb` getter so the wiring is assertable from a test.

## Tests

New file `packages/server/src/utils/setupTaskService.test.ts`, two tests, both failing before
the change and passing after:

| Test | Before | After |
| --- | --- | --- |
| `should not open a separate connection pool when using SQLite` | FAIL — `Received: [Function knex]` | PASS |
| `should serialise task state writes with the main connection when using SQLite` | FAIL — `Expected: false, Received: true` | PASS |

The second test holds an open transaction on the main pool — which under SQLite occupies its
only connection — then issues a task-state write and asserts it has *not* completed 500 ms
later. That can only hold if both share one pool. The first test also covers the Postgres
path, asserting the separate pool is still created there.

## Verification

| Check | Result |
| --- | --- |
| `yarn tsc` (packages/server) | exit 0 |
| `yarn tsc` (monorepo) | exit 0 |
| `yarn test setupTaskService` before fix | 2 failed |
| `yarn test setupTaskService` after fix | 2 passed |
| `yarn test TaskService` | 5 passed, no regression |
| `yarn test` (full server suite) | 79 suites / 399 tests passed |
| `yarn lint-staged` (linter + spellcheck + checkIgnoredFiles) | clean |

Also verified end-to-end with a Docker image built from this branch against a SQLite volume.

## Scope and risk

Three files, +96/-2. The behaviour change is confined to SQLite in production — the branch
that previously created a second pool. Postgres deployments and Joplin Cloud are unaffected,
and dev/test behaviour is unchanged (the separate pool was already disabled there).

## Follow-ups worth filing separately

Out of scope here, but the same area:

- **`TransactionHandler` can still be poisoned in principle.** If a `COMMIT` and its fallback
  `ROLLBACK` both fail, the connection returns to the pool inside a transaction. That is now
  unreachable from server code on SQLite, but an external writer on the same file — a backup
  tool, the `sqlite3` CLI, a second container on the same volume — would reproduce it. The
  durable fix is to evict the connection from the pool rather than swallow the rollback error.
- **No `busy_timeout` or WAL mode is set** anywhere in `packages/server/src/db.ts`.
  `PRAGMA journal_mode=WAL` plus a few seconds of `busy_timeout` would make external
  concurrency survivable rather than fatal.
- **`waitForConnection()` leaks a knex instance per failed attempt** (`db.ts:123`). Harmless
  today because those failures are terminal, but it is the same class of stray-pool mistake.
