### PR TITLE
Desktop: Fixes #16059: Stop external editing on note deletion

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -162,6 +162,10 @@ class Application extends BaseApplication {
 			await AlarmService.updateNoteNotification(action.id, action.type === 'NOTE_DELETE');
 		}
 
+		if (action.type === 'NOTE_DELETE' && store.getState().watchedNoteFiles.includes(action.id)) {
+			await ExternalEditWatcher.instance().stopWatching(action.id);
+		}
+
 		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'featureFlag.autoUpdaterServiceEnabled' || action.type === 'SETTING_UPDATE_ALL') {
 			if (Setting.value('featureFlag.autoUpdaterServiceEnabled')) this.setupAutoUpdaterService();
 		}


### PR DESCRIPTION
When a note open in an external editor is trashed from the app, it should be unwatched, as trashed notes should be readonly. This PR implements unwatching notes at the point of trashing.

This fixes https://github.com/laurent22/joplin/issues/16059

### Testing

**See video:**

https://github.com/user-attachments/assets/9350fd8a-af40-44a4-8392-8e013b17e97a