### PR TITLE
Desktop, Mobile: Fixes #15770: HTML notes: Fix certain content incorrectly renders as linked text

### DIFF
--- a/packages/app-cli/tests/html_to_html/anchor_missing_href.dest.html
+++ b/packages/app-cli/tests/html_to_html/anchor_missing_href.dest.html
@@ -1,1 +1,1 @@
-<a data-from-md href='#'>test</a>
+<a>test</a>

--- a/packages/renderer/htmlUtils.test.ts
+++ b/packages/renderer/htmlUtils.test.ts
@@ -1,4 +1,4 @@
-import htmlUtils, { extractHtmlBody, htmlDocIsImageOnly, removeWrappingParagraphAndTrailingEmptyElements } from './htmlUtils';
+import htmlUtils, { extractHtmlBody, htmlDocIsImageOnly, ProcessAnchorTagsAction, removeWrappingParagraphAndTrailingEmptyElements } from './htmlUtils';
 
 describe('htmlUtils', () => {
 
@@ -112,5 +112,38 @@ describe('htmlUtils', () => {
 			expect(output).not.toContain(`href="${href}"`);
 			expect(output).toContain('href="#"');
 		}
+	});
+
+	it.each([
+		{
+			label: 'should replace anchor href attributes',
+			input: '<a>test <a href="href-1"></a></a><div><a href="href-1">another</a></div>',
+			mapper: (): ProcessAnchorTagsAction => (
+				{ type: 'replaceSource', href: 'updated' }
+			),
+			expected: '<a href="updated">test <a href="updated"></a></a><div><a href="updated">another</a></div>',
+		},
+		{
+			label: 'should replace full anchor opening tags',
+			input: '<a>test</a>',
+			mapper: (): ProcessAnchorTagsAction => (
+				{ type: 'replaceElement', html: '<a data-test>' }
+			),
+			expected: '<a data-test>test</a>',
+		},
+		{
+			label: 'should preserve comments',
+			input: '<a>test <a href="href-1"><!-- test --></a></a><!-- Test! -->',
+			mapper: (): null => null,
+			expected: '<a>test <a href="href-1"><!-- test --></a></a><!-- Test! -->',
+		},
+		{
+			label: 'should gracefully handle unbalanced tags',
+			input: '<div><a>test <a href="href-1"> test</a></span>',
+			mapper: (): null => null,
+			expected: '<div><a>test <a href="href-1"> test</a>',
+		},
+	])('should replace anchor tags: $label', ({ input, mapper, expected }) => {
+		expect(htmlUtils.processAnchorTags(input, mapper)).toBe(expected);
 	});
 });

