### PR TITLE
Desktop: Validate x-callback-url response targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,6 +249,7 @@ packages/app-desktop/gui/KeymapConfig/utils/useCommandStatus.js
 packages/app-desktop/gui/KeymapConfig/utils/useKeymap.js
 packages/app-desktop/gui/MainLayoutPane.js
 packages/app-desktop/gui/MainScreen.js
+packages/app-desktop/gui/MainScreen/handleCallbackUrl.test.js
 packages/app-desktop/gui/MainScreen/handleCallbackUrl.js
 packages/app-desktop/gui/MasterPasswordDialog/Dialog.js
 packages/app-desktop/gui/MenuBar.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -274,6 +274,7 @@ packages/app-desktop/gui/KeymapConfig/utils/useCommandStatus.js
 packages/app-desktop/gui/KeymapConfig/utils/useKeymap.js
 packages/app-desktop/gui/MainLayoutPane.js
 packages/app-desktop/gui/MainScreen.js
+packages/app-desktop/gui/MainScreen/handleCallbackUrl.test.js
 packages/app-desktop/gui/MainScreen/handleCallbackUrl.js
 packages/app-desktop/gui/MasterPasswordDialog/Dialog.js
 packages/app-desktop/gui/MenuBar.js

--- a/packages/app-desktop/gui/MainScreen/handleCallbackUrl.test.ts
+++ b/packages/app-desktop/gui/MainScreen/handleCallbackUrl.test.ts
@@ -1,0 +1,63 @@
+import { utils as commandUtils } from '@joplin/lib/services/CommandService';
+import executeCallbackUrl from './handleCallbackUrl';
+
+const openExternal = jest.fn();
+
+jest.mock('../../services/bridge', () => ({
+	__esModule: true,
+	default: () => ({
+		openExternal: (url: string) => openExternal(url),
+	}),
+}));
+
+const setSelectedNoteId = (noteId: string | null) => {
+	// executeCallbackUrl reads the selected note id via commandUtils.store; a
+	// null id makes handleGetCurrentNote take its x-error branch, which routes
+	// the caller-supplied target through respond() without touching the DB.
+	commandUtils.store = {
+		getState: () => ({ selectedNoteIds: noteId ? [noteId] : [] }),
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial store is enough for this path
+	} as any;
+};
+
+describe('handleCallbackUrl', () => {
+	beforeEach(() => {
+		openExternal.mockClear();
+		setSelectedNoteId(null);
+	});
+
+	test.each([
+		'x-custom-scheme://arbitrary-scheme-reached',
+		'file:///etc/passwd',
+		'ms-msdt://something',
+		'mailto:someone@example.com',
+		'not a url',
+	])('should not dispatch a callback target with a disallowed scheme (%s)', async (target) => {
+		await executeCallbackUrl(`joplin://x-callback-url/getCurrentNote?x-error=${encodeURIComponent(target)}`);
+		expect(openExternal).not.toHaveBeenCalled();
+	});
+
+	test.each([
+		'http://example.com/cb',
+		'https://example.com/cb',
+	])('should dispatch a callback target with an allowed scheme (%s)', async (target) => {
+		await executeCallbackUrl(`joplin://x-callback-url/getCurrentNote?x-error=${encodeURIComponent(target)}`);
+		expect(openExternal).toHaveBeenCalledTimes(1);
+		expect(openExternal.mock.calls[0][0]).toContain(`${target}?`);
+	});
+
+	it('should not leak the raw error message on the error path', async () => {
+		// Force a throw inside the try block so the catch path builds the response.
+		commandUtils.store = {
+			getState: () => { throw new Error('secret path /home/victim/.config/joplin/database.sqlite'); },
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial store is enough for this path
+		} as any;
+
+		await executeCallbackUrl(`joplin://x-callback-url/getCurrentNote?x-error=${encodeURIComponent('https://example.com/cb')}`);
+
+		expect(openExternal).toHaveBeenCalledTimes(1);
+		const responseUrl = openExternal.mock.calls[0][0];
+		expect(responseUrl).not.toContain('secret path');
+		expect(responseUrl).not.toContain('database.sqlite');
+	});
+});

--- a/packages/app-desktop/gui/MainScreen/handleCallbackUrl.test.ts
+++ b/packages/app-desktop/gui/MainScreen/handleCallbackUrl.test.ts
@@ -1,12 +1,12 @@
 import { utils as commandUtils } from '@joplin/lib/services/CommandService';
 import executeCallbackUrl from './handleCallbackUrl';
 
-const openExternal = jest.fn();
+const mockOpenExternal = jest.fn();
 
 jest.mock('../../services/bridge', () => ({
 	__esModule: true,
 	default: () => ({
-		openExternal: (url: string) => openExternal(url),
+		openExternal: (url: string) => mockOpenExternal(url),
 	}),
 }));
 
