### PR TITLE
Desktop: Fixes #15890: Limit maximum size of stored OCR text

### DIFF
--- a/packages/lib/services/ocr/OcrService.test.ts
+++ b/packages/lib/services/ocr/OcrService.test.ts
@@ -1,4 +1,4 @@
-import { createNoteAndResource, newOcrService, ocrSampleDir, resourceFetcher, setupDatabaseAndSynchronizer, supportDir, switchClient, synchronizerStart } from '../../testing/test-utils';
+import { createNoteAndResource, newOcrService, ocrSampleDir, resourceFetcher, setupDatabaseAndSynchronizer, supportDir, switchClient, synchronizerStart, withWarningSilenced } from '../../testing/test-utils';
 import { supportedMimeTypes } from './OcrService';
 import Resource from '../../models/Resource';
 import { ResourceEntity, ResourceOcrDriverId, ResourceOcrStatus } from '../database/types';
@@ -8,6 +8,22 @@ import Setting from '../../models/Setting';
 import createAccessiblePdf from './utils/createAccessiblePdf';
 import { PdfOcrDetails } from './utils/types';
 import * as fs from 'fs-extra';
+import shim from '../../shim';
+import { copyFile } from 'fs/promises';
+import { join } from 'path';
+import { KB } from '@joplin/utils/bytes';
+
+const highConfidenceTestOcrResource = {
+	expectedText: 'This is a lot of 12 point text to test the\n' +
+		'ocr code and see if it works on all types\n' +
+		'of file format.\n' +
+		'The quick brown dog jumped over the\n' +
+		'lazy fox. The quick brown dog jumped\n' +
+		'over the lazy fox. The quick brown dog\n' +
+		'jumped over the lazy fox. The quick\n' +
+		'brown dog jumped over the lazy fox.',
+	path: `${ocrSampleDir}/testocr.png`,
+};
 
 describe('OcrService', () => {
 
@@ -20,7 +36,7 @@ describe('OcrService', () => {
 	});
 
 	it('should process resources', async () => {
-		const { resource: resource1 } = await createNoteAndResource({ path: `${ocrSampleDir}/testocr.png` });
+		const { resource: resource1 } = await createNoteAndResource({ path: highConfidenceTestOcrResource.path });
 		const { resource: resource2 } = await createNoteAndResource({ path: `${supportDir}/photo.jpg` });
 		const { resource: resource3 } = await createNoteAndResource({ path: `${ocrSampleDir}/with_bullets.png` });
 
@@ -32,22 +48,14 @@ describe('OcrService', () => {
 		const service = newOcrService();
 		await service.processResources();
 
-		const expectedText = 'This is a lot of 12 point text to test the\n' +
-			'ocr code and see if it works on all types\n' +
-			'of file format.\n' +
-			'The quick brown dog jumped over the\n' +
-			'lazy fox. The quick brown dog jumped\n' +
-			'over the lazy fox. The quick brown dog\n' +
-			'jumped over the lazy fox. The quick\n' +
-			'brown dog jumped over the lazy fox.';
 		const processedResource1: ResourceEntity = await Resource.load(resource1.id);
-		expect(processedResource1.ocr_text).toBe(expectedText);
+		expect(processedResource1.ocr_text).toBe(highConfidenceTestOcrResource.expectedText);
 		expect(processedResource1.ocr_status).toBe(ResourceOcrStatus.Done);
 		expect(processedResource1.ocr_error).toBe('');
 
 		const details = Resource.unserializeOcrDetails(processedResource1.ocr_details);
 		const lines = details.map(l => l.words.map(w => w.t).join(' ')).join('\n');
-		expect(lines).toBe(expectedText);
+		expect(lines).toBe(highConfidenceTestOcrResource.expectedText);
 		expect(details[0].words[0].t).toBe('This');
 		expect(details[0].words[0]).toEqual({ 't': 'This', 'bb': [36, 96, 92, 116], 'bl': [36, 96, 116, 116] });
 
@@ -392,25 +400,65 @@ describe('OcrService', () => {
 
 	it('should truncate long OCR text', async () => {
 		const service = newOcrService();
-		const { reset } = service.testing_setOcrMaxSize(10);
+		service.testing_setOcrMaxSize(10);
+
+		const { resource: resource1 } = await createNoteAndResource({ path: `${ocrSampleDir}/multi_page__embedded_text.pdf` });
+		const { resource: resource2 } = await createNoteAndResource({ path: `${ocrSampleDir}/testocr.png` });
+		await msleep(1);
+		expect(await Resource.needOcrCount(supportedMimeTypes)).toBe(2);
+
+		await service.processResources();
+
+		expect(await Resource.load(resource1.id)).toMatchObject({
+			ocr_text: 'This is...',
+		});
+		// PNG resources are unlikely to go over the actual ocr_text length limit, but the logic should
+		// support them anyway:
+		expect(await Resource.load(resource2.id)).toMatchObject({
+			ocr_text: 'This is...',
+		});
+	});
+
+	it('should truncate long OCR text in accessible-mode PDFs', async () => {
+		Setting.setValue('ocr.pdfMode', 'accessible');
+
+		const pdfToImages = jest.spyOn(shim, 'pdfToImages');
+		pdfToImages.mockImplementation(async (_pdfPath, outputDirectory) => {
+			const paths = [];
+			for (let i = 0; i < 10; i++) {
+				const outputPath = join(outputDirectory, `page-${i}.png`);
+				await copyFile(`${ocrSampleDir}/testocr.png`, outputPath);
+				paths.push(outputPath);
+			}
+			return paths;
+		});
+
+		const service = newOcrService();
+		const estimatedMetadataSizePerPage = 2 * KB;
+		const maxSize = (highConfidenceTestOcrResource.expectedText.length + estimatedMetadataSizePerPage) * 2;
+		service.testing_setOcrMaxSize(maxSize);
+
 		try {
-			const { resource: resource1 } = await createNoteAndResource({ path: `${ocrSampleDir}/multi_page__embedded_text.pdf` });
-			const { resource: resource2 } = await createNoteAndResource({ path: `${ocrSampleDir}/testocr.png` });
+			const { resource } = await createNoteAndResource({ path: `${ocrSampleDir}/multi_page__embedded_text.pdf` });
 			await msleep(1);
-			expect(await Resource.needOcrCount(supportedMimeTypes)).toBe(2);
+			expect(await Resource.needOcrCount(supportedMimeTypes)).toBe(1);
 
-			await service.processResources();
+			await withWarningSilenced(/Recognize: Truncated/, async () => {
+				await service.processResources();
+			});
 
-			expect(await Resource.load(resource1.id)).toMatchObject({
-				ocr_text: 'This is...',
+			const reloaded = await Resource.load(resource.id);
+			expect(reloaded).toMatchObject({
+				ocr_text: [
+					highConfidenceTestOcrResource.expectedText,
+					highConfidenceTestOcrResource.expectedText,
+					'...',
+				].join('\n'),
 			});
-			// PNG resources are unlikely to go over the actual ocr_text length limit, but the logic should
-			// support them anyway:
-			expect(await Resource.load(resource2.id)).toMatchObject({
-				ocr_text: 'This is...',
-			});
+			const parsedOcrDetails: PdfOcrDetails = JSON.parse(reloaded.ocr_details);
+			expect(parsedOcrDetails.pages).toHaveLength(2);
 		} finally {
-			reset();
+			pdfToImages.mockRestore();
 		}
 	});
 

--- a/packages/lib/services/ocr/OcrService.test.ts
+++ b/packages/lib/services/ocr/OcrService.test.ts
@@ -11,7 +11,6 @@ import * as fs from 'fs-extra';
 import shim from '../../shim';
 import { copyFile } from 'fs/promises';
 import { join } from 'path';
-import { KB } from '@joplin/utils/bytes';
 
 const highConfidenceTestOcrResource = {
 	expectedText: 'This is a lot of 12 point text to test the\n' +
@@ -427,7 +426,7 @@ describe('OcrService', () => {
 		const pdfToImages = jest.spyOn(shim, 'pdfToImages');
 		pdfToImages.mockImplementation(async (_pdfPath, outputDirectory) => {
 			const paths = [];
-			for (let i = 0; i < 10; i++) {
+			for (let i = 0; i < 5; i++) {
 				const outputPath = join(outputDirectory, `page-${i}.png`);
 				await copyFile(`${ocrSampleDir}/testocr.png`, outputPath);
 				paths.push(outputPath);
@@ -436,8 +435,7 @@ describe('OcrService', () => {
 		});
 
 		const service = newOcrService();
-		const estimatedMetadataSizePerPage = 2 * KB;
-		const maxSize = (highConfidenceTestOcrResource.expectedText.length + estimatedMetadataSizePerPage) * 2;
+		const maxSize = highConfidenceTestOcrResource.expectedText.length * 2 + '.\n...'.length;
 		service.testing_setOcrMaxSize(maxSize);
 
 		try {
@@ -457,8 +455,10 @@ describe('OcrService', () => {
 					'...',
 				].join('\n'),
 			});
+
+			// Should **not** truncate ocr_details
 			const parsedOcrDetails: PdfOcrDetails = JSON.parse(reloaded.ocr_details);
-			expect(parsedOcrDetails.pages).toHaveLength(2);
+			expect(parsedOcrDetails.pages).toHaveLength(5);
 		} finally {
 			pdfToImages.mockRestore();
 		}

--- a/packages/lib/services/ocr/OcrService.test.ts
+++ b/packages/lib/services/ocr/OcrService.test.ts
@@ -390,4 +390,28 @@ describe('OcrService', () => {
 		expect(pdfBytes.length).toBeGreaterThan(jpegBuffer.length * 1.5);
 	});
 
+	it('should truncate long OCR text', async () => {
+		const service = newOcrService();
+		const { reset } = service.testing_setOcrMaxSize(10);
+		try {
+			const { resource: resource1 } = await createNoteAndResource({ path: `${ocrSampleDir}/multi_page__embedded_text.pdf` });
+			const { resource: resource2 } = await createNoteAndResource({ path: `${ocrSampleDir}/testocr.png` });
+			await msleep(1);
+			expect(await Resource.needOcrCount(supportedMimeTypes)).toBe(2);
+
+			await service.processResources();
+
+			expect(await Resource.load(resource1.id)).toMatchObject({
+				ocr_text: 'This is...',
+			});
+			// PNG resources are unlikely to go over the actual ocr_text length limit, but the logic should
+			// support them anyway:
+			expect(await Resource.load(resource2.id)).toMatchObject({
+				ocr_text: 'This is...',
+			});
+		} finally {
+			reset();
+		}
+	});
+
 });

--- a/packages/lib/services/ocr/OcrService.test.ts
+++ b/packages/lib/services/ocr/OcrService.test.ts
@@ -422,6 +422,8 @@ describe('OcrService', () => {
 	it('should truncate long OCR text in accessible-mode PDFs', async () => {
 		Setting.setValue('ocr.pdfMode', 'accessible');
 
+		// Converting PDFs to images requires the <canvas> element, which isn't available in a testing
+		// environment.
 		const pdfToImages = jest.spyOn(shim, 'pdfToImages');
 		pdfToImages.mockImplementation(async (_pdfPath, outputDirectory) => {
 			const paths = [];

--- a/packages/lib/services/ocr/OcrService.ts
+++ b/packages/lib/services/ocr/OcrService.ts
@@ -75,7 +75,9 @@ export default class OcrService {
 		this.handwrittenTextQueue_.keepTaskResults = false;
 	}
 
-	private ocrDataMaxSize_: number = 10 * MB;
+	// The maximum OCR data length in characters. Depending on the encoded text, the byte length can
+	// larger than this:
+	private ocrDataMaxSize_: number = 6 * MB;
 	public testing_setOcrMaxSize(value: number) {
 		this.ocrDataMaxSize_ = value;
 	}

--- a/packages/lib/services/ocr/OcrService.ts
+++ b/packages/lib/services/ocr/OcrService.ts
@@ -9,8 +9,12 @@ import { Minute } from '@joplin/utils/time';
 import Logger from '@joplin/utils/Logger';
 import TaskQueue from '../../TaskQueue';
 import eventManager, { EventName } from '../../eventManager';
+import { MB } from '@joplin/utils/bytes';
+import { substrWithEllipsis } from '../../string-utils';
 
 const logger = Logger.create('OcrService');
+
+const ocrTextMaxLength = 10 * MB;
 
 // From: https://github.com/naptha/tesseract.js/blob/master/docs/image-format.md
 export const supportedMimeTypes = [
@@ -113,7 +117,7 @@ export default class OcrService {
 					return {
 						...emptyRecognizeResult(),
 						ocr_status: ResourceOcrStatus.Done,
-						ocr_text: pageTexts.join('\n'),
+						ocr_text: substrWithEllipsis(pageTexts.join('\n'), 0, ocrTextMaxLength),
 					};
 				}
 			}
@@ -164,7 +168,7 @@ export default class OcrService {
 			return {
 				...emptyRecognizeResult(),
 				ocr_status: ResourceOcrStatus.Done,
-				ocr_text: results.map(r => r.ocr_text).join('\n'),
+				ocr_text: substrWithEllipsis(results.map(r => r.ocr_text).join('\n'), 0, ocrTextMaxLength),
 				ocr_details: ocrDetails,
 			};
 		} else {

--- a/packages/lib/services/ocr/OcrService.ts
+++ b/packages/lib/services/ocr/OcrService.ts
@@ -56,7 +56,7 @@ const getOcrDriverId = (resource: ResourceEntity) => {
 	return resource.ocr_driver_id === 0 ? ResourceOcrDriverId.PrintedText : resource.ocr_driver_id;
 };
 
-const truncateLongOcrDetails = (details: PdfOcrDetails) => {
+const truncateLongOcrDetails = (details: PdfOcrDetails, targetLength: number) => {
 	const result: PdfOcrDetails = {
 		...details,
 		pages: [],
@@ -67,20 +67,25 @@ const truncateLongOcrDetails = (details: PdfOcrDetails) => {
 		size += 2;
 		const newPage: PdfOcrPage = { ...page, lines: [] };
 		for (const line of page.lines) {
+			if (size > targetLength) break;
 			size += 2;
 
 			const newLine: RecognizeResultLine = { ...line, words: [] };
 			for (const word of line.words) {
-				size += word.t.length;
+				// Slightly increase the size to account for larger size when JSON
+				size += word.t.length + 3;
+
 				newLine.words.push(word);
 			}
 
 			newPage.lines.push(newLine);
-
-			if (size > ocrTextMaxLength) break;
 		}
 
 		result.pages.push(newPage);
+		if (size > targetLength) {
+			logger.warn('Truncating long ocr_details at roughly', size, 'bytes');
+			break;
+		}
 	}
 
 	return result;
@@ -191,7 +196,7 @@ export default class OcrService {
 				const pdfOcrDetails = truncateLongOcrDetails({
 					version: 1,
 					pages: pdfOcrPages,
-				});
+				}, ocrTextMaxLength);
 				ocrDetails = JSON.stringify(pdfOcrDetails);
 			}
 

--- a/packages/lib/services/ocr/OcrService.ts
+++ b/packages/lib/services/ocr/OcrService.ts
@@ -9,12 +9,11 @@ import { Minute } from '@joplin/utils/time';
 import Logger from '@joplin/utils/Logger';
 import TaskQueue from '../../TaskQueue';
 import eventManager, { EventName } from '../../eventManager';
-import { MB } from '@joplin/utils/bytes';
+import { bytesToHuman, MB } from '@joplin/utils/bytes';
 import { substrWithEllipsis } from '../../string-utils';
 
 const logger = Logger.create('OcrService');
 
-const ocrTextMaxLength = 10 * MB;
 
 // From: https://github.com/naptha/tesseract.js/blob/master/docs/image-format.md
 export const supportedMimeTypes = [
@@ -56,41 +55,6 @@ const getOcrDriverId = (resource: ResourceEntity) => {
 	return resource.ocr_driver_id === 0 ? ResourceOcrDriverId.PrintedText : resource.ocr_driver_id;
 };
 
-const truncateLongOcrDetails = (details: PdfOcrDetails, targetLength: number) => {
-	const result: PdfOcrDetails = {
-		...details,
-		pages: [],
-	};
-
-	let size = 0;
-	for (const page of result.pages) {
-		size += 2;
-		const newPage: PdfOcrPage = { ...page, lines: [] };
-		for (const line of page.lines) {
-			if (size > targetLength) break;
-			size += 2;
-
-			const newLine: RecognizeResultLine = { ...line, words: [] };
-			for (const word of line.words) {
-				// Slightly increase the size to account for larger size when JSON
-				size += word.t.length + 3;
-
-				newLine.words.push(word);
-			}
-
-			newPage.lines.push(newLine);
-		}
-
-		result.pages.push(newPage);
-		if (size > targetLength) {
-			logger.warn('Truncating long ocr_details at roughly', size, 'bytes');
-			break;
-		}
-	}
-
-	return result;
-};
-
 export default class OcrService {
 
 	private drivers_: OcrDriverBase[];
@@ -112,6 +76,16 @@ export default class OcrService {
 		this.handwrittenTextQueue_.keepTaskResults = false;
 	}
 
+	private ocrDataMaxSize_: number = 10 * MB;
+	public testing_setOcrMaxSize(value: number) {
+		const original = this.ocrDataMaxSize_;
+		this.ocrDataMaxSize_ = value;
+
+		return {
+			reset: () => { this.ocrDataMaxSize_ = original; },
+		};
+	}
+
 	private async pdfExtractDir(): Promise<string> {
 		if (this.pdfExtractDir_ !== null) return this.pdfExtractDir_;
 		const p = `${Setting.value('tempDir')}/ocr_pdf_extract`;
@@ -122,6 +96,10 @@ export default class OcrService {
 
 	public get running() {
 		return this.runInBackground;
+	}
+
+	private mapOcrText_(text: string) {
+		return substrWithEllipsis(text, 0, this.ocrDataMaxSize_);
 	}
 
 	private async recognize(language: string, resource: ResourceEntity): Promise<RecognizeResult|null> {
@@ -152,7 +130,7 @@ export default class OcrService {
 					return {
 						...emptyRecognizeResult(),
 						ocr_status: ResourceOcrStatus.Done,
-						ocr_text: substrWithEllipsis(pageTexts.join('\n'), 0, ocrTextMaxLength),
+						ocr_text: substrWithEllipsis(pageTexts.join('\n'), 0, this.ocrDataMaxSize_),
 					};
 				}
 			}
@@ -164,7 +142,13 @@ export default class OcrService {
 
 			try {
 				let pageIndex = 0;
+				let sizeEstimate = 0;
 				for (const imagePath of imageFilePaths) {
+					if (sizeEstimate > this.ocrDataMaxSize_) {
+						logger.warn(`Recognize: Truncated: ${resourceInfo(resource)} after ${pageIndex + 1} pages (at roughly ${bytesToHuman(sizeEstimate)} of OCR data).`);
+						break;
+					}
+
 					logger.info(`Recognize: ${resourceInfo(resource)}: Processing PDF page ${pageIndex + 1} / ${imageFilePaths.length}...`);
 					const result = await driver.recognize(language, imagePath, resource.id);
 					results.push(result);
@@ -180,8 +164,11 @@ export default class OcrService {
 						pdfOcrPages.push({
 							lines: pageLines,
 						});
+
+						sizeEstimate += result.ocr_details.length;
 					}
 
+					sizeEstimate += result.ocr_text.length;
 					pageIndex++;
 				}
 			} finally {
@@ -193,21 +180,25 @@ export default class OcrService {
 			// Only create PDF OCR details structure if setting is enabled
 			let ocrDetails = '';
 			if (saveOcrDetails) {
-				const pdfOcrDetails = truncateLongOcrDetails({
+				const pdfOcrDetails: PdfOcrDetails = {
 					version: 1,
 					pages: pdfOcrPages,
-				}, ocrTextMaxLength);
+				};
 				ocrDetails = JSON.stringify(pdfOcrDetails);
 			}
 
 			return {
 				...emptyRecognizeResult(),
 				ocr_status: ResourceOcrStatus.Done,
-				ocr_text: substrWithEllipsis(results.map(r => r.ocr_text).join('\n'), 0, ocrTextMaxLength),
+				ocr_text: this.mapOcrText_(results.map(r => r.ocr_text).join('\n')),
 				ocr_details: ocrDetails,
 			};
 		} else {
-			return driver.recognize(language, resourceFilePath, resource.id);
+			const result = await driver.recognize(language, resourceFilePath, resource.id);
+			return {
+				...result,
+				ocr_text: this.mapOcrText_(result.ocr_text),
+			};
 		}
 	}
 

--- a/packages/lib/services/ocr/OcrService.ts
+++ b/packages/lib/services/ocr/OcrService.ts
@@ -140,7 +140,8 @@ export default class OcrService {
 				let pageIndex = 0;
 				let sizeEstimate = 0;
 				for (const imagePath of imageFilePaths) {
-					if (sizeEstimate > this.ocrDataMaxSize_) {
+					// TODO: Fow now, do not truncate ocr_details, since doing so breaks creating accessible PDFs
+					if (!saveOcrDetails && sizeEstimate > this.ocrDataMaxSize_) {
 						logger.warn(`Recognize: Truncated: ${resourceInfo(resource)} after ${pageIndex + 1} pages (at roughly ${bytesToHuman(sizeEstimate)} of OCR data).`);
 						resultText.push('...');
 						break;

--- a/packages/lib/services/ocr/OcrService.ts
+++ b/packages/lib/services/ocr/OcrService.ts
@@ -78,12 +78,7 @@ export default class OcrService {
 
 	private ocrDataMaxSize_: number = 10 * MB;
 	public testing_setOcrMaxSize(value: number) {
-		const original = this.ocrDataMaxSize_;
 		this.ocrDataMaxSize_ = value;
-
-		return {
-			reset: () => { this.ocrDataMaxSize_ = original; },
-		};
 	}
 
 	private async pdfExtractDir(): Promise<string> {
@@ -137,7 +132,7 @@ export default class OcrService {
 
 			const imageFilePaths = await shim.pdfToImages(resourceFilePath, await this.pdfExtractDir());
 
-			const results: RecognizeResult[] = [];
+			const resultText: string[] = [];
 			const pdfOcrPages: PdfOcrPage[] = [];
 
 			try {
@@ -146,12 +141,13 @@ export default class OcrService {
 				for (const imagePath of imageFilePaths) {
 					if (sizeEstimate > this.ocrDataMaxSize_) {
 						logger.warn(`Recognize: Truncated: ${resourceInfo(resource)} after ${pageIndex + 1} pages (at roughly ${bytesToHuman(sizeEstimate)} of OCR data).`);
+						resultText.push('...');
 						break;
 					}
 
 					logger.info(`Recognize: ${resourceInfo(resource)}: Processing PDF page ${pageIndex + 1} / ${imageFilePaths.length}...`);
 					const result = await driver.recognize(language, imagePath, resource.id);
-					results.push(result);
+					resultText.push(result.ocr_text);
 
 					if (saveOcrDetails) {
 						// Parse OCR details for this page
@@ -190,7 +186,7 @@ export default class OcrService {
 			return {
 				...emptyRecognizeResult(),
 				ocr_status: ResourceOcrStatus.Done,
-				ocr_text: this.mapOcrText_(results.map(r => r.ocr_text).join('\n')),
+				ocr_text: this.mapOcrText_(resultText.join('\n')),
 				ocr_details: ocrDetails,
 			};
 		} else {

--- a/packages/lib/services/ocr/OcrService.ts
+++ b/packages/lib/services/ocr/OcrService.ts
@@ -56,6 +56,36 @@ const getOcrDriverId = (resource: ResourceEntity) => {
 	return resource.ocr_driver_id === 0 ? ResourceOcrDriverId.PrintedText : resource.ocr_driver_id;
 };
 
+const truncateLongOcrDetails = (details: PdfOcrDetails) => {
+	const result: PdfOcrDetails = {
+		...details,
+		pages: [],
+	};
+
+	let size = 0;
+	for (const page of result.pages) {
+		size += 2;
+		const newPage: PdfOcrPage = { ...page, lines: [] };
+		for (const line of page.lines) {
+			size += 2;
+
+			const newLine: RecognizeResultLine = { ...line, words: [] };
+			for (const word of line.words) {
+				size += word.t.length;
+				newLine.words.push(word);
+			}
+
+			newPage.lines.push(newLine);
+
+			if (size > ocrTextMaxLength) break;
+		}
+
+		result.pages.push(newPage);
+	}
+
+	return result;
+};
+
 export default class OcrService {
 
 	private drivers_: OcrDriverBase[];
@@ -158,10 +188,10 @@ export default class OcrService {
 			// Only create PDF OCR details structure if setting is enabled
 			let ocrDetails = '';
 			if (saveOcrDetails) {
-				const pdfOcrDetails: PdfOcrDetails = {
+				const pdfOcrDetails = truncateLongOcrDetails({
 					version: 1,
 					pages: pdfOcrPages,
-				};
+				});
 				ocrDetails = JSON.stringify(pdfOcrDetails);
 			}
 

--- a/packages/lib/services/ocr/OcrService.ts
+++ b/packages/lib/services/ocr/OcrService.ts
@@ -77,7 +77,7 @@ export default class OcrService {
 
 	// The maximum OCR data length in characters. Depending on the encoded text, the byte length can
 	// larger than this:
-	private ocrDataMaxSize_: number = 6 * MB;
+	private ocrDataMaxSize_: number = 7 * MB;
 	public testing_setOcrMaxSize(value: number) {
 		this.ocrDataMaxSize_ = value;
 	}

--- a/packages/lib/services/ocr/OcrService.ts
+++ b/packages/lib/services/ocr/OcrService.ts
@@ -14,7 +14,6 @@ import { substrWithEllipsis } from '../../string-utils';
 
 const logger = Logger.create('OcrService');
 
-
 // From: https://github.com/naptha/tesseract.js/blob/master/docs/image-format.md
 export const supportedMimeTypes = [
 	'application/pdf',


### PR DESCRIPTION
# Problem

Large `ocr_text` values can crash the mobile app during sync (see [comment](https://github.com/laurent22/joplin/issues/15890#issuecomment-5363218315)) or cause sync to fail.

# Solution

Limit `ocr_text` to around 10-20 MB, per attachment.

For me, on an Android VM, 75 MB `ocr_text` crashes the app during sync, but 60 MB is okay (though causes the attachment to be skipped during indexing).

For reference, the OCR text for [An Infinitely Large Napkin](https://venhance.github.io/napkin/Napkin.pdf) (a math textbook with 1052 pages) is about 2 MB.

Fixes #15890 in the default configuration.

> [!IMPORTANT]
>
> **#15890 can still occur if "OCR: PDF processing mode" is set to "accessible":** This pull request does **not** truncate `ocr_details`, since doing so breaks the "create accessible PDF" function for large PDFs (see [comment](https://github.com/laurent22/joplin/pull/16325#issuecomment-5428846017)). Fully resolving #16325 will involve also truncating `ocr_details` (see the `TODO` comment in `OcrService.ts`) and adjusting "create accessible document" to better handle the case where `ocr_details` is truncated.

# Testing

This pull request includes new automated tests.

I've also manually verified that:
- the OCR text for [An Infinitely Large Napkin](https://venhance.github.io/napkin/Napkin.pdf) is not truncated in `normal` OCR mode
- [An Infinitely Large Napkin](https://venhance.github.io/napkin/Napkin.pdf) is only partially processed in accessible mode: OCR processing now stops after a few hundred pages.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
