### PR TITLE
Desktop: Improve chat connection check

### DIFF
--- a/packages/lib/components/shared/config/config-shared.ts
+++ b/packages/lib/components/shared/config/config-shared.ts
@@ -124,6 +124,7 @@ export const checkAiConfig = async (comp: ConfigScreenComponent) => {
 	try {
 		const { default: AiService } = await import('../../../services/ai/AiService');
 		const result = await AiService.instance().chat([
+			{ role: ChatRole.System, content: 'Keep replies brief, but non-empty.' },
 			{ role: ChatRole.User, content: 'Reply with the single word OK.' },
 		], { maxTokens: 20 });
 		const text = (result.text || '').trim();


### PR DESCRIPTION
# Problem

Certain models (e.g. locally-hosted `gemma4:e2b`) usually send an empty response to the chat connection check.

# Solution

Add a system prompt to the connection check.

This *may* fix #16003.

# Testing

- Ollama/`gemma4:e2b` went from 10 successful checks in 50 trials to 34 successful checks in 50 trials.
- Joplin Cloud continues to pass the connection check (5/5 trials).


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
