### PR TITLE
Server: Scope password-reset tokens to their intended purpose

### DIFF
--- a/packages/server/src/migrations/20260821120000_token_purpose.ts
+++ b/packages/server/src/migrations/20260821120000_token_purpose.ts
@@ -1,0 +1,13 @@
+import { DbConnection } from '../db';
+
+export const up = async (db: DbConnection) => {
+	await db.schema.alterTable('tokens', (table) => {
+		table.string('purpose', 32).defaultTo('').notNullable();
+	});
+};
+
+export const down = async (db: DbConnection) => {
+	await db.schema.alterTable('tokens', (table) => {
+		table.dropColumn('purpose');
+	});
+};

--- a/packages/server/src/models/TokenModel.ts
+++ b/packages/server/src/models/TokenModel.ts
@@ -3,6 +3,13 @@ import { ErrorForbidden, ErrorNotFound } from '../utils/errors';
 import { uuidgen } from '../utils/uuid';
 import BaseModel from './BaseModel';
 
+// A token minted for one purpose must not be accepted for another - e.g. a CSRF
+// or confirmation token (both purpose-less) must not be usable to reset a
+// password.
+export enum TokenPurpose {
+	PasswordReset = 'password_reset',
+}
+
 export default class TokenModel extends BaseModel<Token> {
 
 	private tokenTtl_: number = 7 * 24 * 60 * 60 * 1000;
@@ -15,10 +22,11 @@ export default class TokenModel extends BaseModel<Token> {
 		return false;
 	}
 
-	public async generate(userId: Uuid): Promise<string> {
+	public async generate(userId: Uuid, purpose = ''): Promise<string> {
 		const token = await this.save({
 			value: uuidgen(32),
 			user_id: userId,
+			purpose,
 		});
 
 		return token.value;
@@ -49,14 +57,15 @@ export default class TokenModel extends BaseModel<Token> {
 	private async byToken(tokenValue: string): Promise<Token> {
 		return this
 			.db(this.tableName)
-			.select(['user_id', 'value'])
+			.select(['user_id', 'value', 'purpose'])
 			.where('value', '=', tokenValue)
 			.first();
 	}
 
-	public async userFromToken(tokenValue: string): Promise<User> {
+	public async userFromToken(tokenValue: string, purpose = ''): Promise<User> {
 		const token = await this.byToken(tokenValue);
 		if (!token) throw new ErrorNotFound(`No such token: ${tokenValue}`);
+		if ((token.purpose || '') !== purpose) throw new ErrorNotFound(`No such token: ${tokenValue}`);
 		const user = this.models().user().load(token.user_id);
 		if (!user) throw new ErrorNotFound('No user associated with this token');
 		return user;

--- a/packages/server/src/models/UserModel.test.ts
+++ b/packages/server/src/models/UserModel.test.ts
@@ -1,6 +1,7 @@
 import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models, checkThrowAsync, expectThrow, expectHttpError, createUser, koaAppContext } from '../utils/testing/testUtils';
 import { EmailSender, UserFlagType } from '../services/database/types';
-import { ErrorBadRequest, ErrorUnprocessableEntity } from '../utils/errors';
+import { ErrorBadRequest, ErrorNotFound, ErrorUnprocessableEntity } from '../utils/errors';
+import { TokenPurpose } from './TokenModel';
 import { betaUserDateRange, stripeConfig } from '../utils/stripe';
 import { accountByType, AccountType } from './UserModel';
 import { failedPaymentFinalAccount, failedPaymentWarningInterval } from './SubscriptionModel';
@@ -550,6 +551,29 @@ describe('UserModel', () => {
 
 		applications = await models().application().all();
 		expect(applications.length).toBe(0);
+	});
+
+	test('should not reset the password using a token that was not issued for that purpose', async () => {
+		const user = await models().user().save({
+			email: 'test@example.com',
+			password: '111111',
+		});
+		const ctx = await koaAppContext();
+
+		// A CSRF or confirmation token has no purpose and must be rejected here.
+		const genericToken = await models().token().generate(user.id);
+
+		await expectHttpError(async () => {
+			await models().user().resetPassword(genericToken, { password: '222222', password2: '222222' });
+		}, ErrorNotFound.httpCode);
+
+		// The password must be unchanged.
+		expect(await models().user().login('test@example.com', '111111', ctx.joplin.services)).toBeTruthy();
+
+		// A token generated for the reset purpose still works.
+		const resetToken = await models().token().generate(user.id, TokenPurpose.PasswordReset);
+		await models().user().resetPassword(resetToken, { password: '222222', password2: '222222' });
+		expect(await models().user().login('test@example.com', '222222', ctx.joplin.services)).toBeTruthy();
 	});
 
 	test('should not log in an user using a email/password combo when the local auth is disabled', async () => {

--- a/packages/server/src/models/UserModel.ts
+++ b/packages/server/src/models/UserModel.ts
@@ -10,6 +10,7 @@ import { getIsMFAEnabled, getMaxItemSize, getMaxTotalItemSize } from './utils/us
 import zxcvbn from 'zxcvbn';
 import { confirmUrl, resetPasswordUrl } from '../utils/urlUtils';
 import { checkRepeatPassword, CheckRepeatPasswordInput } from '../routes/index/users';
+import { TokenPurpose } from './TokenModel';
 import accountConfirmationTemplate from '../views/emails/accountConfirmationTemplate';
 import resetPasswordTemplate from '../views/emails/resetPasswordTemplate';
 import { betaStartSubUrl, betaUserDateRange, betaUserTrialPeriodDays, isBetaUser, stripeConfig } from '../utils/stripe';
@@ -586,7 +587,7 @@ export default class UserModel extends BaseModel<User> {
 	}
 
 	public async generateLinkForPasswordReset(userId: Uuid) {
-		const validationToken = await this.models().token().generate(userId);
+		const validationToken = await this.models().token().generate(userId, TokenPurpose.PasswordReset);
 		return resetPasswordUrl(validationToken);
 	}
 
@@ -604,7 +605,7 @@ export default class UserModel extends BaseModel<User> {
 
 	public async resetPassword(token: string, fields: CheckRepeatPasswordInput) {
 		checkRepeatPassword(fields, true);
-		const user = await this.models().token().userFromToken(token);
+		const user = await this.models().token().userFromToken(token, TokenPurpose.PasswordReset);
 
 		await this.withTransaction(async () => {
 			await this.models().user().save({ id: user.id, password: fields.password });

--- a/packages/server/src/services/database/types.ts
+++ b/packages/server/src/services/database/types.ts
@@ -237,6 +237,7 @@ export interface Token extends WithDates {
 	id?: number;
 	value?: string;
 	user_id?: Uuid;
+	purpose?: string;
 }
 
 export interface Subscription {
@@ -488,6 +489,7 @@ export const databaseSchema: DatabaseTables = {
 		id: { type: 'number', defaultValue: null },
 		value: { type: 'string', defaultValue: null },
 		user_id: { type: 'string', defaultValue: '' },
+		purpose: { type: 'string', defaultValue: '' },
 		updated_time: { type: 'string', defaultValue: null },
 		created_time: { type: 'string', defaultValue: null },
 	},


### PR DESCRIPTION
Tokens are all minted through the same TokenModel.generate() and stored with only a value and user id, so any valid token for a user (CSRF, email confirmation, etc.) was accepted by the password-reset flow.

Adds a purpose column to the tokens table. Password-reset tokens are now generated and validated with a dedicated password_reset purpose; all other tokens stay purpose-less and behave as before.