### PR TITLE
Chore: Tests: Mobile: Fix "failed to set timeout" warning in note screen tests

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -766,6 +766,11 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		this.commandRegistration_?.deregister();
 		this.commandRegistration_ = null;
 
+		if (this.focusUpdateIID_) {
+			shim.clearInterval(this.focusUpdateIID_);
+			this.focusUpdateIID_ = null;
+		}
+
 		this.props.dispatch({
 			type: 'SET_NOTE_EDITOR_VISIBLE',
 			visible: false,


### PR DESCRIPTION
# Problem

Running `yarn test screens/Note` in `packages/app-mobile` logs a focus-related warning:
```
bash$ yarn test screens/Note
SafeAreaView has been deprecated and will be removed in a future release. Please use 'react-native-safe-area-context' instead. See https://github.com/th3rdwave/react-native-safe-area-context
 PASS  components/screens/Notes/NewNoteButton.test.tsx
SafeAreaView has been deprecated and will be removed in a future release. Please use 'react-native-safe-area-context' instead. See https://github.com/th3rdwave/react-native-safe-area-context
 PASS  components/screens/NoteRevisionViewer.test.tsx
SafeAreaView has been deprecated and will be removed in a future release. Please use 'react-native-safe-area-context' instead. See https://github.com/th3rdwave/react-native-safe-area-context
 PASS  components/screens/Note/Note.test.tsx (41.868 s)
  ● Console

    console.warn
      17:23:41: screens/Note: Timeout while trying to set focus on body

      314 |                             }
      315 |
    > 316 |                             (consoleObj as unknown as Record<string, (...args: unknown[])=> void>)[fn](...items);
          |                                                                                                       ^
      317 |                     } else if (target.type === 'file') {
      318 |                             logLine = this.logInfoToString(level, targetPrefix, ...object);
      319 |

      at apply (../utils/Logger.ts:316:79)
      at Logger._loop [as log] (../utils/Logger.ts:285:48)
      at Object.apply [as warn] (../utils/Logger.ts:150:69)
      at Timeout._onTimeout (components/screens/Note/Note.tsx:1550:12)

A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.

Test Suites: 3 passed, 3 total
Tests:       26 passed, 26 total
Snapshots:   0 total
Time:        42.819 s, estimated 43 s
Ran all test suites matching /screens\/Note/i.
```

This happen when the autofocus task runs after the note editor unmounts.

# Solution

Clear the autofocus interval when unmounting the note editor.

# Testing

## Manual regression testing

1. Start the web app
2. Create a new note. Verify that the body auto-focuses.
3. Create a new to-do. Verify that the title field auto-focuses.

## Re-running the tests

Running `yarn test screens/Note` in `packages/app-mobile` no-longer logs the "timeout while trying to focus" warning:
```
bash$ yarn test screens/Note
SafeAreaView has been deprecated and will be removed in a future release. Please use 'react-native-safe-area-context' instead. See https://github.com/th3rdwave/react-native-safe-area-context
 PASS  components/screens/Notes/NewNoteButton.test.tsx
SafeAreaView has been deprecated and will be removed in a future release. Please use 'react-native-safe-area-context' instead. See https://github.com/th3rdwave/react-native-safe-area-context
SafeAreaView has been deprecated and will be removed in a future release. Please use 'react-native-safe-area-context' instead. See https://github.com/th3rdwave/react-native-safe-area-context
 PASS  components/screens/NoteRevisionViewer.test.tsx
 PASS  components/screens/Note/Note.test.tsx (43.295 s)
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.

Test Suites: 3 passed, 3 total
Tests:       26 passed, 26 total
Snapshots:   0 total
Time:        44.188 s
Ran all test suites matching /screens\/Note/i.
```


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
