### PR TITLE
Desktop: Prevent ability to link to note or set tags for a trashed note after switching to all notes

### DIFF
--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.ts
@@ -34,6 +34,6 @@ export const runtime = (): CommandRuntime => {
 			return result;
 		},
 
-		enabledCondition: '(markdownEditorPaneVisible || richTextEditorVisible) && !noteIsReadOnly && !noteIsDeleted',
+		enabledCondition: 'oneNoteSelected && (markdownEditorPaneVisible || richTextEditorVisible) && !noteIsReadOnly && !noteIsDeleted',
 	};
 };

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/setTags.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/setTags.ts
@@ -81,6 +81,6 @@ export const runtime = (comp: WindowControl): CommandRuntime => {
 				},
 			});
 		},
-		enabledCondition: 'someNotesSelected && !inTrash',
+		enabledCondition: 'someNotesSelected && !allSelectedNotesAreDeleted && !inTrash',
 	};
 };


### PR DESCRIPTION
When switching between the trash and the all notes notebook, currently the selected note in the trash does not change following that transition, and this results in the link to note and set tags options becoming enabled, despite the rest of the note and toolbar options being readonly / disabled. This PR addresses these issues by amending the enabled conditions for these commands to appropriately consider that the items are trashed, even when the trash is no longer selected

This fixes issues relating to https://github.com/laurent22/joplin/issues/16229

### Testing

**See video:**

https://github.com/user-attachments/assets/8901a1c6-2af1-4780-af69-36b68f2bb392

