### PR TITLE
Desktop: Resolves #16209: Unpublish button uses a misleading share icon

### DIFF
--- a/packages/app-desktop/gui/PublishFolderDialog.tsx
+++ b/packages/app-desktop/gui/PublishFolderDialog.tsx
@@ -98,7 +98,7 @@ export function PublishFolderDialog(props: Props) {
 						</div>
 					</div>
 					{publishedShare && (
-						<Button disabled={isUnpublishing} tooltip={_('Unpublish notebook')} iconName="fas fa-share-alt" onClick={onUnpublishFolderClick}/>
+						<Button disabled={isUnpublishing} tooltip={_('Unpublish notebook')} iconName="fas fa-unlink" onClick={onUnpublishFolderClick}/>
 					)}
 				</div>
 				<button

--- a/packages/app-desktop/gui/ShareNoteDialog.tsx
+++ b/packages/app-desktop/gui/ShareNoteDialog.tsx
@@ -134,7 +134,7 @@ const NoteItem: React.FC<NoteItemProps> = ({ note, shares }) => {
 	const published = useIsPublished(note, shares);
 
 	const unshareButton = published && (
-		<Button tooltip={_('Unpublish note')} iconName='fas fa-share-alt' onClick={() => onUnshareNoteClick({ noteId: note.id })}/>
+		<Button tooltip={_('Unpublish note')} iconName='fas fa-unlink' onClick={() => onUnshareNoteClick({ noteId: note.id })}/>
 	);
 
 	return (


### PR DESCRIPTION
Resolves #16209

I changed the icon for unpublishing notes and unpublishing notebooks

Before:
<img width="529" height="270" alt="Image" src="https://github.com/user-attachments/assets/5f94fb0e-61ae-49c6-b34c-2d8d4c888999" />

After:
<img width="529" height="250" alt="Image" src="https://github.com/user-attachments/assets/574f4507-0801-4d9a-a63c-53cd0212475b" />