### PR TITLE
Desktop: Fixes #16317: Markdown editor: Disable table editor when opting out of in-editor rendering

### DIFF
--- a/packages/lib/components/shared/NoteEditor/WarningBanner/useEditorTypeMigrationBanner.ts
+++ b/packages/lib/components/shared/NoteEditor/WarningBanner/useEditorTypeMigrationBanner.ts
@@ -25,6 +25,7 @@ const useEditorTypeMigrationBanner = ({ markdownEditorEnabled, inEditorRendering
 				onPress: () => {
 					Setting.setValue('editor.inlineRendering', false);
 					Setting.setValue('editor.imageRendering', false);
+					Setting.setValue('editor.tableEditing', false);
 					onMigrationComplete();
 				},
 			},


### PR DESCRIPTION
# Problem

Clicking the "Disable it" button in the "Certain Markdown formatting is now rendered..." banner keeps the table editor enabled.

# Solution

Also disable the table editor when disabling the in-editor rendering.

Fixes #16317.

> [!NOTE]
>
> Users who have previously opted out of in-editor rendering will still have table rendering enabled, since it's a [separate setting in `builtInMetadata.ts` with a `true` default value.](https://github.com/laurent22/joplin/blob/3156f23fa2cf2b1851df6408d9e1bab06db50ac9/packages/lib/models/settings/builtInMetadata.ts#L1943)
>
> Options include:
> - Do nothing in this case. (The approach currently taken by this pull request)
> - Add a startup task that sets the default `editor.tableEditing` to the value of `editor.inlineRendering` if `editor.migration < 2`.
> - Re-show the confirmation banner for some users (if `!editor.inlineRendering && editor.tableEditing && editor.migration < 2`).

# Screen recording

https://github.com/user-attachments/assets/6d386393-1939-4685-8d9f-0eff7225601e

<!--





Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
