### PR TITLE
Mobile: Fixes #16312: Improve shadow colors in dark mode

### DIFF
--- a/packages/app-mobile/components/BottomDrawer.tsx
+++ b/packages/app-mobile/components/BottomDrawer.tsx
@@ -102,7 +102,8 @@ const useStyles = ({ theme, menuType, dragging, alignment, draggable, dragOffset
 				),
 
 				shadowRadius: 4,
-				shadowColor: theme.shadowColor,
+				shadowColor: theme.shadowColorOpaque,
+				shadowOpacity: theme.shadowOpacity,
 				elevation: 2,
 
 

--- a/packages/app-mobile/components/BottomDrawer.tsx
+++ b/packages/app-mobile/components/BottomDrawer.tsx
@@ -102,8 +102,7 @@ const useStyles = ({ theme, menuType, dragging, alignment, draggable, dragOffset
 				),
 
 				shadowRadius: 4,
-				shadowColor: theme.color,
-				shadowOpacity: 0.15,
+				shadowColor: theme.shadowColor,
 				elevation: 2,
 
 

--- a/packages/app-mobile/components/global-style.ts
+++ b/packages/app-mobile/components/global-style.ts
@@ -27,6 +27,8 @@ const baseStyle = {
 
 export type ThemeStyle = BaseTheme & typeof baseStyle & {
 	backgroundColorHover4: string;
+	shadowColorOpaque: string;
+	shadowOpacity: number;
 
 	fontSize: number;
 	fontSizeSmaller: number;
@@ -133,6 +135,9 @@ function extraStyles(theme: BaseTheme) {
 
 		backgroundColorHover4: Color(theme.color4).alpha(0.12).rgb().string(),
 		borderRadius: 8,
+
+		shadowColorOpaque: Color(theme.shadowColor).alpha(1).rgb().string(),
+		shadowOpacity: Color(theme.shadowColor).alpha(),
 	};
 }
 

--- a/packages/lib/services/style/themeToCss.test.ts
+++ b/packages/lib/services/style/themeToCss.test.ts
@@ -19,6 +19,7 @@ const input: Theme = {
 	dividerColor: '#dddddd',
 	selectedColor: '#e5e5e5',
 	urlColor: '#155BDA',
+	shadowColor: 'rgba(0,0,0,0.2)',
 
 	// Color scheme "2" is used for the sidebar. It's white text over
 	// dark blue background.
@@ -106,6 +107,7 @@ const expected = `
 	--joplin-search-marker-color: black;
 	--joplin-selected-color: #e5e5e5;
 	--joplin-selected-color2: #131313;
+	--joplin-shadow-color: rgba(0,0,0,0.2);
 	--joplin-table-background-color: rgb(247, 247, 247);
 	--joplin-text-selection-color: #a0a0ff;
 	--joplin-url-color: #155BDA;

--- a/packages/lib/services/style/themeToCss.test.ts
+++ b/packages/lib/services/style/themeToCss.test.ts
@@ -19,7 +19,7 @@ const input: Theme = {
 	dividerColor: '#dddddd',
 	selectedColor: '#e5e5e5',
 	urlColor: '#155BDA',
-	shadowColor: 'rgba(0,0,0,0.2)',
+	shadowColor: 'rgba(0,0,0,0.15)',
 
 	// Color scheme "2" is used for the sidebar. It's white text over
 	// dark blue background.
@@ -107,7 +107,7 @@ const expected = `
 	--joplin-search-marker-color: black;
 	--joplin-selected-color: #e5e5e5;
 	--joplin-selected-color2: #131313;
-	--joplin-shadow-color: rgba(0,0,0,0.2);
+	--joplin-shadow-color: rgba(0,0,0,0.15);
 	--joplin-table-background-color: rgb(247, 247, 247);
 	--joplin-text-selection-color: #a0a0ff;
 	--joplin-url-color: #155BDA;

--- a/packages/lib/theme.ts
+++ b/packages/lib/theme.ts
@@ -109,6 +109,7 @@ export const withDerivedColors = (theme: Theme) => {
 
 	return {
 		...theme,
+
 		borderColor4: rgbString(Color(theme.color).alpha(0.3)),
 		iconColor: rgbString(Color(theme.color).alpha(0.8)),
 		focusOutlineColor: theme.colorWarn,

--- a/packages/lib/themes/light.ts
+++ b/packages/lib/themes/light.ts
@@ -19,6 +19,7 @@ const theme: Theme = {
 	selectedColor: '#e5e5e5',
 	urlColor: '#155BDA',
 	colorErrorSelected: '#d00000',
+	shadowColor: 'rgba(0,0,0,0.2)',
 
 	// Color scheme "2" is used for the sidebar. It's white text over
 	// dark blue background.

--- a/packages/lib/themes/light.ts
+++ b/packages/lib/themes/light.ts
@@ -19,7 +19,7 @@ const theme: Theme = {
 	selectedColor: '#e5e5e5',
 	urlColor: '#155BDA',
 	colorErrorSelected: '#d00000',
-	shadowColor: 'rgba(0,0,0,0.2)',
+	shadowColor: 'rgba(0,0,0,0.15)',
 
 	// Color scheme "2" is used for the sidebar. It's white text over
 	// dark blue background.

--- a/packages/lib/themes/type.ts
+++ b/packages/lib/themes/type.ts
@@ -21,6 +21,7 @@ export interface Theme {
 	dividerColor: string;
 	selectedColor: string;
 	urlColor: string;
+	shadowColor: string;
 
 	// Color scheme "2" is used for the sidebar. It's white text over
 	// dark blue background.


### PR DESCRIPTION
# Summary

This pull request adjusts the new note menu and kebab menus to use a dark shadow, even in dark mode.

Fixes #16312.


# Screenshots
## iOS
| Theme | Before | After |
|-------|--------|-------|
| Light | <img width="300" height="629" alt="screenshot: light background, dark shadow" src="https://github.com/user-attachments/assets/cd8c8177-6945-4218-9767-ca1a8012506b" /> | <img width="300" height="629" alt="light background, dark shadow" src="https://github.com/user-attachments/assets/2d920ce3-ec4c-4a9f-b8ae-8d94e60080b8" /> |
| Dark | <img width="300" height="629" alt="dark background, light shadow" src="https://github.com/user-attachments/assets/6cf668d3-7c54-434f-aed0-6f17f0fb3361" /> | <img width="300" height="629" alt="dark background, dark shadow" src="https://github.com/user-attachments/assets/cfe468ad-8d16-4fd8-9f88-fdc2d44cfac5" /> |



## Android
| Theme | Before | After |
|-------|--------|-------|
| Light | <img width="767" height="562" alt="light background, dark shadow" src="https://github.com/user-attachments/assets/c6490326-b385-46d5-a72f-0ac5d74e076c" /> | <img width="767" height="562" alt="light background, dark shadow" src="https://github.com/user-attachments/assets/248fece1-9bca-4d58-9028-065437412510" /> |
| Dark | <img width="767" height="562" alt="dark background, light shadow" src="https://github.com/user-attachments/assets/60567d2c-703c-4fe4-9b7a-ac2e4bbc87f9" /> | <img width="767" height="562" alt="dark background, dark shadow" src="https://github.com/user-attachments/assets/fd299db6-b5b3-4427-82bb-1c512e7301d1" /> |


**Note**: Android screenshots were taken before db11384e277757e4643b908e4feee726e0a1de02.



## Web

| Theme | Before | After |
|-------|--------|-------|
| Light | <img width="507" height="522" alt="light background, dark shadow" src="https://github.com/user-attachments/assets/48ed24bf-f60f-4020-91bb-e7ae0d079a17" /> | <img width="507" height="522" alt="light background, dark shadow" src="https://github.com/user-attachments/assets/a3ebbbc6-e20c-4ddf-b563-df109638b5b1" /> |
| Dark | <img width="507" height="522" alt="dark background, light shadow" src="https://github.com/user-attachments/assets/9c080446-caa2-4797-a0a4-5cc8b58f9496" /> | <img width="507" height="522" alt="dark background, dark shadow" src="https://github.com/user-attachments/assets/f73366c4-19d8-4ec4-8ee6-820ee03d863c" /> |






<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---


**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
