### PR TITLE
Server: Enforce session and CSRF checks on the application authorisation POST

### DIFF
--- a/packages/server/src/routes/index/applications.test.ts
+++ b/packages/server/src/routes/index/applications.test.ts
@@ -117,6 +117,33 @@ describe('index/applications', () => {
 		await expectHttpError(async () => execRequest(session.id, 'POST', 'applications/asdf/confirm', { applicationAuthId: 'asdf2' }, null), ErrorForbidden.httpCode);
 	});
 
+	test('should reject the authorisation POST without a valid CSRF token', async () => {
+		const { user, session } = await createUserAndSession(1);
+		await models().user().save({ id: user.id });
+
+		await getApplicationConfirm('asdf', session.id);
+
+		// Build the POST manually to send an invalid _csrf instead of the valid
+		// one koaAppContext injects automatically.
+		const context = await koaAppContext({
+			sessionId: session.id,
+			request: {
+				method: 'POST',
+				url: '/applications/asdf/confirm',
+				body: {
+					applicationAuthId: 'asdf',
+				},
+			},
+		});
+		(context.req as unknown as { body: Record<string, string> }).body._csrf = 'not-a-valid-token';
+
+		await routeHandler(context);
+
+		// routeHandler writes the error to the response rather than re-throwing.
+		expect(context.response.status).toBe(ErrorForbidden.httpCode);
+		expect((await models().application().all()).length).toBe(0);
+	});
+
 	test('should throw Bad Request if application auth id does not exist', async () => {
 		const { user, session } = await createUserAndSession(1);
 		await models().user().save({ id: user.id });

--- a/packages/server/src/routes/index/applications.ts
+++ b/packages/server/src/routes/index/applications.ts
@@ -1,7 +1,7 @@
 
 import { SubPath, redirect } from '../../utils/routeUtils';
 import Router from '../../utils/Router';
-import { RouteType } from '../../utils/types';
+import { HttpMethod, RouteType } from '../../utils/types';
 import { AppContext } from '../../utils/types';
 import defaultView from '../../utils/defaultView';
 import { formParse, userIp } from '../../utils/requestUtils';
@@ -16,7 +16,10 @@ import { ErrorForbidden } from '../../utils/errors';
 
 const router: Router = new Router(RouteType.Web);
 
-router.publicSchemas.push('applications/:id/confirm');
+// Only the GET consent page is public. The authorising POST must keep the CSRF
+// check, else a cross-site request could authorise an application for a
+// logged-in user.
+router.publicSchemasByMethod[HttpMethod.GET] = ['applications/:id/confirm'];
 
 function makeView(error: Error = null, applicationAuthId: string, csrfTag: string) {
 	const view = defaultView('applications/confirm', 'Confirm application authorisation');

--- a/packages/server/src/utils/Router.ts
+++ b/packages/server/src/utils/Router.ts
@@ -16,6 +16,11 @@ export default class Router {
 	public public = false;
 	public publicSchemas: string[] = [];
 
+	// Schemas that are public for the listed methods only, and private for all
+	// others (e.g. a GET consent page that's reachable before login, while its
+	// POST still goes through the session and CSRF checks).
+	public publicSchemasByMethod: Partial<Record<HttpMethod, string[]>> = {};
+
 	public responseFormat: RouteResponseFormat = null;
 
 	private routes_: Record<string, Record<string, RouteInfo>> = {};
@@ -47,8 +52,9 @@ export default class Router {
 		throw new ErrorNotFound(`Could not resolve: ${method} ${schema}`);
 	}
 
-	public isPublic(schema: string): boolean {
-		return this.public || this.publicSchemas.includes(schema);
+	public isPublic(schema: string, method: HttpMethod): boolean {
+		if (this.public || this.publicSchemas.includes(schema)) return true;
+		return !!this.publicSchemasByMethod[method]?.includes(schema);
 	}
 
 	public alias(method: HttpMethod, path: string, target: string) {

--- a/packages/server/src/utils/routeUtils.ts
+++ b/packages/server/src/utils/routeUtils.ts
@@ -216,7 +216,7 @@ export async function execRequest(routes: Routers, ctx: AppContext): Promise<Exe
 	const endPoint = match.route.findEndPoint(ctx.request.method as HttpMethod, match.subPath.schema);
 	if (ctx.URL && !isValidOrigin(ctx.URL.origin, baseUrl(endPoint.type), endPoint.type)) throw new ErrorNotFound(`Invalid origin: ${ctx.URL.origin}`, ErrorCode.InvalidOrigin);
 
-	const isPublicRoute = match.route.isPublic(match.subPath.schema);
+	const isPublicRoute = match.route.isPublic(match.subPath.schema, ctx.request.method as HttpMethod);
 
 	// This is a generic catch-all for all private end points - if we
 	// couldn't get a valid session, we exit now. Individual end points


### PR DESCRIPTION
The `applications/:id/confirm` route was marked public by schema, which made both its GET and POST skip the session and CSRF checks. Only the GET (the consent page shown before login) needs to be public; the POST that actually authorises the application should go through the normal checks.

Adds per-method control to the router (`publicSchemasByMethod`) so a route can be public for GET only, and applies it to the confirm route. The authorising POST now requires a valid session and CSRF token, as the form already provides.