### PR TITLE
Desktop: Fixes #16015: Fix sync wizard extended options are partially offscreen

### DIFF
--- a/packages/app-desktop/gui/styles/dialog-modal-layer.scss
+++ b/packages/app-desktop/gui/styles/dialog-modal-layer.scss
@@ -5,8 +5,8 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
+	padding: 20px;
 	align-items: flex-start;
-	justify-content: center;
 	border: none;
 	margin: 0;
 	background-color: transparent;
@@ -20,11 +20,13 @@
 		color: var(--joplin-color);
 		padding: 16px;
 		box-shadow: 6px 6px 20px rgba(0,0,0,0.5);
-		margin: 20px;
 		min-height: fit-content;
 		display: flex;
 		flex-direction: column;
 		border-radius: 10px;
+
+		margin-left: auto;
+		margin-right: auto;
 	}
 
 	&::backdrop {
@@ -34,6 +36,7 @@
 	&.-fullscreen {
 		max-width: 100vw;
 		max-height: 100vh;
+		padding: 0;
 
 		&::backdrop {
 			background-color: var(--joplin-background-color);

--- a/packages/app-desktop/gui/styles/dialog-modal-layer.scss
+++ b/packages/app-desktop/gui/styles/dialog-modal-layer.scss
@@ -24,7 +24,6 @@
 		display: flex;
 		flex-direction: column;
 		border-radius: 10px;
-
 		margin-left: auto;
 		margin-right: auto;
 	}


### PR DESCRIPTION
# Problem

On desktop, the sync wizard extended options are partially offscreen in small windows and cannot be scrolled to.

# Solution

Center the `<Dialog>` element's content using a different method. Use `margin-left: auto`, `margin-right: auto` instead of `justify-content: center`. `justify-content` seems to cause scroll issues where `margin` does not.

Fixes #16015.

# Testing
## Screen recordings

| Label | Before | After |
|------|--------|-------|
| Showing the sync wizard, small window | <video src="https://github.com/user-attachments/assets/1f7be19d-336b-4a83-b64b-75782cd18718"></video> | <video src="https://github.com/user-attachments/assets/60efb887-8b88-41da-b0a3-f7949e4e90c3"></video> |
| Showing the sync wizard, large window | <video src="https://github.com/user-attachments/assets/476d4175-be61-468e-8b12-e340469e49bc"></video> | <video src="https://github.com/user-attachments/assets/37e49821-5d6c-4cca-a480-4439e79f3f19"></video> |
| Dismissing the sync wizard by clicking outside the window | <video src="https://github.com/user-attachments/assets/46f764ab-4e5a-4708-8128-18a24a7bd564"></video> | <video src="https://github.com/user-attachments/assets/3bfbaac6-361b-4cac-9cfa-dbcdceef908e"></video> |
| Showing the image editor dialog (regression testing) | <video src="https://github.com/user-attachments/assets/3a0e5179-e127-4e64-ba48-aa61429fe322"></video> | <video src="https://github.com/user-attachments/assets/4af9ee84-37b1-4617-aad3-8220bcec436c"></video> |
| Showing the move-to dialog (regression testing) | <video src="https://github.com/user-attachments/assets/d63f7809-2d1f-48e3-9d38-bbe93334e4ed"></video> | <video src="https://github.com/user-attachments/assets/e22580d7-21b8-42a5-842d-e7f2b7b1187e"></video> |


























