### PR TITLE
Desktop: Resolves #15721: exporting handwritten notes into pdf exports white ink on white paper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,7 @@ packages/app-cli/tests/services/plugins/sandboxProxy.js
 packages/app-cli/tests/testUtils.js
 packages/app-cli/tools/populateDatabase.js
 packages/app-desktop/ElectronAppWrapper.js
+packages/app-desktop/InteropServiceHelper.test.js
 packages/app-desktop/InteropServiceHelper.js
 packages/app-desktop/app.reducer.test.js
 packages/app-desktop/app.reducer.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -183,6 +183,7 @@ packages/app-cli/tests/services/plugins/sandboxProxy.js
 packages/app-cli/tests/testUtils.js
 packages/app-cli/tools/populateDatabase.js
 packages/app-desktop/ElectronAppWrapper.js
+packages/app-desktop/InteropServiceHelper.test.js
 packages/app-desktop/InteropServiceHelper.js
 packages/app-desktop/app.reducer.test.js
 packages/app-desktop/app.reducer.js

--- a/packages/app-desktop/InteropServiceHelper.test.ts
+++ b/packages/app-desktop/InteropServiceHelper.test.ts
@@ -1,0 +1,66 @@
+import InteropService from '@joplin/lib/services/interop/InteropService';
+import shim from '@joplin/lib/shim';
+import darkTheme from '@joplin/lib/themes/dark';
+import InteropServiceHelper from './InteropServiceHelper';
+const Color = require('color');
+
+const mockWindow = {
+	destroy: jest.fn(),
+	loadURL: jest.fn(),
+	webContents: {
+		executeJavaScript: jest.fn(),
+		on: jest.fn(),
+		printToPDF: jest.fn(),
+	},
+};
+
+jest.mock('./services/bridge', () => ({
+	__esModule: true,
+	default: () => ({ newBrowserWindow: () => mockWindow }),
+}));
+
+describe('InteropServiceHelper', () => {
+	beforeEach(() => {
+		jest.spyOn(InteropService.instance(), 'export').mockResolvedValue({ warnings: [] });
+		jest.spyOn(shim, 'setTimeout').mockImplementation(callback => void callback());
+		mockWindow.webContents.on.mockImplementation((_event, callback) => callback());
+		mockWindow.webContents.executeJavaScript.mockImplementation(script => Promise.resolve(window.eval(script)));
+		mockWindow.webContents.printToPDF.mockResolvedValue(Buffer.from('pdf'));
+	});
+
+	afterEach(() => {
+		document.body.replaceChildren();
+		jest.restoreAllMocks();
+		jest.clearAllMocks();
+	});
+
+	test('should add a dark print background only to valid js-draw images', async () => {
+		const drawingSvg = '<svg><style id="js-draw-style-sheet"/><path stroke="#ffffff"/></svg>';
+		const otherSvg = '<svg><path stroke="#ffffff"/></svg>';
+		const drawingDataUrl = `data:image/svg+xml;base64,${Buffer.from(drawingSvg).toString('base64')}`;
+		const otherDataUrl = `data:image/svg+xml;base64,${Buffer.from(otherSvg).toString('base64')}`;
+		document.body.innerHTML = `
+			<img id="invalid" src="data:image/svg+xml;base64,==">
+			<img id="drawing" src="${drawingDataUrl}">
+			<img id="other" src="${otherDataUrl}">
+		`;
+
+		await InteropServiceHelper.exportNoteToPdf('note-id', { printBackground: true });
+
+		const invalid = document.querySelector<HTMLImageElement>('#invalid');
+		const drawing = document.querySelector<HTMLImageElement>('#drawing');
+		const other = document.querySelector<HTMLImageElement>('#other');
+		expect(invalid.style.backgroundColor).toBe('');
+		expect(drawing.src).toBe(drawingDataUrl);
+		expect(drawing.style.backgroundColor).toBe(Color(darkTheme.backgroundColor).rgb().string());
+		expect(other.src).toBe(otherDataUrl);
+		expect(other.style.backgroundColor).toBe('');
+	});
+
+	test('should clean up when preparing js-draw images fails', async () => {
+		mockWindow.webContents.executeJavaScript.mockRejectedValueOnce(new Error('Preparation failed'));
+
+		await expect(InteropServiceHelper.exportNoteToPdf('note-id', { printBackground: true })).rejects.toThrow('Preparation failed');
+		expect(mockWindow.destroy).toHaveBeenCalled();
+	});
+});

