### PR TITLE
Desktop: Fixes #12811: Rich Text Editor: Save note changes after changing formatting

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1558,6 +1558,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 		editor.on(TinyMceEditorEvents.JoplinChange, onChangeHandler);
 		editor.on(TinyMceEditorEvents.Undo, onChangeHandler);
 		editor.on(TinyMceEditorEvents.Redo, onChangeHandler);
+		editor.on(TinyMceEditorEvents.FormatApply, onChangeHandler);
+		editor.on(TinyMceEditorEvents.FormatRemove, onChangeHandler);
 		editor.on(TinyMceEditorEvents.ExecCommand, onExecCommand);
 		editor.on(TinyMceEditorEvents.SetAttrib, onSetAttrib);
 		editor.on('TableModified', onTableModified);
@@ -1575,6 +1577,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 				editor.off(TinyMceEditorEvents.JoplinChange, onChangeHandler);
 				editor.off(TinyMceEditorEvents.Undo, onChangeHandler);
 				editor.off(TinyMceEditorEvents.Redo, onChangeHandler);
+				editor.off(TinyMceEditorEvents.FormatApply, onChangeHandler);
+				editor.off(TinyMceEditorEvents.FormatRemove, onChangeHandler);
 				editor.off(TinyMceEditorEvents.ExecCommand, onExecCommand);
 				editor.off(TinyMceEditorEvents.SetAttrib, onSetAttrib);
 				editor.off('TableModified', onTableModified);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.ts
@@ -15,6 +15,8 @@ export enum TinyMceEditorEvents {
 	Redo = 'Redo',
 	ExecCommand = 'ExecCommand',
 	SetAttrib = 'SetAttrib',
+	FormatApply = 'FormatApply',
+	FormatRemove = 'FormatRemove',
 }
 
 export type DispatchDidUpdateCallback = (editor: Editor)=> void;


### PR DESCRIPTION
# Problem

In the desktop app's Rich Text Editor, changes to a note were not saved if the user:
1. Selected some text.
2. Changed formatting using a keyboard shortcut (e.g. <kbd>alt</kbd>-<kbd>shift</kbd>-<kbd>1</kbd> to toggle heading-1 formatting).
3. Switched notes.

# Solution

Schedule a note content save in response to the TinyMCE `FormatApply` and `FormatRemove` events.

Fixes #12811.

# Screen recording

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/d082120a-556b-4547-9f7d-b77584f0c4d8"></video> | <video src="https://github.com/user-attachments/assets/9fbd6cd3-e662-485d-97e3-bde2c8088156"></video> |



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
