### PR TITLE
Desktop: Improve refresh for whiteboards and ensure undo stack is cleared upon note refresh

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -787,7 +787,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 		}
 	}
 
-	if (formNote.encryption_applied || !formNote.id || !effectiveNoteId) {
+	if ((!editorPlugin && reloadInProgress) || formNote.encryption_applied || !formNote.id || !effectiveNoteId) {
 		return renderNoNotes(styles.root);
 	}
 


### PR DESCRIPTION
Following on from the PRs I have implemented to prevent the possibility of remote changes to notes being lost due to races when a refresh occurs for the currently open note, this PR aims to address remaining issues. There are still some issues with inconsistent behaviour with editor plugins, however, editor plugins do not have the same risk of data overwriting the remote version of a note when a sync occurs in the background, as they do not use debounced auto saving. In order to avoid additional complexity, behaviour of editor plugins has not been changed on this PR.

**This PR implements the following changes:**
1. When no editor plugin is shown, the current behaviour is an update to the current note via the sync, will immediately refresh the note. When E2EE is enabled, the editor is fully unmounted during refresh and decryption, but it is not fully unmounted when E2EE is disabled. The PR changes this so that regardless of whether E2EE is enabled, a refresh causes a full editor unmount (via renderNoNotes), which means the undo stack will be cleared following the refresh, which will prevent the possibility of the user accidentally undoing the remote updates in the note
2. When the visual view is shown for a whiteboard note, when E2EE is not enabled, there are race conditions possible which will overwrite the remote version if a refresh occurs while typing on the whiteboard, due the the same issue of the editor not being fully unmounted. The PR makes the full unmount also apply when E2EE is not enabled in this view, which prevents this race condition from occurring

This supersedes https://github.com/laurent22/joplin/pull/16309

### Testing

**Video demonstrating the refresh behaviour for regular note view, whiteboard and editor plugin with E2EE enabled:**

https://github.com/user-attachments/assets/2f126a5a-7f34-488a-9fd2-39d76c8ed908

**Video demonstrating the refresh behaviour for regular note view, whiteboard and editor plugin with E2EE disabled:**

https://github.com/user-attachments/assets/6b98c80e-9eee-4249-b63d-c31f3d91593e