--- a/packages/app-desktop/InteropServiceHelper.ts
+++ b/packages/app-desktop/InteropServiceHelper.ts
@@ -10,6 +10,7 @@ import { PluginStates } from '@joplin/lib/services/plugins/reducer';
 import bridge from './services/bridge';
 import Setting from '@joplin/lib/models/Setting';
 import Note from '@joplin/lib/models/Note';
+import darkTheme from '@joplin/lib/themes/dark';
 import { friendlySafeFilename } from '@joplin/lib/path-utils';
 import time from '@joplin/lib/time';
 import { BrowserWindow, BrowserWindowConstructorOptions } from 'electron';
@@ -43,6 +44,7 @@ export default class InteropServiceHelper {
 		const result = await service.export(fullExportOptions);
 		// eslint-disable-next-line no-console
 		console.info('Export HTML result: ', result);
+
 		return tempFile;
 	}
 
@@ -81,6 +83,31 @@ export default class InteropServiceHelper {
 					// So we need to add an additional timer to make sure fonts are loaded
 					// as it doesn't seem there's any easy way to figure that out.
 					shim.setTimeout(async () => {
+						try {
+							// Add a dark background behind js-draw images so light ink stays visible when printing.
+							await win.webContents.executeJavaScript(`
+								const embeddedSvgSelector = 'img[src^="data:image/svg+xml;base64,"]';
+								for (const image of document.querySelectorAll(embeddedSvgSelector)) {
+									const base64Svg = image.src.substring(image.src.indexOf(',') + 1);
+									let svg;
+									try {
+										svg = atob(base64Svg);
+									} catch {
+										continue;
+									}
+									const isJsDrawImage = svg.includes('id="js-draw-style-sheet"');
+
+									if (isJsDrawImage) {
+										image.style.backgroundColor = '${darkTheme.backgroundColor}';
+									}
+								}
+							`);
+						} catch (error) {
+							cleanup();
+							reject(error);
+							return;
+						}
+
 						if (target === 'pdf') {
 							try {
 								// The below line "opens" all <details> tags


### PR DESCRIPTION
Resolves #15721

White ink on a transparent background is visible with the dark theme, but it becomes invisible when exported because the PDF background is white. It also becomes invisible in Joplin when the user switches to the light theme.

I first tried to change the white ink to black, but js-draw does not provide a way to detect pen lines separately in the SVG. Because of this, I would need to guess which light colors should be changed, and this a bit hard to guess and may change other colors by mistake for example: 
 - A user upload a svg of an object with a white background and a dark object

Instead, I did go with the second proposition which is to add dark background behind js-draw images before PDF export or printing ( I used joplin dark theme background instead of a normal dark color). This keeps the printed result close to what the user sees in Joplin and avoids changing the drawing's original colors

Also i made sure that invalid base64 svg data is skipped, and failures while preparing the images clean up the print window and reject the export.

I first put this logic in the exported HTML, but this may create big copies in memory and cause an OOM error, so I moved it to the print window and updated the images there.


https://github.com/user-attachments/assets/1a61afae-00c4-4469-9f21-c5332df5a255

[light_theme.pdf](https://github.com/user-attachments/files/31351275/light_theme.pdf)

[dark_theme.pdf](https://github.com/user-attachments/files/31351277/dark_theme.pdf)
