### PR TITLE
Desktop: Add reveal in notebook option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -548,6 +548,7 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/commands/renameTag.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/resetLayout.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/restoreFolder.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/restoreNote.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/revealInNotebook.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/revealResourceFile.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/search.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/setTags.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -574,6 +574,7 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/commands/renameTag.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/resetLayout.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/restoreFolder.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/restoreNote.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/revealInNotebook.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/revealResourceFile.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/search.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/setTags.js

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -877,6 +877,7 @@ function useMenu(props: Props) {
 						separator(),
 						menuItemDic.showNoteProperties,
 						menuItemDic.showNoteContentProperties,
+						menuItemDic.revealInNotebook,
 						separator(),
 						menuItemDic.permanentlyDeleteNote,
 					],

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/index.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/index.ts
@@ -33,6 +33,7 @@ import * as renameTag from './renameTag';
 import * as resetLayout from './resetLayout';
 import * as restoreFolder from './restoreFolder';
 import * as restoreNote from './restoreNote';
+import * as revealInNotebook from './revealInNotebook';
 import * as revealResourceFile from './revealResourceFile';
 import * as search from './search';
 import * as setTags from './setTags';
@@ -92,6 +93,7 @@ const index: any[] = [
 	resetLayout,
 	restoreFolder,
 	restoreNote,
+	revealInNotebook,
 	revealResourceFile,
 	search,
 	setTags,

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/revealInNotebook.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/revealInNotebook.ts
@@ -1,5 +1,6 @@
 import CommandService, { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
+import Folder from '@joplin/lib/models/Folder';
 import Note from '@joplin/lib/models/Note';
 import { defaultWindowId, stateUtils } from '@joplin/lib/reducer';
 import { getTrashFolderId } from '@joplin/lib/services/trash';
@@ -16,7 +17,7 @@ export const runtime = (): CommandRuntime => {
 			noteId = noteId || stateUtils.selectedNoteId(context.state);
 			const note = await Note.load(noteId);
 			if (!note) throw new Error(`No such note: ${noteId}`);
-			const folderId = note.deleted_time ? getTrashFolderId() : note.parent_id;
+			const folderId = note.deleted_time ? getTrashFolderId() : note.is_conflict ? Folder.conflictFolderId() : note.parent_id;
 			const mainWindowState = stateUtils.windowStateById(context.state, defaultWindowId);
 			const folderAlreadySelected = mainWindowState.selectedFolderId === folderId;
 			const noteAlreadySelected = stateUtils.selectedNoteId(mainWindowState) === note.id;

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/revealInNotebook.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/revealInNotebook.ts
@@ -1,0 +1,33 @@
+import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
+import { _ } from '@joplin/lib/locale';
+import Note from '@joplin/lib/models/Note';
+import { defaultWindowId, stateUtils } from '@joplin/lib/reducer';
+import { getTrashFolderId } from '@joplin/lib/services/trash';
+import bridge from '../../../services/bridge';
+
+export const declaration: CommandDeclaration = {
+	name: 'revealInNotebook',
+	label: () => _('Reveal in notebook'),
+};
+
+export const runtime = (): CommandRuntime => {
+	return {
+		execute: async (context: CommandContext, noteId: string = null) => {
+			noteId = noteId || stateUtils.selectedNoteId(context.state);
+			const note = await Note.load(noteId);
+			if (!note) throw new Error(`No such note: ${noteId}`);
+
+			context.dispatch({
+				type: 'WINDOW_FOCUS',
+				windowId: defaultWindowId,
+			});
+			context.dispatch({
+				type: 'FOLDER_AND_NOTE_SELECT',
+				folderId: note.deleted_time ? getTrashFolderId() : note.parent_id,
+				noteId: note.id,
+			});
+			bridge().switchToMainWindow();
+		},
+		enabledCondition: 'someNotesSelected && !multipleNotesSelected',
+	};
+};

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/revealInNotebook.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/revealInNotebook.ts
@@ -3,7 +3,7 @@ import { _ } from '@joplin/lib/locale';
 import Folder from '@joplin/lib/models/Folder';
 import Note from '@joplin/lib/models/Note';
 import { defaultWindowId, stateUtils } from '@joplin/lib/reducer';
-import { getTrashFolderId } from '@joplin/lib/services/trash';
+import { getDisplayParentId } from '@joplin/lib/services/trash';
 import bridge from '../../../services/bridge';
 
 export const declaration: CommandDeclaration = {
@@ -17,7 +17,8 @@ export const runtime = (): CommandRuntime => {
 			noteId = noteId || stateUtils.selectedNoteId(context.state);
 			const note = await Note.load(noteId);
 			if (!note) throw new Error(`No such note: ${noteId}`);
-			const folderId = note.deleted_time ? getTrashFolderId() : note.is_conflict ? Folder.conflictFolderId() : note.parent_id;
+			const parentFolder = await Folder.load(note.parent_id);
+			const folderId = note.is_conflict && !note.deleted_time ? Folder.conflictFolderId() : getDisplayParentId(note, parentFolder);
 			const mainWindowState = stateUtils.windowStateById(context.state, defaultWindowId);
 			const folderAlreadySelected = mainWindowState.selectedFolderId === folderId;
 			const noteAlreadySelected = stateUtils.selectedNoteId(mainWindowState) === note.id;

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/revealInNotebook.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/revealInNotebook.ts
@@ -1,4 +1,4 @@
-import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
+import CommandService, { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
 import Note from '@joplin/lib/models/Note';
 import { defaultWindowId, stateUtils } from '@joplin/lib/reducer';
@@ -16,6 +16,10 @@ export const runtime = (): CommandRuntime => {
 			noteId = noteId || stateUtils.selectedNoteId(context.state);
 			const note = await Note.load(noteId);
 			if (!note) throw new Error(`No such note: ${noteId}`);
+			const folderId = note.deleted_time ? getTrashFolderId() : note.parent_id;
+			const mainWindowState = stateUtils.windowStateById(context.state, defaultWindowId);
+			const folderAlreadySelected = mainWindowState.selectedFolderId === folderId;
+			const noteAlreadySelected = stateUtils.selectedNoteId(mainWindowState) === note.id;
 
 			context.dispatch({
 				type: 'WINDOW_FOCUS',
@@ -23,10 +27,12 @@ export const runtime = (): CommandRuntime => {
 			});
 			context.dispatch({
 				type: 'FOLDER_AND_NOTE_SELECT',
-				folderId: note.deleted_time ? getTrashFolderId() : note.parent_id,
+				folderId,
 				noteId: note.id,
 			});
 			bridge().switchToMainWindow();
+			if (folderAlreadySelected) await CommandService.instance().execute('focusElementSideBar');
+			if (folderAlreadySelected && noteAlreadySelected) await CommandService.instance().execute('focusElementNoteList', note.id);
 		},
 		enabledCondition: 'someNotesSelected && !multipleNotesSelected',
 	};

--- a/packages/app-desktop/gui/menuCommandNames.ts
+++ b/packages/app-desktop/gui/menuCommandNames.ts
@@ -80,6 +80,7 @@ export default function() {
 		'exportDeletionLog',
 		'toggleSafeMode',
 		'showShareNoteDialog',
+		'revealInNotebook',
 		'showShareFolderDialog',
 		'leaveSharedFolder',
 		'gotoAnything',


### PR DESCRIPTION
Currently, the desktop app shows a pill showing the notebook which a note is contained within when search, tag, or smart filters are selected. However, if the user has a large scrollable list of notebooks, it may not be clear which notebook the selected note is contained within. In addition, if a note is opened in a separate window, there is no indication at all which notebook the note belongs to.

This PR adds a reveal in notebook menu option, which opens the notebook of the note and selects the note, scrolling both the notebook and note into view. For trashed items, it will go to the root of the trash folder for notes deleted individually, or to the trashed folder if folder was trashed as well. For conflicts, it will go to the root of the conflicts folder. For a note with no parent id which is not trashed, it will reveal the note in the all notes notebook.

### Testing

**See video:**

https://github.com/user-attachments/assets/c7dc8db0-87d7-42b6-82a1-f6beb6cc3c64