### PR TITLE
Chore: Update actions/setup-java to v6

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -30,7 +30,7 @@ jobs:
           docker system prune -af || true
           df -h /
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '20'


### PR DESCRIPTION
## Summary

Updates the Android build workflow from `actions/setup-java@v5` to `@v6`.

## Testing

- Verified all active workflow references use setup-java v6
- Ran `git diff --check`