### PR TITLE
Android: Improve performance of file system sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1029,6 +1029,7 @@ packages/app-mobile/utils/database-driver-react-native.web.js
 packages/app-mobile/utils/debounce.js
 packages/app-mobile/utils/focusView.js
 packages/app-mobile/utils/fs-driver/constants.js
+packages/app-mobile/utils/fs-driver/fs-driver-rn.test.js
 packages/app-mobile/utils/fs-driver/fs-driver-rn.js
 packages/app-mobile/utils/fs-driver/fs-driver-rn.web.js
 packages/app-mobile/utils/fs-driver/fs-driver-rn.web.worker.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1054,6 +1054,7 @@ packages/app-mobile/utils/database-driver-react-native.web.js
 packages/app-mobile/utils/debounce.js
 packages/app-mobile/utils/focusView.js
 packages/app-mobile/utils/fs-driver/constants.js
+packages/app-mobile/utils/fs-driver/fs-driver-rn.test.js
 packages/app-mobile/utils/fs-driver/fs-driver-rn.js
 packages/app-mobile/utils/fs-driver/fs-driver-rn.web.js
 packages/app-mobile/utils/fs-driver/fs-driver-rn.web.worker.js

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
@@ -60,6 +60,27 @@ describe('FsDriverRN SAF destination lookup', () => {
 		expect(mockSaf.copyFileToDirectory).not.toHaveBeenCalled();
 	});
 
