### PR TITLE
Chore: Embedding tests: Silence expected warnings

### DIFF
--- a/packages/lib/services/ai/EmbeddingIndexer.test.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.test.ts
@@ -364,7 +364,9 @@ describe('EmbeddingIndexer', () => {
 		Setting.setValue('ai.enabled', true);
 		const spy = jest.spyOn(NoteEmbedding, 'vectorSearchAvailable').mockReturnValue(false);
 		try {
-			await EmbeddingIndexer.instance().runInBackground();
+			await withWarningSilenced(/Not starting background indexer: sqlite-vec extension is not loaded/, async () => {
+				await EmbeddingIndexer.instance().runInBackground();
+			});
 			const status = await EmbeddingIndexer.instance().getStatus();
 			expect(status.indexerState).toBe('vector-search-unavailable');
 		} finally {

--- a/packages/lib/services/ai/EmbeddingIndexer.test.ts
+++ b/packages/lib/services/ai/EmbeddingIndexer.test.ts
@@ -1,4 +1,4 @@
-import { setupDatabaseAndSynchronizer, switchClient, db, msleep } from '../../testing/test-utils';
+import { setupDatabaseAndSynchronizer, switchClient, db, msleep, withWarningSilenced } from '../../testing/test-utils';
 import Setting from '../../models/Setting';
 import Folder from '../../models/Folder';
 import Note from '../../models/Note';
@@ -342,7 +342,9 @@ describe('EmbeddingIndexer', () => {
 		AiService.instance().setEmbeddingProvider(failingProvider);
 
 		// First tick processes both — bad fails, good succeeds.
-		await EmbeddingIndexer.instance().maintenance();
+		await withWarningSilenced(/synthetic failure/, async () => {
+			await EmbeddingIndexer.instance().maintenance();
+		});
 		// Second tick must NOT retry the bad note (would re-incur failureCalls).
 		await EmbeddingIndexer.instance().maintenance();
 		await EmbeddingIndexer.instance().maintenance();


### PR DESCRIPTION
# Problem

Running the embedding tests in `packages/lib` (`yarn test embed`) emits warnings from:
- https://github.com/laurent22/joplin/blob/b070bfed1fa67aecaae25eb8c31eb323941d46e3/packages/lib/services/ai/EmbeddingIndexer.test.ts#L324
  ```
  16:55:04: EmbeddingIndexer: Initial scan failed for note 2dd69725607340579d82c0f20ef65f8c (will retry next session): Error: synthetic failure
      at TestEmbeddingProvider.embed (/home/self/Documents/joplin/packages/lib/services/ai/EmbeddingIndexer.test.ts:337:12)
      at EmbeddingIndexer.embed [as indexNote] (/home/self/Documents/joplin/packages/lib/services/ai/EmbeddingIndexer.ts:294:34)
      at EmbeddingIndexer.runInitialScanBatch (/home/self/Documents/joplin/packages/lib/services/ai/EmbeddingIndexer.ts:254:5)
      at EmbeddingIndexer.maintenance (/home/self/Documents/joplin/packages/lib/services/ai/EmbeddingIndexer.ts:171:5)
      at Object.<anonymous> (/home/self/Documents/joplin/packages/lib/services/ai/EmbeddingIndexer.test.ts:345:3)
   ```
- https://github.com/laurent22/joplin/blob/b070bfed1fa67aecaae25eb8c31eb323941d46e3/packages/lib/services/ai/EmbeddingIndexer.test.ts#L356
    ```
    17:02:28: EmbeddingIndexer: Not starting background indexer: sqlite-vec extension is not loaded on this platform
    ```

Both warnings are caused by simulated failure conditions.

# Solution

Silence the warnings.

# Testing

Run `yarn test embed` from `packages/lib`. Verify that the warnings are no longer logged:
```
bash$ yarn test embed
Unknown CPU vendor. cpuinfo_vendor value: 0
onnxruntime cpuid_info warning: Unknown CPU vendor. cpuinfo_vendor value: 0
onnxruntime cpuid_info warning: Unknown CPU vendor. cpuinfo_vendor value: 0
onnxruntime cpuid_info warning: Unknown CPU vendor. cpuinfo_vendor value: 0
Unknown CPU vendor. cpuinfo_vendor value: 0
 PASS  services/ai/testing/TestEmbeddingProvider.test.js
 PASS  services/ai/LocalEmbeddingProvider.test.js
 PASS  services/ai/EmbeddingModelDownloader.test.js
 PASS  models/NoteEmbedding.test.js
 PASS  services/ai/EmbeddingIndexer.test.js
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.

Test Suites: 5 passed, 5 total
Tests:       1 skipped, 62 passed, 63 total
Snapshots:   0 total
Time:        17.905 s
Ran all test suites matching /embed/i.
```

> [!NOTE]
>
> I suspect that the remaining `onnxruntime cpuid_info warning: Unknown CPU vendor. cpuinfo_vendor value: 0` warnings are caused by my development environment (Ubuntu 26.04 VM on MacOS).

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
