### PR TITLE
Desktop: Resolves #16350: External editor: Add additional logic to avoid overwriting a note with older content

### DIFF
--- a/packages/lib/services/ExternalEditWatcher.test.ts
+++ b/packages/lib/services/ExternalEditWatcher.test.ts
@@ -101,7 +101,12 @@ describe('ExternalEditWatcher', () => {
 		}
 	});
 
-	test('should ignore change events that don\'t change the note', async () => {
+	// In some cases, multiple "update" events are received when Joplin updates an external
+	// editor's temporary file. If an update event doesn't change the temp file's content (e.g.
+	// if the update event only adjusts the timestamp), Joplin should ignore the event to avoid
+	// overwriting the note with old content.
+	// See #16350.
+	test('should ignore change events that don\'t change the file\'s content', async () => {
 		const { filePaths, watcher, notes } = await createAndWatchNotes([
 			{ title: 'Test', body: 'Initial content' },
 		]);

--- a/packages/lib/services/ExternalEditWatcher.test.ts
+++ b/packages/lib/services/ExternalEditWatcher.test.ts
@@ -126,8 +126,12 @@ describe('ExternalEditWatcher', () => {
 
 			// Updating the file without changing its content should not overwrite the new content
 			// in the note:
-			await utimes(filePaths[0], new Date().getTime() + Second, new Date().getTime() + Second);
-			await msleep(500);
+			await utimes(filePaths[0], new Date(new Date().getTime() + Second), new Date(new Date().getTime() + Second));
+
+			// Should be unchanged after a brief delay
+			await msleep(200);
+			// ...and after any pending change events are applied
+			await watcher.stopWatching(notes[0].id);
 			expect(await Note.load(notes[0].id)).toMatchObject({ body: 'Out-of-sync' });
 		} finally {
 			await watcher.stopWatchingAll();

--- a/packages/lib/services/ExternalEditWatcher.test.ts
+++ b/packages/lib/services/ExternalEditWatcher.test.ts
@@ -1,8 +1,8 @@
 import { setupDatabaseAndSynchronizer, switchClient } from '../testing/test-utils';
 import ExternalEditWatcher from './ExternalEditWatcher';
-import { appendFile } from 'fs/promises';
+import { appendFile, readFile, utimes } from 'fs/promises';
 import Note from '../models/Note';
-import { msleep } from '@joplin/utils/time';
+import { msleep, Second } from '@joplin/utils/time';
 import waitFor from '../testing/waitFor';
 import { NoteEntity } from './database/types';
 
@@ -96,6 +96,34 @@ describe('ExternalEditWatcher', () => {
 					body: 'Test (updated 2)',
 				});
 			});
+		} finally {
+			await watcher.stopWatchingAll();
+		}
+	});
+
+	test('should ignore change events that don\'t change the note', async () => {
+		const { filePaths, watcher, notes } = await createAndWatchNotes([
+			{ title: 'Test', body: 'Initial content' },
+		]);
+		try {
+			// Apply an edit and wait to ensure that the initial watcher events
+			// have been processed.
+			await appendFile(filePaths[0], ' (updated)');
+			await waitFor(async () => {
+				expect(await Note.load(notes[0].id)).toMatchObject({
+					title: 'Test',
+					body: 'Initial content (updated)',
+				});
+			});
+
+			await Note.save({ id: notes[0].id, body: 'Out-of-sync' });
+			expect(await readFile(filePaths[0], 'utf-8')).toContain('Initial content');
+
+			// Updating the file without changing its content should not overwrite the new content
+			// in the note:
+			await utimes(filePaths[0], new Date().getTime() + Second, new Date().getTime() + Second);
+			await msleep(500);
+			expect(await Note.load(notes[0].id)).toMatchObject({ body: 'Out-of-sync' });
 		} finally {
 			await watcher.stopWatchingAll();
 		}

--- a/packages/lib/services/ExternalEditWatcher.ts
+++ b/packages/lib/services/ExternalEditWatcher.ts
@@ -9,6 +9,7 @@ import { openFileWithExternalEditor } from './ExternalEditWatcher/utils';
 import AsyncActionQueue from '../AsyncActionQueue';
 import { EventEmitter } from 'events';
 import * as chokidar from 'chokidar';
+const md5 = require('md5');
 const { ErrorNotFound } = require('./rest/utils/errors');
 
 interface ChangeEventContext {
@@ -20,6 +21,9 @@ type DispatchFn = (action: { type: string; [key: string]: unknown })=> void;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Concrete bridge type lives in app-desktop; lib references it structurally
 type BridgeFn = ()=> any;
 
+const hashNoteContent = (content: string) => md5(content);
+type ItemId = string;
+
 export default class ExternalEditWatcher {
 
 	private dispatch: DispatchFn;
@@ -29,7 +33,8 @@ export default class ExternalEditWatcher {
 	private watcher_: any = null;
 	private changeEventQueue_: AsyncActionQueue<ChangeEventContext>;
 	private eventEmitter_: EventEmitter = new EventEmitter();
-	private skipNextChangeEvent_: Record<string, boolean> = {};
+	private skipNextChangeEvent_: Map<ItemId, boolean> = new Map();
+	private lastNoteContentHash_: Map<ItemId, string> = new Map();
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See watcher_ above
 	private chokidar_: any = chokidar;
 
@@ -135,13 +140,12 @@ export default class ExternalEditWatcher {
 				} else if (event === 'change') {
 					const id = this.noteFilePathToId_(path);
 
-					if (!this.skipNextChangeEvent_[id]) {
+					if (!this.skipNextChangeEvent_.has(id)) {
 						this.changeEventQueue_.push(() => this.onNoteChange_(path), { path });
 					} else {
 						this.logger().debug('ExternalEditWatcher: Skipping this event.');
+						this.skipNextChangeEvent_.delete(id);
 					}
-
-					this.skipNextChangeEvent_ = {};
 				} else if (event === 'error') {
 					this.logger().error('ExternalEditWatcher: error');
 				}
@@ -198,6 +202,13 @@ export default class ExternalEditWatcher {
 
 			if (!noteContent) this.logger().warn(`ExternalEditWatcher: Could not re-read note - user might have purposely deleted note content: ${id}`);
 		}
+
+		const contentHash = hashNoteContent(noteContent);
+		if (contentHash === this.lastNoteContentHash_.get(id)) {
+			this.logger().info('ExternalEditWatcher: No changes since last write');
+			return;
+		}
+		this.lastNoteContentHash_.set(id, contentHash);
 
 		this.logger().debug('ExternalEditWatcher: Updating note object.');
 
@@ -287,6 +298,8 @@ export default class ExternalEditWatcher {
 		const filePath = this.noteIdToFilePath_(noteId);
 		if (this.watcher_) this.watcher_.unwatch(filePath);
 		await shim.fsDriver().remove(filePath);
+
+		this.lastNoteContentHash_.delete(noteId);
 		this.dispatch({
 			type: 'NOTE_FILE_WATCHER_REMOVE',
 			id: noteId,
@@ -304,6 +317,8 @@ export default class ExternalEditWatcher {
 
 		if (this.watcher_) this.watcher_.close();
 		this.watcher_ = null;
+		this.skipNextChangeEvent_.clear();
+		this.lastNoteContentHash_.clear();
 		this.logger().info('ExternalEditWatcher: Stopped watching all files');
 		this.dispatch({
 			type: 'NOTE_FILE_WATCHER_CLEAR',
@@ -322,7 +337,7 @@ export default class ExternalEditWatcher {
 
 		// When the note file is updated programmatically, we skip the next change event to
 		// avoid update loops. We only want to listen to file changes made by the user.
-		this.skipNextChangeEvent_[note.id] = true;
+		this.skipNextChangeEvent_.set(note.id, true);
 
 		await this.writeNoteToFile_(note);
 	}
@@ -335,7 +350,10 @@ export default class ExternalEditWatcher {
 
 		const filePath = this.noteIdToFilePath_(note.id);
 		const noteContent = await Note.serializeForEdit(note);
+
+		this.lastNoteContentHash_.set(note.id, hashNoteContent(noteContent));
 		await shim.fsDriver().writeFile(filePath, noteContent, 'utf-8');
+
 		return filePath;
 	}
 }

--- a/packages/lib/services/ExternalEditWatcher.ts
+++ b/packages/lib/services/ExternalEditWatcher.ts
@@ -353,8 +353,8 @@ export default class ExternalEditWatcher {
 		const filePath = this.noteIdToFilePath_(note.id);
 		const noteContent = await Note.serializeForEdit(note);
 
-		this.lastNoteContentHash_.set(note.id, hashNoteContent(noteContent));
 		await shim.fsDriver().writeFile(filePath, noteContent, 'utf-8');
+		this.lastNoteContentHash_.set(note.id, hashNoteContent(noteContent));
 
 		return filePath;
 	}

--- a/packages/lib/services/ExternalEditWatcher.ts
+++ b/packages/lib/services/ExternalEditWatcher.ts
@@ -208,7 +208,6 @@ export default class ExternalEditWatcher {
 			this.logger().info('ExternalEditWatcher: No changes since last write');
 			return;
 		}
-		this.lastNoteContentHash_.set(id, contentHash);
 
 		this.logger().debug('ExternalEditWatcher: Updating note object.');
 
@@ -217,6 +216,8 @@ export default class ExternalEditWatcher {
 		updatedNote.parent_id = note.parent_id;
 		await Note.save(updatedNote);
 		this.eventEmitter_.emit('noteChange', { id: updatedNote.id, note: updatedNote });
+
+		this.lastNoteContentHash_.set(id, contentHash);
 	}
 
 	private noteIdToFilePath_(noteId: string) {
@@ -300,6 +301,7 @@ export default class ExternalEditWatcher {
 		await shim.fsDriver().remove(filePath);
 
 		this.lastNoteContentHash_.delete(noteId);
+		this.skipNextChangeEvent_.delete(noteId);
 		this.dispatch({
 			type: 'NOTE_FILE_WATCHER_REMOVE',
 			id: noteId,


### PR DESCRIPTION
# Problem

If multiple "Update" events are emitted after writing a file for an external editor, the second update can overwrite a note's content in Joplin, even if the note has not been changed externally by the user.

> [!IMPORTANT]
>
> While this pull request implements a change that should fix #16350 based on provided logs, I have been unable to reproduce the issue locally. I'm testing on MacOS, with Joplin built from b7beb0bd and Visual Studio Code 1.135.0.

# Solution

- Store a hash of the last content read/written to the external editor temp file. When a change event occurs, skip the event if the hash matches the last content.
- Also keep the previous "skip next change" logic. This should avoid unnecessary file reads when changing a note from Joplin.


May resolve #16350.

# Testing

This pull request adds a new automated test that verifies that timestamp-only changes to an external editor file doesn't update the note in Joplin.

I've also manually tested this change by:
1. Opening a short note in Joplin.
2. Opening the note in an external editor (Visual Studio Code).
3. Making a change from the external editor. Verifying that the change is reflected in Joplin.
4. Making a change from Joplin. Verifying that the change is reflected in the external editor.
5. Adding a large amount of content to the note from the external editor and saving.
6. Clicking "stop external editing".


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
