### PR TITLE
Desktop: Improve refresh for whiteboards and editor plugins and ensure consistency regardless of whether E2EE is enabled

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -86,6 +86,8 @@ function NoteEditorContent(props: NoteEditorProps) {
 	const [titleHasBeenManuallyChanged, setTitleHasBeenManuallyChanged] = useState(false);
 	const [isReadOnly, setIsReadOnly] = useState<boolean>(false);
 	const [reloadInProgress, setReloadInProgress] = useState(false);
+	const [pluginForceReloadRequest, setPluginForceReloadRequest] = useState(0);
+	const [pluginRefreshPending, setPluginRefreshPending] = useState(false);
 
 	const editorRef = useRef<NoteBodyEditorRef|null>(null);
 	const titleInputRef = useRef<HTMLInputElement|null>(null);
@@ -120,8 +122,34 @@ function NoteEditorContent(props: NoteEditorProps) {
 	}, []);
 
 	const effectiveNoteId = useEffectiveNoteId(props);
+	const currentNoteSelection = useMemo(() => ({ noteId: effectiveNoteId, time: Date.now() }), [effectiveNoteId]);
 	const { editorPlugin, editorView } = usePluginEditorView(props.plugins);
 	const builtInEditorVisible = !editorPlugin;
+	const forcePluginReload = useCallback(() => {
+		setPluginForceReloadRequest(previous => previous + 1);
+	}, []);
+	const refreshPluginWhenDecrypted = useCallback(async () => {
+		if (!effectiveNoteId) return;
+		setPluginRefreshPending(true);
+		try {
+			const storedNote = await Note.load(effectiveNoteId, { fields: ['encryption_applied', 'updated_time'] });
+			if (formNoteRef.current.id !== effectiveNoteId) return;
+			if (!storedNote || storedNote.updated_time <= formNoteRef.current.updated_time) {
+				setPluginRefreshPending(false);
+				return;
+			}
+			if (!storedNote.encryption_applied) {
+				setPluginRefreshPending(false);
+				forcePluginReload();
+			}
+		} catch (error) {
+			setPluginRefreshPending(false);
+			logger.warn('Could not check whether the plugin note has been decrypted', error);
+		}
+	}, [effectiveNoteId, forcePluginReload]);
+	useEffect(() => {
+		setPluginRefreshPending(false);
+	}, [editorPlugin, effectiveNoteId]);
 	const windowId = useContext(WindowIdContext);
 	const onDecryptFailedChange = useCallback((value: boolean) => {
 		props.dispatch({ type: 'SET_ACTIVE_NOTE_IS_UNDECRYPTABLE', value, windowId });
@@ -165,9 +193,35 @@ function NoteEditorContent(props: NoteEditorProps) {
 		onDecryptFailedChange,
 		onReloadInProgressChange,
 		editorNoteReloadTimeRequest: props.editorNoteReloadTimeRequest,
+		forceReloadRequest: pluginForceReloadRequest,
+		pluginRefreshPending,
+		onPluginRefreshPendingChange: setPluginRefreshPending,
 	});
 	setFormNoteRef.current = setFormNote;
 	formNoteRef.current = { ...formNote };
+
+	const previousManualSyncStartedTimeRef = useRef(props.lastManualSyncStartedTime);
+	useEffect(() => {
+		if (props.lastManualSyncStartedTime === previousManualSyncStartedTimeRef.current) return () => {};
+		previousManualSyncStartedTimeRef.current = props.lastManualSyncStartedTime;
+		if (!editorPlugin || !effectiveNoteId) return () => {};
+		void refreshPluginWhenDecrypted();
+		return () => {};
+	}, [editorPlugin, effectiveNoteId, props.lastManualSyncStartedTime, refreshPluginWhenDecrypted]);
+
+	const previousEditorNoteReloadTimeRequestRef = useRef(props.editorNoteReloadTimeRequest);
+	useEffect(() => {
+		if (props.editorNoteReloadTimeRequest === previousEditorNoteReloadTimeRequestRef.current) return;
+		const previousEditorNoteReloadTimeRequest = previousEditorNoteReloadTimeRequestRef.current;
+		previousEditorNoteReloadTimeRequestRef.current = props.editorNoteReloadTimeRequest;
+		if (editorPlugin
+			&& props.manualSyncStarted
+			&& props.lastManualSyncStartedTime > previousEditorNoteReloadTimeRequest
+			&& props.lastManualSyncStartedTime > currentNoteSelection.time
+		) {
+			void refreshPluginWhenDecrypted();
+		}
+	}, [currentNoteSelection.time, editorPlugin, props.editorNoteReloadTimeRequest, props.lastManualSyncStartedTime, props.manualSyncStarted, refreshPluginWhenDecrypted]);
 
 	useEffect(() => {
 		if (!isNoteLockEnabled()) return () => {};
@@ -923,6 +977,8 @@ const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 		noteLockSessionUnlocked: state.noteLockSessionUnlocked,
 		hasNoteLockKey: hasNoteLockKey(state.settings['syncInfoCache']),
 		editorNoteReloadTimeRequest: windowState.windowEditorNoteReloadTimeRequest,
+		lastManualSyncStartedTime: state.lastManualSyncStartedTime,
+		manualSyncStarted: state.manualSyncStarted,
 	};
 };
 

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -122,6 +122,10 @@ function NoteEditorContent(props: NoteEditorProps) {
 	const effectiveNoteId = useEffectiveNoteId(props);
 	const { editorPlugin, editorView } = usePluginEditorView(props.plugins);
 	const builtInEditorVisible = !editorPlugin;
+	const whiteboardEditorVisible = builtInEditorVisible
+		&& hasWhiteboardFence(formNoteRef.current?.body ?? '')
+		&& !props.whiteboardForceMarkdown?.[formNoteRef.current?.id];
+	const formNoteRefreshEnabled = builtInEditorVisible && !whiteboardEditorVisible;
 	const windowId = useContext(WindowIdContext);
 	const onDecryptFailedChange = useCallback((value: boolean) => {
 		props.dispatch({ type: 'SET_ACTIVE_NOTE_IS_UNDECRYPTABLE', value, windowId });
@@ -159,7 +163,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 		editorRef: editorRef,
 		onBeforeLoad: formNote_beforeLoad,
 		onAfterLoad: formNote_afterLoad,
-		builtInEditorVisible,
+		builtInEditorVisible: formNoteRefreshEnabled,
 		editorId,
 		noteLockSessionUnlocked: props.noteLockSessionUnlocked,
 		onDecryptFailedChange,
@@ -787,7 +791,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 		}
 	}
 
-	if (formNote.encryption_applied || !formNote.id || !effectiveNoteId) {
+	if ((!editorPlugin && (formNote.encryption_applied || reloadInProgress)) || !formNote.id || !effectiveNoteId) {
 		return renderNoNotes(styles.root);
 	}
 

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -122,10 +122,6 @@ function NoteEditorContent(props: NoteEditorProps) {
 	const effectiveNoteId = useEffectiveNoteId(props);
 	const { editorPlugin, editorView } = usePluginEditorView(props.plugins);
 	const builtInEditorVisible = !editorPlugin;
-	const whiteboardEditorVisible = builtInEditorVisible
-		&& hasWhiteboardFence(formNoteRef.current?.body ?? '')
-		&& !props.whiteboardForceMarkdown?.[formNoteRef.current?.id];
-	const formNoteRefreshEnabled = builtInEditorVisible && !whiteboardEditorVisible;
 	const windowId = useContext(WindowIdContext);
 	const onDecryptFailedChange = useCallback((value: boolean) => {
 		props.dispatch({ type: 'SET_ACTIVE_NOTE_IS_UNDECRYPTABLE', value, windowId });
@@ -163,7 +159,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 		editorRef: editorRef,
 		onBeforeLoad: formNote_beforeLoad,
 		onAfterLoad: formNote_afterLoad,
-		builtInEditorVisible: formNoteRefreshEnabled,
+		builtInEditorVisible,
 		editorId,
 		noteLockSessionUnlocked: props.noteLockSessionUnlocked,
 		onDecryptFailedChange,

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -77,6 +77,8 @@ export interface NoteEditorProps {
 	noteLockSessionUnlocked: boolean;
 	hasNoteLockKey: boolean;
 	editorNoteReloadTimeRequest: number;
+	lastManualSyncStartedTime: number;
+	manualSyncStarted: boolean;
 }
 
 export interface NoteBodyEditorRef {
@@ -172,6 +174,7 @@ export interface FormNote {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Editor-specific content shape (e.g. TinyMCE retains the raw editor object here); per-editor type
 	bodyEditorContent?: any;
 	markup_language: number;
+	updated_time: number;
 	user_updated_time: number;
 	encryption_applied: number;
 	is_locked: number;
@@ -230,6 +233,7 @@ export function defaultFormNote(): FormNote {
 		saveActionQueue: null,
 		originalCss: '',
 		hasChanged: false,
+		updated_time: 0,
 		user_updated_time: 0,
 		encryption_applied: 0,
 		is_locked: 0,

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
@@ -272,6 +272,40 @@ describe('useFormNote', () => {
 		formNote.unmount();
 	});
 
+	it('should force a reload for a plugin editor', async () => {
+		const note = await Note.save({ title: 'Original', body: '...' });
+		const onReloadInProgressChange = jest.fn();
+		const props = { ...defaultFormNoteProps, noteId: note.id, builtInEditorVisible: false, forceReloadRequest: 0, onReloadInProgressChange };
+		const formNote = renderHook(hookProps => useFormNote(hookProps), { initialProps: props });
+		await waitFor(() => expect(formNote.result.current.formNote.title).toBe('Original'));
+
+		await Note.save({ id: note.id, title: 'Stored title' }, { changeId: 'test-editor' });
+		formNote.rerender({ ...props, forceReloadRequest: 1 });
+
+		await waitFor(() => expect(onReloadInProgressChange).toHaveBeenCalledWith(true));
+		await waitFor(() => expect(formNote.result.current.formNote.title).toBe('Stored title'));
+		await waitFor(() => expect(onReloadInProgressChange).toHaveBeenLastCalledWith(false));
+		formNote.unmount();
+	});
+
+	it('should refresh a pending plugin editor after decryption finishes', async () => {
+		const note = await Note.save({ title: 'Original', body: '...' });
+		const onReloadInProgressChange = jest.fn();
+		const onPluginRefreshPendingChange = jest.fn();
+		const props = { ...defaultFormNoteProps, noteId: note.id, builtInEditorVisible: false, pluginRefreshPending: true, onPluginRefreshPendingChange, onReloadInProgressChange };
+		const formNote = renderHook(hookProps => useFormNote(hookProps), { initialProps: props });
+		await waitFor(() => expect(formNote.result.current.formNote.title).toBe('Original'));
+
+		await act(async () => {
+			await Note.save({ id: note.id, title: 'Decrypted', encryption_applied: 0 });
+			await ItemChange.waitForAllSaved();
+		});
+		await waitFor(() => expect(formNote.result.current.formNote.title).toBe('Decrypted'));
+		expect(onPluginRefreshPendingChange).toHaveBeenCalledWith(false);
+		await waitFor(() => expect(onReloadInProgressChange).toHaveBeenLastCalledWith(false));
+		formNote.unmount();
+	});
+
 	it('should clear reloadInProgress after overlapping reload requests', async () => {
 		const note = await Note.save({ title: 'Original', body: '...' });
 		const onReloadInProgressChange = jest.fn();

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
@@ -138,6 +138,7 @@ describe('useFormNote', () => {
 			return {
 				...defaultFormNoteProps,
 				noteId: testNote.id,
+				builtInEditorVisible: true,
 			};
 		};
 
@@ -227,6 +228,7 @@ describe('useFormNote', () => {
 		const props = {
 			...defaultFormNoteProps,
 			noteId: note.id,
+			builtInEditorVisible: true,
 			onReloadInProgressChange,
 		};
 
@@ -254,7 +256,7 @@ describe('useFormNote', () => {
 	it('should force a reload when editorNoteReloadTimeRequest changes', async () => {
 		const note = await Note.save({ title: 'Original', body: '...' });
 		const onReloadInProgressChange = jest.fn();
-		const props = { ...defaultFormNoteProps, noteId: note.id, editorNoteReloadTimeRequest: 0, onReloadInProgressChange };
+		const props = { ...defaultFormNoteProps, noteId: note.id, builtInEditorVisible: true, editorNoteReloadTimeRequest: 0, onReloadInProgressChange };
 		const formNote = renderHook(hookProps => useFormNote(hookProps), { initialProps: props });
 		await waitFor(() => expect(formNote.result.current.formNote.title).toBe('Original'));
 
@@ -273,7 +275,7 @@ describe('useFormNote', () => {
 	it('should clear reloadInProgress after overlapping reload requests', async () => {
 		const note = await Note.save({ title: 'Original', body: '...' });
 		const onReloadInProgressChange = jest.fn();
-		const props = { ...defaultFormNoteProps, noteId: note.id, editorNoteReloadTimeRequest: 0, onReloadInProgressChange };
+		const props = { ...defaultFormNoteProps, noteId: note.id, builtInEditorVisible: true, editorNoteReloadTimeRequest: 0, onReloadInProgressChange };
 		const formNote = renderHook(hookProps => useFormNote(hookProps), { initialProps: props });
 		await waitFor(() => expect(formNote.result.current.formNote.title).toBe('Original'));
 

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -38,6 +38,9 @@ export interface HookDependencies {
 	onDecryptFailedChange(value: boolean): void;
 	onReloadInProgressChange?(value: boolean): void;
 	editorNoteReloadTimeRequest?: number;
+	forceReloadRequest?: number;
+	pluginRefreshPending?: boolean;
+	onPluginRefreshPendingChange?(value: boolean): void;
 }
 
 type MapFormNoteCallback = (previousFormNote: FormNote)=> FormNote;
@@ -94,11 +97,12 @@ const loadNoteForForm = async (noteId: string): Promise<{ note: NoteEntity|null;
 };
 
 type InitNoteStateCallback = (note: NoteEntity, isNew: boolean, force?: boolean)=> Promise<FormNote>;
-const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: string, noteId: string, initNoteState: InitNoteStateCallback, clearFormNote: ()=> void, builtInEditorVisible: boolean, noteLockSessionUnlocked: boolean, setDecryptFailed: (value: boolean)=> void, setLoadBlocked: (value: boolean)=> void, onReloadInProgressChange: (value: boolean)=> void, editorNoteReloadTimeRequest: number) => {
+const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: string, noteId: string, initNoteState: InitNoteStateCallback, clearFormNote: ()=> void, builtInEditorVisible: boolean, noteLockSessionUnlocked: boolean, setDecryptFailed: (value: boolean)=> void, setLoadBlocked: (value: boolean)=> void, onReloadInProgressChange: (value: boolean)=> void, editorNoteReloadTimeRequest: number, forceReloadRequest: number, pluginRefreshPending: boolean, onPluginRefreshPendingChange: (value: boolean)=> void) => {
 	// Increasing the value of this counter cancels any ongoing note refreshes and starts
 	// a new refresh.
 	const [formNoteRefreshRequest, setFormNoteRefreshRequest] = useState({ counter: 0, force: false });
 	const previousEditorNoteReloadTimeRequestRef = useRef(editorNoteReloadTimeRequest);
+	const previousForceReloadRequestRef = useRef(forceReloadRequest);
 	const prevBuiltInEditorVisible = usePrevious<boolean>(builtInEditorVisible);
 	// Seeded because usePrevious defaults to null, which would read as a session change on mount.
 	const prevNoteLockSessionUnlocked = usePrevious<boolean>(noteLockSessionUnlocked, noteLockSessionUnlocked);
@@ -169,6 +173,12 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 		refreshFormNote(true);
 	}, [editorNoteReloadTimeRequest, builtInEditorVisible, refreshFormNote]);
 
+	useEffect(() => {
+		if (forceReloadRequest === previousForceReloadRequestRef.current) return;
+		previousForceReloadRequestRef.current = forceReloadRequest;
+		refreshFormNote(true);
+	}, [forceReloadRequest, refreshFormNote]);
+
 	// When switching from the plugin editor to the built-in editor, we refresh the note since the
 	// plugin may have modified it via the data API.
 	useEffect(() => {
@@ -190,10 +200,11 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 		if (!noteId) return ()=>{};
 
 		let cancelled = false;
+		let pendingRefreshHandled = false;
 
 		type ChangeEventSlice = { itemId: string; changeId: string };
-		const listener = ({ itemId, changeId }: ChangeEventSlice) => {
-			if (!builtInEditorVisible) return;
+		const listener = async ({ itemId, changeId }: ChangeEventSlice) => {
+			if (!builtInEditorVisible && !pluginRefreshPending) return;
 			// If this change came from the current editor, it should already be
 			// handled by calls to `setFormNote`. If events from the current editor
 			// aren't ignored, most user-activated note changes (e.g. a keypress)
@@ -201,7 +212,19 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 			const isExternalChange = !(changeId ?? 'unknown').endsWith(editorId);
 			if (itemId === noteId && !cancelled && isExternalChange) {
 				if (formNoteRef.current.hasChanged) return;
-				refreshFormNote();
+				if (pluginRefreshPending) {
+					try {
+						const storedNote = await Note.load(noteId, { fields: ['encryption_applied'] });
+						if (cancelled || pendingRefreshHandled || storedNote?.encryption_applied) return;
+						pendingRefreshHandled = true;
+						onPluginRefreshPendingChange(false);
+						refreshFormNote(true);
+					} catch (error) {
+						logger.warn('Could not check whether the plugin note has been decrypted', error);
+					}
+				} else {
+					refreshFormNote();
+				}
 			}
 		};
 		eventManager.on(EventName.ItemChange, listener);
@@ -210,7 +233,7 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 			eventManager.off(EventName.ItemChange, listener);
 			cancelled = true;
 		};
-	}, [formNoteRef, noteId, editorId, refreshFormNote, builtInEditorVisible]);
+	}, [formNoteRef, noteId, editorId, refreshFormNote, builtInEditorVisible, pluginRefreshPending, onPluginRefreshPendingChange]);
 };
 
 export default function useFormNote(dependencies: HookDependencies) {
@@ -219,6 +242,9 @@ export default function useFormNote(dependencies: HookDependencies) {
 	} = dependencies;
 	const onReloadInProgressChange = dependencies.onReloadInProgressChange ?? (() => {});
 	const editorNoteReloadTimeRequest = dependencies.editorNoteReloadTimeRequest ?? 0;
+	const forceReloadRequest = dependencies.forceReloadRequest ?? 0;
+	const pluginRefreshPending = dependencies.pluginRefreshPending ?? false;
+	const onPluginRefreshPendingChange = dependencies.onPluginRefreshPendingChange ?? (() => {});
 
 	const [formNote, setFormNote] = useState<FormNote>(defaultFormNote());
 	const [isNewNote, setIsNewNote] = useState(false);
@@ -265,6 +291,7 @@ export default function useFormNote(dependencies: HookDependencies) {
 			bodyWillChangeId: 0,
 			bodyChangeId: 0,
 			markup_language: n.markup_language,
+			updated_time: n.updated_time,
 			saveActionQueue: new AsyncActionQueue(300),
 			originalCss: originalCss,
 			hasChanged: false,
@@ -305,7 +332,7 @@ export default function useFormNote(dependencies: HookDependencies) {
 		setFormNote(formNoteRef.current);
 	}, []);
 
-	useRefreshFormNoteOnChange(formNoteRef, editorId, noteId, initNoteState, clearFormNote, builtInEditorVisible, noteLockSessionUnlocked, setDecryptFailed, setLoadBlocked, onReloadInProgressChange, editorNoteReloadTimeRequest);
+	useRefreshFormNoteOnChange(formNoteRef, editorId, noteId, initNoteState, clearFormNote, builtInEditorVisible, noteLockSessionUnlocked, setDecryptFailed, setLoadBlocked, onReloadInProgressChange, editorNoteReloadTimeRequest, forceReloadRequest, pluginRefreshPending, onPluginRefreshPendingChange);
 
 	useEffect(() => {
 		if (!noteId) {

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -165,8 +165,9 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 	useEffect(() => {
 		if (editorNoteReloadTimeRequest === previousEditorNoteReloadTimeRequestRef.current) return;
 		previousEditorNoteReloadTimeRequestRef.current = editorNoteReloadTimeRequest;
+		if (!builtInEditorVisible) return;
 		refreshFormNote(true);
-	}, [editorNoteReloadTimeRequest, refreshFormNote]);
+	}, [editorNoteReloadTimeRequest, builtInEditorVisible, refreshFormNote]);
 
 	// When switching from the plugin editor to the built-in editor, we refresh the note since the
 	// plugin may have modified it via the data API.
@@ -192,6 +193,7 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 
 		type ChangeEventSlice = { itemId: string; changeId: string };
 		const listener = ({ itemId, changeId }: ChangeEventSlice) => {
+			if (!builtInEditorVisible) return;
 			// If this change came from the current editor, it should already be
 			// handled by calls to `setFormNote`. If events from the current editor
 			// aren't ignored, most user-activated note changes (e.g. a keypress)
@@ -208,7 +210,7 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 			eventManager.off(EventName.ItemChange, listener);
 			cancelled = true;
 		};
-	}, [formNoteRef, noteId, editorId, refreshFormNote]);
+	}, [formNoteRef, noteId, editorId, refreshFormNote, builtInEditorVisible]);
 };
 
 export default function useFormNote(dependencies: HookDependencies) {

--- a/packages/app-desktop/gui/NoteEditor/utils/useScheduleSaveCallbacks.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useScheduleSaveCallbacks.ts
@@ -47,7 +47,7 @@ const useScheduleSaveCallbacks = (props: Props) => {
 				const savedNote = await Note.save(note, { changeId: `editorChange-${props.editorId}`, useNoteLock: true, noteLockKey: latestFormNote.noteLockKey });
 
 				props.setFormNote.current((prev: FormNote) => {
-					return { ...prev, user_updated_time: savedNote.user_updated_time, hasChanged: false };
+					return { ...prev, updated_time: savedNote.updated_time, user_updated_time: savedNote.user_updated_time, hasChanged: false };
 				});
 
 				void ExternalEditWatcher.instance().updateNoteFile(savedNote);

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -61,6 +61,7 @@ export interface SyncStartOptions {
 	syncSteps?: string[];
 	throwOnError?: boolean;
 	saveContextHandler?: (newContext: SyncContext)=> void;
+	manualSync?: boolean;
 }
 
 function isCannotSyncError(error: { code?: string; type?: string; message?: string } | null): boolean {
@@ -433,7 +434,7 @@ export default class Synchronizer {
 
 		this.progressReport_.startTime = time.unixMs();
 
-		this.dispatch({ type: 'SYNC_STARTED' });
+		this.dispatch({ type: 'SYNC_STARTED', ...(options.manualSync ? { manualSync: true } : {}) });
 		eventManager.emit(EventName.SyncStart);
 
 		this.logSyncOperation('starting', null, null, `Starting synchronisation to target ${syncTargetId}... supportsAccurateTimestamp = ${this.api().supportsAccurateTimestamp}; supportsMultiPut = ${this.api().supportsMultiPut}} [${synchronizationId}]`);

--- a/packages/lib/commands/synchronize.ts
+++ b/packages/lib/commands/synchronize.ts
@@ -69,7 +69,7 @@ export const runtime = (): CommandRuntime => {
 				sync.cancel();
 				return 'cancel';
 			} else {
-				void reg.scheduleSync(0);
+				void reg.scheduleSync(0, { manualSync: true });
 				return 'sync';
 			}
 		},

--- a/packages/lib/reducer.test.ts
+++ b/packages/lib/reducer.test.ts
@@ -1117,4 +1117,22 @@ describe('reducer', () => {
 
 		jest.useRealTimers();
 	});
+
+	it('should update the manual sync start time only for manual syncs', () => {
+		jest.useFakeTimers();
+		const now = Date.now();
+		let state = reducer(defaultState, { type: 'SYNC_STARTED' });
+		expect(state.lastManualSyncStartedTime).toBe(0);
+		expect(state.manualSyncStarted).toBe(false);
+
+		state = reducer(state, { type: 'SYNC_STARTED', manualSync: true });
+		expect(state.lastManualSyncStartedTime).toBe(now);
+		expect(state.manualSyncStarted).toBe(true);
+		state = reducer(state, { type: 'SYNC_STARTED', manualSync: true });
+		expect(state.lastManualSyncStartedTime).toBe(now + 1);
+
+		state = reducer(state, { type: 'SYNC_COMPLETED' });
+		expect(state.manualSyncStarted).toBe(false);
+		jest.useRealTimers();
+	});
 });

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -169,6 +169,8 @@ export interface State extends WindowState {
 	screens: Record<string, { screen: string; props?: Record<string, unknown> }>;
 	historyCanGoBack: boolean;
 	syncStarted: boolean;
+	manualSyncStarted: boolean;
+	lastManualSyncStartedTime: number;
 	syncPending: boolean;
 	showQuitSyncDialog: boolean;
 	syncReport: ProgressReport;
@@ -222,6 +224,8 @@ export const defaultState: State = {
 	screens: {},
 	historyCanGoBack: false,
 	syncStarted: false,
+	manualSyncStarted: false,
+	lastManualSyncStartedTime: 0,
 	syncPending: false,
 	showQuitSyncDialog: false,
 	syncReport: { errors: [] },
@@ -1436,10 +1440,15 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 
 		case 'SYNC_STARTED':
 			draft.syncStarted = true;
+			draft.manualSyncStarted = !!action.manualSync;
+			if (action.manualSync) {
+				draft.lastManualSyncStartedTime = Math.max(Date.now(), draft.lastManualSyncStartedTime + 1);
+			}
 			break;
 
 		case 'SYNC_COMPLETED':
 			draft.syncStarted = false;
+			draft.manualSyncStarted = false;
 			break;
 
 		case 'SYNC_PENDING_UPDATE':


### PR DESCRIPTION
Following on from the PRs I have implemented to prevent the possibility of remote changes to notes being lost due to races when a refresh occurs for the currently open note, this PR aims to address the remaining issues, particularly regarding the behaviour of whiteboard and editor plugins.

Currently on the desktop app, when E2EE is enabled, the editor is unmounted completely during decryption, which causes a refresh regardless of whether the note is a regular note, a whiteboard, or a note created via an editor plugin (e.g. a YesYouKan kanban board). For editor plugins, performing a refresh any time the current note is being updated by a sync running the background can be problematic, because changes in an editor plugin usually must be committed (e.g. submitting a card on the kanban board) before they will be saved, and therefore an unexpected refresh would lose these changes, without creating any conflict. Following discussion with Laurent, it was considered acceptable behaviour that editor plugins should not refresh when updated via the sync, as such editors would tend to contain content which can be seen in an overall view which the user would notice if changes are missing (unlike potentially pages long notes), and therefore in the rare case where updating the note via the editor plugin overwrites the remote version, due to not being fully in sync at the time of starting editing, this would be an acceptable compromise. However, ideally manually syncing the note via the sync button or the keyboard shortcut to sync, should be able to refresh the note, instead of ignoring a change in this scenario, so have put together a solution for this.

**This PR implements the following changes:**
1. When no editor plugin is shown, the current behaviour is an update to the current note via the sync, will immediately refresh the note. When E2EE is enabled, the editor is fully unmounted during refresh and decryption, but it is not fully unmounted when E2EE is disabled. The PR changes this so that regardless of whether E2EE is enabled, a refresh causes a full editor unmount (via renderNoNotes), which means the undo stack will be cleared following the refresh, which will prevent the possibility of the user accidentally undoing the remote updates in the note
2. When the visual view is shown for a whiteboard note, when E2EE is not enabled, there are race conditions possible which will overwrite the remote version if a refresh occurs while typing on the whiteboard, due the the same issue of the editor not being fully unmounted. The PR makes the full unmount also apply when E2EE is not enabled in this view, which prevents this race condition from occurring
3. When an editor plugin is shown, currently a refresh occurs when it is updated via the sync if E2EE is enabled only. The PR changes this so that a refresh does **not** occur in this scenario, when a sync is automatically triggered, regardless of whether E2EE is enabled
4. When an editor plugin is shown, if a sync has been manually triggered while on the currently selected note, and the user has not since switched away to a different note, then a refresh will occur upon the remote item being downloaded. In the event that the remote item was already downloaded for the current note via an automatically triggered sync, manually syncing at this point will immediately reload the note (without unmounting, but this should be fine as plugins would not use the main undo stack or use debounced auto save, which can produce race conditions that unmounting would prevent). In both of these cases, a reload will only occur if the stored version has a newer updated_time than the currently loaded local note, which avoids unnecessarily reloading the note during manual sync, if nothing has actually changed.

### Testing

**Video demonstrating the refresh behaviour for regular note view, whiteboard and editor plugin with E2EE enabled:**

https://github.com/user-attachments/assets/0b987292-019d-4384-bc87-fa46d49cfd41

**Video demonstrating the refresh behaviour for regular note view, whiteboard and editor plugin with E2EE disabled:**

https://github.com/user-attachments/assets/2beff2a1-56d2-43e4-b96b-3984fe8deb94

**Video demonstrating manual sync behaviour for editor plugins (with E2EE enabled):**

https://github.com/user-attachments/assets/1778b69c-5e90-4dc3-b79d-010b94a23fa8