### PR TITLE
Desktop: Rich Text Editor: Fix error while saving changes

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.ts
@@ -6,7 +6,9 @@ import shim from '@joplin/lib/shim';
 const useLinkTooltips = (editor: Editor|null) => {
 	const resetModifiedTitles = useCallback(() => {
 		if (!editor) return;
-		for (const element of editor.getDoc().querySelectorAll('a[data-joplin-original-title]')) {
+		const doc = editor.getDoc();
+		if (!doc) return;
+		for (const element of doc.querySelectorAll('a[data-joplin-original-title]')) {
 			element.setAttribute('title', element.getAttribute('data-joplin-original-title') ?? '');
 			element.removeAttribute('data-joplin-original-title');
 		}


### PR DESCRIPTION
# Problem

While editng a note, the following error was observed in the console:
```
TypeError: Cannot read properties of null (reading 'querySelectorAll')
    at resetLinkTooltips (useLinkTooltips.ts:9:38)
    at execOnChangeEvent (TinyMCE.tsx:1268:3)
    at Timeout._onTimeout (TinyMCE.tsx:1319:10)
    at listOnTimeout (node:internal/timers:605:17)
    at processTimers (node:internal/timers:541:7)
```

After this error, the "toggle editors" button remained greyed out and it wasn't possible to switch editors.



# Solution

Add a null check: Check that `editor.getDoc()` is defined within `resetModifiedTitles`, before using it.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