+	it('should overwrite a destination discovered by stat after an older listing', async () => {
+		const driver = new FsDriverRN();
+		mockSaf.listFiles.mockResolvedValueOnce([]);
+		await driver.readDirStats(parentPath);
+		mockSaf.stat.mockResolvedValueOnce({
+			name: 'existing.md',
+			uri: destinationPath,
+			documentUri: destinationUri,
+			type: 'file',
+			size: 0,
+			lastModified: 0,
+		});
+
+		await driver.stat(destinationPath);
+		await driver.writeFile(destinationPath, 'updated', 'utf8');
+
+		expect(mockSaf.listFiles).toHaveBeenCalledTimes(1);
+		expect(mockSaf.writeFile).toHaveBeenCalledWith(destinationUri, 'updated', { encoding: 'utf8' });
+		expect(mockSaf.writeFileInDirectory).not.toHaveBeenCalled();
+	});
+
 	it('should reject a directory entry whose URI is not relative to the listed directory', async () => {
 		const driver = new FsDriverRN();
 		mockSaf.listFiles.mockResolvedValueOnce([{

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
@@ -111,6 +111,68 @@ describe('FsDriverRN SAF destination lookup', () => {
 		expect(mockSaf.writeFile).toHaveBeenLastCalledWith(destinationUri, 'retried', { encoding: 'utf8' });
 	});
 
+	it('should resolve a replacement document after a cached URI becomes stale', async () => {
+		const driver = new FsDriverRN();
+		const replacementUri = 'content://provider/document/replacement';
+		await driver.writeFile(destinationPath, 'first', 'utf8');
+		mockSaf.writeFile.mockRejectedValueOnce(Object.assign(new Error('Document no longer exists'), { code: 'ENOENT' }));
+
+		await expect(driver.writeFile(destinationPath, 'failed', 'utf8')).rejects.toThrow('Document no longer exists');
+		expect(mockSaf.writeFile).toHaveBeenCalledTimes(2);
+		expect(mockSaf.writeFileInDirectory).not.toHaveBeenCalled();
+
+		mockSaf.listFiles.mockResolvedValueOnce([{
+			name: 'existing.md',
+			uri: destinationPath,
+			documentUri: replacementUri,
+		}]);
+		await driver.writeFile(destinationPath, 'retried', 'utf8');
+
+		expect(mockSaf.listFiles).toHaveBeenCalledTimes(2);
+		expect(mockSaf.writeFile).toHaveBeenLastCalledWith(replacementUri, 'retried', { encoding: 'utf8' });
+		expect(mockSaf.writeFileInDirectory).not.toHaveBeenCalled();
+	});
+
+	it('should not replay or fall back after an ambiguous cached copy failure', async () => {
+		const driver = new FsDriverRN();
+		const sourcePath = '/local/source.md';
+		await driver.copy(sourcePath, destinationPath);
+		mockSaf.copyFile.mockRejectedValueOnce(Object.assign(new Error('Copy close failed'), { code: 'EIO' }));
+
+		await expect(driver.copy(sourcePath, destinationPath)).rejects.toThrow('Copy close failed');
+
+		expect(mockSaf.copyFile).toHaveBeenCalledTimes(2);
+		expect(mockSaf.copyFileToDirectory).not.toHaveBeenCalled();
+
+		await driver.copy(sourcePath, destinationPath);
+		expect(mockSaf.listFiles).toHaveBeenCalledTimes(2);
+		expect(mockSaf.copyFile).toHaveBeenLastCalledWith(sourcePath, destinationUri, { replaceIfDestinationExists: true });
+		expect(mockSaf.copyFileToDirectory).not.toHaveBeenCalled();
+	});
+
+	it('should invalidate a failed directory mutation without retrying it through another route', async () => {
+		const driver = new FsDriverRN();
+		const newPath = `${parentPath}/new.md`;
+		mockSaf.listFiles.mockResolvedValue([]);
+		mockSaf.writeFileInDirectory.mockRejectedValueOnce(Object.assign(new Error('Close failed'), { code: 'EIO' }));
+
+		await expect(driver.writeFile(newPath, 'new', 'utf8')).rejects.toThrow('Close failed');
+
+		expect(mockSaf.writeFileInDirectory).toHaveBeenCalledTimes(1);
+		expect(mockSaf.writeFile).not.toHaveBeenCalled();
+
+		mockSaf.listFiles.mockResolvedValueOnce([{
+			name: 'new.md',
+			uri: newPath,
+			documentUri: 'content://provider/document/new',
+		}]);
+		await driver.writeFile(newPath, 'retried', 'utf8');
+
+		expect(mockSaf.listFiles).toHaveBeenCalledTimes(2);
+		expect(mockSaf.writeFile).toHaveBeenCalledWith('content://provider/document/new', 'retried', { encoding: 'utf8' });
+		expect(mockSaf.writeFileInDirectory).toHaveBeenCalledTimes(1);
+	});
+
 	it('should reject a directory entry whose URI is not relative to the listed directory', async () => {
 		const driver = new FsDriverRN();
 		mockSaf.listFiles.mockResolvedValueOnce([{

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
@@ -36,7 +36,7 @@ describe('FsDriverRN SAF destination lookup', () => {
 		mockSaf.writeFile.mockResolvedValue(undefined);
 		mockSaf.copyFile.mockResolvedValue(undefined);
 		mockSaf.writeFileInDirectory.mockResolvedValue({ uri: `${parentPath}/new.md` });
-		mockSaf.copyFileToDirectory.mockResolvedValue(`${parentPath}/new.md`);
+		mockSaf.copyFileToDirectory.mockResolvedValue({ uri: `${parentPath}/new.md` });
 	});
 
 	it('should overwrite an existing file discovered while warming an empty cache', async () => {
@@ -136,7 +136,7 @@ describe('FsDriverRN SAF destination lookup', () => {
 			parentPath, 'new.md', 'new', { encoding: 'utf8', replaceIfDestinationExists: true },
 		);
 		expect(mockSaf.copyFileToDirectory).toHaveBeenCalledWith(
-			'/local/source.md', parentPath, 'copied.md', { replaceIfDestinationExists: true, returnDocumentUriOnly: true },
+			'/local/source.md', parentPath, 'copied.md', { replaceIfDestinationExists: true },
 		);
 	});
 

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
@@ -36,7 +36,7 @@ describe('FsDriverRN SAF destination lookup', () => {
 		mockSaf.writeFile.mockResolvedValue(undefined);
 		mockSaf.copyFile.mockResolvedValue(undefined);
 		mockSaf.writeFileInDirectory.mockResolvedValue({ uri: `${parentPath}/new.md` });
-		mockSaf.copyFileToDirectory.mockResolvedValue({ uri: `${parentPath}/new.md` });
+		mockSaf.copyFileToDirectory.mockResolvedValue(`${parentPath}/new.md`);
 	});
 
 	it('should overwrite an existing file discovered while warming an empty cache', async () => {
@@ -136,7 +136,7 @@ describe('FsDriverRN SAF destination lookup', () => {
 			parentPath, 'new.md', 'new', { encoding: 'utf8', replaceIfDestinationExists: true },
 		);
 		expect(mockSaf.copyFileToDirectory).toHaveBeenCalledWith(
-			'/local/source.md', parentPath, 'copied.md', { replaceIfDestinationExists: true },
+			'/local/source.md', parentPath, 'copied.md', { replaceIfDestinationExists: true, returnDocumentUriOnly: true },
 		);
 	});
 

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
@@ -35,6 +35,8 @@ describe('FsDriverRN SAF destination lookup', () => {
 		}]);
 		mockSaf.writeFile.mockResolvedValue(undefined);
 		mockSaf.copyFile.mockResolvedValue(undefined);
+		mockSaf.writeFileInDirectory.mockResolvedValue({ uri: `${parentPath}/new.md` });
+		mockSaf.copyFileToDirectory.mockResolvedValue({ uri: `${parentPath}/new.md` });
 	});
 
 	it('should overwrite an existing file discovered while warming an empty cache', async () => {
@@ -79,6 +81,21 @@ describe('FsDriverRN SAF destination lookup', () => {
 		expect(mockSaf.listFiles).toHaveBeenCalledTimes(1);
 		expect(mockSaf.writeFile).toHaveBeenCalledWith(destinationUri, 'updated', { encoding: 'utf8' });
 		expect(mockSaf.writeFileInDirectory).not.toHaveBeenCalled();
+	});
+
+	it('should explicitly enable replacement for directory-based writes and copies', async () => {
+		const driver = new FsDriverRN();
+		mockSaf.listFiles.mockResolvedValue([]);
+
+		await driver.writeFile(`${parentPath}/new.md`, 'new', 'utf8');
+		await driver.copy('/local/source.md', `${parentPath}/copied.md`);
+
+		expect(mockSaf.writeFileInDirectory).toHaveBeenCalledWith(
+			parentPath, 'new.md', 'new', { encoding: 'utf8', replaceIfDestinationExists: true },
+		);
+		expect(mockSaf.copyFileToDirectory).toHaveBeenCalledWith(
+			'/local/source.md', parentPath, 'copied.md', { replaceIfDestinationExists: true },
+		);
 	});
 
 	it('should reject a directory entry whose URI is not relative to the listed directory', async () => {

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
@@ -1,0 +1,60 @@
+const mockSaf = {
+	copyFile: jest.fn(),
+	copyFileToDirectory: jest.fn(),
+	listFiles: jest.fn(),
+	stat: jest.fn(),
+	writeFile: jest.fn(),
+	writeFileInDirectory: jest.fn(),
+};
+
+jest.mock('rn-fetch-blob', () => ({
+	__esModule: true,
+	default: { fs: {} },
+}));
+
+jest.mock('@joplin/react-native-saf-x', () => ({
+	__esModule: true,
+	default: mockSaf,
+	openDocumentTree: jest.fn(),
+}));
+
+import FsDriverRN from './fs-driver-rn';
+
+describe('FsDriverRN SAF destination lookup', () => {
+	const parentPath = 'content://provider/tree/root';
+	const destinationPath = `${parentPath}/existing.md`;
+	const destinationUri = 'content://provider/document/existing';
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockSaf.stat.mockResolvedValue({ uri: parentPath, documentUri: parentPath });
+		mockSaf.listFiles.mockResolvedValue([{
+			name: 'existing.md',
+			uri: destinationPath,
+			documentUri: destinationUri,
+		}]);
+		mockSaf.writeFile.mockResolvedValue(undefined);
+		mockSaf.copyFile.mockResolvedValue(undefined);
+	});
+
+	it('should overwrite an existing file discovered while warming an empty cache', async () => {
+		const driver = new FsDriverRN();
+
+		await driver.writeFile(destinationPath, 'updated', 'utf8');
+
+		expect(mockSaf.listFiles).toHaveBeenCalledWith(parentPath);
+		expect(mockSaf.writeFile).toHaveBeenCalledWith(destinationUri, 'updated', { encoding: 'utf8' });
+		expect(mockSaf.writeFileInDirectory).not.toHaveBeenCalled();
+	});
+
+	it('should overwrite an existing copy destination discovered while warming an empty cache', async () => {
+		const driver = new FsDriverRN();
+		const sourcePath = '/local/source.md';
+
+		await driver.copy(sourcePath, destinationPath);
+
+		expect(mockSaf.listFiles).toHaveBeenCalledWith(parentPath);
+		expect(mockSaf.copyFile).toHaveBeenCalledWith(sourcePath, destinationUri, { replaceIfDestinationExists: true });
+		expect(mockSaf.copyFileToDirectory).not.toHaveBeenCalled();
+	});
+});

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
@@ -41,9 +41,11 @@ describe('FsDriverRN SAF destination lookup', () => {
 		const driver = new FsDriverRN();
 
 		await driver.writeFile(destinationPath, 'updated', 'utf8');
+		await driver.writeFile(destinationPath, 'updated again', 'utf8');
 
-		expect(mockSaf.listFiles).toHaveBeenCalledWith(parentPath);
-		expect(mockSaf.writeFile).toHaveBeenCalledWith(destinationUri, 'updated', { encoding: 'utf8' });
+		expect(mockSaf.listFiles).toHaveBeenCalledTimes(1);
+		expect(mockSaf.writeFile).toHaveBeenNthCalledWith(1, destinationUri, 'updated', { encoding: 'utf8' });
+		expect(mockSaf.writeFile).toHaveBeenNthCalledWith(2, destinationUri, 'updated again', { encoding: 'utf8' });
 		expect(mockSaf.writeFileInDirectory).not.toHaveBeenCalled();
 	});
 

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
@@ -98,6 +98,19 @@ describe('FsDriverRN SAF destination lookup', () => {
 		);
 	});
 
+	it('should refresh a cached destination after a non-ENOENT write failure without replaying it', async () => {
+		const driver = new FsDriverRN();
+		await driver.writeFile(destinationPath, 'first', 'utf8');
+		mockSaf.writeFile.mockRejectedValueOnce(Object.assign(new Error('Provider failure'), { code: 'EIO' }));
+
+		await expect(driver.writeFile(destinationPath, 'failed', 'utf8')).rejects.toThrow('Provider failure');
+		expect(mockSaf.writeFile).toHaveBeenCalledTimes(2);
+
+		await driver.writeFile(destinationPath, 'retried', 'utf8');
+		expect(mockSaf.listFiles).toHaveBeenCalledTimes(2);
+		expect(mockSaf.writeFile).toHaveBeenLastCalledWith(destinationUri, 'retried', { encoding: 'utf8' });
+	});
+
 	it('should reject a directory entry whose URI is not relative to the listed directory', async () => {
 		const driver = new FsDriverRN();
 		mockSaf.listFiles.mockResolvedValueOnce([{

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
@@ -83,6 +83,48 @@ describe('FsDriverRN SAF destination lookup', () => {
 		expect(mockSaf.writeFileInDirectory).not.toHaveBeenCalled();
 	});
 
+	it('should obtain fresh metadata through the cached document URI', async () => {
+		const driver = new FsDriverRN();
+		await driver.writeFile(destinationPath, 'first', 'utf8');
+		mockSaf.stat.mockResolvedValueOnce({
+			name: 'existing.md',
+			uri: destinationUri,
+			documentUri: destinationUri,
+			type: 'file',
+			size: 5,
+			lastModified: 123,
+		});
+
+		const stat = await driver.stat(destinationPath);
+
+		expect(mockSaf.stat).toHaveBeenLastCalledWith(destinationUri);
+		expect(stat.size).toBe(5);
+		expect(stat.mtime.getTime()).toBe(123);
+	});
+
+	it('should retry a stat through the logical path after a cached URI becomes stale', async () => {
+		const driver = new FsDriverRN();
+		const replacementUri = 'content://provider/document/replacement';
+		await driver.writeFile(destinationPath, 'first', 'utf8');
+		mockSaf.stat
+			.mockRejectedValueOnce(Object.assign(new Error('Document no longer exists'), { code: 'ENOENT' }))
+			.mockResolvedValueOnce({
+				name: 'existing.md',
+				uri: destinationPath,
+				documentUri: replacementUri,
+				type: 'file',
+				size: 7,
+				lastModified: 456,
+			});
+
+		await driver.stat(destinationPath);
+		await driver.writeFile(destinationPath, 'updated', 'utf8');
+
+		expect(mockSaf.stat).toHaveBeenNthCalledWith(2, destinationUri);
+		expect(mockSaf.stat).toHaveBeenNthCalledWith(3, destinationPath);
+		expect(mockSaf.writeFile).toHaveBeenLastCalledWith(replacementUri, 'updated', { encoding: 'utf8' });
+	});
+
 	it('should explicitly enable replacement for directory-based writes and copies', async () => {
 		const driver = new FsDriverRN();
 		mockSaf.listFiles.mockResolvedValue([]);

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.test.ts
@@ -59,4 +59,21 @@ describe('FsDriverRN SAF destination lookup', () => {
 		expect(mockSaf.copyFile).toHaveBeenCalledWith(sourcePath, destinationUri, { replaceIfDestinationExists: true });
 		expect(mockSaf.copyFileToDirectory).not.toHaveBeenCalled();
 	});
+
+	it('should reject a directory entry whose URI is not relative to the listed directory', async () => {
+		const driver = new FsDriverRN();
+		mockSaf.listFiles.mockResolvedValueOnce([{
+			name: 'existing.md',
+			uri: destinationUri,
+			documentUri: destinationUri,
+		}]);
+
+		await expect(driver.readDirStats(parentPath)).rejects.toThrow('Document URI does not start with directory path');
+		await driver.writeFile(destinationPath, 'updated', 'utf8');
+
+		// The invalid listing must not be treated as complete or populate the
+		// document cache. A subsequent operation obtains a fresh listing.
+		expect(mockSaf.listFiles).toHaveBeenCalledTimes(2);
+		expect(mockSaf.writeFile).toHaveBeenCalledWith(destinationUri, 'updated', { encoding: 'utf8' });
+	});
 });

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -146,6 +146,10 @@ export default class FsDriverRN extends FsDriverBase {
 	}
 
 	private async writeSafFile_(path: string, content: string, encoding: SupportedEncoding) {
+		if (this.safDocumentUris_.has(path)) {
+			return this.withCachedSafUri_(path, resolvedPath => RNSAF.writeFile(resolvedPath, content, { encoding }));
+		}
+
 		const lastSlashIndex = path.lastIndexOf('/');
 		const parentPath = path.substring(0, lastSlashIndex);
 		try {
@@ -153,10 +157,6 @@ export default class FsDriverRN extends FsDriverBase {
 		} catch (error) {
 			if (error?.code !== 'ENOENT') throw error;
 			return RNSAF.writeFile(path, content, { encoding });
-		}
-
-		if (this.safDocumentUris_.has(path)) {
-			return this.withCachedSafUri_(path, resolvedPath => RNSAF.writeFile(resolvedPath, content, { encoding }));
 		}
 
 		const parentUri = this.safDirectoryUris_.get(parentPath);
@@ -177,6 +177,11 @@ export default class FsDriverRN extends FsDriverBase {
 	}
 
 	private async copyToSaf_(source: string, dest: string): Promise<void> {
+		if (this.safDocumentUris_.has(dest)) {
+			await this.withCachedSafUri_(dest, resolvedDest => RNSAF.copyFile(source, resolvedDest, { replaceIfDestinationExists: true }));
+			return;
+		}
+
 		const lastSlashIndex = dest.lastIndexOf('/');
 		const parentPath = dest.substring(0, lastSlashIndex);
 		try {
@@ -184,11 +189,6 @@ export default class FsDriverRN extends FsDriverBase {
 		} catch (error) {
 			if (error?.code !== 'ENOENT') throw error;
 			await RNSAF.copyFile(source, dest, { replaceIfDestinationExists: true });
-			return;
-		}
-
-		if (this.safDocumentUris_.has(dest)) {
-			await this.withCachedSafUri_(dest, resolvedDest => RNSAF.copyFile(source, resolvedDest, { replaceIfDestinationExists: true }));
 			return;
 		}
 
@@ -484,7 +484,7 @@ export default class FsDriverRN extends FsDriverBase {
 	public async unlink(path: string) {
 		try {
 			if (isScopedUri(path)) {
-				await RNSAF.unlink(path);
+				await this.withCachedSafUri_(path, resolvedPath => RNSAF.unlink(resolvedPath));
 				return;
 			}
 			await RNFS.unlink(path);

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -335,9 +335,12 @@ export default class FsDriverRN extends FsDriverBase {
 
 	public async move(source: string, dest: string) {
 		if (isScopedUri(source) || isScopedUri(dest)) {
-			await RNSAF.moveFile(source, dest, { replaceIfDestinationExists: true });
-			this.invalidateSafPath_(source);
-			this.invalidateSafPath_(dest);
+			try {
+				await RNSAF.moveFile(source, dest, { replaceIfDestinationExists: true });
+			} finally {
+				this.invalidateSafPath_(source);
+				this.invalidateSafPath_(dest);
+			}
 			return;
 		}
 		return RNFS.moveFile(source, dest);
@@ -345,9 +348,12 @@ export default class FsDriverRN extends FsDriverBase {
 
 	public async rename(source: string, dest: string) {
 		if (isScopedUri(source) || isScopedUri(dest)) {
-			await RNSAF.rename(source, dest);
-			this.invalidateSafPath_(source);
-			this.invalidateSafPath_(dest);
+			try {
+				await RNSAF.rename(source, dest);
+			} finally {
+				this.invalidateSafPath_(source);
+				this.invalidateSafPath_(dest);
+			}
 			return;
 		}
 		return RNFS.moveFile(source, dest);

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -209,6 +209,17 @@ export default class FsDriverRN extends FsDriverBase {
 		await RNSAF.copyFile(source, dest, { replaceIfDestinationExists: true });
 	}
 
+	private async appendSafFile_(path: string, content: string, encoding: SupportedEncoding) {
+		const hasCachedUri = this.safDocumentUris_.has(path);
+		try {
+			return await this.withCachedSafUri_(path, resolvedPath => RNSAF.writeFile(resolvedPath, content, { encoding, append: true }));
+		} finally {
+			// A cache-cold append resolves by path and may create the destination.
+			// Force the parent listing to be refreshed before a later create/update.
+			if (!hasCachedUri) this.invalidateSafPath_(path);
+		}
+	}
+
 	public appendFileSync() {
 		throw new Error('Not implemented: appendFileSync');
 	}
@@ -220,7 +231,7 @@ export default class FsDriverRN extends FsDriverBase {
 		const encoding = normalizeEncoding(rawEncoding);
 
 		if (isScopedUri(path)) {
-			return this.withCachedSafUri_(path, resolvedPath => RNSAF.writeFile(resolvedPath, content, { encoding, append: true }));
+			return this.appendSafFile_(path, content, encoding);
 		}
 		return RNFS.appendFile(path, content, encoding);
 	}

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -58,7 +58,8 @@ export default class FsDriverRN extends FsDriverBase {
 	private listedSafDirectories_ = new Set<string>();
 
 	private cachedSafUri_(path: string) {
-		return this.safDocumentUris_.get(path) ?? path;
+		const normalizedPath = this.normalizeSafPath_(path);
+		return this.safDocumentUris_.get(normalizedPath) ?? normalizedPath;
 	}
 
 	private normalizeSafPath_(path: string) {
@@ -92,6 +93,7 @@ export default class FsDriverRN extends FsDriverBase {
 	}
 
 	private async withCachedSafUri_<T>(path: string, callback: (resolvedPath: string)=> Promise<T>, retryIfStale = false): Promise<T> {
+		path = this.normalizeSafPath_(path);
 		const cachedUri = this.cachedSafUri_(path);
 		try {
 			return await callback(cachedUri);
@@ -147,6 +149,7 @@ export default class FsDriverRN extends FsDriverBase {
 	}
 
 	private async writeSafFile_(path: string, content: string, encoding: SupportedEncoding) {
+		path = this.normalizeSafPath_(path);
 		if (this.safDocumentUris_.has(path)) {
 			return this.withCachedSafUri_(path, resolvedPath => RNSAF.writeFile(resolvedPath, content, { encoding }));
 		}
@@ -178,6 +181,7 @@ export default class FsDriverRN extends FsDriverBase {
 	}
 
 	private async copyToSaf_(source: string, dest: string): Promise<void> {
+		dest = this.normalizeSafPath_(dest);
 		if (this.safDocumentUris_.has(dest)) {
 			await this.withCachedSafUri_(dest, resolvedDest => RNSAF.copyFile(source, resolvedDest, { replaceIfDestinationExists: true }));
 			return;
@@ -211,6 +215,7 @@ export default class FsDriverRN extends FsDriverBase {
 	}
 
 	private async appendSafFile_(path: string, content: string, encoding: SupportedEncoding) {
+		path = this.normalizeSafPath_(path);
 		const hasCachedUri = this.safDocumentUris_.has(path);
 		try {
 			return await this.withCachedSafUri_(path, resolvedPath => RNSAF.writeFile(resolvedPath, content, { encoding, append: true }));
@@ -321,6 +326,10 @@ export default class FsDriverRN extends FsDriverBase {
 			const stat = stats[i];
 
 			const relativePath = toRelativePath(stat);
+			if (isScoped) {
+				const document = stat as DocumentFileDetail;
+				this.safDocumentUris_.set(`${directoryPath}/${relativePath}`, document.documentUri ?? document.uri);
+			}
 			const standardStat = this.rnfsStatToStd_(stat, relativePath);
 			output.push(standardStat);
 

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -110,9 +110,13 @@ export default class FsDriverRN extends FsDriverBase {
 			// Only non-mutating operations may retry a stale URI immediately. A
 			// mutating native operation can report ENOENT during its final metadata
 			// check, after it has already changed the destination.
-			if (cachedUri === path || error?.code !== 'ENOENT') throw error;
+			if (cachedUri === path) throw error;
 			this.invalidateSafPath_(path);
-			if (!retryIfStale) throw error;
+			// Providers do not consistently report stale documents as ENOENT. Clear
+			// the cached URI after any failure so a later operation resolves fresh
+			// state, but only replay this operation when staleness is confirmed and
+			// the caller has declared an immediate retry safe.
+			if (error?.code !== 'ENOENT' || !retryIfStale) throw error;
 			return callback(path);
 		}
 	}

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -439,7 +439,11 @@ export default class FsDriverRN extends FsDriverBase {
 	public async copy(source: string, dest: string) {
 		if (isScopedUri(source) || isScopedUri(dest)) {
 			if (isScopedUri(source)) {
-				await this.withCachedSafUri_(source, resolvedSource => RNSAF.copyFile(resolvedSource, dest, { replaceIfDestinationExists: true }));
+				try {
+					await this.withCachedSafUri_(source, resolvedSource => RNSAF.copyFile(resolvedSource, dest, { replaceIfDestinationExists: true }));
+				} finally {
+					if (isScopedUri(dest)) this.invalidateSafPath_(dest);
+				}
 			} else {
 				await this.copyToSaf_(source, dest);
 			}
@@ -464,18 +468,18 @@ export default class FsDriverRN extends FsDriverBase {
 		try {
 			if (isScopedUri(path)) {
 				await RNSAF.unlink(path);
-				this.invalidateSafPath_(path);
 				return;
 			}
 			await RNFS.unlink(path);
 		} catch (error) {
-			if (isScopedUri(path)) this.invalidateSafPath_(path);
 			if (error && ((error.message && error.message.indexOf('exist') >= 0) || error.code === 'ENOENT')) {
 				// Probably { [Error: File does not exist] framesToPop: 1, code: 'EUNSPECIFIED' }
 				// which unfortunately does not have a proper error code. Can be ignored.
 			} else {
 				throw error;
 			}
+		} finally {
+			if (isScopedUri(path)) this.invalidateSafPath_(path);
 		}
 	}
 

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -222,8 +222,12 @@ export default class FsDriverRN extends FsDriverBase {
 		const parentUri = this.safDirectoryUris_.get(parentPath);
 		if (parentUri) {
 			try {
-				const document = await RNSAF.copyFileToDirectory(source, parentUri, dest.substring(lastSlashIndex + 1), { replaceIfDestinationExists: true });
-				this.safDocumentUris_.set(dest, document.documentUri ?? document.uri);
+				const documentUri = await RNSAF.copyFileToDirectory(source, parentUri, dest.substring(lastSlashIndex + 1), {
+					replaceIfDestinationExists: true,
+					returnDocumentUriOnly: true,
+				});
+				if (typeof documentUri !== 'string') throw new Error('Expected copyFileToDirectory to return a document URI');
+				this.safDocumentUris_.set(dest, documentUri);
 				return;
 			} catch (error) {
 				// The operation may have created and copied the destination before

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -309,41 +309,41 @@ export default class FsDriverRN extends FsDriverBase {
 		if (!options) options = { recursive: false };
 
 		const isScoped = isScopedUri(path);
-		const directoryPath = isScoped ? this.normalizeSafPath_(path) : path;
+		if (isScoped) path = this.normalizeSafPath_(path);
 
 		let stats: RnfsStatLike[] = [];
 		try {
 			if (isScoped) {
-				await this.safDirectoryUri_(directoryPath);
-				stats = await RNSAF.listFiles(directoryPath);
+				await this.safDirectoryUri_(path);
+				stats = await RNSAF.listFiles(path);
 			} else {
-				stats = await RNFS.readDir(directoryPath);
+				stats = await RNFS.readDir(path);
 			}
 		} catch (error) {
-			if (isScoped) this.invalidateSafDirectory_(directoryPath);
-			throw new Error(`Could not read directory: ${directoryPath}: ${error.message}`);
+			if (isScoped) this.invalidateSafDirectory_(path);
+			throw new Error(`Could not read directory: ${path}: ${error.message}`);
 		}
 
 		const toRelativePath = (stat: RnfsStatLike) => {
-			if (isScoped) return this.safRelativePath_(directoryPath, stat as DocumentFileDetail);
+			if (isScoped) return this.safRelativePath_(path, stat as DocumentFileDetail);
 
 			let relativePath = (stat as StatResultT | ReadDirResItemT).path;
 
 			// Workaround: Paths returned by RNFS.readDir can include a leading /private/, when this isn't included
 			// in the original path variable:
-			if (relativePath.startsWith('/private/') && !directoryPath.startsWith('/private/')) {
+			if (relativePath.startsWith('/private/') && !path.startsWith('/private/')) {
 				relativePath = relativePath.replace(/^\/private/, '');
 			}
 
-			if (!relativePath.startsWith(directoryPath)) {
-				logger.warn('readDirStats: Relative path does not start with original:', { relativePath, path: directoryPath });
+			if (!relativePath.startsWith(path)) {
+				logger.warn('readDirStats: Relative path does not start with original:', { relativePath, path });
 			}
 
-			relativePath = relativePath.substring(directoryPath.length + 1);
+			relativePath = relativePath.substring(path.length + 1);
 			return relativePath;
 		};
 		const relativePaths = stats.map(toRelativePath);
-		if (isScoped) this.cacheSafDirectoryListing_(directoryPath, stats as DocumentFileDetail[], relativePaths);
+		if (isScoped) this.cacheSafDirectoryListing_(path, stats as DocumentFileDetail[], relativePaths);
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Output combines DocumentFileDetail (SAF) or normalized Stat (RNFS) entries
 		let output: any[] = [];
@@ -359,7 +359,7 @@ export default class FsDriverRN extends FsDriverBase {
 				// Use the original stat.
 				output = await this.readUriDirStatsHandleRecursion_(stat as DocumentFileDetail, output, options);
 			} else {
-				output = await this.readDirStatsHandleRecursion_(directoryPath, standardStat, output, options);
+				output = await this.readDirStatsHandleRecursion_(path, standardStat, output, options);
 			}
 		}
 		return output;

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -119,7 +119,7 @@ export default class FsDriverRN extends FsDriverBase {
 		return directoryUri;
 	}
 
-	private cacheSafDirectoryListing_(path: string, documents: DocumentFileDetail[]) {
+	private cacheSafDirectoryListing_(path: string, documents: DocumentFileDetail[], relativePaths: string[] = null) {
 		const normalizedPath = path.replace(/\/$/, '');
 		const pathPrefix = `${normalizedPath}/`;
 		for (const cachedPath of this.safDocumentUris_.keys()) {
@@ -128,8 +128,9 @@ export default class FsDriverRN extends FsDriverBase {
 			}
 		}
 
-		for (const document of documents) {
-			this.safDocumentUris_.set(`${pathPrefix}${document.name}`, document.documentUri ?? document.uri);
+		for (let i = 0; i < documents.length; i++) {
+			const document = documents[i];
+			this.safDocumentUris_.set(`${pathPrefix}${relativePaths?.[i] ?? document.name}`, document.documentUri ?? document.uri);
 		}
 		this.listedSafDirectories_.add(normalizedPath);
 	}
@@ -294,7 +295,6 @@ export default class FsDriverRN extends FsDriverBase {
 			if (isScoped) {
 				await this.safDirectoryUri_(directoryPath);
 				stats = await RNSAF.listFiles(directoryPath);
-				this.cacheSafDirectoryListing_(directoryPath, stats as DocumentFileDetail[]);
 			} else {
 				stats = await RNFS.readDir(directoryPath);
 			}
@@ -319,17 +319,15 @@ export default class FsDriverRN extends FsDriverBase {
 			relativePath = relativePath.substring(directoryPath.length + 1);
 			return relativePath;
 		};
+		const relativePaths = stats.map(toRelativePath);
+		if (isScoped) this.cacheSafDirectoryListing_(directoryPath, stats as DocumentFileDetail[], relativePaths);
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Output combines DocumentFileDetail (SAF) or normalized Stat (RNFS) entries
 		let output: any[] = [];
 		for (let i = 0; i < stats.length; i++) {
 			const stat = stats[i];
 
-			const relativePath = toRelativePath(stat);
-			if (isScoped) {
-				const document = stat as DocumentFileDetail;
-				this.safDocumentUris_.set(`${directoryPath}/${relativePath}`, document.documentUri ?? document.uri);
-			}
+			const relativePath = relativePaths[i];
 			const standardStat = this.rnfsStatToStd_(stat, relativePath);
 			output.push(standardStat);
 

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -274,13 +274,14 @@ export default class FsDriverRN extends FsDriverBase {
 		let stats: RnfsStatLike[] = [];
 		try {
 			if (isScoped) {
+				await this.safDirectoryUri_(path);
 				stats = await RNSAF.listFiles(path);
 				this.cacheSafDirectoryListing_(path, stats as DocumentFileDetail[]);
-				await this.safDirectoryUri_(path);
 			} else {
 				stats = await RNFS.readDir(path);
 			}
 		} catch (error) {
+			if (isScoped) this.invalidateSafDirectory_(path);
 			throw new Error(`Could not read directory: ${path}: ${error.message}`);
 		}
 
@@ -368,7 +369,11 @@ export default class FsDriverRN extends FsDriverBase {
 
 	public async mkdir(path: string) {
 		if (isScopedUri(path)) {
-			await RNSAF.mkdir(path);
+			try {
+				await RNSAF.mkdir(path);
+			} finally {
+				this.invalidateSafPath_(path);
+			}
 			return;
 		}
 

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -421,10 +421,22 @@ export default class FsDriverRN extends FsDriverBase {
 	}
 
 	public async stat(path: string) {
+		const isScoped = isScopedUri(path);
 		try {
 			let r;
-			if (isScopedUri(path)) {
+			if (isScoped) {
 				r = await RNSAF.stat(path);
+				const normalizedPath = this.normalizeSafPath_(path);
+				const documentUri = r.documentUri ?? r.uri;
+				if (r.type === 'directory') {
+					this.safDirectoryUris_.set(normalizedPath, documentUri);
+				} else {
+					// stat() is used immediately before upload conflict resolution.
+					// Retain the document found by that live lookup so an accepted
+					// upload overwrites it rather than creating another document from
+					// an older parent listing.
+					this.safDocumentUris_.set(normalizedPath, documentUri);
+				}
 			} else {
 				r = await RNFS.stat(path);
 			}
@@ -434,6 +446,7 @@ export default class FsDriverRN extends FsDriverBase {
 				// Probably { [Error: File does not exist] framesToPop: 1, code: 'EUNSPECIFIED' }
 				//     or   { [Error: The file {file} couldn’t be opened because there is no such file.], code: 'ENSCOCOAERRORDOMAIN260' }
 				// which unfortunately does not have a proper error code. Can be ignored.
+				if (isScoped) this.invalidateSafPath_(path);
 				return null;
 			} else {
 				throw error;

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -53,6 +53,25 @@ const normalizeEncoding = (encoding: string): SupportedEncoding => {
 };
 
 export default class FsDriverRN extends FsDriverBase {
+	private safDocumentUris_ = new Map<string, string>();
+
+	private cachedSafUri_(path: string) {
+		return this.safDocumentUris_.get(path) ?? path;
+	}
+
+	private async withCachedSafUri_<T>(path: string, callback: (resolvedPath: string)=> Promise<T>): Promise<T> {
+		const cachedUri = this.cachedSafUri_(path);
+		try {
+			return await callback(cachedUri);
+		} catch (error) {
+			// A document URI can become invalid if another client replaces the file.
+			// Discard it and fall back to resolving the path by name in that case.
+			if (cachedUri === path) throw error;
+			this.safDocumentUris_.delete(path);
+			return callback(path);
+		}
+	}
+
 	public appendFileSync() {
 		throw new Error('Not implemented: appendFileSync');
 	}
@@ -149,6 +168,10 @@ export default class FsDriverRN extends FsDriverBase {
 			const stat = stats[i];
 
 			const relativePath = toRelativePath(stat);
+			if (isScoped) {
+				const document = stat as DocumentFileDetail;
+				this.safDocumentUris_.set(`${path.replace(/\/$/, '')}/${relativePath}`, document.documentUri ?? document.uri);
+			}
 			const standardStat = this.rnfsStatToStd_(stat, relativePath);
 			output.push(standardStat);
 
@@ -260,7 +283,7 @@ export default class FsDriverRN extends FsDriverBase {
 		const encoding = normalizeEncoding(rawEncoding);
 
 		if (isScopedUri(path)) {
-			return RNSAF.readFile(path, { encoding: encoding });
+			return this.withCachedSafUri_(path, resolvedPath => RNSAF.readFile(resolvedPath, { encoding: encoding }));
 		}
 		return RNFS.readFile(path, encoding);
 	}
@@ -270,7 +293,11 @@ export default class FsDriverRN extends FsDriverBase {
 		let retry = false;
 		try {
 			if (isScopedUri(source) || isScopedUri(dest)) {
-				await RNSAF.copyFile(source, dest, { replaceIfDestinationExists: true });
+				if (isScopedUri(source)) {
+					await this.withCachedSafUri_(source, resolvedSource => RNSAF.copyFile(resolvedSource, dest, { replaceIfDestinationExists: true }));
+				} else {
+					await RNSAF.copyFile(source, dest, { replaceIfDestinationExists: true });
+				}
 				return;
 			}
 			await RNFS.copyFile(source, dest);

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -73,10 +73,11 @@ export default class FsDriverRN extends FsDriverBase {
 
 	private safRelativePath_(directoryPath: string, document: DocumentFileDetail) {
 		directoryPath = this.normalizeSafPath_(directoryPath);
-		if (!document.uri.startsWith(directoryPath)) {
-			logger.warn('safRelativePath_: Document URI does not start with directory path:', { uri: document.uri, directoryPath });
+		const pathPrefix = `${directoryPath}/`;
+		if (!document.uri.startsWith(pathPrefix)) {
+			throw new Error(`Cannot derive SAF relative path: Document URI does not start with directory path: ${document.uri}`);
 		}
-		return document.uri.substring(directoryPath.length + 1);
+		return document.uri.substring(pathPrefix.length);
 	}
 
 	private invalidateSafDirectory_(path: string) {

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -135,8 +135,9 @@ export default class FsDriverRN extends FsDriverBase {
 				this.safDocumentUris_.set(path, document.documentUri ?? document.uri);
 				return;
 			} catch (error) {
-				// The directory may have been replaced since it was listed. Fall back to
-				// resolving the destination by path.
+				// Only retry when the cached parent no longer exists. Other failures may
+				// occur after the write succeeded and must not replay the mutation.
+				if (error?.code !== 'ENOENT') throw error;
 				this.safDirectoryUris_.delete(parentPath);
 				this.listedSafDirectories_.delete(parentPath);
 			}
@@ -171,6 +172,9 @@ export default class FsDriverRN extends FsDriverBase {
 				this.safDocumentUris_.set(dest, document.documentUri ?? document.uri);
 				return;
 			} catch (error) {
+				// Only retry when the cached parent no longer exists. Other failures may
+				// occur after the copy succeeded and must not replay the mutation.
+				if (error?.code !== 'ENOENT') throw error;
 				this.safDirectoryUris_.delete(parentPath);
 				this.listedSafDirectories_.delete(parentPath);
 			}
@@ -395,16 +399,17 @@ export default class FsDriverRN extends FsDriverBase {
 
 	// Always overwrite destination
 	public async copy(source: string, dest: string) {
+		if (isScopedUri(source) || isScopedUri(dest)) {
+			if (isScopedUri(source)) {
+				await this.withCachedSafUri_(source, resolvedSource => RNSAF.copyFile(resolvedSource, dest, { replaceIfDestinationExists: true }));
+			} else {
+				await this.copyToSaf_(source, dest);
+			}
+			return;
+		}
+
 		let retry = false;
 		try {
-			if (isScopedUri(source) || isScopedUri(dest)) {
-				if (isScopedUri(source)) {
-					await this.withCachedSafUri_(source, resolvedSource => RNSAF.copyFile(resolvedSource, dest, { replaceIfDestinationExists: true }));
-				} else {
-					await this.copyToSaf_(source, dest);
-				}
-				return;
-			}
 			await RNFS.copyFile(source, dest);
 		} catch (error) {
 			// On iOS it will throw an error if the file already exist
@@ -413,11 +418,7 @@ export default class FsDriverRN extends FsDriverBase {
 		}
 
 		if (retry) {
-			if (isScopedUri(source) || isScopedUri(dest)) {
-				await RNSAF.copyFile(source, dest, { replaceIfDestinationExists: true });
-			} else {
-				await RNFS.copyFile(source, dest);
-			}
+			await RNFS.copyFile(source, dest);
 		}
 	}
 

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -71,6 +71,14 @@ export default class FsDriverRN extends FsDriverBase {
 		return normalizedPath.substring(0, normalizedPath.lastIndexOf('/'));
 	}
 
+	private safRelativePath_(directoryPath: string, document: DocumentFileDetail) {
+		directoryPath = this.normalizeSafPath_(directoryPath);
+		if (!document.uri.startsWith(directoryPath)) {
+			logger.warn('safRelativePath_: Document URI does not start with directory path:', { uri: document.uri, directoryPath });
+		}
+		return document.uri.substring(directoryPath.length + 1);
+	}
+
 	private invalidateSafDirectory_(path: string) {
 		const normalizedPath = this.normalizeSafPath_(path);
 		this.safDirectoryUris_.delete(normalizedPath);
@@ -130,7 +138,8 @@ export default class FsDriverRN extends FsDriverBase {
 
 		for (let i = 0; i < documents.length; i++) {
 			const document = documents[i];
-			this.safDocumentUris_.set(`${pathPrefix}${relativePaths?.[i] ?? document.name}`, document.documentUri ?? document.uri);
+			const relativePath = relativePaths?.[i] ?? this.safRelativePath_(normalizedPath, document);
+			this.safDocumentUris_.set(`${pathPrefix}${relativePath}`, document.documentUri ?? document.uri);
 		}
 		this.listedSafDirectories_.add(normalizedPath);
 	}
@@ -304,7 +313,9 @@ export default class FsDriverRN extends FsDriverBase {
 		}
 
 		const toRelativePath = (stat: RnfsStatLike) => {
-			let relativePath = isScoped ? (stat as DocumentFileDetail).uri : (stat as StatResultT | ReadDirResItemT).path;
+			if (isScoped) return this.safRelativePath_(directoryPath, stat as DocumentFileDetail);
+
+			let relativePath = (stat as StatResultT | ReadDirResItemT).path;
 
 			// Workaround: Paths returned by RNFS.readDir can include a leading /private/, when this isn't included
 			// in the original path variable:

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -172,6 +172,9 @@ export default class FsDriverRN extends FsDriverBase {
 			if (error?.code !== 'ENOENT') throw error;
 			return RNSAF.writeFile(path, content, { encoding });
 		}
+		if (this.safDocumentUris_.has(path)) {
+			return this.withCachedSafUri_(path, resolvedPath => RNSAF.writeFile(resolvedPath, content, { encoding }));
+		}
 
 		const parentUri = this.safDirectoryUris_.get(parentPath);
 		if (parentUri) {
@@ -204,6 +207,10 @@ export default class FsDriverRN extends FsDriverBase {
 		} catch (error) {
 			if (error?.code !== 'ENOENT') throw error;
 			await RNSAF.copyFile(source, dest, { replaceIfDestinationExists: true });
+			return;
+		}
+		if (this.safDocumentUris_.has(dest)) {
+			await this.withCachedSafUri_(dest, resolvedDest => RNSAF.copyFile(source, resolvedDest, { replaceIfDestinationExists: true }));
 			return;
 		}
 

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -222,12 +222,8 @@ export default class FsDriverRN extends FsDriverBase {
 		const parentUri = this.safDirectoryUris_.get(parentPath);
 		if (parentUri) {
 			try {
-				const documentUri = await RNSAF.copyFileToDirectory(source, parentUri, dest.substring(lastSlashIndex + 1), {
-					replaceIfDestinationExists: true,
-					returnDocumentUriOnly: true,
-				});
-				if (typeof documentUri !== 'string') throw new Error('Expected copyFileToDirectory to return a document URI');
-				this.safDocumentUris_.set(dest, documentUri);
+				const document = await RNSAF.copyFileToDirectory(source, parentUri, dest.substring(lastSlashIndex + 1), { replaceIfDestinationExists: true });
+				this.safDocumentUris_.set(dest, document.documentUri ?? document.uri);
 				return;
 			} catch (error) {
 				// The operation may have created and copied the destination before

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -91,16 +91,17 @@ export default class FsDriverRN extends FsDriverBase {
 		this.invalidateSafDirectory_(this.safParentPath_(normalizedPath));
 	}
 
-	private async withCachedSafUri_<T>(path: string, callback: (resolvedPath: string)=> Promise<T>): Promise<T> {
+	private async withCachedSafUri_<T>(path: string, callback: (resolvedPath: string)=> Promise<T>, retryIfStale = false): Promise<T> {
 		const cachedUri = this.cachedSafUri_(path);
 		try {
 			return await callback(cachedUri);
 		} catch (error) {
-			// ENOENT confirms that the cached document URI is stale. Retrying other
-			// errors could repeat an operation that succeeded before failing while
-			// closing the stream (and, for appends, duplicate the appended content).
+			// Only non-mutating operations may retry a stale URI immediately. A
+			// mutating native operation can report ENOENT during its final metadata
+			// check, after it has already changed the destination.
 			if (cachedUri === path || error?.code !== 'ENOENT') throw error;
 			this.invalidateSafPath_(path);
+			if (!retryIfStale) throw error;
 			return callback(path);
 		}
 	}
@@ -166,10 +167,10 @@ export default class FsDriverRN extends FsDriverBase {
 				this.safDocumentUris_.set(path, document.documentUri ?? document.uri);
 				return;
 			} catch (error) {
-				// Only retry when the cached parent no longer exists. Other failures may
-				// occur after the write succeeded and must not replay the mutation.
+				// The operation may have created and written the destination before
+				// failing during close or its final metadata check. Never replay it here.
 				this.invalidateSafDirectory_(parentPath);
-				if (error?.code !== 'ENOENT') throw error;
+				throw error;
 			}
 		}
 
@@ -199,10 +200,10 @@ export default class FsDriverRN extends FsDriverBase {
 				this.safDocumentUris_.set(dest, document.documentUri ?? document.uri);
 				return;
 			} catch (error) {
-				// Only retry when the cached parent no longer exists. Other failures may
-				// occur after the copy succeeded and must not replay the mutation.
+				// The operation may have created and copied the destination before
+				// failing during close or its final metadata check. Never replay it here.
 				this.invalidateSafDirectory_(parentPath);
-				if (error?.code !== 'ENOENT') throw error;
+				throw error;
 			}
 		}
 
@@ -447,7 +448,7 @@ export default class FsDriverRN extends FsDriverBase {
 		const encoding = normalizeEncoding(rawEncoding);
 
 		if (isScopedUri(path)) {
-			return this.withCachedSafUri_(path, resolvedPath => RNSAF.readFile(resolvedPath, { encoding: encoding }));
+			return this.withCachedSafUri_(path, resolvedPath => RNSAF.readFile(resolvedPath, { encoding: encoding }), true);
 		}
 		return RNFS.readFile(path, encoding);
 	}
@@ -484,7 +485,9 @@ export default class FsDriverRN extends FsDriverBase {
 	public async unlink(path: string) {
 		try {
 			if (isScopedUri(path)) {
-				await this.withCachedSafUri_(path, resolvedPath => RNSAF.unlink(resolvedPath));
+				// Deletion is idempotent and unlink does not perform a post-delete stat,
+				// so retrying a confirmed stale document URI is safe here.
+				await this.withCachedSafUri_(path, resolvedPath => RNSAF.unlink(resolvedPath), true);
 				return;
 			}
 			await RNFS.unlink(path);

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -429,8 +429,11 @@ export default class FsDriverRN extends FsDriverBase {
 		try {
 			let r;
 			if (isScoped) {
-				r = await RNSAF.stat(path);
 				const normalizedPath = this.normalizeSafPath_(path);
+				// A direct document URI avoids resolving the filename by walking the
+				// parent directory. stat() still queries the provider for fresh metadata,
+				// and a confirmed stale URI is safely retried through the logical path.
+				r = await this.withCachedSafUri_(normalizedPath, resolvedPath => RNSAF.stat(resolvedPath), true);
 				const documentUri = r.documentUri ?? r.uri;
 				if (r.type === 'directory') {
 					this.safDirectoryUris_.set(normalizedPath, documentUri);

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -55,6 +55,7 @@ const normalizeEncoding = (encoding: string): SupportedEncoding => {
 export default class FsDriverRN extends FsDriverBase {
 	private safDocumentUris_ = new Map<string, string>();
 	private safDirectoryUris_ = new Map<string, string>();
+	private listedSafDirectories_ = new Set<string>();
 
 	private cachedSafUri_(path: string) {
 		return this.safDocumentUris_.get(path) ?? path;
@@ -65,9 +66,10 @@ export default class FsDriverRN extends FsDriverBase {
 		try {
 			return await callback(cachedUri);
 		} catch (error) {
-			// A document URI can become invalid if another client replaces the file.
-			// Discard it and fall back to resolving the path by name in that case.
-			if (cachedUri === path) throw error;
+			// ENOENT confirms that the cached document URI is stale. Retrying other
+			// errors could repeat an operation that succeeded before failing while
+			// closing the stream (and, for appends, duplicate the appended content).
+			if (cachedUri === path || error?.code !== 'ENOENT') throw error;
 			this.safDocumentUris_.delete(path);
 			return callback(path);
 		}
@@ -84,13 +86,43 @@ export default class FsDriverRN extends FsDriverBase {
 		return directoryUri;
 	}
 
+	private cacheSafDirectoryListing_(path: string, documents: DocumentFileDetail[]) {
+		const normalizedPath = path.replace(/\/$/, '');
+		const pathPrefix = `${normalizedPath}/`;
+		for (const cachedPath of this.safDocumentUris_.keys()) {
+			if (cachedPath.startsWith(pathPrefix) && !cachedPath.substring(pathPrefix.length).includes('/')) {
+				this.safDocumentUris_.delete(cachedPath);
+			}
+		}
+
+		for (const document of documents) {
+			this.safDocumentUris_.set(`${pathPrefix}${document.name}`, document.documentUri ?? document.uri);
+		}
+		this.listedSafDirectories_.add(normalizedPath);
+	}
+
+	private async ensureSafDirectoryListed_(path: string) {
+		const normalizedPath = path.replace(/\/$/, '');
+		if (this.listedSafDirectories_.has(normalizedPath)) return;
+
+		const documents = await RNSAF.listFiles(normalizedPath);
+		this.cacheSafDirectoryListing_(normalizedPath, documents);
+		await this.safDirectoryUri_(normalizedPath);
+	}
+
 	private async writeSafFile_(path: string, content: string, encoding: SupportedEncoding) {
+		const lastSlashIndex = path.lastIndexOf('/');
+		const parentPath = path.substring(0, lastSlashIndex);
+		try {
+			await this.ensureSafDirectoryListed_(parentPath);
+		} catch (error) {
+			// Fall back to resolving the destination by path below.
+		}
+
 		if (this.safDocumentUris_.has(path)) {
 			return this.withCachedSafUri_(path, resolvedPath => RNSAF.writeFile(resolvedPath, content, { encoding }));
 		}
 
-		const lastSlashIndex = path.lastIndexOf('/');
-		const parentPath = path.substring(0, lastSlashIndex);
 		let parentUri: string = null;
 		try {
 			parentUri = await this.safDirectoryUri_(parentPath);
@@ -106,6 +138,7 @@ export default class FsDriverRN extends FsDriverBase {
 				// The directory may have been replaced since it was listed. Fall back to
 				// resolving the destination by path.
 				this.safDirectoryUris_.delete(parentPath);
+				this.listedSafDirectories_.delete(parentPath);
 			}
 		}
 
@@ -113,13 +146,19 @@ export default class FsDriverRN extends FsDriverBase {
 	}
 
 	private async copyToSaf_(source: string, dest: string): Promise<void> {
+		const lastSlashIndex = dest.lastIndexOf('/');
+		const parentPath = dest.substring(0, lastSlashIndex);
+		try {
+			await this.ensureSafDirectoryListed_(parentPath);
+		} catch (error) {
+			// Fall back to resolving the destination by path below.
+		}
+
 		if (this.safDocumentUris_.has(dest)) {
 			await this.withCachedSafUri_(dest, resolvedDest => RNSAF.copyFile(source, resolvedDest, { replaceIfDestinationExists: true }));
 			return;
 		}
 
-		const lastSlashIndex = dest.lastIndexOf('/');
-		const parentPath = dest.substring(0, lastSlashIndex);
 		let parentUri: string = null;
 		try {
 			parentUri = await this.safDirectoryUri_(parentPath);
@@ -133,6 +172,7 @@ export default class FsDriverRN extends FsDriverBase {
 				return;
 			} catch (error) {
 				this.safDirectoryUris_.delete(parentPath);
+				this.listedSafDirectories_.delete(parentPath);
 			}
 		}
 
@@ -205,6 +245,7 @@ export default class FsDriverRN extends FsDriverBase {
 		try {
 			if (isScoped) {
 				stats = await RNSAF.listFiles(path);
+				this.cacheSafDirectoryListing_(path, stats as DocumentFileDetail[]);
 				await this.safDirectoryUri_(path);
 			} else {
 				stats = await RNFS.readDir(path);
@@ -236,10 +277,6 @@ export default class FsDriverRN extends FsDriverBase {
 			const stat = stats[i];
 
 			const relativePath = toRelativePath(stat);
-			if (isScoped) {
-				const document = stat as DocumentFileDetail;
-				this.safDocumentUris_.set(`${path.replace(/\/$/, '')}/${relativePath}`, document.documentUri ?? document.uri);
-			}
 			const standardStat = this.rnfsStatToStd_(stat, relativePath);
 			output.push(standardStat);
 

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -73,6 +73,17 @@ export default class FsDriverRN extends FsDriverBase {
 		}
 	}
 
+	private async safDirectoryUri_(path: string) {
+		const normalizedPath = path.replace(/\/$/, '');
+		const cachedUri = this.safDirectoryUris_.get(normalizedPath);
+		if (cachedUri) return cachedUri;
+
+		const directory = await RNSAF.stat(normalizedPath);
+		const directoryUri = directory.documentUri ?? directory.uri;
+		this.safDirectoryUris_.set(normalizedPath, directoryUri);
+		return directoryUri;
+	}
+
 	private async writeSafFile_(path: string, content: string, encoding: SupportedEncoding) {
 		if (this.safDocumentUris_.has(path)) {
 			return this.withCachedSafUri_(path, resolvedPath => RNSAF.writeFile(resolvedPath, content, { encoding }));
@@ -80,7 +91,12 @@ export default class FsDriverRN extends FsDriverBase {
 
 		const lastSlashIndex = path.lastIndexOf('/');
 		const parentPath = path.substring(0, lastSlashIndex);
-		const parentUri = this.safDirectoryUris_.get(parentPath);
+		let parentUri: string = null;
+		try {
+			parentUri = await this.safDirectoryUri_(parentPath);
+		} catch (error) {
+			// Fall back to path-based creation below.
+		}
 		if (parentUri) {
 			try {
 				const document = await RNSAF.writeFileInDirectory(parentUri, path.substring(lastSlashIndex + 1), content, { encoding });
@@ -104,7 +120,12 @@ export default class FsDriverRN extends FsDriverBase {
 
 		const lastSlashIndex = dest.lastIndexOf('/');
 		const parentPath = dest.substring(0, lastSlashIndex);
-		const parentUri = this.safDirectoryUris_.get(parentPath);
+		let parentUri: string = null;
+		try {
+			parentUri = await this.safDirectoryUri_(parentPath);
+		} catch (error) {
+			// Fall back to path-based creation below.
+		}
 		if (parentUri) {
 			try {
 				const document = await RNSAF.copyFileToDirectory(source, parentUri, dest.substring(lastSlashIndex + 1));
@@ -184,8 +205,7 @@ export default class FsDriverRN extends FsDriverBase {
 		try {
 			if (isScoped) {
 				stats = await RNSAF.listFiles(path);
-				const directory = await RNSAF.stat(path);
-				this.safDirectoryUris_.set(path.replace(/\/$/, ''), directory.documentUri ?? directory.uri);
+				await this.safDirectoryUri_(path);
 			} else {
 				stats = await RNFS.readDir(path);
 			}

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -54,6 +54,7 @@ const normalizeEncoding = (encoding: string): SupportedEncoding => {
 
 export default class FsDriverRN extends FsDriverBase {
 	private safDocumentUris_ = new Map<string, string>();
+	private safDirectoryUris_ = new Map<string, string>();
 
 	private cachedSafUri_(path: string) {
 		return this.safDocumentUris_.get(path) ?? path;
@@ -72,6 +73,51 @@ export default class FsDriverRN extends FsDriverBase {
 		}
 	}
 
+	private async writeSafFile_(path: string, content: string, encoding: SupportedEncoding) {
+		if (this.safDocumentUris_.has(path)) {
+			return this.withCachedSafUri_(path, resolvedPath => RNSAF.writeFile(resolvedPath, content, { encoding }));
+		}
+
+		const lastSlashIndex = path.lastIndexOf('/');
+		const parentPath = path.substring(0, lastSlashIndex);
+		const parentUri = this.safDirectoryUris_.get(parentPath);
+		if (parentUri) {
+			try {
+				const document = await RNSAF.writeFileInDirectory(parentUri, path.substring(lastSlashIndex + 1), content, { encoding });
+				this.safDocumentUris_.set(path, document.documentUri ?? document.uri);
+				return;
+			} catch (error) {
+				// The directory may have been replaced since it was listed. Fall back to
+				// resolving the destination by path.
+				this.safDirectoryUris_.delete(parentPath);
+			}
+		}
+
+		return RNSAF.writeFile(path, content, { encoding });
+	}
+
+	private async copyToSaf_(source: string, dest: string): Promise<void> {
+		if (this.safDocumentUris_.has(dest)) {
+			await this.withCachedSafUri_(dest, resolvedDest => RNSAF.copyFile(source, resolvedDest, { replaceIfDestinationExists: true }));
+			return;
+		}
+
+		const lastSlashIndex = dest.lastIndexOf('/');
+		const parentPath = dest.substring(0, lastSlashIndex);
+		const parentUri = this.safDirectoryUris_.get(parentPath);
+		if (parentUri) {
+			try {
+				const document = await RNSAF.copyFileToDirectory(source, parentUri, dest.substring(lastSlashIndex + 1));
+				this.safDocumentUris_.set(dest, document.documentUri ?? document.uri);
+				return;
+			} catch (error) {
+				this.safDirectoryUris_.delete(parentPath);
+			}
+		}
+
+		await RNSAF.copyFile(source, dest, { replaceIfDestinationExists: true });
+	}
+
 	public appendFileSync() {
 		throw new Error('Not implemented: appendFileSync');
 	}
@@ -83,7 +129,7 @@ export default class FsDriverRN extends FsDriverBase {
 		const encoding = normalizeEncoding(rawEncoding);
 
 		if (isScopedUri(path)) {
-			return RNSAF.writeFile(path, content, { encoding, append: true });
+			return this.withCachedSafUri_(path, resolvedPath => RNSAF.writeFile(resolvedPath, content, { encoding, append: true }));
 		}
 		return RNFS.appendFile(path, content, encoding);
 	}
@@ -93,7 +139,7 @@ export default class FsDriverRN extends FsDriverBase {
 		const encoding = normalizeEncoding(rawEncoding);
 
 		if (isScopedUri(path)) {
-			return RNSAF.writeFile(path, content, { encoding: encoding });
+			return this.writeSafFile_(path, content, encoding);
 		}
 
 		// We need to use rn-fetch-blob here due to this bug:
@@ -138,6 +184,8 @@ export default class FsDriverRN extends FsDriverBase {
 		try {
 			if (isScoped) {
 				stats = await RNSAF.listFiles(path);
+				const directory = await RNSAF.stat(path);
+				this.safDirectoryUris_.set(path.replace(/\/$/, ''), directory.documentUri ?? directory.uri);
 			} else {
 				stats = await RNFS.readDir(path);
 			}
@@ -296,7 +344,7 @@ export default class FsDriverRN extends FsDriverBase {
 				if (isScopedUri(source)) {
 					await this.withCachedSafUri_(source, resolvedSource => RNSAF.copyFile(resolvedSource, dest, { replaceIfDestinationExists: true }));
 				} else {
-					await RNSAF.copyFile(source, dest, { replaceIfDestinationExists: true });
+					await this.copyToSaf_(source, dest);
 				}
 				return;
 			}

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -61,6 +61,36 @@ export default class FsDriverRN extends FsDriverBase {
 		return this.safDocumentUris_.get(path) ?? path;
 	}
 
+	private normalizeSafPath_(path: string) {
+		return path.replace(/\/$/, '');
+	}
+
+	private safParentPath_(path: string) {
+		const normalizedPath = this.normalizeSafPath_(path);
+		return normalizedPath.substring(0, normalizedPath.lastIndexOf('/'));
+	}
+
+	private invalidateSafDirectory_(path: string) {
+		const normalizedPath = this.normalizeSafPath_(path);
+		this.safDirectoryUris_.delete(normalizedPath);
+		this.listedSafDirectories_.delete(normalizedPath);
+	}
+
+	private invalidateSafPath_(path: string) {
+		const normalizedPath = this.normalizeSafPath_(path);
+		const pathPrefix = `${normalizedPath}/`;
+		for (const cachedPath of this.safDocumentUris_.keys()) {
+			if (cachedPath === normalizedPath || cachedPath.startsWith(pathPrefix)) this.safDocumentUris_.delete(cachedPath);
+		}
+		for (const cachedPath of this.safDirectoryUris_.keys()) {
+			if (cachedPath === normalizedPath || cachedPath.startsWith(pathPrefix)) this.safDirectoryUris_.delete(cachedPath);
+		}
+		for (const cachedPath of this.listedSafDirectories_) {
+			if (cachedPath === normalizedPath || cachedPath.startsWith(pathPrefix)) this.listedSafDirectories_.delete(cachedPath);
+		}
+		this.invalidateSafDirectory_(this.safParentPath_(normalizedPath));
+	}
+
 	private async withCachedSafUri_<T>(path: string, callback: (resolvedPath: string)=> Promise<T>): Promise<T> {
 		const cachedUri = this.cachedSafUri_(path);
 		try {
@@ -70,7 +100,7 @@ export default class FsDriverRN extends FsDriverBase {
 			// errors could repeat an operation that succeeded before failing while
 			// closing the stream (and, for appends, duplicate the appended content).
 			if (cachedUri === path || error?.code !== 'ENOENT') throw error;
-			this.safDocumentUris_.delete(path);
+			this.invalidateSafPath_(path);
 			return callback(path);
 		}
 	}
@@ -102,12 +132,17 @@ export default class FsDriverRN extends FsDriverBase {
 	}
 
 	private async ensureSafDirectoryListed_(path: string) {
-		const normalizedPath = path.replace(/\/$/, '');
+		const normalizedPath = this.normalizeSafPath_(path);
 		if (this.listedSafDirectories_.has(normalizedPath)) return;
 
-		const documents = await RNSAF.listFiles(normalizedPath);
-		this.cacheSafDirectoryListing_(normalizedPath, documents);
-		await this.safDirectoryUri_(normalizedPath);
+		try {
+			await this.safDirectoryUri_(normalizedPath);
+			const documents = await RNSAF.listFiles(normalizedPath);
+			this.cacheSafDirectoryListing_(normalizedPath, documents);
+		} catch (error) {
+			this.invalidateSafDirectory_(normalizedPath);
+			throw error;
+		}
 	}
 
 	private async writeSafFile_(path: string, content: string, encoding: SupportedEncoding) {
@@ -116,19 +151,15 @@ export default class FsDriverRN extends FsDriverBase {
 		try {
 			await this.ensureSafDirectoryListed_(parentPath);
 		} catch (error) {
-			// Fall back to resolving the destination by path below.
+			if (error?.code !== 'ENOENT') throw error;
+			return RNSAF.writeFile(path, content, { encoding });
 		}
 
 		if (this.safDocumentUris_.has(path)) {
 			return this.withCachedSafUri_(path, resolvedPath => RNSAF.writeFile(resolvedPath, content, { encoding }));
 		}
 
-		let parentUri: string = null;
-		try {
-			parentUri = await this.safDirectoryUri_(parentPath);
-		} catch (error) {
-			// Fall back to path-based creation below.
-		}
+		const parentUri = this.safDirectoryUris_.get(parentPath);
 		if (parentUri) {
 			try {
 				const document = await RNSAF.writeFileInDirectory(parentUri, path.substring(lastSlashIndex + 1), content, { encoding });
@@ -137,9 +168,8 @@ export default class FsDriverRN extends FsDriverBase {
 			} catch (error) {
 				// Only retry when the cached parent no longer exists. Other failures may
 				// occur after the write succeeded and must not replay the mutation.
+				this.invalidateSafDirectory_(parentPath);
 				if (error?.code !== 'ENOENT') throw error;
-				this.safDirectoryUris_.delete(parentPath);
-				this.listedSafDirectories_.delete(parentPath);
 			}
 		}
 
@@ -152,7 +182,9 @@ export default class FsDriverRN extends FsDriverBase {
 		try {
 			await this.ensureSafDirectoryListed_(parentPath);
 		} catch (error) {
-			// Fall back to resolving the destination by path below.
+			if (error?.code !== 'ENOENT') throw error;
+			await RNSAF.copyFile(source, dest, { replaceIfDestinationExists: true });
+			return;
 		}
 
 		if (this.safDocumentUris_.has(dest)) {
@@ -160,12 +192,7 @@ export default class FsDriverRN extends FsDriverBase {
 			return;
 		}
 
-		let parentUri: string = null;
-		try {
-			parentUri = await this.safDirectoryUri_(parentPath);
-		} catch (error) {
-			// Fall back to path-based creation below.
-		}
+		const parentUri = this.safDirectoryUris_.get(parentPath);
 		if (parentUri) {
 			try {
 				const document = await RNSAF.copyFileToDirectory(source, parentUri, dest.substring(lastSlashIndex + 1));
@@ -174,9 +201,8 @@ export default class FsDriverRN extends FsDriverBase {
 			} catch (error) {
 				// Only retry when the cached parent no longer exists. Other failures may
 				// occur after the copy succeeded and must not replay the mutation.
+				this.invalidateSafDirectory_(parentPath);
 				if (error?.code !== 'ENOENT') throw error;
-				this.safDirectoryUris_.delete(parentPath);
-				this.listedSafDirectories_.delete(parentPath);
 			}
 		}
 
@@ -310,6 +336,9 @@ export default class FsDriverRN extends FsDriverBase {
 	public async move(source: string, dest: string) {
 		if (isScopedUri(source) || isScopedUri(dest)) {
 			await RNSAF.moveFile(source, dest, { replaceIfDestinationExists: true });
+			this.invalidateSafPath_(source);
+			this.invalidateSafPath_(dest);
+			return;
 		}
 		return RNFS.moveFile(source, dest);
 	}
@@ -317,6 +346,9 @@ export default class FsDriverRN extends FsDriverBase {
 	public async rename(source: string, dest: string) {
 		if (isScopedUri(source) || isScopedUri(dest)) {
 			await RNSAF.rename(source, dest);
+			this.invalidateSafPath_(source);
+			this.invalidateSafPath_(dest);
+			return;
 		}
 		return RNFS.moveFile(source, dest);
 	}
@@ -426,10 +458,12 @@ export default class FsDriverRN extends FsDriverBase {
 		try {
 			if (isScopedUri(path)) {
 				await RNSAF.unlink(path);
+				this.invalidateSafPath_(path);
 				return;
 			}
 			await RNFS.unlink(path);
 		} catch (error) {
+			if (isScopedUri(path)) this.invalidateSafPath_(path);
 			if (error && ((error.message && error.message.indexOf('exist') >= 0) || error.code === 'ENOENT')) {
 				// Probably { [Error: File does not exist] framesToPop: 1, code: 'EUNSPECIFIED' }
 				// which unfortunately does not have a proper error code. Can be ignored.

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -180,7 +180,7 @@ export default class FsDriverRN extends FsDriverBase {
 		const parentUri = this.safDirectoryUris_.get(parentPath);
 		if (parentUri) {
 			try {
-				const document = await RNSAF.writeFileInDirectory(parentUri, path.substring(lastSlashIndex + 1), content, { encoding });
+				const document = await RNSAF.writeFileInDirectory(parentUri, path.substring(lastSlashIndex + 1), content, { encoding, replaceIfDestinationExists: true });
 				this.safDocumentUris_.set(path, document.documentUri ?? document.uri);
 				return;
 			} catch (error) {
@@ -218,7 +218,7 @@ export default class FsDriverRN extends FsDriverBase {
 		const parentUri = this.safDirectoryUris_.get(parentPath);
 		if (parentUri) {
 			try {
-				const document = await RNSAF.copyFileToDirectory(source, parentUri, dest.substring(lastSlashIndex + 1));
+				const document = await RNSAF.copyFileToDirectory(source, parentUri, dest.substring(lastSlashIndex + 1), { replaceIfDestinationExists: true });
 				this.safDocumentUris_.set(dest, document.documentUri ?? document.uri);
 				return;
 			} catch (error) {

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -281,19 +281,20 @@ export default class FsDriverRN extends FsDriverBase {
 		if (!options) options = { recursive: false };
 
 		const isScoped = isScopedUri(path);
+		const directoryPath = isScoped ? this.normalizeSafPath_(path) : path;
 
 		let stats: RnfsStatLike[] = [];
 		try {
 			if (isScoped) {
-				await this.safDirectoryUri_(path);
-				stats = await RNSAF.listFiles(path);
-				this.cacheSafDirectoryListing_(path, stats as DocumentFileDetail[]);
+				await this.safDirectoryUri_(directoryPath);
+				stats = await RNSAF.listFiles(directoryPath);
+				this.cacheSafDirectoryListing_(directoryPath, stats as DocumentFileDetail[]);
 			} else {
-				stats = await RNFS.readDir(path);
+				stats = await RNFS.readDir(directoryPath);
 			}
 		} catch (error) {
-			if (isScoped) this.invalidateSafDirectory_(path);
-			throw new Error(`Could not read directory: ${path}: ${error.message}`);
+			if (isScoped) this.invalidateSafDirectory_(directoryPath);
+			throw new Error(`Could not read directory: ${directoryPath}: ${error.message}`);
 		}
 
 		const toRelativePath = (stat: RnfsStatLike) => {
@@ -301,15 +302,15 @@ export default class FsDriverRN extends FsDriverBase {
 
 			// Workaround: Paths returned by RNFS.readDir can include a leading /private/, when this isn't included
 			// in the original path variable:
-			if (relativePath.startsWith('/private/') && !path.startsWith('/private/')) {
+			if (relativePath.startsWith('/private/') && !directoryPath.startsWith('/private/')) {
 				relativePath = relativePath.replace(/^\/private/, '');
 			}
 
-			if (!relativePath.startsWith(path)) {
-				logger.warn('readDirStats: Relative path does not start with original:', { relativePath, path });
+			if (!relativePath.startsWith(directoryPath)) {
+				logger.warn('readDirStats: Relative path does not start with original:', { relativePath, path: directoryPath });
 			}
 
-			relativePath = relativePath.substring(path.length + 1);
+			relativePath = relativePath.substring(directoryPath.length + 1);
 			return relativePath;
 		};
 
@@ -327,7 +328,7 @@ export default class FsDriverRN extends FsDriverBase {
 				// Use the original stat.
 				output = await this.readUriDirStatsHandleRecursion_(stat as DocumentFileDetail, output, options);
 			} else {
-				output = await this.readDirStatsHandleRecursion_(path, standardStat, output, options);
+				output = await this.readDirStatsHandleRecursion_(directoryPath, standardStat, output, options);
 			}
 		}
 		return output;

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/SafXModule.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/SafXModule.java
@@ -83,6 +83,30 @@ public class SafXModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void writeFileInDirectory(
+    String directoryUri,
+    String fileName,
+    String data,
+    String encoding,
+    String mimeType,
+    final Promise promise) {
+    this.efficientDocumentHelper.writeFileInDirectory(
+      directoryUri, fileName, data, encoding, mimeType, promise
+    );
+  }
+
+  @ReactMethod
+  public void copyFileToDirectory(
+    String sourceUri,
+    String directoryUri,
+    String fileName,
+    final Promise promise) {
+    this.efficientDocumentHelper.copyFileToDirectory(
+      sourceUri, directoryUri, fileName, promise
+    );
+  }
+
+  @ReactMethod
   public void transferFile(
     String srcUri, String destUri, boolean replaceIfDestExists, boolean copy, Promise promise) {
     this.efficientDocumentHelper.transferFile(srcUri, destUri, replaceIfDestExists, copy, promise);

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/SafXModule.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/SafXModule.java
@@ -102,10 +102,9 @@ public class SafXModule extends ReactContextBaseJavaModule {
     String directoryUri,
     String fileName,
     boolean replaceIfDestinationExists,
-    boolean returnDocumentUriOnly,
     final Promise promise) {
     this.efficientDocumentHelper.copyFileToDirectory(
-      sourceUri, directoryUri, fileName, replaceIfDestinationExists, returnDocumentUriOnly, promise
+      sourceUri, directoryUri, fileName, replaceIfDestinationExists, promise
     );
   }
 

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/SafXModule.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/SafXModule.java
@@ -89,9 +89,10 @@ public class SafXModule extends ReactContextBaseJavaModule {
     String data,
     String encoding,
     String mimeType,
+    boolean replaceIfDestinationExists,
     final Promise promise) {
     this.efficientDocumentHelper.writeFileInDirectory(
-      directoryUri, fileName, data, encoding, mimeType, promise
+      directoryUri, fileName, data, encoding, mimeType, replaceIfDestinationExists, promise
     );
   }
 
@@ -100,9 +101,10 @@ public class SafXModule extends ReactContextBaseJavaModule {
     String sourceUri,
     String directoryUri,
     String fileName,
+    boolean replaceIfDestinationExists,
     final Promise promise) {
     this.efficientDocumentHelper.copyFileToDirectory(
-      sourceUri, directoryUri, fileName, promise
+      sourceUri, directoryUri, fileName, replaceIfDestinationExists, promise
     );
   }
 

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/SafXModule.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/SafXModule.java
@@ -102,9 +102,10 @@ public class SafXModule extends ReactContextBaseJavaModule {
     String directoryUri,
     String fileName,
     boolean replaceIfDestinationExists,
+    boolean returnDocumentUriOnly,
     final Promise promise) {
     this.efficientDocumentHelper.copyFileToDirectory(
-      sourceUri, directoryUri, fileName, replaceIfDestinationExists, promise
+      sourceUri, directoryUri, fileName, replaceIfDestinationExists, returnDocumentUriOnly, promise
     );
   }
 

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/DocumentStat.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/DocumentStat.java
@@ -93,6 +93,7 @@ public class DocumentStat {
   public WritableMap getWritableMap() {
     WritableMap fileMap = Arguments.createMap();
     fileMap.putString("uri", UriHelper.denormalize(uri));
+    fileMap.putString("documentUri", internalUri.toString());
     fileMap.putString("name", displayName);
     if (isDirectory) {
       fileMap.putString("type", "directory");

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
@@ -513,13 +513,7 @@ public class EfficientDocumentHelper {
   private void copyFileContents(final Uri sourceUri, final Uri destinationUri) throws IOException {
     try (InputStream inStream = context.getContentResolver().openInputStream(sourceUri);
          OutputStream outStream = context.getContentResolver().openOutputStream(destinationUri, "wt")) {
-      // Some SAF providers have significant overhead for each write. A larger
-      // buffer substantially reduces the number of provider calls for large
-      // resources. Avoid allocating 1 MiB for every small resource, which can
-      // otherwise cause GC pauses during a batch upload. available() is only a
-      // sizing hint; reads still continue until EOF.
-      int bufferSize = Math.max(64 * 1024, Math.min(1024 * 1024, inStream.available()));
-      byte[] buffer = new byte[bufferSize];
+      byte[] buffer = new byte[1024 * 4];
       int length;
       while ((length = inStream.read(buffer)) > 0) {
         outStream.write(buffer, 0, length);

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
@@ -480,7 +480,9 @@ public class EfficientDocumentHelper {
   private void copyFileContents(final Uri sourceUri, final Uri destinationUri) throws IOException {
     try (InputStream inStream = context.getContentResolver().openInputStream(sourceUri);
          OutputStream outStream = context.getContentResolver().openOutputStream(destinationUri, "wt")) {
-      byte[] buffer = new byte[1024 * 64];
+      // Some SAF providers have significant overhead for each write. A larger
+      // buffer substantially reduces the number of provider calls for resources.
+      byte[] buffer = new byte[1024 * 1024];
       int length;
       while ((length = inStream.read(buffer)) > 0) {
         outStream.write(buffer, 0, length);
@@ -886,16 +888,7 @@ public class EfficientDocumentHelper {
 
           }
 
-          try (InputStream inStream =
-                 context.getContentResolver().openInputStream(srcUri);
-               OutputStream outStream =
-                 context.getContentResolver().openOutputStream(destUri, "wt")) {
-            byte[] buffer = new byte[1024 * 4];
-            int length;
-            while ((length = inStream.read(buffer)) > 0) {
-              outStream.write(buffer, 0, length);
-            }
-          }
+          copyFileContents(srcUri, destUri);
 
           if (!copy) {
             unlink(srcUri);

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
@@ -760,14 +760,22 @@ public class EfficientDocumentHelper {
       public Object doAsync() {
         try {
           Uri uri;
+          Uri suppliedUri = UriHelper.getUnifiedUri(unknownStr);
 
-          try {
-            uri = getDocumentUri(unknownStr, false, true);
-            if (uri == null) {
-              throw new FileNotFoundExceptionFast();
+          if (UriHelper.isDocumentUri(suppliedUri)) {
+            // A direct document URI already identifies the destination. Opening its
+            // output stream validates it, so querying it first only adds provider
+            // overhead to every cached overwrite.
+            uri = suppliedUri;
+          } else {
+            try {
+              uri = getDocumentUri(unknownStr, false, true);
+              if (uri == null) {
+                throw new FileNotFoundExceptionFast();
+              }
+            } catch (FileNotFoundException e) {
+              uri = createFile(unknownStr, mimeType);
             }
-          } catch (FileNotFoundException e) {
-            uri = createFile(unknownStr, mimeType);
           }
 
           writeToFile(uri, data, encoding, append);

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
@@ -873,7 +873,6 @@ public class EfficientDocumentHelper {
     String directoryUriString,
     String fileName,
     boolean replaceIfDestinationExists,
-    boolean returnDocumentUriOnly,
     final Promise promise) {
     Async.execute(new Async.Task<Object>() {
       @Override
@@ -894,7 +893,6 @@ public class EfficientDocumentHelper {
             directoryUri, fileName, sourceMimeType, replaceIfDestinationExists
           );
           copyFileContents(sourceUri, destinationUri);
-          if (returnDocumentUriOnly) return destinationUri.toString();
           return getStat(destinationUri).getWritableMap();
         } catch (Exception e) {
           return e;

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
@@ -873,6 +873,7 @@ public class EfficientDocumentHelper {
     String directoryUriString,
     String fileName,
     boolean replaceIfDestinationExists,
+    boolean returnDocumentUriOnly,
     final Promise promise) {
     Async.execute(new Async.Task<Object>() {
       @Override
@@ -893,6 +894,7 @@ public class EfficientDocumentHelper {
             directoryUri, fileName, sourceMimeType, replaceIfDestinationExists
           );
           copyFileContents(sourceUri, destinationUri);
+          if (returnDocumentUriOnly) return destinationUri.toString();
           return getStat(destinationUri).getWritableMap();
         } catch (Exception e) {
           return e;

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
@@ -514,8 +514,12 @@ public class EfficientDocumentHelper {
     try (InputStream inStream = context.getContentResolver().openInputStream(sourceUri);
          OutputStream outStream = context.getContentResolver().openOutputStream(destinationUri, "wt")) {
       // Some SAF providers have significant overhead for each write. A larger
-      // buffer substantially reduces the number of provider calls for resources.
-      byte[] buffer = new byte[1024 * 1024];
+      // buffer substantially reduces the number of provider calls for large
+      // resources. Avoid allocating 1 MiB for every small resource, which can
+      // otherwise cause GC pauses during a batch upload. available() is only a
+      // sizing hint; reads still continue until EOF.
+      int bufferSize = Math.max(64 * 1024, Math.min(1024 * 1024, inStream.available()));
+      byte[] buffer = new byte[bufferSize];
       int length;
       while ((length = inStream.read(buffer)) > 0) {
         outStream.write(buffer, 0, length);
@@ -875,10 +879,18 @@ public class EfficientDocumentHelper {
       public Object doAsync() {
         try {
           Uri sourceUri = getDocumentUri(sourceUriString, false, true);
-          DocumentStat sourceStat = getStat(sourceUri);
+          String sourceMimeType = null;
+          // Extensionless Joplin resources are deliberately created with */* so
+          // providers do not append an extension. A source stat cannot affect the
+          // destination in that case and only adds another provider round trip.
+          int extensionIndex = fileName.lastIndexOf('.');
+          if (extensionIndex > 0 && extensionIndex < fileName.length() - 1) {
+            DocumentStat sourceStat = getStat(sourceUri);
+            sourceMimeType = sourceStat.getMimeType();
+          }
           Uri directoryUri = getDocumentUri(directoryUriString, false, true);
           Uri destinationUri = createFileInDirectory(
-            directoryUri, fileName, sourceStat.getMimeType(), replaceIfDestinationExists
+            directoryUri, fileName, sourceMimeType, replaceIfDestinationExists
           );
           copyFileContents(sourceUri, destinationUri);
           return getStat(destinationUri).getWritableMap();

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
@@ -431,15 +431,19 @@ public class EfficientDocumentHelper {
         "Invalid file name: Could not extract filename from uri string provided");
     }
 
-    // maybe edited maybe not
+    String creationMimeType = "*/*";
+
+    // Some providers append the extension associated with the MIME type. Pass
+    // the MIME type only when the requested name already has an extension;
+    // extensionless Joplin resource IDs must remain extensionless.
     String correctFileName = fileName;
 
-    // only files with mime type are special, so we treat it special
     if (mimeType != null && !mimeType.equals("")) {
-      int indexOfDot = fileName.indexOf('.');
+      int indexOfDot = fileName.lastIndexOf('.');
       // len - 1 because there should be an extension that has at least 1 letter
-      if (indexOfDot != -1 && indexOfDot < fileName.length() - 1) {
+      if (indexOfDot > 0 && indexOfDot < fileName.length() - 1) {
         correctFileName = fileName.substring(0, indexOfDot);
+        creationMimeType = mimeType;
       }
     }
 
@@ -463,7 +467,7 @@ public class EfficientDocumentHelper {
     Uri createdFile = DocumentsContract.createDocument(
       context.getContentResolver(),
       parentDirOfFile,
-      mimeType != null && !mimeType.equals("") ? mimeType : "*/*",
+      creationMimeType,
       correctFileName
     );
 

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
@@ -412,9 +412,11 @@ public class EfficientDocumentHelper {
 
     Uri parentDirOfFile = getDocumentUri(unknownStr, true, false);
 
-    // it should be safe because user cannot select sd root or primary root
-    // and any other path would have at least one '/' to provide a file name in a folder
     String fileName = UriHelper.getFileName(unknownStr);
+    return createFileInDirectory(parentDirOfFile, fileName, mimeType);
+  }
+
+  private Uri createFileInDirectory(final Uri parentDirOfFile, final String fileName, final String mimeType) throws IOException {
     if (fileName.indexOf(':') != -1) {
       throw new IOExceptionFast(
         "Invalid file name: Could not extract filename from uri string provided");
@@ -462,6 +464,28 @@ public class EfficientDocumentHelper {
     }
 
     return createdFile;
+  }
+
+  private void writeToFile(final Uri uri, final String data, final String encoding, final boolean append) throws IOException {
+    byte[] bytes = GeneralHelper.stringToBytes(data, encoding);
+
+    try (OutputStream out =
+           context
+             .getContentResolver()
+             .openOutputStream(uri, append ? "wa" : "wt")) {
+      out.write(bytes);
+    }
+  }
+
+  private void copyFileContents(final Uri sourceUri, final Uri destinationUri) throws IOException {
+    try (InputStream inStream = context.getContentResolver().openInputStream(sourceUri);
+         OutputStream outStream = context.getContentResolver().openOutputStream(destinationUri, "wt")) {
+      byte[] buffer = new byte[1024 * 4];
+      int length;
+      while ((length = inStream.read(buffer)) > 0) {
+        outStream.write(buffer, 0, length);
+      }
+    }
   }
 
   // all public methods SHOULD be below here
@@ -744,16 +768,71 @@ public class EfficientDocumentHelper {
             uri = createFile(unknownStr, mimeType);
           }
 
-          byte[] bytes = GeneralHelper.stringToBytes(data, encoding);
-
-          try (OutputStream out =
-                 context
-                   .getContentResolver()
-                   .openOutputStream(uri, append ? "wa" : "wt")) {
-            out.write(bytes);
-          }
+          writeToFile(uri, data, encoding, append);
 
           return null;
+        } catch (Exception e) {
+          return e;
+        }
+      }
+
+      @Override
+      public void doSync(Object o) {
+        if (o instanceof Exception) {
+          rejectWithException((Exception) o, promise);
+        } else {
+          promise.resolve(o);
+        }
+      }
+    });
+  }
+
+  public void writeFileInDirectory(
+    String directoryUriString,
+    String fileName,
+    String data,
+    String encoding,
+    String mimeType,
+    final Promise promise) {
+    Async.execute(new Async.Task<Object>() {
+      @Override
+      public Object doAsync() {
+        try {
+          Uri directoryUri = getDocumentUri(directoryUriString, false, true);
+          Uri fileUri = createFileInDirectory(directoryUri, fileName, mimeType);
+          writeToFile(fileUri, data, encoding, false);
+          return getStat(fileUri).getWritableMap();
+        } catch (Exception e) {
+          return e;
+        }
+      }
+
+      @Override
+      public void doSync(Object o) {
+        if (o instanceof Exception) {
+          rejectWithException((Exception) o, promise);
+        } else {
+          promise.resolve(o);
+        }
+      }
+    });
+  }
+
+  public void copyFileToDirectory(
+    String sourceUriString,
+    String directoryUriString,
+    String fileName,
+    final Promise promise) {
+    Async.execute(new Async.Task<Object>() {
+      @Override
+      public Object doAsync() {
+        try {
+          Uri sourceUri = getDocumentUri(sourceUriString, false, true);
+          DocumentStat sourceStat = getStat(sourceUri);
+          Uri directoryUri = getDocumentUri(directoryUriString, false, true);
+          Uri destinationUri = createFileInDirectory(directoryUri, fileName, sourceStat.getMimeType());
+          copyFileContents(sourceUri, destinationUri);
+          return getStat(destinationUri).getWritableMap();
         } catch (Exception e) {
           return e;
         }

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
@@ -386,7 +386,9 @@ public class EfficientDocumentHelper {
     return newUri;
   }
 
-  private Uri createFile(final String unknownStr, final String mimeType) throws IOException {
+  private Uri createFile(
+    final String unknownStr, final String mimeType, final boolean replaceIfDestinationExists
+  ) throws IOException {
     Uri uri = null;
 
     try {
@@ -395,6 +397,7 @@ public class EfficientDocumentHelper {
     }
 
     if (uri != null) {
+      if (replaceIfDestinationExists) return uri;
       throw new IOExceptionFast("a file or directory already exist at: " + uri);
     }
 
@@ -405,6 +408,7 @@ public class EfficientDocumentHelper {
       file.getParentFile().mkdirs();
       boolean created = file.createNewFile();
       if (!created) {
+        if (replaceIfDestinationExists && file.exists() && file.isFile()) return uri;
         throw new IOExceptionFast("could not create file at: " + unknownStr);
       }
       return uri;
@@ -413,10 +417,15 @@ public class EfficientDocumentHelper {
     Uri parentDirOfFile = getDocumentUri(unknownStr, true, false);
 
     String fileName = UriHelper.getFileName(unknownStr);
-    return createFileInDirectory(parentDirOfFile, fileName, mimeType);
+    return createFileInDirectory(parentDirOfFile, fileName, mimeType, replaceIfDestinationExists);
   }
 
-  private Uri createFileInDirectory(final Uri parentDirOfFile, final String fileName, final String mimeType) throws IOException {
+  private Uri createFileInDirectory(
+    final Uri parentDirOfFile,
+    final String fileName,
+    final String mimeType,
+    final boolean replaceIfDestinationExists
+  ) throws IOException {
     if (fileName.indexOf(':') != -1) {
       throw new IOExceptionFast(
         "Invalid file name: Could not extract filename from uri string provided");
@@ -449,18 +458,31 @@ public class EfficientDocumentHelper {
     String createdFileName = UriHelper.getFileName(createdFile.toString());
 
     if (!createdFileName.equals(fileName)) {
-      // some times setting mimetypes causes name changes, this is to prevent that.
-      try {
-        createdFile = renameTo(createdFile, fileName);
-      } catch (RenameFailedException e) {
-        unlink(e.getResultUri());
+      // A provider can change the name when a document with the requested name
+      // already exists. Do not try to rename this document into the occupied
+      // destination: a rename can partially succeed before reporting an error.
+      // Delete the document returned by this create call. Replacement-capable
+      // callers can then resolve and overwrite the intended destination;
+      // create-only callers retain their collision failure semantics.
+      unlink(createdFile);
+      if (!replaceIfDestinationExists) {
         throw new IOExceptionFast(
           "The created file name was not as expected: input name was '"
-            + e.getInputName()
-            + "' "
-            + "but got: '"
-            + e.getResultName());
+            + fileName
+            + "' but got: '"
+            + createdFileName
+            + "'");
       }
+      DocumentStat existingFile = findFile(parentDirOfFile, fileName);
+      if (existingFile == null || existingFile.isDirectory()) {
+        throw new IOExceptionFast(
+          "The created file name was not as expected and the existing destination could not be resolved: input name was '"
+            + fileName
+            + "' but got: '"
+            + createdFileName
+            + "'");
+      }
+      return existingFile.getInternalUri();
     }
 
     return createdFile;
@@ -601,7 +623,7 @@ public class EfficientDocumentHelper {
       @Override
       public Object doAsync() {
         try {
-          Uri uri = createFile(unknownStr, mimeType);
+          Uri uri = createFile(unknownStr, mimeType, false);
           return getStat(uri).getWritableMap();
         } catch (Exception e) {
           return e;
@@ -774,7 +796,7 @@ public class EfficientDocumentHelper {
                 throw new FileNotFoundExceptionFast();
               }
             } catch (FileNotFoundException e) {
-              uri = createFile(unknownStr, mimeType);
+              uri = createFile(unknownStr, mimeType, true);
             }
           }
 
@@ -803,13 +825,16 @@ public class EfficientDocumentHelper {
     String data,
     String encoding,
     String mimeType,
+    boolean replaceIfDestinationExists,
     final Promise promise) {
     Async.execute(new Async.Task<Object>() {
       @Override
       public Object doAsync() {
         try {
           Uri directoryUri = getDocumentUri(directoryUriString, false, true);
-          Uri fileUri = createFileInDirectory(directoryUri, fileName, mimeType);
+          Uri fileUri = createFileInDirectory(
+            directoryUri, fileName, mimeType, replaceIfDestinationExists
+          );
           writeToFile(fileUri, data, encoding, false);
           return getStat(fileUri).getWritableMap();
         } catch (Exception e) {
@@ -832,6 +857,7 @@ public class EfficientDocumentHelper {
     String sourceUriString,
     String directoryUriString,
     String fileName,
+    boolean replaceIfDestinationExists,
     final Promise promise) {
     Async.execute(new Async.Task<Object>() {
       @Override
@@ -840,7 +866,9 @@ public class EfficientDocumentHelper {
           Uri sourceUri = getDocumentUri(sourceUriString, false, true);
           DocumentStat sourceStat = getStat(sourceUri);
           Uri directoryUri = getDocumentUri(directoryUriString, false, true);
-          Uri destinationUri = createFileInDirectory(directoryUri, fileName, sourceStat.getMimeType());
+          Uri destinationUri = createFileInDirectory(
+            directoryUri, fileName, sourceStat.getMimeType(), replaceIfDestinationExists
+          );
           copyFileContents(sourceUri, destinationUri);
           return getStat(destinationUri).getWritableMap();
         } catch (Exception e) {
@@ -888,10 +916,10 @@ public class EfficientDocumentHelper {
             }
           } catch (FileNotFoundException e) {
             if (srcStats != null) {
-              destUri = createFile(unknownDestUri, srcStats.getMimeType());
+              destUri = createFile(unknownDestUri, srcStats.getMimeType(), replaceIfDestExists);
             } else {
               // createFile() will treat mimetype null as "*/*"
-              destUri = createFile(unknownDestUri, null);
+              destUri = createFile(unknownDestUri, null, replaceIfDestExists);
             }
 
           }

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
@@ -447,6 +447,13 @@ public class EfficientDocumentHelper {
       }
     }
 
+    // Directory-based callers have already listed the parent and rechecked its
+    // document cache. Querying the directory again here would make bulk creation
+    // quadratic on providers that cannot filter children. A provider that permits
+    // exact same-name siblings could still race with an unrelated external writer
+    // between that listing and createDocument(). This is an inherent, pre-existing
+    // SAF limitation shared by other createDocument call sites; provider-renamed
+    // collisions are detected and cleaned up below.
     Uri createdFile = DocumentsContract.createDocument(
       context.getContentResolver(),
       parentDirOfFile,

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
@@ -447,23 +447,6 @@ public class EfficientDocumentHelper {
       }
     }
 
-    // Do not rely on createDocument() changing the display name when a sibling
-    // already exists. SAF providers may allow exact duplicate display names, in
-    // which case the newly-created URI would otherwise be mistaken for the
-    // intended overwrite destination. Resolve the existing document before
-    // creating anything and write to its document ID directly when replacement
-    // is requested.
-    DocumentStat existingFile = findFile(parentDirOfFile, fileName);
-    if (existingFile != null) {
-      if (existingFile.isDirectory()) {
-        throw new IOExceptionFast(
-          "a directory with the same name already exists in destination: " + fileName);
-      }
-      if (replaceIfDestinationExists) return existingFile.getInternalUri();
-      throw new IOExceptionFast(
-        "a document with the same name already exists in destination: " + fileName);
-    }
-
     Uri createdFile = DocumentsContract.createDocument(
       context.getContentResolver(),
       parentDirOfFile,
@@ -494,7 +477,7 @@ public class EfficientDocumentHelper {
             + createdFileName
             + "'");
       }
-      existingFile = findFile(parentDirOfFile, fileName);
+      DocumentStat existingFile = findFile(parentDirOfFile, fileName);
       if (existingFile == null || existingFile.isDirectory()) {
         throw new IOExceptionFast(
           "The created file name was not as expected and the existing destination could not be resolved: input name was '"

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
@@ -443,6 +443,23 @@ public class EfficientDocumentHelper {
       }
     }
 
+    // Do not rely on createDocument() changing the display name when a sibling
+    // already exists. SAF providers may allow exact duplicate display names, in
+    // which case the newly-created URI would otherwise be mistaken for the
+    // intended overwrite destination. Resolve the existing document before
+    // creating anything and write to its document ID directly when replacement
+    // is requested.
+    DocumentStat existingFile = findFile(parentDirOfFile, fileName);
+    if (existingFile != null) {
+      if (existingFile.isDirectory()) {
+        throw new IOExceptionFast(
+          "a directory with the same name already exists in destination: " + fileName);
+      }
+      if (replaceIfDestinationExists) return existingFile.getInternalUri();
+      throw new IOExceptionFast(
+        "a document with the same name already exists in destination: " + fileName);
+    }
+
     Uri createdFile = DocumentsContract.createDocument(
       context.getContentResolver(),
       parentDirOfFile,
@@ -473,7 +490,7 @@ public class EfficientDocumentHelper {
             + createdFileName
             + "'");
       }
-      DocumentStat existingFile = findFile(parentDirOfFile, fileName);
+      existingFile = findFile(parentDirOfFile, fileName);
       if (existingFile == null || existingFile.isDirectory()) {
         throw new IOExceptionFast(
           "The created file name was not as expected and the existing destination could not be resolved: input name was '"

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
@@ -480,7 +480,7 @@ public class EfficientDocumentHelper {
   private void copyFileContents(final Uri sourceUri, final Uri destinationUri) throws IOException {
     try (InputStream inStream = context.getContentResolver().openInputStream(sourceUri);
          OutputStream outStream = context.getContentResolver().openOutputStream(destinationUri, "wt")) {
-      byte[] buffer = new byte[1024 * 4];
+      byte[] buffer = new byte[1024 * 64];
       int length;
       while ((length = inStream.read(buffer)) > 0) {
         outStream.write(buffer, 0, length);

--- a/packages/react-native-saf-x/src/index.ts
+++ b/packages/react-native-saf-x/src/index.ts
@@ -68,6 +68,7 @@ interface SafxInterface {
 
 export type DocumentFileDetail = {
 	uri: string;
+	documentUri?: string;
 	name: string;
 	type: 'directory' | 'file';
 	lastModified: number;

--- a/packages/react-native-saf-x/src/index.ts
+++ b/packages/react-native-saf-x/src/index.ts
@@ -56,8 +56,9 @@ interface SafxInterface {
 		data: string,
 		encoding?: Encoding,
 		mimeType?: string,
+		replaceIfDestinationExists?: boolean,
 	): Promise<DocumentFileDetail>;
-	copyFileToDirectory(sourceUri: string, directoryUri: string, fileName: string): Promise<DocumentFileDetail>;
+	copyFileToDirectory(sourceUri: string, directoryUri: string, fileName: string, replaceIfDestinationExists?: boolean): Promise<DocumentFileDetail>;
 	createFile(uriString: string, mimeType?: string): Promise<DocumentFileDetail>;
 	unlink(uriString: string): Promise<boolean>;
 	mkdir(uriString: string): Promise<DocumentFileDetail>;
@@ -166,15 +167,15 @@ export function writeFileInDirectory(
 	directoryUri: string,
 	fileName: string,
 	data: string,
-	options?: Pick<FileOperationOptions, 'encoding' | 'mimeType'>,
+	options?: Pick<FileOperationOptions, 'encoding' | 'mimeType'> & FileTransferOptions,
 ) {
 	if (!options) options = {};
-	const { encoding, mimeType } = options;
-	return SafX.writeFileInDirectory(directoryUri, fileName, data, encoding, mimeType);
+	const { encoding, mimeType, replaceIfDestinationExists = false } = options;
+	return SafX.writeFileInDirectory(directoryUri, fileName, data, encoding, mimeType, replaceIfDestinationExists);
 }
 
-export function copyFileToDirectory(sourceUri: string, directoryUri: string, fileName: string) {
-	return SafX.copyFileToDirectory(sourceUri, directoryUri, fileName);
+export function copyFileToDirectory(sourceUri: string, directoryUri: string, fileName: string, options: FileTransferOptions = {}) {
+	return SafX.copyFileToDirectory(sourceUri, directoryUri, fileName, !!options.replaceIfDestinationExists);
 }
 
 // Creates an empty file at given uri.

--- a/packages/react-native-saf-x/src/index.ts
+++ b/packages/react-native-saf-x/src/index.ts
@@ -50,6 +50,14 @@ interface SafxInterface {
 		mimeType?: string,
 		append?: boolean,
 	): Promise<void>;
+	writeFileInDirectory(
+		directoryUri: string,
+		fileName: string,
+		data: string,
+		encoding?: Encoding,
+		mimeType?: string,
+	): Promise<DocumentFileDetail>;
+	copyFileToDirectory(sourceUri: string, directoryUri: string, fileName: string): Promise<DocumentFileDetail>;
 	createFile(uriString: string, mimeType?: string): Promise<DocumentFileDetail>;
 	unlink(uriString: string): Promise<boolean>;
 	mkdir(uriString: string): Promise<DocumentFileDetail>;
@@ -154,6 +162,21 @@ export function writeFile(
 	return SafX.writeFile(uriString, data, encoding, mimeType, !!append);
 }
 
+export function writeFileInDirectory(
+	directoryUri: string,
+	fileName: string,
+	data: string,
+	options?: Pick<FileOperationOptions, 'encoding' | 'mimeType'>,
+) {
+	if (!options) options = {};
+	const { encoding, mimeType } = options;
+	return SafX.writeFileInDirectory(directoryUri, fileName, data, encoding, mimeType);
+}
+
+export function copyFileToDirectory(sourceUri: string, directoryUri: string, fileName: string) {
+	return SafX.copyFileToDirectory(sourceUri, directoryUri, fileName);
+}
+
 // Creates an empty file at given uri.
 // Rejects if a file or directory exist at given uri.
 export function createFile(
@@ -244,6 +267,8 @@ export default {
 	exists,
 	readFile,
 	writeFile,
+	writeFileInDirectory,
+	copyFileToDirectory,
 	createFile,
 	unlink,
 	mkdir,

--- a/packages/react-native-saf-x/src/index.ts
+++ b/packages/react-native-saf-x/src/index.ts
@@ -58,7 +58,13 @@ interface SafxInterface {
 		mimeType?: string,
 		replaceIfDestinationExists?: boolean,
 	): Promise<DocumentFileDetail>;
-	copyFileToDirectory(sourceUri: string, directoryUri: string, fileName: string, replaceIfDestinationExists?: boolean): Promise<DocumentFileDetail>;
+	copyFileToDirectory(
+		sourceUri: string,
+		directoryUri: string,
+		fileName: string,
+		replaceIfDestinationExists?: boolean,
+		returnDocumentUriOnly?: boolean,
+	): Promise<DocumentFileDetail | string>;
 	createFile(uriString: string, mimeType?: string): Promise<DocumentFileDetail>;
 	unlink(uriString: string): Promise<boolean>;
 	mkdir(uriString: string): Promise<DocumentFileDetail>;
@@ -175,7 +181,13 @@ export function writeFileInDirectory(
 }
 
 export function copyFileToDirectory(sourceUri: string, directoryUri: string, fileName: string, options: FileTransferOptions = {}) {
-	return SafX.copyFileToDirectory(sourceUri, directoryUri, fileName, !!options.replaceIfDestinationExists);
+	return SafX.copyFileToDirectory(
+		sourceUri,
+		directoryUri,
+		fileName,
+		!!options.replaceIfDestinationExists,
+		!!options.returnDocumentUriOnly,
+	);
 }
 
 // Creates an empty file at given uri.
@@ -232,6 +244,8 @@ export function stat(uriString: string) {
 
 type FileTransferOptions = {
 	replaceIfDestinationExists?: boolean;
+	/** Return only the direct destination URI, avoiding a final metadata query. */
+	returnDocumentUriOnly?: boolean;
 };
 
 // Copy file from source uri to destination uri.

--- a/packages/react-native-saf-x/src/index.ts
+++ b/packages/react-native-saf-x/src/index.ts
@@ -58,13 +58,7 @@ interface SafxInterface {
 		mimeType?: string,
 		replaceIfDestinationExists?: boolean,
 	): Promise<DocumentFileDetail>;
-	copyFileToDirectory(
-		sourceUri: string,
-		directoryUri: string,
-		fileName: string,
-		replaceIfDestinationExists?: boolean,
-		returnDocumentUriOnly?: boolean,
-	): Promise<DocumentFileDetail | string>;
+	copyFileToDirectory(sourceUri: string, directoryUri: string, fileName: string, replaceIfDestinationExists?: boolean): Promise<DocumentFileDetail>;
 	createFile(uriString: string, mimeType?: string): Promise<DocumentFileDetail>;
 	unlink(uriString: string): Promise<boolean>;
 	mkdir(uriString: string): Promise<DocumentFileDetail>;
@@ -181,13 +175,7 @@ export function writeFileInDirectory(
 }
 
 export function copyFileToDirectory(sourceUri: string, directoryUri: string, fileName: string, options: FileTransferOptions = {}) {
-	return SafX.copyFileToDirectory(
-		sourceUri,
-		directoryUri,
-		fileName,
-		!!options.replaceIfDestinationExists,
-		!!options.returnDocumentUriOnly,
-	);
+	return SafX.copyFileToDirectory(sourceUri, directoryUri, fileName, !!options.replaceIfDestinationExists);
 }
 
 // Creates an empty file at given uri.
@@ -244,8 +232,6 @@ export function stat(uriString: string) {
 
 type FileTransferOptions = {
 	replaceIfDestinationExists?: boolean;
-	/** Return only the direct destination URI, avoiding a final metadata query. */
-	returnDocumentUriOnly?: boolean;
 };
 
 // Copy file from source uri to destination uri.


### PR DESCRIPTION
Discussion on the thread here https://discourse.joplinapp.org/t/introducing-janis-an-android-client-reader/50752 highlighted that the reason for such poor performance when using file system sync on Android was actually due to an inefficiency in the Joplin code, rather than an inherent limitation of SAF. The cause of the inefficiency is due to the following:

> each subsequent get(path) resolves the filename via findFile(), and findFile() queries and walks the directory’s full child cursor again. For a flat Joplin sync target, that becomes approximately O(n²) directory-entry work

This PR improves Android filesystem sync performance by caching the direct SAF document URIs returned during directory listing. Subsequent read, update, and delete operations can access existing sync items directly instead of repeatedly scanning the directory by filename. It also caches direct directory URIs so new sync items and resources can be created or copied into their destination directory without an additional directory walk.

These changes significantly improve read and write operations across both sync items and resource files. Also, Android SAF copy operations are no longer automatically replayed after a native copy failure. Instead, affected URI and directory caches are invalidated so a later sync can resolve the destination’s actual state. This prevents a copy that completed before a stream-close or metadata error from being repeated, deleted, or duplicated. Only safe non-mutating or idempotent operations immediately retry confirmed stale-URI (ENOENT) failures.

The only significant thing not addressed, is that enabling E2EE seems to cause large resource uploads to be very slow. For example a 50mb resource took 35s to upload to remote, and a 177mb resource took 112s. Decrypting larger items was also about as slow, which points to E2EE being the issue. I did attempt increasing the buffer size when copying files, but this did not improve performance, and caused issues with external SAF providers. Addressing those performance issues are out of scope for the PR.

Also on a larger sync target (1300+ items with E2EE enabled), uploading the welcome notebook resources on the initial sync performed a bit slower (still within a second or two though), but when uploading similarly sized resources incrementally, this was not the case, so it is likely just an issue during initialialisation, and did not seem worth looking into further.

All the code changes should only impact file system sync on Android, where scope URIs are used.

### Testing

Using a real Android 16 device, I tested a full sync on a file system sync target of 800+ items and compared the results with current and new code, with E2EE enabled. The performance gains were huge. The full sync completed without issues, and I verified fetch, update, create and delete operations all worked correctly and were fast. I also tested resource uploads and downloads, and for small resources there were also significant performance gains (as mentioned, larger resources seemed to be slow to encrypt / decrypt). I verified on another profile that changes are correctly reflected on the sync target.

I also did some testing on an older Android 10 device, syncing to a directory on an external sd card (just testing a small profile, checking it still works rather than testing performance). I verified that if modifying the sync target directly, by updating a note item and incrementing the internal updated_time in the sync item, detects and reflects the change when syncing, as per existing behaviour. I also verified a removed file from the sync target will be recreated when adding it back before syncing.

Finally, I did some tests with an external SAF provider using the RSAF app, to point to Box.com sync. Aside from this provider causing operations to wait for the remote upload to complete before completing an operation, the symptoms of the choppy file system sync bottleneck were still aparent, and when comparing results with the old and new application code, there was no difference in performance of the sync. I suspect this is due to improper handling of SAF in the RSAF app itself, and so is out of scope.

**Video before (large initial sync with E2EE enabled, with local SAF provider):**

https://github.com/user-attachments/assets/24b08b15-2359-442d-9853-bfcbe62dab21

**Video after (using same sync target):**

https://github.com/user-attachments/assets/48c1ec27-9307-4c16-8b63-6437801e46f5