### PR TITLE
Desktop: Fixes #16250: Fix exiting having no visible effect when on the settings screen during a long sync

### DIFF
--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -39,7 +39,6 @@ import TrashNotification from './TrashNotification/TrashNotification';
 import UpdateNotification from './UpdateNotification/UpdateNotification';
 import PluginNotification from './PluginNotification/PluginNotification';
 import { Toast } from '@joplin/lib/services/plugins/api/types';
-import QuitSyncDialog from './QuitSyncDialog';
 import Logger from '@joplin/utils/Logger';
 import checkForUpdates, { isReleaseVersion } from '../checkForUpdates';
 
@@ -803,7 +802,6 @@ class MainScreenComponent extends React.Component<Props, State> {
 					themeId={this.props.themeId}
 					toast={this.props.toast}
 				/>
-				<QuitSyncDialog themeId={this.props.themeId} />
 				{messageComp}
 				{layoutComp}
 			</div>

--- a/packages/app-desktop/gui/Root.tsx
+++ b/packages/app-desktop/gui/Root.tsx
@@ -33,6 +33,7 @@ import SsoLoginScreen from './SsoLoginScreen/SsoLoginScreen';
 import SamlShared from '@joplin/lib/components/shared/SamlShared';
 import PopupNotificationProvider from './PopupNotification/PopupNotificationProvider';
 import { ThemeProvider, StyleSheetManager, createGlobalStyle } from 'styled-components';
+import QuitSyncDialog from './QuitSyncDialog';
 
 interface Props {
 	themeId: number;
@@ -178,6 +179,7 @@ class RootComponent extends React.Component<Props, any> {
 						<MenuBar/>
 						<GlobalStyle/>
 						<WindowCommandsAndDialogs windowId={defaultWindowId} />
+						<QuitSyncDialog themeId={this.props.themeId} />
 						<Navigator style={navigatorStyle} screens={screens} className={`profile-${this.props.profileConfigCurrentProfileId}`} />
 						{this.renderSecondaryWindows()}
 						{this.renderModalMessage(this.modalDialogProps())}


### PR DESCRIPTION
A synchronization in progress dialog (with the option to quit now or cancel) was added when quitting the desktop app while a sync is in progress or scheduled, in order to help ensure that outgoing changes are synced before quitting the app. This dialog however only shows on the main screen, and not on other screens such as the settings screen, even though the dialog does open, but is hidden. This PR addresses the issue by including the dialog at the root instead, to ensure it will show regardless of which screen the user is on.

This fixes https://github.com/laurent22/joplin/issues/16250

### Testing

**See video:**

https://github.com/user-attachments/assets/b868701c-21e2-4b35-a8f5-1662c86fa435