@@ -16,13 +16,12 @@ const setSelectedNoteId = (noteId: string | null) => {
 	// the caller-supplied target through respond() without touching the DB.
 	commandUtils.store = {
 		getState: () => ({ selectedNoteIds: noteId ? [noteId] : [] }),
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial store is enough for this path
-	} as any;
+	};
 };
 
 describe('handleCallbackUrl', () => {
 	beforeEach(() => {
-		openExternal.mockClear();
+		mockOpenExternal.mockClear();
 		setSelectedNoteId(null);
 	});
 
@@ -34,7 +33,7 @@ describe('handleCallbackUrl', () => {
 		'not a url',
 	])('should not dispatch a callback target with a disallowed scheme (%s)', async (target) => {
 		await executeCallbackUrl(`joplin://x-callback-url/getCurrentNote?x-error=${encodeURIComponent(target)}`);
-		expect(openExternal).not.toHaveBeenCalled();
+		expect(mockOpenExternal).not.toHaveBeenCalled();
 	});
 
 	test.each([
@@ -42,22 +41,22 @@ describe('handleCallbackUrl', () => {
 		'https://example.com/cb',
 	])('should dispatch a callback target with an allowed scheme (%s)', async (target) => {
 		await executeCallbackUrl(`joplin://x-callback-url/getCurrentNote?x-error=${encodeURIComponent(target)}`);
-		expect(openExternal).toHaveBeenCalledTimes(1);
-		expect(openExternal.mock.calls[0][0]).toContain(`${target}?`);
+		expect(mockOpenExternal).toHaveBeenCalledTimes(1);
+		expect(mockOpenExternal.mock.calls[0][0]).toContain(`${target}?`);
 	});
 
 	it('should not leak the raw error message on the error path', async () => {
 		// Force a throw inside the try block so the catch path builds the response.
 		commandUtils.store = {
 			getState: () => { throw new Error('secret path /home/victim/.config/joplin/database.sqlite'); },
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial store is enough for this path
-		} as any;
+		};
 
 		await executeCallbackUrl(`joplin://x-callback-url/getCurrentNote?x-error=${encodeURIComponent('https://example.com/cb')}`);
 
-		expect(openExternal).toHaveBeenCalledTimes(1);
-		const responseUrl = openExternal.mock.calls[0][0];
+		expect(mockOpenExternal).toHaveBeenCalledTimes(1);
+		const responseUrl = mockOpenExternal.mock.calls[0][0];
 		expect(responseUrl).not.toContain('secret path');
 		expect(responseUrl).not.toContain('database.sqlite');
+		expect(new URL(responseUrl).searchParams.get('errorMessage')).toBe('The command could not be completed');
 	});
 });

--- a/packages/app-desktop/gui/MainScreen/handleCallbackUrl.ts
+++ b/packages/app-desktop/gui/MainScreen/handleCallbackUrl.ts
@@ -12,6 +12,23 @@ const logger = Logger.create('handleCallbackUrl');
 // Opens the caller's x-success / x-error URL with the result appended as query params.
 const respond = (target: string, params: Record<string, string> = {}) => {
 	if (!target) return;
+
+	// The callback target is untrusted input from the x-callback-url. Anything
+	// that is not file: is handed straight to shell.openExternal(), i.e. the OS
+	// URI dispatcher, so restrict it to schemes we're willing to invoke. This
+	// also covers the x-error path below, which fires on any thrown exception.
+	let protocol;
+	try {
+		protocol = new URL(target).protocol;
+	} catch (error) {
+		logger.warn('Rejected malformed callback target:', target);
+		return;
+	}
+	if (protocol !== 'http:' && protocol !== 'https:') {
+		logger.warn(`Rejected callback target with disallowed scheme "${protocol}":`, target);
+		return;
+	}
+
 	const query = Object.entries(params)
 		.map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
 		.join('&');
@@ -95,7 +112,9 @@ const executeCallbackUrl = async (url: string) => {
 		}
 	} catch (error) {
 		logger.error(`Error handling callback URL command "${info.command}":`, error);
-		respond(info.params['x-error'], { errorMessage: error.message });
+		// Return an opaque status rather than error.message, which can leak
+		// profile paths and item ids to the caller-supplied x-error target.
+		respond(info.params['x-error'], { errorMessage: 'The command could not be completed' });
 	}
 };
 

--- a/packages/app-desktop/gui/MainScreen/handleCallbackUrl.ts
+++ b/packages/app-desktop/gui/MainScreen/handleCallbackUrl.ts
@@ -21,11 +21,13 @@ const respond = (target: string, params: Record<string, string> = {}) => {
 	try {
 		protocol = new URL(target).protocol;
 	} catch (error) {
-		logger.warn('Rejected malformed callback target:', target);
+		// Don't log the caller-supplied target: it's untrusted and may contain
+		// secrets in its query or fragment.
+		logger.warn('Rejected malformed callback target');
 		return;
 	}
 	if (protocol !== 'http:' && protocol !== 'https:') {
-		logger.warn(`Rejected callback target with disallowed scheme "${protocol}":`, target);
+		logger.warn(`Rejected callback target with disallowed scheme "${protocol}"`);
 		return;
 	}
 


### PR DESCRIPTION
Restrict the schemes that `x-callback-url` response targets (`x-success` / `x-error`) can use before they're opened. Targets are now parsed and limited to `http:`/`https:`; malformed or other-scheme values are ignored and logged instead of being passed through to the OS.

Also stops echoing raw error messages back to the caller's `x-error` target — the detail is still logged locally, but the response now returns a generic status.