### PR TITLE
Desktop: Always show the notebook pill on the open note

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -67,6 +67,7 @@ import getResourceBaseUrl from './utils/getResourceBaseUrl';
 import useInitialCursorLocation from './utils/useInitialCursorLocation';
 import NotePositionService, { EditorCursorLocations } from '@joplin/lib/services/NotePositionService';
 import { blur } from '@joplin/lib/utils/focusHandler';
+import bridge from '../../services/bridge';
 
 const debounce = require('debounce');
 
@@ -709,9 +710,9 @@ function NoteEditorContent(props: NoteEditorProps) {
 		);
 	};
 
-	function renderSearchInfo() {
+	function renderFolderInfo() {
 		const theme = themeStyle(props.themeId);
-		if (formNoteFolder && ['Search', 'Tag', 'SmartFilter'].includes(props.notesParentType)) {
+		if (formNoteFolder) {
 			return (
 				<div style={{ paddingTop: 10, paddingBottom: 10, paddingLeft: theme.editorPaddingLeft }}>
 					<Button
@@ -720,10 +721,15 @@ function NoteEditorContent(props: NoteEditorProps) {
 						title={_('In: %s', substrWithEllipsis(formNoteFolder.title, 0, 100))}
 						onClick={() => {
 							props.dispatch({
+								type: 'WINDOW_FOCUS',
+								windowId: defaultWindowId,
+							});
+							props.dispatch({
 								type: 'FOLDER_AND_NOTE_SELECT',
 								folderId: formNoteFolder.id,
 								noteId: formNote.id,
 							});
+							bridge().switchToMainWindow();
 						}}
 					/>
 					<div style={{ flex: 1 }}></div>
@@ -830,7 +836,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 					onTitleChange={onTitleChange}
 					disabled={isReadOnly || reloadInProgress}
 				/>
-				{renderSearchInfo()}
+				{renderFolderInfo()}
 				<div style={{ display: 'flex', flex: 1, paddingLeft: theme.editorPaddingLeft, maxHeight: '100%', minHeight: '0' }}>
 					{editor}
 					{renderPluginEditor()}


### PR DESCRIPTION
Currently, the desktop app shows a pill showing the notebook which a note is contained within only when search, tag, or smart filters are selected. Clicking the pill also reveals the note in the notebook which it belongs to. However, if the user has a large scrollable list of notebooks, it may not be clear which notebook the selected note is contained within. In addition, if a note is opened in a separate window, there is no indication at all which notebook the note belongs to.

This PR changes the behaviour so that the notebook pill will always show on the current note, as suggested here https://discourse.joplinapp.org/t/always-show-notebook-bread-crumb-underneath-title/50784. In addition, if the note is open in a separate window, and the primary window has been closed or minimised, when clicking the pill, the primary window will be opened in order to reveal the note in the notebook

### Testing

**See video:**

https://github.com/user-attachments/assets/f8ead7ae-972c-4284-8c6b-efd3aa6fcc77

