### PR TITLE
Desktop: Fixes #16288: Markdown editor: Keep the selection when typing a fenced code block

### DIFF
--- a/packages/editor/CodeMirror/configFromSettings.test.ts
+++ b/packages/editor/CodeMirror/configFromSettings.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { EditorSelection } from '@codemirror/state';
+import Setting from '@joplin/lib/models/Setting';
+import { expect, describe, it } from '@jest/globals';
+import createEditor from './createEditor';
+import createEditorSettings from '../testing/createEditorSettings';
+import typeText from './testing/typeText';
+
+const createControl = (initialText: string) => {
+	const settings = createEditorSettings(Setting.THEME_LIGHT);
+	settings.automatchBraces = true;
+	return createEditor(document.body, {
+		initialText,
+		initialNoteId: '',
+		settings,
+		onEvent: _event => {},
+		onLogMessage: _message => {},
+		onPasteFile: null,
+		resolveImageSrc: src => Promise.resolve(src),
+		onLocalize: input => input,
+	});
+};
+
+describe('configFromSettings', () => {
+	it('should not auto-close backticks when closing a fenced block', async () => {
+		// Regression test for https://github.com/laurent22/joplin/issues/12569 --
+		// with the cursor after two backticks and nothing selected, the third
+		// backtick closes the fence and must not be auto-paired.
+		const control = createControl('``');
+		const editor = control.editor;
+		editor.dispatch({ selection: EditorSelection.cursor(2) });
+
+		typeText(editor, '`');
+
+		expect(editor.state.doc.toString()).toBe('```');
+	});
+
+	it('should wrap a selection in a fenced code block when typing three backticks', async () => {
+		const control = createControl('hello');
+		const editor = control.editor;
+		editor.dispatch({ selection: EditorSelection.range(0, 'hello'.length) });
+
+		typeText(editor, '`');
+		typeText(editor, '`');
+		typeText(editor, '`');
+
+		expect(editor.state.doc.toString()).toBe('```hello```');
+	});
+});

--- a/packages/editor/CodeMirror/configFromSettings.ts
+++ b/packages/editor/CodeMirror/configFromSettings.ts
@@ -23,6 +23,12 @@ import renderBlockImages from './extensions/rendering/renderBlockImages';
 const closingFencedBlock = StateField.define<boolean>({
 	create: () => false,
 	update: (_, tr) => {
+		// With a selection, a backtick wraps the selection rather than closing a
+		// block, so the two backticks before it are the ones a previous keystroke
+		// added. Treating that as a closing fence stops the third backtick
+		// wrapping and it overwrites the selection instead.
+		if (!tr.state.selection.main.empty) return false;
+
 		const pos = tr.state.selection.main.from;
 		const textBefore = tr.state.doc.sliceString(Math.max(0, pos - 2), pos);
 		const backticksBefore = textBefore.length - textBefore.replace(/`+$/, '').length;


### PR DESCRIPTION
## Problem

Selecting text in the Markdown editor and typing three backticks was supposed to wrap the selection in a fenced code block. Instead the selection was overwritten and the result was five backticks with no text, as reported in #16288.

Reproduction (desktop, `Automatically match braces` enabled):

1. Type `hello` and select it.
2. Type `` ` `` three times.
3. Expected `` ```hello``` ``. Actual: the text is gone and only five backticks remain.

## Cause

`closingFencedBlock` in `packages/editor/CodeMirror/configFromSettings.ts` reports whether the cursor is closing a fenced block. While it is true, the backtick is filtered out of the `closeBrackets` bracket list, so a typed backtick is inserted literally instead of wrapping.

The field only looked at the two characters before `selection.main.from`, so it could not tell a cursor from a selection:

- first backtick wraps the selection, giving `` `hello` ``
- second wraps again, giving ``` ``hello`` ```
- `from` now sits directly after two backticks, so the field turns on
- the third backtick is inserted as a plain character, replacing the selection

That accounts for both halves of the report: the text disappearing, and five backticks rather than six.

## Solution

`closingFencedBlock` now returns `false` whenever the selection is non-empty. A backtick typed over a selection wraps that selection and can never be closing a fence, so the case the field exists for — a cursor sitting after two backticks, #12569 — is unaffected.

The change is one condition plus a comment.

## Testing

Added `packages/editor/CodeMirror/configFromSettings.test.ts` with two tests:

- typing three backticks over a selection produces `` ```hello``` ``
- typing a third backtick with the cursor after two backticks still produces ``` ``` ``` and is not auto-paired (regression test for #12569)

Verified the first test fails and the second passes without the change, so it isolates this bug rather than the surrounding behaviour.

`yarn jest` in `packages/editor`: 317 tests pass. Two ProseMirror suites fail to import on my machine, but they fail identically on a clean checkout with this branch stashed, so they are unrelated to this change. `eslint` clean on both files.

## Scope

Desktop only. Mobile passes `automatchBraces: false` in `NoteEditor.tsx`, so `closeBrackets` is never installed there and the bug cannot occur.