### PR TITLE
Chore: Desktop: Add performance logging for the embedding indexer

### DIFF
--- a/packages/lib/services/ai/EmbeddingIndexer.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.ts
@@ -162,7 +162,6 @@ export default class EmbeddingIndexer {
 		if (this.maintenanceRunning_) return;
 		this.maintenanceRunning_ = true;
 
-
 		try {
 			await perfLogger.track('EmbeddingIndexer/maintenance', async () => {
 				const provider = AiService.instance().getActiveEmbeddingProvider();

--- a/packages/lib/services/ai/EmbeddingIndexer.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.ts
@@ -11,8 +11,11 @@ import AiService from './AiService';
 import { chunkText } from './chunker';
 import { EmbeddingProvider, IndexStatus } from './types';
 import { AiIndexState, AiIndexStatus } from '../plugins/api/types';
+import PerformanceLogger from '../../PerformanceLogger';
 
 const logger = Logger.create('EmbeddingIndexer');
+const perfLogger = PerformanceLogger.create();
+
 
 // Tick cadence after the initial scan is done — slow enough to avoid burning
 // CPU on every edit, fast enough that newly-saved notes are searchable
@@ -158,26 +161,29 @@ export default class EmbeddingIndexer {
 	public async maintenance() {
 		if (this.maintenanceRunning_) return;
 		this.maintenanceRunning_ = true;
-		try {
-			const provider = AiService.instance().getActiveEmbeddingProvider();
-			if (!provider) return;
 
-			await this.handleModelChange(provider);
-			// Until the initial scan completes, walk the whole vault one batch
-			// per tick. Then switch to change-feed-only mode. The tick that
-			// finishes the scan still runs the change feed so edits made
-			// during the scan don't wait an extra interval.
-			if (!Setting.value('ai.embedding.initialScanDone')) {
-				await this.runInitialScanBatch(provider);
+		await perfLogger.track('EmbeddingIndexer/maintenance', async () => {
+			try {
+				const provider = AiService.instance().getActiveEmbeddingProvider();
+				if (!provider) return;
+
+				await this.handleModelChange(provider);
+				// Until the initial scan completes, walk the whole vault one batch
+				// per tick. Then switch to change-feed-only mode. The tick that
+				// finishes the scan still runs the change feed so edits made
+				// during the scan don't wait an extra interval.
+				if (!Setting.value('ai.embedding.initialScanDone')) {
+					await this.runInitialScanBatch(provider);
+				}
+				if (Setting.value('ai.embedding.initialScanDone')) {
+					await this.processChangeBatch(provider);
+				}
+			} catch (error) {
+				logger.error('Maintenance run failed:', error);
+			} finally {
+				this.maintenanceRunning_ = false;
 			}
-			if (Setting.value('ai.embedding.initialScanDone')) {
-				await this.processChangeBatch(provider);
-			}
-		} catch (error) {
-			logger.error('Maintenance run failed:', error);
-		} finally {
-			this.maintenanceRunning_ = false;
-		}
+		});
 	}
 
 	// Wipe-and-rebuild when the active provider's modelId changes — vectors

--- a/packages/lib/services/ai/EmbeddingIndexer.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.ts
@@ -162,8 +162,9 @@ export default class EmbeddingIndexer {
 		if (this.maintenanceRunning_) return;
 		this.maintenanceRunning_ = true;
 
-		await perfLogger.track('EmbeddingIndexer/maintenance', async () => {
-			try {
+
+		try {
+			await perfLogger.track('EmbeddingIndexer/maintenance', async () => {
 				const provider = AiService.instance().getActiveEmbeddingProvider();
 				if (!provider) return;
 
@@ -178,12 +179,12 @@ export default class EmbeddingIndexer {
 				if (Setting.value('ai.embedding.initialScanDone')) {
 					await this.processChangeBatch(provider);
 				}
-			} catch (error) {
-				logger.error('Maintenance run failed:', error);
-			} finally {
-				this.maintenanceRunning_ = false;
-			}
-		});
+			});
+		} catch (error) {
+			logger.error('Maintenance run failed:', error);
+		} finally {
+			this.maintenanceRunning_ = false;
+		}
 	}
 
 	// Wipe-and-rebuild when the active provider's modelId changes — vectors


### PR DESCRIPTION
# Summary

This pull request adds performance logging to the embedding indexer, using the existing `PerformanceLogger`.


**Why**: After adding a very large note to Joplin, I noticed slow startup and reduced responsiveness for a short period after the next startup completed. This change should help debug similar issues by logging when background indexing starts and how long it takes.




<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
