### PR TITLE
Chore: Server: Fix `truncateUserDataTables` debug command only deletes old changes

### DIFF
--- a/packages/server/src/tools/debug/truncateUserDataTables.ts
+++ b/packages/server/src/tools/debug/truncateUserDataTables.ts
@@ -2,6 +2,7 @@ import { DbConnection, truncateTables } from '../../db';
 
 const includedTables = [
 	'changes',
+	'changes_2',
 	'emails',
 	'events',
 	'item_resources',


### PR DESCRIPTION
# Problem

`truncateUserDataTables` is used by the `createTestUsers` debug command to reset user data in the database. It currently deletes legacy changes in the `changes` table, but does not delete new changes in the [`changes_2` table](https://github.com/laurent22/joplin/pull/14712).

# Solution

Update `truncateUserDataTables` to clear changes in `changes_2`, in addition to `changes`.

# Testing

1. Run the sync fuzzer against Joplin Server with a SQLite database.
2. Wait for the fuzzer to fail (see https://github.com/laurent22/joplin/issues/16153).
3. Open the SQLite database and query the number of legacy and new changes:
    ```
    sqlite> SELECT count(*) FROM changes;
    0
    sqlite> SELECT count(*) FROM changes_2;
    6479
    ```
4. Run the `createTestUsers` command:
   ```bash
   curl --data '{"action": "createTestUsers", "count": 40, "fromNum": 1}' -H 'Content-Type: application/json' http://localhost:22300/api/debug
   ```
5. Check the number of legacy and new changes:
    ```
    sqlite> SELECT count(*) FROM changes;
    0
    sqlite> SELECT count(*) FROM changes_2;
    0
    ```
6. Check that the expected number of users exists:
    ```
    sqlite> SELECT count(*) FROM users;
    41
    ```
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
