### PR TITLE
Desktop: Fixes #15258: Show a warning icon when a sync completes with errors

### DIFF
--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -32,13 +32,15 @@ const SidebarComponent = (props: Props) => {
 	const renderSynchronizeButton = (type: string) => {
 		const label = type === 'sync' ? _('Synchronise') : _('Cancel');
 		const nothingToSync = type === 'sync' && !props.syncPending && syncCompletedWithoutError(props.syncReport);
-		const iconName = nothingToSync ? 'fas fa-check' : 'icon-sync';
+		const syncHasErrors = type === 'sync' && !props.syncPending && !!props.syncReport.errors?.length;
+		const iconName = syncHasErrors ? 'fas fa-exclamation-triangle' : nothingToSync ? 'fas fa-check' : 'icon-sync';
 
 		return (
 			<StyledSynchronizeButton
 				level={ButtonLevel.SidebarSecondary}
-				className={`sidebar-sync-button ${type === 'sync' ? '' : '-syncing'} ${nothingToSync ? '-synced' : ''}`}
+				className={`sidebar-sync-button ${type === 'sync' ? '' : '-syncing'} ${nothingToSync ? '-synced' : ''} ${syncHasErrors ? '-error' : ''}`}
 				iconName={iconName}
+				iconLabel={syncHasErrors ? _('Synchronisation error') : undefined}
 				key="sync_button"
 				title={label}
 				onClick={() => {

--- a/packages/app-desktop/gui/Sidebar/styles/index.ts
+++ b/packages/app-desktop/gui/Sidebar/styles/index.ts
@@ -112,10 +112,6 @@ export const StyledShareIcon = styled.i`
 
 export const StyledSynchronizeButton = styled(Button)`
 	width: 100%;
-
-	&.-error > .icon {
-		font-size: 1.25em;
-	}
 `;
 
 export const StyledAddButton = styled(Button)`

--- a/packages/app-desktop/gui/Sidebar/styles/index.ts
+++ b/packages/app-desktop/gui/Sidebar/styles/index.ts
@@ -112,6 +112,10 @@ export const StyledShareIcon = styled.i`
 
 export const StyledSynchronizeButton = styled(Button)`
 	width: 100%;
+
+	&.-error > .icon {
+		font-size: 1.25em;
+	}
 `;
 
 export const StyledAddButton = styled(Button)`

--- a/packages/app-desktop/gui/Sidebar/styles/sidebar-sync-button.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/sidebar-sync-button.scss
@@ -38,6 +38,10 @@
 		font-size: 0.85em;
 	}
 
+	&.-error > .icon {
+		font-size: 1.25em;
+	}
+
 	&:not(.-syncing):not(.-synced) > .icon {
 		animation: icon-fade-in-b 300ms ease-in-out;
 	}


### PR DESCRIPTION
Since the introduction of the collapsible sync status in the desktop app, sync failures are no longer visible during sync if the status is collapsed. This PR resolves this by showing a warning icon when the sync completes with an error.

This fixes https://github.com/laurent22/joplin/issues/15258

### Testing

I verified the new failed state by forcing a fail-safe error, and checked that it works correctly both with and without the status collapsed

**See video showing the sync status transitions:**

https://github.com/user-attachments/assets/3a551c25-e0ed-42b3-a6fb-065fa8dd6db4