### PR TITLE
Desktop: Fixes #16178: Alt instance killed on primary profile switch

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -931,6 +931,14 @@ export default class ElectronAppWrapper {
 		const alreadyRunning = await this.ensureSingleInstance();
 		if (alreadyRunning) return;
 
+		// If the previous instance had launched an alt instance before restarting,
+		// relaunch it now. The alt instance was killed when the old primary exited
+		const relaunchFlagPath = path.join(this.profilePath_, '.relaunch_alt_instance');
+		if (fs.existsSync(relaunchFlagPath)) {
+			fs.removeSync(relaunchFlagPath);
+			void bridge().launchAltAppInstance(this.env_);
+		}
+
 		await this.fixLinuxAccessibility_();
 
 		// Session must be created before handleCustomProtocols() so both use the same object.

--- a/packages/app-desktop/bridge.ts
+++ b/packages/app-desktop/bridge.ts
@@ -14,6 +14,7 @@ import isSafeToOpen from './utils/isSafeToOpen';
 import { closeSync, openSync, readSync, statSync } from 'fs';
 import { KB } from '@joplin/utils/bytes';
 import { defaultWindowId } from '@joplin/lib/reducer';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
 import { execCommand } from '@joplin/utils';
 
 interface LastSelectedPath {
@@ -43,6 +44,7 @@ export class Bridge {
 	private appId_: string;
 	private logFilePath_ = '';
 	private altInstanceId_ = '';
+	private altInstanceWasLaunched_ = false;
 
 	private extraAllowedExtensions_: string[] = [];
 	private onAllowedExtensionsChangeListener_: OnAllowedExtensionsChange = ()=>{};
@@ -582,15 +584,17 @@ export class Bridge {
 		} else {
 			return {
 				execPath: bridge().electronApp().electronApp().getPath('exe'),
-				args: [].concat(altInstanceArgs),
+				args: ['.'].concat(altInstanceArgs),
 			};
 		}
 	}
 
 	private async launchAppInstanceById(env: string, altInstanceId: string) {
 		if (this.electronApp().ipcServerStarted()) {
+			const { spawn } = require('child_process');
 			const cmd = this.appLaunchCommand(env, altInstanceId);
-			await execCommand([cmd.execPath].concat(cmd.args), { detached: true });
+			const child = spawn(cmd.execPath, cmd.args, { detached: true, stdio: 'ignore' });
+			child.unref();
 		} else {
 			const buttonIndex = this.showErrorMessageBox('Cannot launch another instance because IPC server could not start.', {
 				buttons: [
@@ -607,10 +611,21 @@ export class Bridge {
 
 	public async launchAltAppInstance(env: string) {
 		await this.launchAppInstanceById(env, 'alt1');
+		this.altInstanceWasLaunched_ = true;
 	}
 
 	public async launchMainAppInstance(env: string) {
 		await this.launchAppInstanceById(env, '');
+	}
+
+	private saveAltInstanceRelaunchFlag() {
+		if (!this.altInstanceWasLaunched_) return;
+		try {
+			const flagPath = join(this.rootProfileDir_, '.relaunch_alt_instance');
+			writeFileSync(flagPath, 'alt1');
+		} catch (_e) {
+			void 0;
+		}
 	}
 
 	public async restart() {
@@ -620,11 +635,13 @@ export class Bridge {
 		const { app } = require('electron');
 
 		if (shim.isPortable()) {
+			this.saveAltInstanceRelaunchFlag();
 			const options = {
 				execPath: process.env.PORTABLE_EXECUTABLE_FILE,
 			};
 			app.relaunch(options);
 		} else if (process.env.APPIMAGE && !this.altInstanceId_) {
+			this.saveAltInstanceRelaunchFlag();
 			app.relaunch({
 				execPath: process.env.APPIMAGE,
 				args: ['--appimage-extract-and-run'],
@@ -658,6 +675,7 @@ export class Bridge {
 				// });
 			}
 		} else {
+			this.saveAltInstanceRelaunchFlag();
 			app.relaunch();
 		}
 


### PR DESCRIPTION
Issue Fix: #16178 

The fix does two things: first, it spawns the alt instance using Node's spawn with `detached: true` and `unref()` instead of `execCommand` so the child is properly decoupled from the parent.
Second, before the primary restarts, it writes a small flag file to disk if an alt instance was open, and on the new primary's startup, it checks for that flag and relaunches the alt instance this handles Windows where the child gets killed regardless. Both pieces are needed because `unref()` alone doesn't help on Windows, and the flag file alone would cause duplicate alt instances.

