### PR TITLE
Desktop: Fixes #15935: Escape square brackets in link titles when importing ENEX

### DIFF
--- a/packages/app-cli/tests/enex_to_md/linkWithBrackets.html
+++ b/packages/app-cli/tests/enex_to_md/linkWithBrackets.html
@@ -1,0 +1,1 @@
+<a href="https://example.com/page">[Draft] Meeting notes</a>

--- a/packages/app-cli/tests/enex_to_md/linkWithBrackets.md
+++ b/packages/app-cli/tests/enex_to_md/linkWithBrackets.md
@@ -1,0 +1,1 @@
+[\[Draft\] Meeting notes](https://example.com/page)

--- a/packages/lib/import-enex-md-gen.ts
+++ b/packages/lib/import-enex-md-gen.ts
@@ -666,6 +666,14 @@ function enexXmlToMdArray(stream: any, resources: ResourceEntity[], tasks: Extra
 			}
 
 			text = !state.inPre ? unwrapInnerText(text) : text;
+
+			// Square brackets inside a link title would close the link early, so
+			// that only part of the title is turned into a link. Code blocks are
+			// excluded because their content is not rendered as Markdown.
+			if (state.anchorAttributes.length && !state.inPre && !state.inCode.length) {
+				text = markdownUtils.escapeTitleText(text);
+			}
+
 			section.lines = collapseWhiteSpaceAndAppend(section.lines, state, text);
 		});
 


### PR DESCRIPTION
Closes #15935

## Problem

When an ENEX file is imported as Markdown, square brackets in a link title are not escaped. A note titled `[Draft] Meeting notes` is converted to:

```
[[Draft] Meeting notes](https://example.com/page)
```

The Markdown parser closes the link at the inner `]`, so only `[Draft]` is turned into a link and the rest of the title is left as plain text. This is what the issue reports: of the three linked notes in the sample ENEX, only the one whose title contains brackets is resolved incorrectly.

## Cause

In `import-enex-md-gen.ts` the anchor is opened by pushing `'['` and closed by pushing `` `](${url})` ``, but the text collected in between is appended verbatim. `markdownUtils.escapeTitleText()` already exists for exactly this purpose ("Titles for markdown links only need escaping for `[` and `]`") and is not called on that path.

## Fix

Escape the text with `markdownUtils.escapeTitleText()` in the `text` handler when the node is inside an anchor. The same title now converts to:

```
[\[Draft\] Meeting notes](https://example.com/page)
```

Code blocks are excluded from the escaping, since their content is not rendered as Markdown and links inside them are handled separately.

## Tests

Added the fixture pair `linkWithBrackets.html` / `linkWithBrackets.md` in `packages/app-cli/tests/enex_to_md`, which is picked up automatically by the existing `should convert ENEX content to Markdown` test. The new fixture fails on `dev` with the unescaped output above and passes with this change.

Verified locally:

- `jest import-enex-md-gen` — 15 passed, including all existing `enex_to_md` fixtures
- `jest EnexToMd markdownUtils import-enex` — 70 passed across 5 suites
- `eslint --quiet` on the changed file — clean

---

Disclosure per contribution guideline 4: this change was written with AI assistance. I have reviewed and understand it, and I'm happy to explain any part of the implementation or adjust the approach.
