### PR TITLE
Chore: Tests: Silence expected handleCallbackUrl warnings

### DIFF
--- a/packages/app-desktop/gui/MainScreen/handleCallbackUrl.test.ts
+++ b/packages/app-desktop/gui/MainScreen/handleCallbackUrl.test.ts
@@ -1,5 +1,6 @@
 import { utils as commandUtils } from '@joplin/lib/services/CommandService';
 import executeCallbackUrl from './handleCallbackUrl';
+import { withWarningSilenced } from '@joplin/lib/testing/test-utils';
 
 const mockOpenExternal = jest.fn();
 
@@ -32,7 +33,9 @@ describe('handleCallbackUrl', () => {
 		'mailto:someone@example.com',
 		'not a url',
 	])('should not dispatch a callback target with a disallowed scheme (%s)', async (target) => {
-		await executeCallbackUrl(`joplin://x-callback-url/getCurrentNote?x-error=${encodeURIComponent(target)}`);
+		await withWarningSilenced(/Rejected malformed callback|Rejected callback target with disallowed scheme/, async () => {
+			await executeCallbackUrl(`joplin://x-callback-url/getCurrentNote?x-error=${encodeURIComponent(target)}`);
+		}, { requireWarning: true });
 		expect(mockOpenExternal).not.toHaveBeenCalled();
 	});
 
@@ -51,7 +54,9 @@ describe('handleCallbackUrl', () => {
 			getState: () => { throw new Error('secret path /home/victim/.config/joplin/database.sqlite'); },
 		};
 
-		await executeCallbackUrl(`joplin://x-callback-url/getCurrentNote?x-error=${encodeURIComponent('https://example.com/cb')}`);
+		await withWarningSilenced(/Error handling callback URL command "getCurrentNote":.*secret path \/home\/victim/, async () => {
+			await executeCallbackUrl(`joplin://x-callback-url/getCurrentNote?x-error=${encodeURIComponent('https://example.com/cb')}`);
+		}, { requireWarning: true });
 
 		expect(mockOpenExternal).toHaveBeenCalledTimes(1);
 		const responseUrl = mockOpenExternal.mock.calls[0][0];


### PR DESCRIPTION
# Problem

Warnings are logged when running the `handleCallbackUrl` tests in `packages/app-desktop`:
```console
$ yarn test handleCallbackUrl
18:25:33: handleCallbackUrl: Rejected callback target with disallowed scheme "x-custom-scheme:"
18:25:34: handleCallbackUrl: Rejected callback target with disallowed scheme "file:"
18:25:34: handleCallbackUrl: Rejected callback target with disallowed scheme "ms-msdt:"
18:25:34: handleCallbackUrl: Rejected callback target with disallowed scheme "mailto:"
18:25:34: handleCallbackUrl: Rejected malformed callback target
18:25:34: handleCallbackUrl: Error handling callback URL command "getCurrentNote": Error: secret path /home/victim/.config/joplin/database.sqlite
    at Object.getState (/home/self/Documents/joplin/packages/app-desktop/gui/MainScreen/handleCallbackUrl.test.ts:51:28)
    at handleGetCurrentNote (/home/self/Documents/joplin/packages/app-desktop/gui/MainScreen/handleCallbackUrl.ts:47:35)
    at executeCallbackUrl (/home/self/Documents/joplin/packages/app-desktop/gui/MainScreen/handleCallbackUrl.ts:108:10)
    at Object.<anonymous> (/home/self/Documents/joplin/packages/app-desktop/gui/MainScreen/handleCallbackUrl.test.ts:54:27)
    at Promise.then.completed (/home/self/Documents/joplin/packages/app-desktop/node_modules/jest-circus/build/utils.js:298:28)
    at new Promise (<anonymous>)
    at callAsyncCircusFn (/home/self/Documents/joplin/packages/app-desktop/node_modules/jest-circus/build/utils.js:231:10)
    at _callCircusTest (/home/self/Documents/joplin/packages/app-desktop/node_modules/jest-circus/build/run.js:316:40)
    at _runTest (/home/self/Documents/joplin/packages/app-desktop/node_modules/jest-circus/build/run.js:252:3)
    at _runTestsForDescribeBlock (/home/self/Documents/joplin/packages/app-desktop/node_modules/jest-circus/build/run.js:126:9)
    at _runTestsForDescribeBlock (/home/self/Documents/joplin/packages/app-desktop/node_modules/jest-circus/build/run.js:121:9)
    at run (/home/self/Documents/joplin/packages/app-desktop/node_modules/jest-circus/build/run.js:71:3)
    at runAndTransformResultsToJestFormat (/home/self/Documents/joplin/packages/app-desktop/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
    at jestAdapter (/home/self/Documents/joplin/packages/app-desktop/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
    at runTestInternal (/home/self/Documents/joplin/packages/app-desktop/node_modules/jest-runner/build/runTest.js:367:16)
    at runTest (/home/self/Documents/joplin/packages/app-desktop/node_modules/jest-runner/build/runTest.js:444:34)
 PASS  gui/MainScreen/handleCallbackUrl.test.ts
  handleCallbackUrl
    ✓ should not dispatch a callback target with a disallowed scheme (x-custom-scheme://arbitrary-scheme-reached) (106 ms)
    ✓ should not dispatch a callback target with a disallowed scheme (file:///etc/passwd) (104 ms)
    ✓ should not dispatch a callback target with a disallowed scheme (ms-msdt://something) (102 ms)
    ✓ should not dispatch a callback target with a disallowed scheme (mailto:someone@example.com) (102 ms)
    ✓ should not dispatch a callback target with a disallowed scheme (not a url) (102 ms)
    ✓ should dispatch a callback target with an allowed scheme (http://example.com/cb) (101 ms)
    ✓ should dispatch a callback target with an allowed scheme (https://example.com/cb) (101 ms)
    ✓ should not leak the raw error message on the error path (121 ms)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        3.305 s
Ran all test suites matching /handleCallbackUrl/i.
```

These warnings are expected, since the tests intentionally use disallowed x-callback-url schemes and/or throw an exception during callback handling.

# Solution

Silence the warnings:

```console
$ yarn test handleCallbackUrl
 PASS  gui/MainScreen/handleCallbackUrl.test.ts
  handleCallbackUrl
    ✓ should not dispatch a callback target with a disallowed scheme (x-custom-scheme://arbitrary-scheme-reached) (103 ms)
    ✓ should not dispatch a callback target with a disallowed scheme (file:///etc/passwd) (103 ms)
    ✓ should not dispatch a callback target with a disallowed scheme (ms-msdt://something) (102 ms)
    ✓ should not dispatch a callback target with a disallowed scheme (mailto:someone@example.com) (108 ms)
    ✓ should not dispatch a callback target with a disallowed scheme (not a url) (101 ms)
    ✓ should dispatch a callback target with an allowed scheme (http://example.com/cb) (104 ms)
    ✓ should dispatch a callback target with an allowed scheme (https://example.com/cb) (107 ms)
    ✓ should not leak the raw error message on the error path (104 ms)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        2.94 s, estimated 4 s
Ran all test suites matching /handleCallbackUrl/i.
```

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
