### PR TITLE
Android: Fix additional space present below new note menu on some devices

### DIFF
--- a/packages/app-mobile/components/BottomDrawer.tsx
+++ b/packages/app-mobile/components/BottomDrawer.tsx
@@ -58,6 +58,12 @@ const useStyles = ({ theme, menuType, dragging, alignment, draggable, dragOffset
 		// On web, any spaceBelowScreenEdge results in a scrollbar and extra scroll.
 		const spaceBelowScreenEdge = Platform.OS === 'web' ? 0 : windowHeight;
 
+		const includeSafeAreaPaddingBottom =
+			// Applying safe-area padding on newer versions of Android results in extra space below the
+			// menu:
+			(Platform.OS === 'android' && Platform.Version < 35)
+			|| Platform.OS === 'ios';
+
 		return StyleSheet.create({
 			backgroundStyle: {
 				backgroundColor: theme.backgroundColorTransparent2,
@@ -94,7 +100,7 @@ const useStyles = ({ theme, menuType, dragging, alignment, draggable, dragOffset
 					borderBottomLeftRadius: 0,
 					marginBottom: -spaceBelowScreenEdge,
 				} : {
-					marginBottom: safeAreaPadding.paddingBottom,
+					marginBottom: includeSafeAreaPaddingBottom ? safeAreaPadding.paddingBottom : 0,
 				}),
 				maxWidth: Math.min(
 					menuType === MenuType.Floating ? 250 : 400,

--- a/packages/app-mobile/components/BottomDrawer.tsx
+++ b/packages/app-mobile/components/BottomDrawer.tsx
@@ -93,7 +93,9 @@ const useStyles = ({ theme, menuType, dragging, alignment, draggable, dragOffset
 					borderBottomRightRadius: 0,
 					borderBottomLeftRadius: 0,
 					marginBottom: -spaceBelowScreenEdge,
-				} : { }),
+				} : {
+					marginBottom: safeAreaPadding.paddingBottom,
+				}),
 				maxWidth: Math.min(
 					menuType === MenuType.Floating ? 250 : 400,
 					windowWidth - menuGapRight - menuGapLeft,

--- a/packages/app-mobile/components/BottomDrawer.tsx
+++ b/packages/app-mobile/components/BottomDrawer.tsx
@@ -58,12 +58,6 @@ const useStyles = ({ theme, menuType, dragging, alignment, draggable, dragOffset
 		// On web, any spaceBelowScreenEdge results in a scrollbar and extra scroll.
 		const spaceBelowScreenEdge = Platform.OS === 'web' ? 0 : windowHeight;
 
-		const includeSafeAreaPaddingBottom =
-			// Applying safe-area padding on newer versions of Android results in extra space below the
-			// menu:
-			(Platform.OS === 'android' && Platform.Version < 35)
-			|| Platform.OS === 'ios';
-
 		return StyleSheet.create({
 			backgroundStyle: {
 				backgroundColor: theme.backgroundColorTransparent2,
@@ -99,9 +93,7 @@ const useStyles = ({ theme, menuType, dragging, alignment, draggable, dragOffset
 					borderBottomRightRadius: 0,
 					borderBottomLeftRadius: 0,
 					marginBottom: -spaceBelowScreenEdge,
-				} : {
-					marginBottom: includeSafeAreaPaddingBottom ? safeAreaPadding.paddingBottom : 0,
-				}),
+				} : { }),
 				maxWidth: Math.min(
 					menuType === MenuType.Floating ? 250 : 400,
 					windowWidth - menuGapRight - menuGapLeft,

--- a/packages/app-mobile/components/buttons/FloatingActionButton.tsx
+++ b/packages/app-mobile/components/buttons/FloatingActionButton.tsx
@@ -59,7 +59,8 @@ const useMenuMarginBottom = (buttonContainerRef: RefObject<View>, themeId: numbe
 		buttonContainerRef.current?.measure((_x, _y, _width, _height, _pageX, pageY) => {
 			// On Android, the safe area padding doesn't seem to be included in windowHeight,
 			// but **does** seem to be taken into account when determining absolute/relative positioning
-			const includeSafeArea = Platform.OS === 'android';
+			// 2026-08-31: Android 15 and later seem to include safe area padding in windowHeight
+			const includeSafeArea = Platform.OS === 'android' && Platform.Version < 35;
 			const extraMargin = theme.marginBottom + (includeSafeArea ? safeAreaPadding.paddingBottom : 0);
 
 			setMenuMarginBottom(windowHeight - pageY + extraMargin);


### PR DESCRIPTION
# Problem

On certain Android devices, additional space is present between the new note menu and the new note button.

This difference may be related to [edge-to-edge support](https://github.com/react-native-community/discussions-and-proposals/discussions/827) in API 35/Android 15.

# Solution

Only apply safe area padding on certain Android versions.


# Testing
## Android: Before/after



All screenshots are from Android emulators:

| Platform/condition | Before | After |
|----------|-------|-------|
| Android 14 | <img width="360" height="641" alt="android-14-before-1" src="https://github.com/user-attachments/assets/3b84bf47-08a7-4108-819c-3b66b0088218" /> | <img width="360" height="641" alt="android-14-after-1" src="https://github.com/user-attachments/assets/793b5e49-8338-4123-b50e-4dc19d17dc1e" /> |
| Android 15 | <img width="360" height="794" alt="android-15-before" src="https://github.com/user-attachments/assets/d3540504-a435-4faa-a711-af441e0ba633" /> | <img width="360" height="794" alt="android-15-after" src="https://github.com/user-attachments/assets/c9b3ad05-3a4f-486a-9738-0acc2043b7bd" /> |
| Android 16 | <img width="357" height="793" alt="android-16-before-2" src="https://github.com/user-attachments/assets/3fe280cf-b8e7-490a-8940-6f7e744df85e" /> | <img width="357" height="793" alt="android-16-after-2" src="https://github.com/user-attachments/assets/0452afc0-13ed-483a-a58b-6def2cef9e32" /> |
| Android 16 (gesture navigation) | <img width="357" height="793" alt="android-16-before-1" src="https://github.com/user-attachments/assets/9c67213b-a5a0-494d-8eb8-5d952d93d4a5" /> | <img width="357" height="793" alt="android-16-after-1" src="https://github.com/user-attachments/assets/e2d02d0d-0dfc-4192-bcd5-23623c9d1871" /> |
| Android 16 (gesture navigation, landscape) | <img width="793" height="357" alt="android-16-landscape-before" src="https://github.com/user-attachments/assets/4e3856b3-798d-46a7-850c-13b981bb85a6" /> | <img width="793" height="357" alt="android-16-landscape-after" src="https://github.com/user-attachments/assets/300a75ad-bdef-441b-95b7-c542480bd1fc" /> |




<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
