### PR TITLE
Desktop: Resolves #16160: Use lock wording for note lock actions and messages

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/controls/NoteLockSettings.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/NoteLockSettings.tsx
@@ -197,7 +197,7 @@ const NoteLockSettings: React.FC<Props> = props => {
 						/>
 					)}
 				</div>
-				<p className='reminder'><strong>{_('Please make sure you remember your password. It cannot be recovered if lost, and any data encrypted with it will become inaccessible.')}</strong></p>
+				<p className='reminder'><strong>{_('Please make sure you remember your password. It cannot be recovered if lost, and any locked notes will become inaccessible.')}</strong></p>
 			</div>
 		);
 	};
@@ -208,7 +208,7 @@ const NoteLockSettings: React.FC<Props> = props => {
 		return (
 			<div className='section'>
 				<h2>{_('Key upgrade')}</h2>
-				<p>{_('The note lock key uses an out-dated encryption algorithm and it is recommended to upgrade it. The upgraded key will still be able to decrypt and encrypt your data as usual.')}</p>
+				<p>{_('The note lock key uses an out-dated algorithm and it is recommended to upgrade it. The upgraded key will still lock and unlock your notes as usual.')}</p>
 				<div className='form'>
 					<LabelledPasswordInput
 						labelText={_('Password')}

--- a/packages/app-desktop/gui/ConfigScreen/controls/NoteLockSettings.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/NoteLockSettings.tsx
@@ -124,6 +124,10 @@ const NoteLockSettings: React.FC<Props> = props => {
 
 	const resetPasswordTitle = `⚠️ ${_('Reset password')} ⚠️`;
 	const actionButtonTitle = mode === ActionMode.Reset ? resetPasswordTitle : _('Save');
+	// The sync advice only applies to a first setup, where there may be nothing to lose yet.
+	const passwordReminder = mode === ActionMode.Create ?
+		_('Please make sure you remember your password. It cannot be recovered if lost, and any locked notes will become inaccessible. If you have already set up the note lock password on another device, there is no need to set it again, as the information required to access your locked notes is updated when you set up sync.') :
+		_('Please make sure you remember your password. It cannot be recovered if lost, and any locked notes will become inaccessible.');
 
 	const getSectionTitle = () => {
 		if (mode === ActionMode.Reset) return resetPasswordTitle;
@@ -197,7 +201,7 @@ const NoteLockSettings: React.FC<Props> = props => {
 						/>
 					)}
 				</div>
-				<p className='reminder'><strong>{_('Please make sure you remember your password. It cannot be recovered if lost, and any locked notes will become inaccessible.')}</strong></p>
+				<p className='reminder'><strong>{passwordReminder}</strong></p>
 			</div>
 		);
 	};

--- a/packages/app-desktop/gui/ConfigScreen/controls/NoteLockSettings.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/NoteLockSettings.tsx
@@ -208,7 +208,7 @@ const NoteLockSettings: React.FC<Props> = props => {
 		return (
 			<div className='section'>
 				<h2>{_('Key upgrade')}</h2>
-				<p>{_('The note lock key uses an out-dated algorithm and it is recommended to upgrade it. The upgraded key will still lock and unlock your notes as usual.')}</p>
+				<p>{_('For better security, your note lock protection can be upgraded to a newer method. Enter your password to upgrade it. Your notes will keep locking and unlocking as usual.')}</p>
 				<div className='form'>
 					<LabelledPasswordInput
 						labelText={_('Password')}

--- a/packages/app-desktop/gui/NoteEditor/NoteLockPanel/NoteLockPanel.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteLockPanel/NoteLockPanel.tsx
@@ -50,7 +50,7 @@ export default function NoteLockPanel(props: Props) {
 
 	const renderAction = () => {
 		if (props.undecryptable) {
-			return <p className="message">{_('This note could not be decrypted. If it was encrypted prior to a password reset, the contents are no longer recoverable.')}</p>;
+			return <p className="message">{_('This note could not be unlocked. If it was locked prior to a password reset, the contents are no longer recoverable.')}</p>;
 		}
 
 		if (!props.hasNoteLockKey) {
@@ -64,7 +64,7 @@ export default function NoteLockPanel(props: Props) {
 
 		return (
 			<form className="form unlock-form" onSubmit={onSubmit}>
-				<p className="message">{_('This note is encrypted. Enter the note lock password to unlock encrypted notes for this session.')}</p>
+				<p className="message">{_('This note is locked. Enter the note lock password to unlock your notes for this session.')}</p>
 				<div className="field">
 					<LabelledPasswordInput
 						labelText={_('Note lock password')}

--- a/packages/app-desktop/gui/NoteEditor/NoteLockPanel/NoteLockPanel.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteLockPanel/NoteLockPanel.tsx
@@ -50,7 +50,7 @@ export default function NoteLockPanel(props: Props) {
 
 	const renderAction = () => {
 		if (props.undecryptable) {
-			return <p className="message">{_('This note could not be unlocked. If it was locked prior to a password reset, the contents are no longer recoverable.')}</p>;
+			return <p className="message">{_('This note could not be unlocked. If it was locked prior to a password reset, the content is no longer recoverable.')}</p>;
 		}
 
 		if (!props.hasNoteLockKey) {
@@ -64,7 +64,7 @@ export default function NoteLockPanel(props: Props) {
 
 		return (
 			<form className="form unlock-form" onSubmit={onSubmit}>
-				<p className="message">{_('This note is locked. Enter the note lock password to unlock your notes for this session.')}</p>
+				<p className="message">{_('This note is locked. Enter your password to unlock your notes for this session.')}</p>
 				<div className="field">
 					<LabelledPasswordInput
 						labelText={_('Note lock password')}

--- a/packages/app-desktop/gui/NoteLockUnlockDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/NoteLockUnlockDialog/Dialog.tsx
@@ -65,7 +65,7 @@ export default function(props: Props) {
 			<div className="dialog-root">
 				<DialogTitle title={_('Unlock notes')}/>
 				<div className="dialog-content">
-					<p>{_('Enter the note lock password to unlock your notes for this session.')}</p>
+					<p>{_('Enter your password to unlock your notes for this session.')}</p>
 					<LabelledPasswordInput
 						labelText={_('Note lock password')}
 						value={password}

--- a/packages/app-desktop/gui/NoteLockUnlockDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/NoteLockUnlockDialog/Dialog.tsx
@@ -63,9 +63,9 @@ export default function(props: Props) {
 	return (
 		<Dialog onCancel={onClose} className="note-lock-unlock-dialog">
 			<div className="dialog-root">
-				<DialogTitle title={_('Unlock encrypted notes')}/>
+				<DialogTitle title={_('Unlock notes')}/>
 				<div className="dialog-content">
-					<p>{_('Enter the note lock password to unlock encrypted notes for this session.')}</p>
+					<p>{_('Enter the note lock password to unlock your notes for this session.')}</p>
 					<LabelledPasswordInput
 						labelText={_('Note lock password')}
 						value={password}

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/disableNoteEncryption.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/disableNoteEncryption.ts
@@ -6,7 +6,7 @@ import bridge from '../../../services/bridge';
 
 export const declaration: CommandDeclaration = {
 	name: 'disableNoteEncryption',
-	label: () => _('Disable encryption'),
+	label: () => _('Remove note lock'),
 };
 
 export const runtime = (): CommandRuntime => {

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/enableNoteEncryption.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/enableNoteEncryption.ts
@@ -10,7 +10,7 @@ import bridge from '../../../services/bridge';
 
 export const declaration: CommandDeclaration = {
 	name: 'enableNoteEncryption',
-	label: () => _('Enable encryption'),
+	label: () => _('Lock this note'),
 };
 
 export const runtime = (): CommandRuntime => {
@@ -30,7 +30,7 @@ export const runtime = (): CommandRuntime => {
 			}
 
 			if (!NoteLockKey.instance().load()) {
-				const setUpNow = bridge().showConfirmMessageBox(_('Encrypting a note requires a note lock password, which has not yet been set. Set it up now?'), {
+				const setUpNow = bridge().showConfirmMessageBox(_('Locking a note requires the note lock password, which has not been set up yet. Set it up now?'), {
 					buttons: [_('Yes'), _('No')],
 				});
 				if (setUpNow) {

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/lockEncryptedNotes.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/lockEncryptedNotes.ts
@@ -5,7 +5,7 @@ import NoteLockSession from '@joplin/lib/services/noteLock/NoteLockSession';
 
 export const declaration: CommandDeclaration = {
 	name: 'lockEncryptedNotes',
-	label: () => _('Lock encrypted notes'),
+	label: () => _('Relock all notes'),
 };
 
 export const runtime = (): CommandRuntime => {

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1387,7 +1387,7 @@ class Setting extends BaseModel {
 			return _('Notes and settings are stored in: %s', toSystemSlashes(this.value('profileDir'), process.platform));
 		}
 		if (name === 'noteLock') {
-			return _('Locked notes are encrypted on this device and can only be read after entering your note lock password. The password is required again after locking or restarting Joplin.');
+			return _('Locked notes are specific notes that are encrypted on the device and protected by your note lock password. They can only be read after entering this password. The password is required again after relocking notes or restarting Joplin.');
 		}
 		if (name === 'ai.tools') {
 			return _('Tools and services to expose to AI. AI agents can use these tools either via the note chat panel or Joplin\'s MCP server (if enabled).');

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1404,7 +1404,7 @@ class Setting extends BaseModel {
 			'general': _('Language, date format'),
 			'appearance': _('Themes, notebook sort order'),
 			'sync': _('Sync, encryption, proxy'),
-			'noteLock': _('Note lock password, auto lock'),
+			'noteLock': _('Note lock password, auto relock'),
 			'joplinCloud': _('Email To Note, login information'),
 			'editor': _('Typography, spellcheck, layout'),
 			'markdownPlugins': _('Media player, math, diagrams, table of contents'),

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -2309,7 +2309,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			public: true,
 			appTypes: [AppType.Desktop, AppType.Mobile],
 			section: 'noteLock',
-			label: () => _('Auto lock when switching note'),
+			label: () => _('Auto relock when switching notes'),
 			show: (settings) => !!settings['featureFlag.noteLock'],
 			storage: SettingStorage.File,
 		},

--- a/packages/lib/services/noteLock/setNoteLockState.ts
+++ b/packages/lib/services/noteLock/setNoteLockState.ts
@@ -14,10 +14,10 @@ import NoteLockSession from './NoteLockSession';
 const checkCanChangeLockState = (note: NoteEntity, noteId: string) => {
 	if (!isNoteLockEnabled()) throw new Error('Note lock is not enabled');
 	if (!note) throw new Error(`No such note: ${noteId}`);
-	if (note.deleted_time) throw new Error('Cannot change encryption of a deleted note');
-	if (note.is_conflict) throw new Error('Cannot change encryption of a conflict note');
-	if (itemIsReadOnlySync(ModelType.Note, ItemChange.SOURCE_UNSPECIFIED, note as ItemSlice, Setting.value('sync.userId'), BaseItem.syncShareCache)) throw new Error('Cannot change encryption of a read-only note');
-	if (!NoteLockSession.instance().isUnlocked()) throw new Error('Cannot change encryption while the note lock session is locked');
+	if (note.deleted_time) throw new Error('Cannot change the note lock of a deleted note');
+	if (note.is_conflict) throw new Error('Cannot change the note lock of a conflict note');
+	if (itemIsReadOnlySync(ModelType.Note, ItemChange.SOURCE_UNSPECIFIED, note as ItemSlice, Setting.value('sync.userId'), BaseItem.syncShareCache)) throw new Error('Cannot change the note lock of a read-only note');
+	if (!NoteLockSession.instance().isUnlocked()) throw new Error('Cannot change the note lock while the session is locked');
 };
 
 const validationFields = ['id', 'is_locked', 'deleted_time', 'is_conflict', 'share_id'];


### PR DESCRIPTION
Part of #16160

Renames the desktop note lock actions and messages from encryption wording to lock wording, as agreed on the issue:

- "Enable encryption" -> "Lock this note"
- "Disable encryption" -> "Remove note lock"
- "Lock encrypted notes" -> "Relock all notes"
- The unlock panel and the unlock dialog drop the encryption wording and both say "unlock your notes for this session", and a note that cannot be decrypted reads "could not be unlocked"
- The first-time setup prompt says locking instead of encrypting
- The note lock settings section description uses the refined wording from the issue, the one place that still mentions encryption
- "Auto lock when switching note" -> "Auto relock when switching notes"
- The password reminder says locked notes instead of encrypted data, and the key upgrade text drops the encryption vocabulary
- The four state-change validation errors (deleted, conflict, read-only, locked session) say note lock instead of encryption

Some of these are shared lib strings, so both apps' config screens pick them up. The CLI messages already use lock wording, and the mobile menu strings are being changed on #16069. Internal code keeps the existing naming, as agreed.

## Screenshots

| Note menu | Unlock dialog | Note that cannot be unlocked |
| --- | --- | --- |
| <img width="220" alt="Note menu with the renamed lock entries" src="https://github.com/user-attachments/assets/2c97bad9-320a-43a5-968b-f80338c8ffa8" /> | <img width="280" alt="Unlock notes dialog" src="https://github.com/user-attachments/assets/ca9497f3-5d14-4aa9-96ca-e185fca96ad9" /> | <img width="280" alt="Cannot be unlocked panel" src="https://github.com/user-attachments/assets/2658ef89-2cb1-441f-ae1c-851a96d9df9e" /> |

| Locked note panel | Note lock settings |
| --- | --- |
| <img width="400" alt="Locked note panel" src="https://github.com/user-attachments/assets/dc3b4e1f-e0fe-4113-8f47-6b291ee3fa5a" /> | <img width="480" alt="Note lock settings section" src="https://github.com/user-attachments/assets/fdcce9a6-24ac-4138-b4c4-36b1ad33b681" /> |

The screenshots predate the wording tweaks from the review, layout is unchanged.

## Testing

- `yarn tsc` for lib and app-desktop, eslint on the changed files, the setNoteLockState suite
- Manually checked on desktop with the flag on: the three menu entries, the unlock dialog, both lock panel states, and the settings section with the new description and the relock label

## AI Assistance Disclosure

I used AI tools while working on this PR for code suggestions and review, and drafting parts of this description. I reviewed the final changes and reran the tests listed above myself.