### PR TITLE
Desktop: Sharing: Improve error message when public key format is unsupported

### DIFF
--- a/packages/lib/services/e2ee/ppk/ppk.ts
+++ b/packages/lib/services/e2ee/ppk/ppk.ts
@@ -3,6 +3,7 @@ import uuid from '../../../uuid';
 import EncryptionService, { EncryptionCustomHandler, EncryptionMethod } from '../EncryptionService';
 import { MasterKeyEntity, PublicKeyAlgorithm, PublicKeyCrypto, PublicKeyCryptoProvider } from '../types';
 import PerformanceLogger from '../../../PerformanceLogger';
+import { _ } from '../../../locale';
 
 const perfLogger = PerformanceLogger.create();
 
@@ -56,12 +57,15 @@ export const setRSA = (rsa: PublicKeyCryptoProvider) => {
 };
 
 const supportsAlgorithm = (algorithm: PublicKeyAlgorithm) => {
-	return Object.prototype.hasOwnProperty.call(rsa_, algorithm);
+	return Object.prototype.hasOwnProperty.call(rsa_, algorithm) && algorithm !== PublicKeyAlgorithm.Unknown;
 };
 
 // Exported for testing purposes
 export const rsa = (algorithm: PublicKeyAlgorithm): PublicKeyCrypto => {
 	if (!rsa_) throw new Error('RSA handler has not been set!!');
+	if (algorithm === PublicKeyAlgorithm.Unknown) {
+		throw new Error(_('Unsupported key format. Joplin may need to be updated.'));
+	}
 	if (!supportsAlgorithm(algorithm)) throw new Error(`Unsupported algorithm: ${algorithm}`);
 	return rsa_[algorithm];
 };

--- a/packages/lib/services/e2ee/ppk/ppk.ts
+++ b/packages/lib/services/e2ee/ppk/ppk.ts
@@ -64,7 +64,8 @@ const supportsAlgorithm = (algorithm: PublicKeyAlgorithm) => {
 export const rsa = (algorithm: PublicKeyAlgorithm): PublicKeyCrypto => {
 	if (!rsa_) throw new Error('RSA handler has not been set!!');
 	if (algorithm === PublicKeyAlgorithm.Unknown) {
-		throw new Error(_('Unsupported key format. Joplin may need to be updated.'));
+		// "Unknown" PPK algorithms may be caused by either a corrupted key or an outdated version of Joplin.
+		throw new Error(_('Unsupported public key format. Please check that Joplin is updated to the latest version and try again.'));
 	}
 	if (!supportsAlgorithm(algorithm)) throw new Error(`Unsupported algorithm: ${algorithm}`);
 	return rsa_[algorithm];


### PR DESCRIPTION
# Problem

Sharing a notebook with an account that uses an unknown PPK algorithm currently results in a confusing `Cannot read properties of null` error:

<img width="616" height="268" alt="screenshot: Cannot read properties of null (reading 'loadKeys')" src="https://github.com/user-attachments/assets/7cc394b5-c0d9-4bb8-a753-f95063ad2e86" />

# Solution

Improve the error message:

<img width="619" height="263" alt="unsupported key format. Please upgrade Joplin to the latest version and try again." src="https://github.com/user-attachments/assets/6ea0103e-986c-4a27-a85f-9461478b148b" />


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
