### PR TITLE
Chore: Tests: Silence expected warning in AsyncActionQueue tests

### DIFF
--- a/packages/lib/AsyncActionQueue.test.ts
+++ b/packages/lib/AsyncActionQueue.test.ts
@@ -1,5 +1,5 @@
 import AsyncActionQueue from './AsyncActionQueue';
-import { runWithFakeTimers } from './testing/test-utils';
+import { runWithFakeTimers, withWarningSilenced } from './testing/test-utils';
 
 describe('AsyncActionQueue', () => {
 	beforeEach(() => {
@@ -62,11 +62,13 @@ describe('AsyncActionQueue', () => {
 			throw error;
 		});
 
-		const processPromise = queue.processAllNow();
-		const rejectionExpectation = expect(processPromise).rejects.toBe(error);
-		await jest.runAllTimersAsync();
-		await rejectionExpectation;
-		expect(queue.isEmpty).toBe(true);
+		await withWarningSilenced(/Unhandled error: Error: Task failed/, async () => {
+			const processPromise = queue.processAllNow();
+			const rejectionExpectation = expect(processPromise).rejects.toBe(error);
+			await jest.runAllTimersAsync();
+			await rejectionExpectation;
+			expect(queue.isEmpty).toBe(true);
+		});
 	});
 
 	test('should handle failures when queue processing is not awaited', async () => {

--- a/packages/lib/AsyncActionQueue.test.ts
+++ b/packages/lib/AsyncActionQueue.test.ts
@@ -58,21 +58,21 @@ describe('AsyncActionQueue', () => {
 		jest.useFakeTimers();
 		const error = new Error('Task failed');
 
-		queue.push(async () => {
-			throw error;
-		});
+		await withWarningSilenced(/Task failed/, async () => {
+			queue.push(async () => {
+				throw error;
+			});
 
-		await withWarningSilenced(/Unhandled error: Error: Task failed/, async () => {
 			const processPromise = queue.processAllNow();
 			const rejectionExpectation = expect(processPromise).rejects.toBe(error);
 			await jest.runAllTimersAsync();
 			await rejectionExpectation;
 			expect(queue.isEmpty).toBe(true);
-		});
+		}, { requireWarning: true });
 	});
 
 	test('should handle failures when queue processing is not awaited', async () => {
-		await runWithFakeTimers(async () => {
+		await runWithFakeTimers(() => withWarningSilenced(/Task failed/, async () => {
 			const queue = new AsyncActionQueue(100);
 			const failingAction = jest.fn(async () => {
 				throw new Error('Task failed');
@@ -81,7 +81,7 @@ describe('AsyncActionQueue', () => {
 
 			await jest.runAllTimersAsync();
 			expect(failingAction).toHaveBeenCalledTimes(1);
-		});
+		}, { requireWarning: true }));
 	});
 
 	test.each([

--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -1196,6 +1196,24 @@ export const withWarningSilenced = async <T> (
 	const mocks: MockSlice[] = [];
 	const warnings: string[] = [];
 
+	const removeMocks = () => {
+		for (const mock of mocks) {
+			mock.mockRestore();
+		}
+	};
+
+	const applyMocks = () => {
+		mockConsoleFunction('warn');
+		mockConsoleFunction('error');
+	};
+
+	// Log an error without recursively calling the mock:
+	const logError = (...args: unknown[]) => {
+		removeMocks();
+		console.error(...args);
+		applyMocks();
+	};
+
 	const mockConsoleFunction = (key: 'warn'|'error') => {
 		const mock = jest.spyOn(console, key);
 		mocks.push(mock);
@@ -1206,21 +1224,13 @@ export const withWarningSilenced = async <T> (
 			const fullMessage = [message, ...args].join(' ');
 			warnings.push(fullMessage);
 			if (!fullMessage.match(warningRegex)) {
-				// Avoid recursively calling the mock:
-				if (key === 'error') {
-					mock.mockRestore();
-				}
-				console.error(`Unexpected warning: ${message}`, ...args);
-				if (key === 'error') {
-					mockConsoleFunction('error');
-				}
+				logError(`Unexpected warning: ${message}`, ...args);
 			}
 		});
 	};
 
 	try {
-		mockConsoleFunction('warn');
-		mockConsoleFunction('error');
+		applyMocks();
 		const result = await task();
 
 		if (requireWarning) {
@@ -1229,9 +1239,7 @@ export const withWarningSilenced = async <T> (
 
 		return result;
 	} finally {
-		for (const mock of mocks) {
-			mock.mockRestore();
-		}
+		removeMocks();
 	}
 };
 

--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -1185,9 +1185,16 @@ export const mockFetch = (requestHandler: MockFetchRequestHandler) => {
 	};
 };
 
-export const withWarningSilenced = async <T> (warningRegex: RegExp, task: ()=> Promise<T>): Promise<T> => {
+interface WithWarningSilencedOptions {
+	requireWarning: boolean;
+}
+
+export const withWarningSilenced = async <T> (
+	warningRegex: RegExp, task: ()=> Promise<T>, { requireWarning }: WithWarningSilencedOptions = { requireWarning: false },
+): Promise<T> => {
 	type MockSlice = { mockRestore(): void };
 	const mocks: MockSlice[] = [];
+	const warnings: string[] = [];
 
 	const mockConsoleFunction = (key: 'warn'|'error') => {
 		const mock = jest.spyOn(console, key);
@@ -1197,11 +1204,16 @@ export const withWarningSilenced = async <T> (warningRegex: RegExp, task: ()=> P
 		// shows how to use .spyOn to hide warnings
 		mock.mockImplementation((message?: unknown, ...args: unknown[]) => {
 			const fullMessage = [message, ...args].join(' ');
+			warnings.push(fullMessage);
 			if (!fullMessage.match(warningRegex)) {
 				// Avoid recursively calling the mock:
-				mock.mockRestore();
-
-				console.error(`Unexpected warning: ${message}\nNote: Further warnings will not be silenced.`, ...args);
+				if (key === 'error') {
+					mock.mockRestore();
+				}
+				console.error(`Unexpected warning: ${message}`, ...args);
+				if (key === 'error') {
+					mockConsoleFunction('error');
+				}
 			}
 		});
 	};
@@ -1209,7 +1221,13 @@ export const withWarningSilenced = async <T> (warningRegex: RegExp, task: ()=> P
 	try {
 		mockConsoleFunction('warn');
 		mockConsoleFunction('error');
-		return await task();
+		const result = await task();
+
+		if (requireWarning) {
+			expect(warnings).toContainEqual(expect.stringMatching(warningRegex));
+		}
+
+		return result;
 	} finally {
 		for (const mock of mocks) {
 			mock.mockRestore();


### PR DESCRIPTION
# Problem

`yarn test AsyncActionQueue` logs an expected warning.

# Solution

Silence the warning and, since it's expected, assert that the warning was logged.

# Testing

## Output before

```console
% yarn test AsyncActionQueue
11:11:57: AsyncActionQueue: Unhandled error: Error: Task failed
    at Object.<anonymous> (/Users/self/dev/joplin/packages/lib/AsyncActionQueue.test.ts:59:17)
    at Promise.then.completed (/Users/self/dev/joplin/packages/lib/node_modules/jest-circus/build/utils.js:298:28)
    at new Promise (<anonymous>)
    at callAsyncCircusFn (/Users/self/dev/joplin/packages/lib/node_modules/jest-circus/build/utils.js:231:10)
    at _callCircusTest (/Users/self/dev/joplin/packages/lib/node_modules/jest-circus/build/run.js:316:40)
    at _runTest (/Users/self/dev/joplin/packages/lib/node_modules/jest-circus/build/run.js:252:3)
    at _runTestsForDescribeBlock (/Users/self/dev/joplin/packages/lib/node_modules/jest-circus/build/run.js:126:9)
    at _runTestsForDescribeBlock (/Users/self/dev/joplin/packages/lib/node_modules/jest-circus/build/run.js:121:9)
    at run (/Users/self/dev/joplin/packages/lib/node_modules/jest-circus/build/run.js:71:3)
    at runAndTransformResultsToJestFormat (/Users/self/dev/joplin/packages/lib/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
    at jestAdapter (/Users/self/dev/joplin/packages/lib/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
    at runTestInternal (/Users/self/dev/joplin/packages/lib/node_modules/jest-runner/build/runTest.js:367:16)
    at runTest (/Users/self/dev/joplin/packages/lib/node_modules/jest-runner/build/runTest.js:444:34)
11:11:58: AsyncActionQueue: Unhandled error: Error: Task failed
    at Object.<anonymous> (/Users/self/dev/joplin/packages/lib/AsyncActionQueue.test.ts:76:11)
    at /Users/self/dev/joplin/packages/lib/node_modules/jest-mock/build/index.js:397:39
    at Object.<anonymous> (/Users/self/dev/joplin/packages/lib/node_modules/jest-mock/build/index.js:404:13)
    at Object.mockConstructor [as action] (/Users/self/dev/joplin/packages/lib/node_modules/jest-mock/build/index.js:148:19)
    at AsyncActionQueue.action [as processQueue] (/Users/self/dev/joplin/packages/lib/AsyncActionQueue.ts:113:21)
    at processQueue (/Users/self/dev/joplin/packages/lib/AsyncActionQueue.ts:90:14)
    at callTimer (/Users/self/dev/joplin/packages/lib/node_modules/@sinonjs/fake-timers/src/fake-timers-src.js:743:24)
    at Object.next (/Users/self/dev/joplin/packages/lib/node_modules/@sinonjs/fake-timers/src/fake-timers-src.js:1431:17)
    at Immediate.<anonymous> (/Users/self/dev/joplin/packages/lib/node_modules/@sinonjs/fake-timers/src/fake-timers-src.js:1529:43)
    at processImmediate (node:internal/timers:504:21)
 PASS  ./AsyncActionQueue.test.js
  AsyncActionQueue
    ✓ should run a single task (103 ms)
    ✓ should merge all tasks by default (103 ms)
    ✓ should reject processAllNow when a task fails (114 ms)
    ✓ should handle failures when queue processing is not awaited (105 ms)
    ✓ should support customising how tasks are merged (103 ms)
    ✓ should support customising how tasks are merged (105 ms)
    ✓ should support customising how tasks are merged (103 ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        3.072 s
Ran all test suites matching /AsyncActionQueue/i.
```

## Output after

```console
% yarn test AsyncActionQueue
 PASS  ./AsyncActionQueue.test.js
  AsyncActionQueue
    ✓ should run a single task (106 ms)
    ✓ should merge all tasks by default (105 ms)
    ✓ should reject processAllNow when a task fails (105 ms)
    ✓ should handle failures when queue processing is not awaited (104 ms)
    ✓ should support customising how tasks are merged (104 ms)
    ✓ should support customising how tasks are merged (103 ms)
    ✓ should support customising how tasks are merged (104 ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        1.927 s, estimated 3 s
Ran all test suites matching /AsyncActionQueue/i.
```

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
