### PR TITLE
Desktop: By default, show only the editor when opening the app for the first time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -624,6 +624,7 @@ packages/app-desktop/integration-tests/util/getMainWindow.js
 packages/app-desktop/integration-tests/util/ignoreFlakyReporter.js
 packages/app-desktop/integration-tests/util/mockClipboard.js
 packages/app-desktop/integration-tests/util/retryOnFailure.js
+packages/app-desktop/integration-tests/util/seedProfileSettings.js
 packages/app-desktop/integration-tests/util/setDarkMode.js
 packages/app-desktop/integration-tests/util/setFilePickerResponse.js
 packages/app-desktop/integration-tests/util/setMessageBoxResponse.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -649,6 +649,7 @@ packages/app-desktop/integration-tests/util/getMainWindow.js
 packages/app-desktop/integration-tests/util/ignoreFlakyReporter.js
 packages/app-desktop/integration-tests/util/mockClipboard.js
 packages/app-desktop/integration-tests/util/retryOnFailure.js
+packages/app-desktop/integration-tests/util/seedProfileSettings.js
 packages/app-desktop/integration-tests/util/setDarkMode.js
 packages/app-desktop/integration-tests/util/setFilePickerResponse.js
 packages/app-desktop/integration-tests/util/setMessageBoxResponse.js

--- a/packages/app-desktop/integration-tests/util/seedProfileSettings.ts
+++ b/packages/app-desktop/integration-tests/util/seedProfileSettings.ts
@@ -1,0 +1,12 @@
+import { join } from 'path';
+import { writeFile } from 'fs-extra';
+
+// Writes the profile's settings.json before the app starts, so that these values are
+// picked up during startup. Currently used to keep the editor+viewer layout that many
+// integration tests rely on -- the app's default only shows the editor.
+const seedProfileSettings = async (profileDirectory: string, values: Record<string, unknown>) => {
+	const settingFilePath = join(profileDirectory, 'settings.json');
+	await writeFile(settingFilePath, JSON.stringify(values), 'utf8');
+};
+
+export default seedProfileSettings;

--- a/packages/app-desktop/integration-tests/util/test.ts
+++ b/packages/app-desktop/integration-tests/util/test.ts
@@ -6,6 +6,7 @@ import createStartupArgs from './createStartupArgs';
 import getMainWindow from './getMainWindow';
 import setDarkMode from './setDarkMode';
 import evaluateWithRetry from './evaluateWithRetry';
+import seedProfileSettings from './seedProfileSettings';
 
 
 type StartWithPluginsResult = { app: ElectronApplication; mainWindow: Page };
@@ -74,6 +75,10 @@ export const test = base.extend<JoplinFixtures>({
 		const profilePath = resolve(join(testDir, 'test-profile'));
 		const profileSubdir = join(profilePath, uuid.createNano());
 		await mkdirp(profileSubdir);
+
+		// Many integration tests interact with the note viewer, which is hidden by the
+		// app's default layout (editor only). Force the editor+viewer layout for tests.
+		await seedProfileSettings(profileSubdir, { noteVisiblePanes: ['editor', 'viewer'] });
 
 		await use(profileSubdir);
 

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1864,7 +1864,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			appTypes: [AppType.Mobile],
 			isGlobal: true,
 		},
-		noteVisiblePanes: { value: ['editor', 'viewer'], type: SettingItemType.Array, storage: SettingStorage.File, isGlobal: true, public: false, appTypes: [AppType.Desktop] },
+		noteVisiblePanes: { value: ['editor'], type: SettingItemType.Array, storage: SettingStorage.File, isGlobal: true, public: false, appTypes: [AppType.Desktop] },
 		tagHeaderIsExpanded: { value: true, type: SettingItemType.Bool, public: false, appTypes: [AppType.Desktop] },
 		folderHeaderIsExpanded: { value: true, type: SettingItemType.Bool, public: false, appTypes: [AppType.Desktop] },
 		syncReportIsVisible: { value: false, type: SettingItemType.Bool, public: false, appTypes: [AppType.Desktop] },


### PR DESCRIPTION
Before we displayed both the editor and viewer, but now that the editor renders the Markdown we can display just that one