### PR TITLE
Desktop, Mobile, Cli: Allow cancelling sync during potentially lengthy start and finish steps

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -618,7 +618,7 @@ export default class Synchronizer {
 				while (true) {
 					if (this.cancelling()) break;
 
-					const result = await BaseItem.itemsThatNeedSync(syncTargetId);
+					const result = await BaseItem.itemsThatNeedSync(syncTargetId, 100, () => this.cancelling());
 					const locals = result.items;
 
 					await itemUploader.preUploadItems(result.items.filter(it => result.neverSyncedItemIds.includes(it.id)));
@@ -1303,7 +1303,7 @@ export default class Synchronizer {
 		// that the user will close or minimise the app when there are un-synced changes, because the sync is reported as completed.
 		// IMPORTANT: This must be the very last step in the sync, to avoid any window to allow an un-synced change to get missed
 		if (!hasErrors && !hasCaughtError && !cancelledBeforeClearedState && !this.cancelling()) {
-			const result = await BaseItem.itemsThatNeedSync(syncTargetId);
+			const result = await BaseItem.itemsThatNeedSync(syncTargetId, 100, () => this.cancelling());
 
 			if (result.items.length > 0) {
 				logger.info('There are more outgoing changes to sync, schedule the sync again');

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -736,7 +736,10 @@ export default class BaseItem extends BaseModel {
 		return !!r;
 	}
 
-	public static async itemsThatNeedSync(syncTarget: number, limit = 100): Promise<ItemsThatNeedSyncResult> {
+	public static async itemsThatNeedSync(syncTarget: number, limit = 100, cancelling: ()=> boolean = () => false): Promise<ItemsThatNeedSyncResult> {
+		const cancelledResult = (): ItemsThatNeedSyncResult => ({ hasMore: false, items: [], neverSyncedItemIds: [] });
+		if (cancelling()) return cancelledResult();
+
 		// Although we keep the master keys in the database, we no longer sync them
 		const classNames = this.syncItemClassNames().filter(n => n !== 'MasterKey');
 
@@ -783,6 +786,7 @@ export default class BaseItem extends BaseModel {
 			);
 
 			const neverSyncedItem = await ItemClass.modelSelectAll(sql);
+			if (cancelling()) return cancelledResult();
 
 			// Secondly get the items that have been synced under this sync target but that have been changed since then
 
@@ -813,6 +817,7 @@ export default class BaseItem extends BaseModel {
 				);
 
 				changedItems = await ItemClass.modelSelectAll(sql);
+				if (cancelling()) return cancelledResult();
 			}
 
 			const neverSyncedItemIds = neverSyncedItem.map((it: BaseItemEntity) => it.id);


### PR DESCRIPTION
As described in https://github.com/laurent22/joplin/issues/16291, for users with a very large note collection, auto sync can cause significant UI lag, due to slow SQL blocking other SQL queries from running. The SQL in question is the 2 queries in the BaseItem.itemsThatNeedSync function. For the OP of the forum issue, these were taking about 500ms and 300ms respectively for the first iteration in the function. However these 2 queries will run for 6 iterations in total if no records are found on every run. Blocking can therefore occur for several seconds while the BaseItem.itemsThatNeedSync function completes.

This PR implements the ability to cancel the sync between query calls in the BaseItem.itemsThatNeedSync, to avoid having to wait for up to 12 slow query calls to complete, before the sync can be cancelled. This does not address the wider issue, that the auto sync can cause significant UI lag for large data sets, due to long running sql causing blocking.

### Testing

I tested the change by artificially slowing down the BaseItem.itemsThatNeedSync function by adding a ~5 second query within the loop, then verifying that it will cancel after the current long running query completes, based on timing. During testing and in the video, I added temporary additional logging for clearer visibility of what it going on at the time.

**See video:**

https://github.com/user-attachments/assets/e8a87862-c516-466c-9f88-bcafd2da12ba