### PR TITLE
Desktop, Mobile: Fixes #16155: Prevent conflicts initially showing alongside the original note in the notebook when created

### DIFF
--- a/packages/lib/reducer.test.ts
+++ b/packages/lib/reducer.test.ts
@@ -5,7 +5,8 @@ import Note from './models/Note';
 import BaseModel from './BaseModel';
 import Folder from './models/Folder';
 import ItemChange from './models/ItemChange';
-// const { ALL_NOTES_FILTER_ID } = require('./reserved-ids');
+import getConflictFolderId from './models/utils/getConflictFolderId';
+import { ALL_NOTES_FILTER_ID } from './reserved-ids';
 
 function initTestState(folders: FolderEntity[], selectedFolderIndex: number, notes: NoteEntity[], selectedNoteIndexes: number[], tags: TagEntity[] = null, selectedTagIndex: number = null) {
 	let state = defaultState;
@@ -1013,6 +1014,30 @@ describe('reducer', () => {
 
 		// Moved note should no longer be visible
 		expect(state.notes.every(n => n.id !== notes[movedNoteIndex].id)).toBe(true);
+	});
+
+	test('conflict notes should only be added to the Conflicts note list', async () => {
+		const folders = await createNTestFolders(1);
+		const notes = await createNTestNotes(1, folders[0]);
+		const conflictNote = {
+			...notes[0],
+			id: '12345678901234567890123456789012',
+			is_conflict: 1,
+		};
+
+		let folderState = initTestState(folders, 0, notes, [0]);
+		folderState = reducer(folderState, { type: 'NOTE_UPDATE_ONE', note: conflictNote });
+		expect(folderState.notes.map(note => note.id)).toEqual([notes[0].id]);
+
+		let allNotesState = initTestState(folders, null, notes, [0]);
+		allNotesState = reducer(allNotesState, { type: 'SMART_FILTER_SELECT', id: ALL_NOTES_FILTER_ID });
+		allNotesState = reducer(allNotesState, { type: 'NOTE_UPDATE_ONE', note: conflictNote });
+		expect(allNotesState.notes.map(note => note.id)).toEqual([notes[0].id]);
+
+		let conflictState = initTestState(folders, null, [], []);
+		conflictState = reducer(conflictState, { type: 'FOLDER_SELECT', id: getConflictFolderId() });
+		conflictState = reducer(conflictState, { type: 'NOTE_UPDATE_ONE', note: conflictNote });
+		expect(conflictState.notes.map(note => note.id)).toEqual([conflictNote.id]);
 	});
 
 	test('sync moving the selected note in a background window should not change its selection', async () => {

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -1182,8 +1182,9 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 					const isViewingAllNotes = (windowDraft.notesParentType === 'SmartFilter' && windowDraft.selectedSmartFilterId === ALL_NOTES_FILTER_ID);
 					const isViewingConflictFolder = windowDraft.notesParentType === 'Folder' && windowDraft.selectedFolderId === Folder.conflictFolderId();
 
-					const noteIsInFolder = function(note: NoteEntity, folderId: string) {
-						if (note.is_conflict && isViewingConflictFolder) return true;
+					const noteIsInCurrentView = function(note: NoteEntity, folderId: string) {
+						if (note.is_conflict) return isViewingConflictFolder;
+						if (isViewingAllNotes) return true;
 						const noteDisplayParentId = getDisplayParentId(note, draft.folders.find(f => f.id === note.parent_id));
 						return folderId === noteDisplayParentId;
 					};
@@ -1202,7 +1203,7 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 								newNotes.splice(i, 1);
 								noteFolderHasChanged = true;
 								movedNotePreviousIndex = i;
-							} else if (isViewingAllNotes || noteIsInFolder(modNote, previousDisplayParentId)) {
+							} else if (noteIsInCurrentView(modNote, previousDisplayParentId)) {
 								// Note is still in the same folder
 								// Merge the properties that have changed (in modNote) into
 								// the object we already have.
@@ -1226,7 +1227,7 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 					// Note was not found - if the current folder is the same as the note folder,
 					// add it to it.
 					if (!found) {
-						if (isViewingAllNotes || noteIsInFolder(modNote, windowDraft.selectedFolderId)) {
+						if (noteIsInCurrentView(modNote, windowDraft.selectedFolderId)) {
 							newNotes.push(modNote);
 						}
 					}


### PR DESCRIPTION
When conflicts are created, initially the conflict note shows alongside the original note in the notebook list, until switching to another notebook and back, if the selected notebook is the all notes notebook. This is because the reducer logic which refreshes the notebook list in this scenario does not correctly handle conflict notes. This PR fixes the issue by applying the isViewingAllNotes check after checking if the note is a conflict, instead of allowing isViewingAllNotes to override the result regardless of whether the note is a conflict.

This fixes https://github.com/laurent22/joplin/issues/16155

### Testing

**See videos showing conflicts created with the fix on desktop and mobile:**

https://github.com/user-attachments/assets/91e4f346-68ef-45b6-bc0f-9c9ed6efdef7

https://github.com/user-attachments/assets/b59fe120-87c0-4161-8e93-d147a6b91ff6

