### PR TITLE
Desktop: Fixes #16234: Fix position does not always re-center when switching to a whiteboard

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -583,7 +583,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 	}, [noteHasWhiteboardFence, props.dispatch]);
 
 	if (useWhiteboardEditor) {
-		editor = <WhiteboardEditor {...editorProps}/>;
+		editor = <WhiteboardEditor key={formNote.id} {...editorProps}/>;
 	} else if (builtInEditorVisible) {
 		if (props.bodyEditor === 'TinyMCE') {
 			editor = <TinyMCE {...editorProps}/>;


### PR DESCRIPTION
When switching between multiple whiteboards, sometimes the whiteboard can appear empty upon switching, because the position is not re-centered correctly, and ends up heavily outside of the main boundary box. The issue was caused by reusing the same whiteboard editor instance when switching notes, allowing note-specific canvas and viewport state to carry over to the next note. This change remounts the whiteboard editor for each note so it initializes with the correct content and a fresh viewport.

This fixes https://github.com/laurent22/joplin/issues/16234

### Testing

**See video (before on right, after on left):**

https://github.com/user-attachments/assets/94fa3f89-8736-41b5-8964-0a35a0c35f01