--- a/packages/renderer/htmlUtils.test.ts
+++ b/packages/renderer/htmlUtils.test.ts
@@ -1,4 +1,4 @@
-import htmlUtils, { extractHtmlBody, htmlDocIsImageOnly, ProcessAnchorTagsAction, removeWrappingParagraphAndTrailingEmptyElements } from './htmlUtils';
+import htmlUtils, { extractHtmlBody, htmlDocIsImageOnly, ProcessAnchorTagsAction, ProcessAnchorTagsEvent, removeWrappingParagraphAndTrailingEmptyElements } from './htmlUtils';
 
 describe('htmlUtils', () => {
 
@@ -145,11 +145,11 @@ describe('htmlUtils', () => {
 		},
 		{
 			label: 'should escape "s and >s in attribute names',
-			input: '<a data-test=">&gt;">Test</a>',
-			mapper: (): ProcessAnchorTagsAction => (
-				{ type: 'replaceSource', href: '">' }
+			input: '<a data-test=">&gt;" href="http://example.com/?test=3&test2=4&amp;test3=5">Test</a>',
+			mapper: (event: ProcessAnchorTagsEvent): ProcessAnchorTagsAction => (
+				{ type: 'replaceSource', href: `${event.href}">` }
 			),
-			expected: '<a data-test="&gt;&gt;" href="&quot;&gt;">Test</a>',
+			expected: '<a data-test="&gt;&gt;" href="http://example.com/?test=3&amp;test2=4&amp;test3=5&quot;&gt;">Test</a>',
 		},
 	])('should replace anchor tags: $label', ({ input, mapper, expected }) => {
 		expect(htmlUtils.processAnchorTags(input, mapper)).toBe(expected);

--- a/packages/renderer/htmlUtils.test.ts
+++ b/packages/renderer/htmlUtils.test.ts
@@ -143,6 +143,14 @@ describe('htmlUtils', () => {
 			mapper: (): null => null,
 			expected: '<div><a>test <a href="href-1"> test</a>',
 		},
+		{
+			label: 'should escape "s and >s in attribute names',
+			input: '<a data-test=">&gt;">Test</a>',
+			mapper: (): ProcessAnchorTagsAction => (
+				{ type: 'replaceSource', href: '">' }
+			),
+			expected: '<a data-test="&gt;&gt;" href="&quot;&gt;">Test</a>',
+		},
 	])('should replace anchor tags: $label', ({ input, mapper, expected }) => {
 		expect(htmlUtils.processAnchorTags(input, mapper)).toBe(expected);
 	});

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -7,8 +7,6 @@ import * as htmlparser2 from '@joplin/fork-htmlparser2';
 // https://stackoverflow.com/a/16119722/561309
 const imageRegex = /<img([^>]*?)src=["']([\s\S]*?)["']([\s\S]*?)>/gi;
 
-const anchorRegex = /<a([^>]*?)href=["']([\s\S]*?)["']([\s\S]*?)>/gi;
-
 const selfClosingElements = [
 	'area',
 	'base',
@@ -77,7 +75,7 @@ interface ProcessAnchorTagsEvent {
 	href: string;
 }
 
-type ProcessAnchorTagsAction =
+export type ProcessAnchorTagsAction =
 	| { type: 'replaceElement'; html: string }
 	| { type: 'replaceSource'; href: string }
 	| { type: 'setAttributes'; attrs: Record<string, string> };
@@ -114,25 +112,28 @@ class HtmlUtils {
 	public processAnchorTags(html: string, callback: ProcessAnchorTagsCallback) {
 		if (!html) return '';
 
-		return html.replace(anchorRegex, (_v, before, href, after) => {
-			const action = callback({ href: href });
+		return replaceElements(html, (event) => {
+			if (event.name === 'a') {
+				const action = callback({ href: event.attrs['href'] });
 
-			if (!action) return `<a${before}href="${href}"${after}>`;
+				if (!action) return { attrs: event.attrs };
 
-			if (action.type === 'replaceElement') {
-				return action.html;
+				if (action.type === 'replaceElement') {
+					return { openingTagHtml: action.html };
+				}
+
+				if (action.type === 'replaceSource') {
+					return { attrs: { ...event.attrs, href: action.href } };
+				}
+
+				if (action.type === 'setAttributes') {
+					return { attrs: action.attrs };
+				}
+
+				throw new Error(`Invalid action: ${(action as ProcessAnchorTagsAction).type}`);
+			} else {
+				return { attrs: event.attrs };
 			}
-
-			if (action.type === 'replaceSource') {
-				return `<img${before}href="${action.href}"${after}>`;
-			}
-
-			if (action.type === 'setAttributes') {
-				const attrHtml = attributesHtml(action.attrs);
-				return `<img${before}${attrHtml}${after}>`;
-			}
-
-			throw new Error(`Invalid action: ${(action as ProcessAnchorTagsAction).type}`);
 		});
 	}
 
@@ -410,6 +411,74 @@ const makeHtmlTag = (name: string, attrs: Record<string, string>) => {
 	if (attrHtml) attrHtml = ` ${attrHtml}`;
 	const closingSign = isSelfClosingTag(name) ? '/>' : '>';
 	return `<${name}${attrHtml}${closingSign}`;
+};
+
+
+interface TagRecord {
+	name: string;
+	attrs: Record<string, string>;
+}
+interface AttrsReplacement {
+	attrs: Record<string, string>;
+	openingTagHtml?: undefined;
+}
+interface OpeningTagReplacement {
+	attrs?: undefined;
+	openingTagHtml: string;
+}
+
+type OnMapTag = (tag: TagRecord)=> OpeningTagReplacement|AttrsReplacement;
+
+const replaceElements = (html: string, tagMapping: OnMapTag) => {
+	const output: string[] = [];
+	type StackEntry = { name: string };
+	const stack: StackEntry[] = [];
+
+	const parser = new htmlparser2.Parser({
+
+		oncomment: (data: string) => {
+			output.push(`<!--${htmlentities(data)}-->`);
+		},
+
+		onopentag: (name: string, attrs: Record<string, string>) => {
+			// Note: "name" and attribute names are always lowercase even
+			// when the input is not. So there is no need to call
+			// "toLowerCase" on them.
+			stack.push({ name });
+
+			const mapping = tagMapping({ name, attrs });
+			let replacement;
+			if (mapping.openingTagHtml) {
+				replacement = mapping.openingTagHtml;
+			} else {
+				attrs = mapping.attrs;
+
+				let attrHtml = attributesHtml(attrs);
+				if (attrHtml) attrHtml = ` ${attrHtml}`;
+				const closingSign = isSelfClosingTag(name) ? '/>' : '>';
+				replacement = `<${name}${attrHtml}${closingSign}`;
+			}
+
+			output.push(replacement);
+		},
+
+		ontext: (encodedText: string) => {
+			output.push(encodedText);
+		},
+
+		onclosetag: (name: string) => {
+			stack.pop();
+			if (!isSelfClosingTag(name)) {
+				output.push(`</${name}>`);
+			}
+		},
+
+	}, { decodeEntities: false });
+
+	parser.write(html);
+	parser.end();
+
+	return output.join('');
 };
 
 // Will return either the content of the <BODY> tag if it exists, or the whole

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -130,7 +130,8 @@ class HtmlUtils {
 					return { attrs: action.attrs };
 				}
 
-				throw new Error(`Invalid action: ${(action as ProcessAnchorTagsAction).type}`);
+				const exhaustivenessCheck: never = action;
+				throw new Error(`Invalid action: ${(exhaustivenessCheck as ProcessAnchorTagsAction).type}`);
 			} else {
 				return { attrs: event.attrs };
 			}

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -5,7 +5,7 @@ import * as htmlparser2 from '@joplin/fork-htmlparser2';
 
 // [\s\S] instead of . for multiline matching
 // https://stackoverflow.com/a/16119722/561309
-const imageRegex = /<img([^>]*?)src=["']([\s\S]*?)["']([\s\S]*?)>/gi;
+const imageRegex = /<img([\s\S]*?)src=["']([\s\S]*?)["']([\s\S]*?)>/gi;
 
 const selfClosingElements = [
 	'area',

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -5,9 +5,9 @@ import * as htmlparser2 from '@joplin/fork-htmlparser2';
 
 // [\s\S] instead of . for multiline matching
 // https://stackoverflow.com/a/16119722/561309
-const imageRegex = /<img([\s\S]*?)src=["']([\s\S]*?)["']([\s\S]*?)>/gi;
+const imageRegex = /<img([^>]*?)src=["']([\s\S]*?)["']([\s\S]*?)>/gi;
 
-const anchorRegex = /<a([\s\S]*?)href=["']([\s\S]*?)["']([\s\S]*?)>/gi;
+const anchorRegex = /<a([^>]*?)href=["']([\s\S]*?)["']([\s\S]*?)>/gi;
 
 const selfClosingElements = [
 	'area',
@@ -338,15 +338,6 @@ class HtmlUtils {
 						classAttr += ' jop-noMdConv';
 						attrs['class'] = classAttr.trim();
 					}
-				}
-
-				// For some reason, entire parts of HTML notes don't show up in
-				// the viewer when there's an anchor tag without an "href"
-				// attribute. It doesn't always happen and it seems to depend on
-				// what else is in the note but in any case adding the "href"
-				// fixes it. https://github.com/laurent22/joplin/issues/5687
-				if (name === 'a' && !attrs['href']) {
-					attrs['href'] = '#';
 				}
 
 				let attrHtml = attributesHtml(attrs);

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -1,5 +1,6 @@
 import { AllHtmlEntities as Entities } from 'html-entities';
 const htmlentities = new Entities().encode;
+const decodeEntities = new Entities().decode;
 import { fileUriToPath } from '@joplin/utils/url';
 import * as htmlparser2 from '@joplin/fork-htmlparser2';
 
@@ -71,7 +72,7 @@ interface ProcessImageEvent {
 }
 type ProcessImageCallback = (data: ProcessImageEvent)=> ProcessImageResult;
 
-interface ProcessAnchorTagsEvent {
+export interface ProcessAnchorTagsEvent {
 	href: string;
 }
 
@@ -447,6 +448,11 @@ const replaceElements = (html: string, tagMapping: OnMapTag) => {
 			// "toLowerCase" on them.
 			stack.push({ name });
 
+			for (const key of Object.keys(attrs)) {
+				if (typeof attrs[key] !== 'string') continue;
+				attrs[key] = decodeEntities(attrs[key]);
+			}
+
 			const mapping = tagMapping({ name, attrs });
 			let replacement;
 			if (mapping.openingTagHtml) {
@@ -463,8 +469,8 @@ const replaceElements = (html: string, tagMapping: OnMapTag) => {
 			output.push(replacement);
 		},
 
-		ontext: (decodedText: string) => {
-			output.push(htmlentities(decodedText));
+		ontext: (encodedText: string) => {
+			output.push(encodedText);
 		},
 
 		onclosetag: (name: string) => {
@@ -474,7 +480,7 @@ const replaceElements = (html: string, tagMapping: OnMapTag) => {
 			}
 		},
 
-	}, { decodeEntities: true });
+	}, { decodeEntities: false });
 
 	parser.write(html);
 	parser.end();

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -463,8 +463,8 @@ const replaceElements = (html: string, tagMapping: OnMapTag) => {
 			output.push(replacement);
 		},
 
-		ontext: (encodedText: string) => {
-			output.push(encodedText);
+		ontext: (decodedText: string) => {
+			output.push(htmlentities(decodedText));
 		},
 
 		onclosetag: (name: string) => {
@@ -474,7 +474,7 @@ const replaceElements = (html: string, tagMapping: OnMapTag) => {
 			}
 		},
 
-	}, { decodeEntities: false });
+	}, { decodeEntities: true });
 
 	parser.write(html);
 	parser.end();

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -73,7 +73,7 @@ interface ProcessImageEvent {
 type ProcessImageCallback = (data: ProcessImageEvent)=> ProcessImageResult;
 
 export interface ProcessAnchorTagsEvent {
-	href: string;
+	href: string|undefined;
 }
 
 export type ProcessAnchorTagsAction =


### PR DESCRIPTION
# Problem

When rendering HTML-format notes, Joplin adds an `href="#"` to anchor elements without an `href` attribute. This results in different styling in Joplin, compared to the original.

The `href="#"` was a workaround for an [older issue](https://github.com/laurent22/joplin/issues/5687) caused by the [regular expression](https://github.com/laurent22/joplin/blob/92eed39ff74f6970d9f9f60de84bef9552088799/packages/renderer/htmlUtils.ts#L10) used to replace anchor elements (which could match, e.g. `<a>some text<a href="...">`, as a single opening tag).

# Solution

- Rewrite `processAnchorTags` to use a proper HTML parser to replace/process anchor elements.
- Remove the workaround that added `href="#"` to anchor tags without an `href` attribute.

Fixes #15770.

> [!NOTE]
>
> To limit the scope of this pull request, only `processAnchorTags` in `packages/renderer/htmlUtils.ts` is updated. `processImageTags`, which uses a similar regular expression, is left as-is.

# Testing

- Imported the ENEX file from #5687. Manually checked that some of the content that was previously missing (without the `href="#"` workaround but with the old `processAnchorTags` logic) is no longer missing.
- Set an HTML note's content to `<a>test</a>`. Verified that `test` is no longer underlined in the note viewer.