### PR TITLE
Mobile, Desktop, Cli: Resolves #16251: Sync: Enable new notebook sharing key format

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -367,12 +367,7 @@ export default class Synchronizer {
 		const password = getMasterPassword(false);
 		if (!password) return localInfo;
 
-		try {
-			localInfo.ppk = await generateKeyPair(this.encryptionService(), password);
-		} catch (error) {
-			// TODO: Remove after RSA encryption is supported on all platforms.
-			logger.error('Failed to generate RSA key pair', error);
-		}
+		localInfo.ppk = await generateKeyPair(this.encryptionService(), password);
 		return localInfo;
 	}
 

--- a/packages/lib/services/e2ee/ppk/ppk.ts
+++ b/packages/lib/services/e2ee/ppk/ppk.ts
@@ -26,8 +26,8 @@ export interface PublicPrivateKeyPair {
 // "ppkMigrations".
 let ppkMigrations = [
 	PublicKeyAlgorithm.RsaV1,
-	// Uncomment to migrate to RsaV2, which uses a different padding type from RsaV1
-	// PublicKeyAlgorithm.RsaV2,
+	// RsaV2 uses a newer padding type
+	PublicKeyAlgorithm.RsaV2,
 
 	// Uncomment to migrate to RsaV3, which uses different encryption libraries, padding type,
 	// and a larger key size. Before migrating:

--- a/packages/lib/services/e2ee/ppk/ppk.ts
+++ b/packages/lib/services/e2ee/ppk/ppk.ts
@@ -25,7 +25,7 @@ export interface PublicPrivateKeyPair {
 // To indicate that clients should migrate to a new PublicKeyAlgorithm, add it to the end of
 // "ppkMigrations".
 let ppkMigrations = [
-	PublicKeyAlgorithm.RsaV1, // RSA-PKCS#1-v1.5-2048
+	PublicKeyAlgorithm.RsaV1, // RSA-PKCS#1-v1.5-2048, not supported on all platforms
 	// RsaV2 uses a newer padding type
 	PublicKeyAlgorithm.RsaV2, // RSA-OAEP-2048
 

--- a/packages/lib/services/e2ee/ppk/ppk.ts
+++ b/packages/lib/services/e2ee/ppk/ppk.ts
@@ -25,15 +25,15 @@ export interface PublicPrivateKeyPair {
 // To indicate that clients should migrate to a new PublicKeyAlgorithm, add it to the end of
 // "ppkMigrations".
 let ppkMigrations = [
-	PublicKeyAlgorithm.RsaV1,
+	PublicKeyAlgorithm.RsaV1, // RSA-PKCS#1-v1.5-2048
 	// RsaV2 uses a newer padding type
-	PublicKeyAlgorithm.RsaV2,
+	PublicKeyAlgorithm.RsaV2, // RSA-OAEP-2048
 
 	// Uncomment to migrate to RsaV3, which uses different encryption libraries, padding type,
 	// and a larger key size. Before migrating:
 	// - Check whether generating keys with this method still blocks the UI on Android/iOS
 	//   (it might not after migrating to React Native's New Architecture).
-	// PublicKeyAlgorithm.RsaV3,
+	// PublicKeyAlgorithm.RsaV3, // RSA-OAEP-4096
 ];
 export const getDefaultPpkAlgorithm = () => ppkMigrations[ppkMigrations.length - 1];
 

--- a/packages/lib/services/e2ee/utils.test.ts
+++ b/packages/lib/services/e2ee/utils.test.ts
@@ -61,6 +61,24 @@ describe('e2ee/utils', () => {
 		}
 	});
 
+	it('should not undo ppk migration when the most recent public key algorithm is not in the migrations list', async () => {
+		const { reset } = testing__setPpkMigrations_([PublicKeyAlgorithm.RsaV1]);
+
+		try {
+			const syncInfo = localSyncInfo();
+			const testPassword = 'test--TEST';
+			Setting.setValue('encryption.masterPassword', testPassword);
+			syncInfo.ppk = await generateKeyPairWithAlgorithm(PublicKeyAlgorithm.RsaV2, encryptionService(), testPassword);
+			saveLocalSyncInfo(syncInfo);
+
+			expect(getPpkAlgorithm(localSyncInfo().ppk)).toBe(PublicKeyAlgorithm.RsaV2);
+			await migratePpk();
+			expect(getPpkAlgorithm(localSyncInfo().ppk)).toBe(PublicKeyAlgorithm.RsaV2);
+		} finally {
+			reset();
+		}
+	});
+
 	it('should not migrate ppk if the key is up-to-date', async () => {
 		const syncInfo = localSyncInfo();
 		const testPassword = 'test 🔑';


### PR DESCRIPTION
# Problem

- When E2EE is enabled, notebook sharing uses PKCS#1-v1.5-2048 to give share participants access to the shared notebook's encryption key (`node-rsa`'s `encryptionScheme: 'pkcs1'` option).
- On web, the [E2EE provider](https://github.com/laurent22/joplin/blob/c174faf77dcf63980b4777d19af373a685f9f5d6/packages/app-mobile/services/e2ee/RSA.react-native.web.ts#L6) does not support RSA-PKCS#1-v1.5. This means that, when E2EE is enabled, the web app:
  1) can't accept shared notebooks because it can't decrypt the notebook sharing key (see [spec](https://joplinapp.org/help/dev/spec/e2ee/#public-private-key-pairs)) and,
  2) doesn't generate a `ppk` on the sync target, preventing other users from sharing notebooks with the account (see #16301).

# Solution

Migrate to `PublicKeyAlgorithm.RsaV2` (RSA-OAEP-2048).

Resolves #16301, #16251.

## Drawbacks

Joplin <v3.5 (prior to https://github.com/laurent22/joplin/pull/12829) does not support `PublicKeyAlgorithm.RsaV2`. This means that Joplin <v3.5 will not be able to **share notebooks** with Joplin versions that use `RsaV2`, since it can't encrypt data using the newer padding scheme. In this case, the error message comes from `node-rsa` and isn't very helpful:

<img width="599" height="294" alt="screenshot: (Joplin 3.4.13) Key format must be specified" src="https://github.com/user-attachments/assets/f0d7a513-9404-4dfa-98c4-a08d44a073ca" />


Joplin <v3.5 can still accept notebooks shared from Joplin versions that use `RsaV2` (related: https://github.com/laurent22/joplin/issues/16304).


# Testing

## Automated tests

`RsaV2` is covered by tests in:
- `e2ee/utils.ts`: Cover key migrations
- [`ppkTestUtils.ts`](https://github.com/laurent22/joplin/blob/c174faf77dcf63980b4777d19af373a685f9f5d6/packages/lib/services/e2ee/ppk/ppkTestUtils.ts#L197): Integration tests that verify that different clients support keys generated by the other client types.

The sync fuzzer also covers sharing and receiving notebooks with E2EE over Joplin Server. I've verified that the sync fuzzer runs successfully for > 75 steps with `--seed=2` (with the default seed, the fuzzer fails; see https://github.com/laurent22/joplin/issues/16153).

## Manual testing

**Verifying that a `ppk` is generated**:
1. Set up file system sync from the web app with a new directory.
2. Inspect `info.json` on the sync target. Verify that a `ppk` field exists and has a `value` with `privateKey` and `publicKey`, where `privateKey` has `ciphertext` and `publicKey` starts with `rsa-v2;`:
   ```json
    ...
            "ppk": {
                    "value": {
                            "id": "iiiYkSGFlVqNdXOa8OHVLk",
                            "keySize": 2048,
                            "privateKey": {
                                    "encryptionMethod": 4,
                                    "ciphertext": "{\"iv\":\"...omitted...\",\"v\":1,\"iter\":10000,\"ks\":256,\"ts\":64,\"mode\":\"ccm\",\"adata\":\"\",\"cipher\":\"aes\",\"salt\":\"XN5O0Ejn1K0=\",\"ct\":\"...omitted...\"}"
                            },
                            "publicKey": "rsa-v2;{\"alg\":\"RSA-OAEP-256\",\"e\":\"AQAB\",\"ext\":true,\"key_ops\":[\"encrypt\"],\"kty\":\"RSA\",\"n\":\"qG5IpI6u1Y1jYZKMHRO9k0ZHRSImnBAucg2YMalqM6xCyXHCibtx_ITUaSbAXe-JaVNsgmP6pvsZF7Sh0PgXotUc-3NCs33q1a8-4ZtwqbcNW4qxwAVjmKhOAt0286LXRHyEI5qzvJRLGc0qMsCZamwZLmbWykkMV8CeTu4yB_jp5E6fK7LNT6sQzJfHernXa_6OjxrmaQ2KRe3EcbFZHi6abDdtFrJuL6Qof0JtZoenQ4BRsBc51MjECeY2QShjPC2wk1Stgnkdj2Cqo9cwcjwwZgWFDA4igmKJRjvTG84kXIozLLIgXsH_obA3JvuRrgJg2Ur-t7iuZ3eILaL7fw\"}",
                            "createdTime": 1787602462500
                    },
                    "updatedTime": 1787602462500
            },
    ...
    ```

**Sharing notebooks**:
1. Sign three different devices into three different accounts:
   - `test@localhost`: Desktop client built from 92eed39ff74f6970d9f9f60de84bef9552088799
   - `test2@localhost`: iOS client built from 92eed39ff74f6970d9f9f60de84bef9552088799
   - `test3@localhost`: Desktop client built from this pull request
3. Enable E2EE on all clients and sync
4. **Sharing from new/desktop to old/mobile**: From `test3@localhost`, share a notebook with `test2@localhost`. Accept the share from iOS, sync, and verify that the share is accepted successfully.
5. **Sharing from old/desktop to new/desktop**: From `test@localhost`, share a notebook with `test3@localhost`. Accept the share from `test3@localhost`. Verify that the content decrypts and sync successfully.
4. **Sharing from new/desktop to new/web**: Create a new `test4@localhost` account and sync the web app built from this pull request. Enable E2EE, then share a notebook from `test3@localhost` to `test4@localhost`. Accept the share and verify that the content decrypts and syncs successfully.
6. **Sharing from old/desktop to new/web**: From `test@localhost`, share a notebook with `test4@localhost`. Accept the share and verify that the share's content syncs successfully.
7. **Sharing from new/desktop to new/desktop**: Sign a new desktop app profile in to `test4@localhost`. Share a new notebook with `test3@localhost`. Accept the notebook from `test3@localhost` and verify that the notebook syncs successfully.

**Sharing notebooks** (more testing from a different server instance):
1. Sign two different devices into two different accounts:
   - `user1@localhost`: Desktop client built from this pull request.
   - `user2@localhost`: Android client built from this pull request.
2. Enable E2EE on all clients.
3. Share a notebook from `user1@localhost` to `user2@localhost`.
4. Accept the share from `user2@localhost` (Android). Verify that the shared notebook's content syncs successfully.

**Note**: Mobile/web currently support accepting -- but not creating -- notebook shares.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
