### PR TITLE
Api, Cli, Desktop, Mobile: Resolves #16336: Disallow locked notes in shared notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1537,6 +1537,8 @@ packages/lib/models/utils/getConflictFolderId.js
 packages/lib/models/utils/isItemId.js
 packages/lib/models/utils/isJoplinServerVariant.js
 packages/lib/models/utils/itemCanBeEncrypted.js
+packages/lib/models/utils/noteLockShareGuard.test.js
+packages/lib/models/utils/noteLockShareGuard.js
 packages/lib/models/utils/onFolderDrop.test.js
 packages/lib/models/utils/onFolderDrop.js
 packages/lib/models/utils/paginatedFeed.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1563,6 +1563,8 @@ packages/lib/models/utils/getConflictFolderId.js
 packages/lib/models/utils/isItemId.js
 packages/lib/models/utils/isJoplinServerVariant.js
 packages/lib/models/utils/itemCanBeEncrypted.js
+packages/lib/models/utils/noteLockShareGuard.test.js
+packages/lib/models/utils/noteLockShareGuard.js
 packages/lib/models/utils/onFolderDrop.test.js
 packages/lib/models/utils/onFolderDrop.js
 packages/lib/models/utils/paginatedFeed.js

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -16,6 +16,8 @@ import JoplinError from '../JoplinError';
 import { LoadOptions, SaveOptions } from './utils/types';
 import { State as ShareState } from '../services/share/reducer';
 import { checkIfItemCanBeAddedToFolder, checkIfItemCanBeChanged, checkIfItemsCanBeChanged, needsShareReadOnlyChecks } from './utils/readOnly';
+import { checkNoteLockShareInvariants } from './utils/noteLockShareGuard';
+import isNoteLockEnabled from '../services/noteLock/isNoteLockEnabled';
 import { checkObjectHasProperties } from '@joplin/utils/object';
 
 const { sprintf } = require('sprintf-js');
@@ -1038,6 +1040,10 @@ export default class BaseItem extends BaseModel {
 					o.parent_id,
 				);
 			}
+		}
+
+		if (isNoteLockEnabled()) {
+			await checkNoteLockShareInvariants(this, this.getClass('Folder'), this.modelType(), options.changeSource, this.syncShareCache, o, isNew);
 		}
 
 		return super.save(o, options);

--- a/packages/lib/models/Folder.test.ts
+++ b/packages/lib/models/Folder.test.ts
@@ -519,4 +519,59 @@ describe('models/Folder', () => {
 		expect(validFolder).toBeNull();
 	});
 
+	it('should return the folder and its ancestors, and nothing else', async () => {
+		const root = await Folder.save({ title: 'root', share_id: 'share-1' });
+		const child = await Folder.save({ title: 'child', parent_id: root.id });
+		const unrelated = await Folder.save({ title: 'unrelated' });
+
+		const ancestors = await Folder.selfAndAncestors(child.id);
+
+		expect(ancestors.map(folder => folder.id).sort()).toEqual([child.id, root.id].sort());
+		expect(ancestors.map(folder => folder.id)).not.toContain(unrelated.id);
+		expect(ancestors.find(folder => folder.id === root.id).share_id).toBe('share-1');
+	});
+
+	it('should find a locked note in the folder itself or in any descendant', async () => {
+		const withLockedNote = await createFolderTree('', [
+			{ title: 'with locked note', children: [{ title: 'locked here', is_locked: 1 }] },
+		]);
+		const withNestedLockedNote = await createFolderTree('', [
+			{
+				title: 'with nested locked note',
+				children: [{ title: 'sub', children: [{ title: 'locked deeper', is_locked: 1 }] }],
+			},
+		]);
+		const withoutLockedNote = await createFolderTree('', [
+			{ title: 'without locked note', children: [{ title: 'plain' }] },
+		]);
+
+		expect(await Folder.hasLockedNotes(withLockedNote.id)).toBe(true);
+		expect(await Folder.hasLockedNotes(withNestedLockedNote.id)).toBe(true);
+		expect(await Folder.hasLockedNotes(withoutLockedNote.id)).toBe(false);
+	});
+
+	it('should ignore conflicts but still count deleted notes', async () => {
+		const conflictOnly = await createFolderTree('', [
+			{ title: 'conflict only', children: [{ title: 'conflict', is_locked: 1, is_conflict: 1 }] },
+		]);
+		const deletedOnly = await createFolderTree('', [
+			{ title: 'deleted only', children: [{ title: 'deleted', is_locked: 1, deleted_time: 1 }] },
+		]);
+
+		// Conflicts never sync. A trashed note keeps its parent, so restoring it would put it back.
+		expect(await Folder.hasLockedNotes(conflictOnly.id)).toBe(false);
+		expect(await Folder.hasLockedNotes(deletedOnly.id)).toBe(true);
+	});
+
+	it('should keep looking below a deleted folder', async () => {
+		const root = await createFolderTree('', [
+			{
+				title: 'root',
+				children: [{ title: 'deleted sub', deleted_time: 1, children: [{ title: 'still live', is_locked: 1 }] }],
+			},
+		]);
+
+		expect(await Folder.hasLockedNotes(root.id)).toBe(true);
+	});
+
 });

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -20,6 +20,8 @@ import getTrashFolderId from '../services/trash/getTrashFolderId';
 import { getCollator } from './utils/getCollator';
 import Setting from './Setting';
 import { itemIsReadOnlySync, ItemSlice } from './utils/readOnly';
+import { folderIsInActiveShare } from './utils/noteLockShareGuard';
+import isNoteLockEnabled from '../services/noteLock/isNoteLockEnabled';
 import ItemChange from './ItemChange';
 import { substrWithEllipsis } from '../string-utils';
 import { unique } from '../ArrayUtils';
@@ -150,6 +152,16 @@ export default class Folder extends BaseItem {
 		const actionLogger = ActionLogger.from(options.sourceDescription);
 		actionLogger.addDescription(`folder titles: ${JSON.stringify(folders.map(folder => folder.title))}`);
 		options.sourceDescription = actionLogger;
+
+		// Same check as the root folder saves below would hit, but before any child is deleted,
+		// so a rejected drop cannot leave a partially trashed tree.
+		if (isNoteLockEnabled() && toTrash && options.toTrashParentId) {
+			if (await folderIsInActiveShare(this, this.syncShareCache, options.toTrashParentId)) {
+				for (const folderId of folderIds) {
+					if (await this.hasLockedNotes(folderId)) throw new Error(_('This notebook cannot be moved to a shared or published notebook because it contains locked notes'));
+				}
+			}
+		}
 
 		if (options.deleteChildren) {
 			const childrenDeleteOptions: DeleteOptions = {
@@ -443,6 +455,52 @@ export default class Folder extends BaseItem {
 		`;
 
 		return this.db().selectAll(sql, [folderId]);
+	}
+
+	// The upward counterpart of allChildrenFolders, so an item can be matched against a share
+	// rooted anywhere above it, by marker or by id. Includes the folder itself.
+	public static async selfAndAncestors(folderId: string) {
+		if (!folderId) return [] as FolderEntity[];
+
+		const sql = `
+			WITH RECURSIVE
+				folders_cte(id, parent_id, share_id, is_shared) AS (
+					SELECT id, parent_id, share_id, is_shared
+						FROM folders
+						WHERE id = ?
+					UNION ALL
+						SELECT folders.id, folders.parent_id, folders.share_id, folders.is_shared
+							FROM folders
+							INNER JOIN folders_cte AS folders_cte ON (folders.id = folders_cte.parent_id)
+				)
+				SELECT id, share_id, is_shared FROM folders_cte;
+		`;
+
+		return this.db().selectAll<FolderEntity>(sql, [folderId]);
+	}
+
+	// Mirrors allChildrenFolders but includes the root, and walks deleted folders that may hold
+	// live notes. Deleted notes count because they can be restored; conflicts never sync.
+	public static async hasLockedNotes(folderId: string) {
+		const sql = `
+			WITH RECURSIVE
+				folders_cte(id) AS (
+					SELECT id
+						FROM folders
+						WHERE id = ?
+					UNION ALL
+						SELECT folders.id
+							FROM folders
+							INNER JOIN folders_cte AS folders_cte ON (folders.parent_id = folders_cte.id)
+				)
+				SELECT 1 FROM notes
+					WHERE parent_id IN (SELECT id FROM folders_cte)
+						AND is_locked = 1
+						AND is_conflict = 0
+					LIMIT 1;
+		`;
+
+		return !!(await this.db().selectOne(sql, [folderId]));
 	}
 
 	public static async rootSharedFolders(activeShares: StateShare[]): Promise<FolderEntity[]> {

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -29,6 +29,7 @@ import { MarkupToHtml } from '@joplin/renderer';
 import { ALL_NOTES_FILTER_ID } from '../reserved-ids';
 import NoteLockNote from '../services/noteLock/NoteLockNote';
 import isNoteLockEnabled from '../services/noteLock/isNoteLockEnabled';
+import { folderIsInActiveShare } from './utils/noteLockShareGuard';
 import { ShareType, StateShare } from '../services/share/reducer';
 
 export interface PreviewsOrder {
@@ -995,6 +996,15 @@ export default class Note extends BaseItem {
 		const changeSource = options && options.changeSource ? options.changeSource : null;
 		const changeType = options && options.toTrash ? ItemChange.TYPE_UPDATE : ItemChange.TYPE_DELETE;
 		const toTrash = options && !!options.toTrash;
+
+		// Dropping onto a deleted folder re-parents through the batch SQL below without going
+		// through BaseItem.save, so the note lock share guard has to run here as well.
+		if (isNoteLockEnabled() && toTrash && options.toTrashParentId) {
+			if (await folderIsInActiveShare(this.getClass('Folder'), this.syncShareCache, options.toTrashParentId)) {
+				const locked = await this.db().selectOne(`SELECT id FROM notes WHERE id IN (${this.escapeIdsForSql(ids)}) AND is_locked = 1 AND is_conflict = 0 LIMIT 1`);
+				if (locked) throw new Error(_('Locked notes cannot be moved to a shared or published notebook'));
+			}
+		}
 
 		while (ids.length) {
 			const processIds = ids.splice(0, 50);

--- a/packages/lib/models/utils/noteLockShareGuard.test.ts
+++ b/packages/lib/models/utils/noteLockShareGuard.test.ts
@@ -1,0 +1,184 @@
+import Setting from '../Setting';
+import Note from '../Note';
+import Folder from '../Folder';
+import BaseItem from '../BaseItem';
+import ItemChange from '../ItemChange';
+import { setupDatabaseAndSynchronizer, switchClient, afterAllCleanUp } from '../../testing/test-utils';
+import { defaultState as defaultShareState, ShareType } from '../../services/share/reducer';
+import onFolderDrop from './onFolderDrop';
+
+type ShareFields = { type: ShareType; folder_id?: string; note_id?: string };
+
+const setShareCache = (shares: ShareFields[]) => {
+	BaseItem.syncShareCache = {
+		...defaultShareState,
+		shares: shares.map((share, index) => ({ id: `share-${index + 1}`, folder_id: '', note_id: '', master_key_id: '', ...share })),
+	};
+};
+
+// evidence is either the folder's own persisted marker or the active share cache, since each can
+// exist without the other while a share is being created or synced.
+const makeSharedFolder = async (evidence: string) => {
+	const folder = await Folder.save({ title: 'shared', ...(evidence === 'marker' ? { share_id: 'share-1' } : {}) });
+	if (evidence === 'cache') setShareCache([{ type: ShareType.Folder, folder_id: folder.id }]);
+	return folder;
+};
+
+describe('noteLockShareGuard', () => {
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+		Setting.setValue('featureFlag.noteLock', true);
+		BaseItem.syncShareCache = defaultShareState;
+	});
+
+	afterAll(async () => {
+		await afterAllCleanUp();
+	});
+
+	test.each([
+		['a persisted folder marker', 'marker'],
+		['the active share cache', 'cache'],
+	])('should refuse locking a note in a shared notebook known through %s', async (_label, evidence) => {
+		const folder = await makeSharedFolder(evidence);
+		const note = await Note.save({ title: 'note', parent_id: folder.id });
+
+		await expect(Note.save({ id: note.id, is_locked: 1 })).rejects.toThrow('cannot be locked');
+		expect((await Note.load(note.id)).is_locked).toBe(0);
+	});
+
+	it('should refuse locking a published note', async () => {
+		const marked = await Note.save({ title: 'marked', is_shared: 1 });
+		await expect(Note.save({ id: marked.id, is_locked: 1 })).rejects.toThrow('cannot be locked');
+
+		const cached = await Note.save({ title: 'cached' });
+		setShareCache([{ type: ShareType.Note, note_id: cached.id }]);
+		await expect(Note.save({ id: cached.id, is_locked: 1 })).rejects.toThrow('cannot be locked');
+	});
+
+	test.each([
+		['a persisted folder marker', 'marker'],
+		['the active share cache', 'cache'],
+	])('should refuse moving a locked note into a shared notebook known through %s', async (_label, evidence) => {
+		const destination = await makeSharedFolder(evidence);
+		const source = await Folder.save({ title: 'private' });
+		const note = await Note.save({ title: 'note', parent_id: source.id, is_locked: 1 });
+
+		await expect(Note.save({ id: note.id, parent_id: destination.id })).rejects.toThrow('cannot be moved');
+		expect((await Note.load(note.id)).parent_id).toBe(source.id);
+	});
+
+	it('should refuse creating a locked note in a shared notebook but allow a conflict copy', async () => {
+		const folder = await makeSharedFolder('marker');
+
+		await expect(Note.save({ title: 'note', is_locked: 1, parent_id: folder.id })).rejects.toThrow('cannot be locked');
+		await expect(Note.save({ title: 'conflict', is_locked: 1, is_conflict: 1, parent_id: folder.id })).resolves.toBeTruthy();
+	});
+
+	it('should refuse moving a notebook that contains a locked note into a shared notebook', async () => {
+		const destination = await makeSharedFolder('marker');
+		const source = await Folder.save({ title: 'source' });
+		await Note.save({ title: 'locked', parent_id: source.id, is_locked: 1 });
+
+		await expect(Folder.save({ id: source.id, parent_id: destination.id })).rejects.toThrow('cannot be moved');
+		expect((await Folder.load(source.id)).parent_id).toBe('');
+
+		const clean = await Folder.save({ title: 'clean' });
+		await expect(Folder.save({ id: clean.id, parent_id: destination.id })).resolves.toBeTruthy();
+	});
+
+	it('should allow moving a locked note between private notebooks', async () => {
+		const source = await Folder.save({ title: 'source' });
+		const destination = await Folder.save({ title: 'destination' });
+		const note = await Note.save({ title: 'note', parent_id: source.id, is_locked: 1 });
+
+		await expect(Note.save({ id: note.id, parent_id: destination.id })).resolves.toBeTruthy();
+		expect((await Note.load(note.id)).parent_id).toBe(destination.id);
+	});
+
+	it('should still allow editing and unlocking a locked note that ended up shared', async () => {
+		const note = await Note.save({ title: 'note', is_locked: 1 });
+		await Note.save({ id: note.id, share_id: 'share-1' });
+
+		await expect(Note.save({ id: note.id, title: 'renamed' })).resolves.toBeTruthy();
+		await expect(Note.save({ id: note.id, is_locked: 0 })).resolves.toBeTruthy();
+	});
+
+	it('should not apply to sync-sourced saves', async () => {
+		const folder = await makeSharedFolder('marker');
+		const note = await Note.save({ title: 'note', parent_id: folder.id });
+
+		await expect(Note.save({ id: note.id, is_locked: 1 }, { changeSource: ItemChange.SOURCE_SYNC })).resolves.toBeTruthy();
+	});
+
+	it('should not fire on share id propagation saves', async () => {
+		const folder = await Folder.save({ title: 'folder' });
+		const note = await Note.save({ title: 'note', parent_id: folder.id, is_locked: 1 });
+		await Folder.save({ id: folder.id, share_id: 'share-1' });
+
+		// The exact save shape used by Folder.updateNoteShareIds() at the start of every sync.
+		await expect(Note.save({
+			id: note.id, share_id: 'share-1', parent_id: folder.id, updated_time: Date.now(),
+		}, { autoTimestamp: false, disableReadOnlyCheck: true })).resolves.toBeTruthy();
+	});
+
+	it('should refuse a batch trash move of a locked note into a deleted folder under a share', async () => {
+		const root = await makeSharedFolder('marker');
+		const sub = await Folder.save({ title: 'sub', parent_id: root.id });
+		await Folder.delete(sub.id, { toTrash: true });
+		const note = await Note.save({ title: 'note', is_locked: 1 });
+
+		// Desktop drag-and-drop onto a deleted folder re-parents through batch SQL, not BaseItem.save.
+		await expect(onFolderDrop([note.id], [], sub.id)).rejects.toThrow('cannot be moved');
+		expect((await Note.load(note.id)).parent_id).toBe('');
+		expect((await Note.load(note.id)).deleted_time).toBe(0);
+
+		await expect(Note.delete(note.id, { toTrash: true })).resolves.toBeUndefined();
+		expect((await Note.load(note.id)).deleted_time).toBeGreaterThan(0);
+	});
+
+	it('should refuse a folder drop onto a deleted folder under a share before trashing its children', async () => {
+		const root = await makeSharedFolder('marker');
+		const target = await Folder.save({ title: 'target', parent_id: root.id });
+		await Folder.delete(target.id, { toTrash: true });
+		const source = await Folder.save({ title: 'source' });
+		const note = await Note.save({ title: 'locked', parent_id: source.id, is_locked: 1 });
+
+		await expect(onFolderDrop([], [source.id], target.id)).rejects.toThrow('cannot be moved');
+		// A late rejection would leave the folder live but its children already in the trash.
+		expect((await Folder.load(source.id)).deleted_time).toBe(0);
+		expect((await Note.load(note.id)).deleted_time).toBe(0);
+		expect((await Note.load(note.id)).parent_id).toBe(source.id);
+	});
+
+	it('should refuse turning a locked conflict into a normal note under a shared notebook', async () => {
+		const folder = await makeSharedFolder('marker');
+		const conflict = await Note.save({ title: 'conflict', is_locked: 1, is_conflict: 1, parent_id: folder.id });
+
+		await expect(Note.moveToFolder(conflict.id, folder.id)).rejects.toThrow('cannot be moved');
+		expect((await Note.load(conflict.id)).is_conflict).toBe(1);
+
+		const privateFolder = await Folder.save({ title: 'private' });
+		await expect(Note.moveToFolder(conflict.id, privateFolder.id)).resolves.toBeTruthy();
+		expect((await Note.load(conflict.id)).is_conflict).toBe(0);
+	});
+
+	// Resolving a conflict in place is the common recovery gesture, so it must not regress.
+	it('should allow resolving a locked conflict onto its own private parent', async () => {
+		const folder = await Folder.save({ title: 'private' });
+		const conflict = await Note.save({ title: 'conflict', is_locked: 1, is_conflict: 1, parent_id: folder.id });
+
+		await expect(Note.moveToFolder(conflict.id, folder.id)).resolves.toBeTruthy();
+		expect((await Note.load(conflict.id)).is_conflict).toBe(0);
+	});
+
+	it('should do nothing when note lock is disabled', async () => {
+		Setting.setValue('featureFlag.noteLock', false);
+		const folder = await Folder.save({ title: 'shared', share_id: 'share-1' });
+		const note = await Note.save({ title: 'note', parent_id: folder.id });
+
+		await expect(Note.save({ id: note.id, is_locked: 1 })).resolves.toBeTruthy();
+	});
+
+});

--- a/packages/lib/models/utils/noteLockShareGuard.ts
+++ b/packages/lib/models/utils/noteLockShareGuard.ts
@@ -1,0 +1,71 @@
+import { ModelType } from '../../BaseModel';
+import { State as ShareState, ShareType } from '../../services/share/reducer';
+import ItemChange from '../ItemChange';
+import { _ } from '../../locale';
+import { FolderEntity, NoteEntity } from '../../services/database/types';
+
+type FolderClass = typeof import('../Folder').default;
+type BaseItemClass = typeof import('../BaseItem').default;
+
+export const noteHasActiveNoteShare = (shareState: ShareState, noteId: string) => {
+	return (shareState?.shares ?? []).some(share => share.type === ShareType.Note && share.note_id === noteId);
+};
+
+export const folderIsInActiveShare = async (Folder: FolderClass, shareState: ShareState, folderId: string) => {
+	const ancestors = await Folder.selfAndAncestors(folderId);
+	if (ancestors.some(folder => folder.share_id || folder.is_shared)) return true;
+
+	const ancestorIds = ancestors.map(folder => folder.id);
+	return (shareState?.shares ?? []).some(share => [ShareType.Folder, ShareType.PublishedFolder].includes(share.type) && !!share.folder_id && ancestorIds.includes(share.folder_id));
+};
+
+// Model-boundary checks for the two share/lock invariants: a note cannot become locked while
+// shared or published, and locked content cannot enter a share. Sync-sourced saves are exempt.
+export const checkNoteLockShareInvariants = async (BaseItem: BaseItemClass, Folder: FolderClass, itemType: ModelType, changeSource: number, shareState: ShareState, o: NoteEntity | FolderEntity, isNew: boolean) => {
+	if (changeSource === ItemChange.SOURCE_SYNC) return;
+
+	if (itemType === ModelType.Note) {
+		const note = o as NoteEntity;
+		const mightLock = !!note.is_locked;
+		const mightMove = 'parent_id' in note && !isNew;
+		if (!mightLock && ('is_locked' in note || !mightMove)) return;
+
+		const previous: NoteEntity = isNew ? null : await BaseItem.loadItemByTypeAndId(itemType, note.id, { fields: ['id', 'parent_id', 'is_locked', 'is_conflict', 'is_shared', 'share_id'] });
+		if (!isNew && !previous) return;
+
+		const wasLocked = !!previous?.is_locked;
+		const isLocked = 'is_locked' in note ? !!note.is_locked : wasLocked;
+		const isConflict = 'is_conflict' in note ? !!note.is_conflict : !!previous?.is_conflict;
+		if (!isLocked || isConflict) return;
+
+		const locking = mightLock && !wasLocked;
+		const parentChanged = mightMove && note.parent_id !== previous.parent_id;
+		// Clearing is_conflict lets the note sync again, so it counts as entering its parent.
+		const conflictCleared = 'is_conflict' in note && !note.is_conflict && !!previous?.is_conflict;
+		if (!locking && !parentChanged && !conflictCleared) return;
+
+		if (locking) {
+			const isShared = 'is_shared' in note ? note.is_shared : previous?.is_shared;
+			const shareId = 'share_id' in note ? note.share_id : previous?.share_id;
+			if (shareId || isShared || noteHasActiveNoteShare(shareState, note.id)) {
+				throw new Error(_('This note cannot be locked because it is shared or published'));
+			}
+		}
+
+		const parentId = 'parent_id' in note ? note.parent_id : previous?.parent_id;
+		if (parentId && await folderIsInActiveShare(Folder, shareState, parentId)) {
+			if (locking) throw new Error(_('This note cannot be locked because it is shared or published'));
+			throw new Error(_('This note cannot be moved to a shared or published notebook because it is locked'));
+		}
+	} else if (itemType === ModelType.Folder) {
+		const folder = o as FolderEntity;
+		if (isNew || !('parent_id' in folder)) return;
+
+		const previous: FolderEntity = await BaseItem.loadItemByTypeAndId(itemType, folder.id, { fields: ['id', 'parent_id'] });
+		if (!previous || folder.parent_id === previous.parent_id || !folder.parent_id) return;
+
+		if (await folderIsInActiveShare(Folder, shareState, folder.parent_id) && await Folder.hasLockedNotes(folder.id)) {
+			throw new Error(_('This notebook cannot be moved to a shared or published notebook because it contains locked notes'));
+		}
+	}
+};

--- a/packages/lib/services/noteLock/setNoteLockState.test.ts
+++ b/packages/lib/services/noteLock/setNoteLockState.test.ts
@@ -8,6 +8,10 @@ import NoteLockService from './NoteLockService';
 import NoteLockSession from './NoteLockSession';
 import { disableNoteLock, enableNoteLock } from './setNoteLockState';
 import eventManager, { EventName } from '../../eventManager';
+import BaseItem from '../../models/BaseItem';
+import { defaultState as defaultShareState, ShareType } from '../share/reducer';
+
+const sharedOrPublishedError = 'Cannot lock a note that is being shared or published';
 
 const setUpUnlockedSession = async (password = '123456') => {
 	await NoteLockKey.instance().create(password);
@@ -24,6 +28,7 @@ describe('setNoteLockState', () => {
 		NoteLockKey.destroyInstance();
 		EncryptionService.instance_ = encryptionService();
 		Setting.setValue('featureFlag.noteLock', true);
+		BaseItem.syncShareCache = defaultShareState;
 	});
 
 	afterAll(async () => {
@@ -83,6 +88,84 @@ describe('setNoteLockState', () => {
 		const note = await Note.save({ title: 'note', body: 'secret', ...fields });
 		await expect(enableNoteLock(note.id)).rejects.toThrow();
 		expect((await Note.load(note.id)).is_locked).toBe(0);
+	});
+
+	test.each([
+		['note in a shared notebook', { share_id: 'share-1' }],
+		['published note', { is_shared: 1 }],
+	])('should refuse to lock a %s', async (_label, fields) => {
+		await setUpUnlockedSession();
+		const note = await Note.save({ title: 'note', body: 'secret', ...fields });
+		await expect(enableNoteLock(note.id)).rejects.toThrow();
+		expect((await Note.load(note.id)).is_locked).toBe(0);
+	});
+
+	// Only entering the lock is blocked: a note that reached either state while already locked
+	// would otherwise have no way back.
+	test.each([
+		['note in a shared notebook', { share_id: 'share-1' }],
+		['published note', { is_shared: 1 }],
+	])('should still allow removing the lock from a %s', async (_label, fields) => {
+		await setUpUnlockedSession();
+		// Two steps because the model guard refuses creating a note that is locked and shared at once.
+		const note = await Note.save({ title: 'note', body: 'secret', is_locked: 1 });
+		await Note.save({ id: note.id, ...fields });
+		await expect(disableNoteLock(note.id)).resolves.toBeUndefined();
+	});
+
+	// Sharing and publishing only stamp share_id and is_shared on the notes during the next sync,
+	// so the note row still looks untouched while the share already exists on the server.
+	test.each([
+		['published notebook', ShareType.PublishedFolder],
+		['shared notebook', ShareType.Folder],
+	])('should refuse to lock a note in an already %s before sync marks the note', async (_label, type) => {
+		await setUpUnlockedSession();
+		const parent = await Folder.save({ title: 'parent' });
+		const folder = await Folder.save({ title: 'child', parent_id: parent.id });
+		const note = await Note.save({ title: 'note', body: 'secret', parent_id: folder.id });
+		BaseItem.syncShareCache = {
+			...defaultShareState,
+			shares: [{ id: 'share-1', type, folder_id: parent.id, note_id: '', master_key_id: '' }],
+		};
+
+		await expect(enableNoteLock(note.id)).rejects.toThrow(sharedOrPublishedError);
+		expect((await Note.load(note.id)).is_locked).toBe(0);
+	});
+
+	it('should refuse to lock a note that is already published on its own', async () => {
+		await setUpUnlockedSession();
+		const note = await Note.save({ title: 'note', body: 'secret' });
+		BaseItem.syncShareCache = {
+			...defaultShareState,
+			shares: [{ id: 'share-1', type: ShareType.Note, folder_id: '', note_id: note.id, master_key_id: '' }],
+		};
+
+		await expect(enableNoteLock(note.id)).rejects.toThrow(sharedOrPublishedError);
+	});
+
+	// A note created inside a shared notebook keeps share_id = '' until the next sync propagates
+	// it, so the ancestor's own marker is the only local evidence in the meantime.
+	test.each([
+		['shared', { share_id: 'share-1' }],
+		['published', { is_shared: 1 }],
+	])('should refuse to lock a note whose notebook is %s while the cache is empty', async (_label, fields) => {
+		await setUpUnlockedSession();
+		const root = await Folder.save({ title: 'root', ...fields });
+		const child = await Folder.save({ title: 'child', parent_id: root.id });
+		const note = await Note.save({ title: 'note', body: 'secret', parent_id: child.id });
+		BaseItem.syncShareCache = { ...defaultShareState, shares: [] };
+
+		await expect(enableNoteLock(note.id)).rejects.toThrow(sharedOrPublishedError);
+		expect((await Note.load(note.id)).is_locked).toBe(0);
+	});
+
+	it('should allow locking again once the share is gone from both the rows and the cache', async () => {
+		await setUpUnlockedSession();
+		const folder = await Folder.save({ title: 'folder' });
+		const note = await Note.save({ title: 'note', body: 'secret', parent_id: folder.id });
+		BaseItem.syncShareCache = { ...defaultShareState, shares: [] };
+
+		await expect(enableNoteLock(note.id)).resolves.toBeUndefined();
 	});
 
 	it('should throw when note lock is not enabled', async () => {

--- a/packages/lib/services/noteLock/setNoteLockState.ts
+++ b/packages/lib/services/noteLock/setNoteLockState.ts
@@ -1,6 +1,7 @@
 import { ModelType } from '../../BaseModel';
 import BaseItem from '../../models/BaseItem';
 import ItemChange from '../../models/ItemChange';
+import Folder from '../../models/Folder';
 import Note from '../../models/Note';
 import Setting from '../../models/Setting';
 import { itemIsReadOnlySync, ItemSlice } from '../../models/utils/readOnly';
@@ -8,6 +9,7 @@ import { NoteEntity } from '../database/types';
 import eventManager, { EventName } from '../../eventManager';
 import isNoteLockEnabled from './isNoteLockEnabled';
 import NoteLockSession from './NoteLockSession';
+import { folderIsInActiveShare, noteHasActiveNoteShare } from '../../models/utils/noteLockShareGuard';
 
 // The UI hides the enable/disable actions for these cases, but the commands can also be
 // invoked directly (keyboard, plugins), so the transitions fail closed here too.
@@ -20,7 +22,14 @@ const checkCanChangeLockState = (note: NoteEntity, noteId: string) => {
 	if (!NoteLockSession.instance().isUnlocked()) throw new Error('Cannot change encryption while the note lock session is locked');
 };
 
-const validationFields = ['id', 'is_locked', 'deleted_time', 'is_conflict', 'share_id'];
+const validationFields = ['id', 'is_locked', 'deleted_time', 'is_conflict', 'share_id', 'is_shared', 'parent_id'];
+
+// Per-item share markers can lag the active share state during creation or sync, in either
+// direction, so both the ancestry and the live share list are consulted.
+const isInActiveShare = async (note: NoteEntity) => {
+	if (noteHasActiveNoteShare(BaseItem.syncShareCache, note.id)) return true;
+	return folderIsInActiveShare(Folder, BaseItem.syncShareCache, note.parent_id);
+};
 
 // These only validate and emit: the note screen listens for the event and persists the
 // change with a scheduled gated save.
@@ -28,6 +37,11 @@ export const enableNoteLock = async (noteId: string) => {
 	const note = await Note.load(noteId, { fields: validationFields });
 	checkCanChangeLockState(note, noteId);
 	if (note.is_locked) throw new Error(`Note is already locked: ${noteId}`);
+	// Recipients cannot read a locked note and a published one would serve its ciphertext, so the
+	// lock is refused here rather than in the shared check, which would also block removing it.
+	if (note.share_id) throw new Error('Cannot lock a note that is in a shared notebook');
+	if (note.is_shared) throw new Error('Cannot lock a note that is published');
+	if (await isInActiveShare(note)) throw new Error('Cannot lock a note that is being shared or published');
 	eventManager.emit(EventName.NoteLockNoteStateChange, { noteId, isLocked: true });
 };
 

--- a/packages/lib/services/rest/routes/folders.test.ts
+++ b/packages/lib/services/rest/routes/folders.test.ts
@@ -2,6 +2,7 @@ import Note from '../../../models/Note';
 import Api, { RequestMethod } from '../Api';
 import { setupDatabaseAndSynchronizer, switchClient } from '../../../testing/test-utils';
 import Folder from '../../../models/Folder';
+import Setting from '../../../models/Setting';
 
 describe('routes/folders', () => {
 
@@ -122,5 +123,23 @@ describe('routes/folders', () => {
 			const notes = await api.route(RequestMethod.GET, `folders/${folder.id}/notes`, { include_deleted: '1' });
 			expect(notes.items.length).toBe(2);
 		}
+	});
+
+	// The next sync serializes the marker and the server attaches the folder tree to the share,
+	// which would carry the locked note along.
+	test('should not let a folder with a locked note gain a sharing state through the API', async () => {
+		Setting.setValue('featureFlag.noteLock', true);
+		const api = new Api();
+		const folder = await Folder.save({ title: 'folder' });
+		await Note.save({ title: 'locked', parent_id: folder.id, is_locked: 1 });
+
+		await expect(api.route(RequestMethod.PUT, `folders/${folder.id}`, null, JSON.stringify({ share_id: 'share-1' }))).rejects.toThrow('sharing state');
+		await expect(api.route(RequestMethod.PUT, `folders/${folder.id}`, null, JSON.stringify({ is_shared: 1 }))).rejects.toThrow('sharing state');
+		expect((await Folder.load(folder.id)).share_id).toBe('');
+		expect((await Folder.load(folder.id)).is_shared).toBe(0);
+
+		Setting.setValue('featureFlag.noteLock', false);
+		await api.route(RequestMethod.PUT, `folders/${folder.id}`, null, JSON.stringify({ title: 'renamed' }));
+		expect((await Folder.load(folder.id)).title).toBe('renamed');
 	});
 });

--- a/packages/lib/services/rest/routes/folders.ts
+++ b/packages/lib/services/rest/routes/folders.ts
@@ -7,7 +7,7 @@ import requestFields from '../utils/requestFields';
 import Folder from '../../../models/Folder';
 import { allForDisplay } from '../../../folders-screen-utils';
 import isNoteLockEnabled from '../../noteLock/isNoteLockEnabled';
-const { ErrorNotFound } = require('../utils/errors');
+const { ErrorForbidden, ErrorNotFound } = require('../utils/errors');
 
 export default async function(request: Request, id: string = null, link: string = null) {
 	const includeDeleted = request.query.include_deleted === '1';
@@ -40,6 +40,19 @@ export default async function(request: Request, id: string = null, link: string 
 	if (request.method === RequestMethod.DELETE) {
 		await Folder.delete(id, { toTrash: request.query.permanent !== '1', sourceDescription: 'api/folders DELETE' });
 		return;
+	}
+
+	if (isNoteLockEnabled() && request.method === RequestMethod.PUT && id) {
+		const folder = await Folder.load(id, { fields: ['id', 'share_id', 'is_shared'] });
+		const newProps = request.bodyJson();
+		if (folder) {
+			// The next sync would upload these markers and attach the folder tree to the share.
+			const gainsShareId = 'share_id' in newProps && !!newProps.share_id && newProps.share_id !== folder.share_id;
+			const gainsIsShared = 'is_shared' in newProps && !!Folder.filter({ is_shared: newProps.is_shared }).is_shared && !folder.is_shared;
+			if ((gainsShareId || gainsIsShared) && await Folder.hasLockedNotes(id)) {
+				throw new ErrorForbidden('The sharing state of a notebook that contains locked notes cannot be changed through the API');
+			}
+		}
 	}
 
 	return defaultAction(BaseModel.TYPE_FOLDER, request, id, link);

--- a/packages/lib/services/rest/routes/notes.test.ts
+++ b/packages/lib/services/rest/routes/notes.test.ts
@@ -269,6 +269,19 @@ describe('routes/notes', () => {
 		expect((await Note.load(note.id)).is_locked).toBe(startLocked);
 	});
 
+	// The next sync serializes these markers and the server attaches the item to the share, so a
+	// locked note must not be able to gain them through the API.
+	test('should not let a locked note gain a sharing state through the API', async () => {
+		Setting.setValue('featureFlag.noteLock', true);
+		const api = new Api();
+		const note = await Note.save({ title: 'locked', body: 'ciphertext', is_locked: 1 });
+
+		await expect(api.route(RequestMethod.PUT, `notes/${note.id}`, null, JSON.stringify({ share_id: 'share-1' }))).rejects.toThrow('sharing state');
+		await expect(api.route(RequestMethod.PUT, `notes/${note.id}`, null, JSON.stringify({ is_shared: 1 }))).rejects.toThrow('sharing state');
+		expect((await Note.load(note.id)).share_id).toBe('');
+		expect((await Note.load(note.id)).is_shared).toBe(0);
+	});
+
 	test('should exclude locked notes from collection responses', async () => {
 		Setting.setValue('featureFlag.noteLock', true);
 		const api = new Api();

--- a/packages/lib/services/rest/routes/notes.ts
+++ b/packages/lib/services/rest/routes/notes.ts
@@ -559,6 +559,12 @@ export default async function(request: Request, id: string = null, link: string 
 			// Compare through the model's own coercion: Number() reads "1foo" as NaN, but the save path stores it as 1.
 			if ('is_locked' in newProps && !!Note.filter({ is_locked: newProps.is_locked }).is_locked !== !!note.is_locked) throw new ErrorForbidden('The note lock state cannot be changed through the API');
 			if (NoteLockNote.isLocked(note) && 'body' in newProps) throw new ErrorForbidden('The body of a locked note cannot be modified through the API');
+			if (NoteLockNote.isLocked(note)) {
+				// The next sync would upload these markers and attach the note to the share.
+				const gainsShareId = 'share_id' in newProps && !!newProps.share_id && newProps.share_id !== note.share_id;
+				const gainsIsShared = 'is_shared' in newProps && !!Note.filter({ is_shared: newProps.is_shared }).is_shared && !note.is_shared;
+				if (gainsShareId || gainsIsShared) throw new ErrorForbidden('The sharing state of a locked note cannot be changed through the API');
+			}
 		}
 
 		if (!('user_updated_time' in newProps)) newProps.user_updated_time = timestamp;

--- a/packages/lib/services/share/ShareService.test.ts
+++ b/packages/lib/services/share/ShareService.test.ts
@@ -604,4 +604,138 @@ describe('ShareService', () => {
 		await expect(service.publishFolder('000000000000000000000000000000F9')).rejects.toThrow('No such folder: 000000000000000000000000000000F9');
 	});
 
+	it('should drop a deleted share from live state so locking works again', async () => {
+		Setting.setValue('featureFlag.noteLock', true);
+		const service = testShareFolderService();
+		const { folder } = await testShareFolder(service);
+		await service.refreshShares();
+		expect(service.shares).toHaveLength(1);
+
+		await service.unshareFolder(folder.id);
+
+		// Left behind, the note lock guard would keep rejecting until the next sync refreshed it.
+		expect(service.shares).toHaveLength(0);
+	});
+
+	it('should drop a deleted note share from live state right after unsharing', async () => {
+		Setting.setValue('featureFlag.noteLock', true);
+		const folder = await Folder.save({ title: 'folder' });
+		const note = await Note.save({ title: 'note', parent_id: folder.id });
+		const serverShares = [
+			{ id: 'share_n1', type: ShareType.Note, note_id: note.id, folder_id: '', master_key_id: '' },
+			{ id: 'share_u1', type: ShareType.Folder, note_id: '', folder_id: 'unrelated-folder', master_key_id: '' },
+		];
+		const service = testShareFolderService({
+			'GET api/shares': () => ({ items: [...serverShares] }),
+		});
+		await service.refreshShares();
+		expect(service.shares).toHaveLength(2);
+
+		await service.unshareNote(note.id);
+
+		// Only the deleted share leaves; an unrelated active share must survive the eviction.
+		expect(service.shares.map(s => s.id)).toEqual(['share_u1']);
+	});
+
+	// The remote DELETE can succeed and the follow-up refresh fail, so the share must leave live
+	// state before the refresh, or the note lock guard keeps rejecting until a later sync.
+	it('should drop a deleted published folder share from live state even when the refresh fails', async () => {
+		Setting.setValue('featureFlag.noteLock', true);
+		const folder = await Folder.save({ title: 'folder' });
+		const serverShares = [
+			{ id: 'share_p1', type: ShareType.PublishedFolder, note_id: '', folder_id: folder.id, master_key_id: '' },
+			{ id: 'share_u1', type: ShareType.Folder, note_id: '', folder_id: 'unrelated-folder', master_key_id: '' },
+		];
+		let failGet = false;
+		const service = testShareFolderService({
+			'GET api/shares': () => {
+				if (failGet) throw new Error('network down');
+				return { items: [...serverShares] };
+			},
+		});
+		await service.refreshShares();
+		expect(service.shares).toHaveLength(2);
+
+		failGet = true;
+		await expect(service.unpublishFolder(folder.id)).rejects.toThrow('network down');
+
+		expect(service.shares.map(s => s.id)).toEqual(['share_u1']);
+	});
+
+	// The eviction must come after the remote DELETE: a failed DELETE means the share still
+	// exists remotely, so forgetting it locally would let a locked note slip into it.
+	it('should keep the share in live state when the remote delete fails', async () => {
+		Setting.setValue('featureFlag.noteLock', true);
+		const folder = await Folder.save({ title: 'folder' });
+		const note = await Note.save({ title: 'note', parent_id: folder.id });
+		const serverShares = [
+			{ id: 'share_n1', type: ShareType.Note, note_id: note.id, folder_id: '', master_key_id: '' },
+			{ id: 'share_p1', type: ShareType.PublishedFolder, note_id: '', folder_id: folder.id, master_key_id: '' },
+		];
+		const service = testShareFolderService({
+			'GET api/shares': () => ({ items: [...serverShares] }),
+			'DELETE api/shares/share_n1': () => { throw new Error('network down'); },
+			'DELETE api/shares/share_p1': () => { throw new Error('network down'); },
+		});
+		await service.refreshShares();
+
+		await expect(service.unshareNote(note.id)).rejects.toThrow('network down');
+		await expect(service.unpublishFolder(folder.id)).rejects.toThrow('network down');
+		expect(service.shares).toHaveLength(2);
+	});
+
+	it('should refuse to share a folder containing a locked note, before posting or moving it', async () => {
+		Setting.setValue('featureFlag.noteLock', true);
+		const parent = await Folder.save({ title: 'parent' });
+		const folder = await Folder.save({ title: 'to share', parent_id: parent.id });
+		await Note.save({ title: 'locked', parent_id: folder.id, is_locked: 1 });
+
+		const postShares = jest.fn();
+		const service = testShareFolderService({ 'POST api/shares': postShares });
+
+		await expect(service.shareFolder(folder.id)).rejects.toThrow();
+		expect(postShares).not.toHaveBeenCalled();
+		// Sharing moves a nested folder to the root, so an unchanged parent shows nothing ran.
+		expect((await Folder.load(folder.id)).parent_id).toBe(parent.id);
+	});
+
+	it('should refuse to publish a locked note or a folder holding one', async () => {
+		Setting.setValue('featureFlag.noteLock', true);
+		const folder = await Folder.save({ title: 'folder' });
+		const note = await Note.save({ title: 'locked', parent_id: folder.id, is_locked: 1 });
+
+		const postShares = jest.fn();
+		const service = testShareFolderService({ 'POST api/shares': postShares });
+
+		await expect(service.shareNote(note.id, false)).rejects.toThrow();
+		await expect(service.publishFolder(folder.id)).rejects.toThrow();
+		expect(postShares).not.toHaveBeenCalled();
+	});
+
+	// Trash is a soft delete that keeps the parent, so restoring the note afterwards would
+	// publish it on the next sync without the user ever choosing to.
+	it('should refuse to publish a folder whose only locked note is in the trash', async () => {
+		Setting.setValue('featureFlag.noteLock', true);
+		const folder = await Folder.save({ title: 'folder' });
+		await Note.save({ title: 'locked', parent_id: folder.id, is_locked: 1, deleted_time: 1 });
+
+		const postShares = jest.fn();
+		const service = testShareFolderService({ 'POST api/shares': postShares });
+
+		await expect(service.publishFolder(folder.id)).rejects.toThrow();
+		expect(postShares).not.toHaveBeenCalled();
+	});
+
+	it('should leave sharing and publishing alone when note lock is disabled', async () => {
+		Setting.setValue('featureFlag.noteLock', false);
+		const toShare = await Folder.save({ title: 'to share' });
+		const toPublish = await Folder.save({ title: 'to publish' });
+		const note = await Note.save({ title: 'locked', parent_id: toPublish.id, is_locked: 1 });
+		await Note.save({ title: 'locked too', parent_id: toShare.id, is_locked: 1 });
+
+		await expect(testShareFolderService().shareFolder(toShare.id)).resolves.toBeTruthy();
+		await expect(testShareFolderService().shareNote(note.id, false)).resolves.toBeTruthy();
+		await expect(testShareFolderService().publishFolder(toPublish.id)).resolves.toBeTruthy();
+	});
+
 });

--- a/packages/lib/services/share/ShareService.ts
+++ b/packages/lib/services/share/ShareService.ts
@@ -14,6 +14,7 @@ import { MasterKeyEntity } from '../e2ee/types';
 import { getMasterPassword } from '../e2ee/utils';
 import ResourceService from '../ResourceService';
 import { addMasterKey, getEncryptionEnabled, localSyncInfo } from '../synchronizer/syncInfoUtils';
+import isNoteLockEnabled from '../noteLock/isNoteLockEnabled';
 import { ShareInvitation, SharePermissions, ShareType, State, stateRootKey, StateShare } from './reducer';
 import PerformanceLogger from '../../PerformanceLogger';
 
@@ -111,6 +112,12 @@ export default class ShareService {
 		const folder = await Folder.load(folderId);
 		if (!folder) throw new Error(`No such folder: ${folderId}`);
 
+		// Recipients cannot read a locked note. Checked here because the steps below already
+		// change the local profile, well before the share request is sent.
+		if (isNoteLockEnabled() && await Folder.hasLockedNotes(folderId)) {
+			throw new Error(_('This notebook cannot be shared because it contains locked notes.'));
+		}
+
 		let folderMasterKey: MasterKeyEntity = null;
 
 		if (getEncryptionEnabled()) {
@@ -178,6 +185,15 @@ export default class ShareService {
 		// shared again.
 		// TODO: Remove the now-unused master key from local sync info.
 		await Folder.save({ id: folderId, master_key_id: '' });
+
+		// The note lock guard reads this list, so a deleted share must leave it right away rather
+		// than at the next sync, otherwise locking stays blocked in a notebook no longer shared.
+		if (isNoteLockEnabled()) {
+			this.store.dispatch({
+				type: 'SHARE_SET',
+				shares: this.shares.filter(s => s.id !== share.id),
+			});
+		}
 
 		// Then reset the "share_id" field for the folder and all sub-items.
 		// This could potentially be done server-side, when deleting the share,
@@ -290,6 +306,10 @@ export default class ShareService {
 	public async shareNote(noteId: string, recursive: boolean): Promise<StateShare> {
 		const note = await Note.load(noteId);
 		if (!note) throw new Error(`No such note: ${noteId}`);
+		// A published locked note would serve its ciphertext to anyone with the link.
+		if (isNoteLockEnabled() && note.is_locked) {
+			throw new Error(_('This note cannot be published because it is locked.'));
+		}
 
 		const share = await this.api().exec('POST', 'api/shares', {}, {
 			note_id: noteId,
@@ -311,6 +331,10 @@ export default class ShareService {
 	public async publishFolder(folderId: string): Promise<StateShare> {
 		const folder = await Folder.load(folderId);
 		if (!folder) throw new Error(`No such folder: ${folderId}`);
+
+		if (isNoteLockEnabled() && await Folder.hasLockedNotes(folderId)) {
+			throw new Error(_('This notebook cannot be published because it contains locked notes.'));
+		}
 
 		const share = await this.api().exec('POST', 'api/shares', {}, {
 			folder_id: folderId,
@@ -350,6 +374,16 @@ export default class ShareService {
 
 		// Clean local state first so next sync can recover if deletion stops midway
 		await this.deleteShare(share.id);
+
+		// Same reason as the SHARE_SET in unshareFolder: the refresh below can fail after a
+		// successful delete, and the note lock guard reads this list.
+		if (isNoteLockEnabled()) {
+			this.store.dispatch({
+				type: 'SHARE_SET',
+				shares: remainingShares,
+			});
+		}
+
 		await this.refreshShares();
 	}
 
@@ -367,6 +401,16 @@ export default class ShareService {
 		}
 
 		await Promise.all(promises);
+
+		// Same reason as the SHARE_SET in unshareFolder: nothing refreshes the list here until a
+		// later sync, and the note lock guard reads it.
+		if (isNoteLockEnabled() && noteShares.length) {
+			const deletedIds = noteShares.map(s => s.id);
+			this.store.dispatch({
+				type: 'SHARE_SET',
+				shares: this.shares.filter(s => !deletedIds.includes(s.id)),
+			});
+		}
 
 		await Note.save({
 			id: note.id,


### PR DESCRIPTION
## Summary

Resolves #16336
Disallows the combinations of note lock and sharing, behind the existing feature flag: a note cannot become locked while it is shared or published, and locked content cannot enter a shared or published notebook.

Sharing and publishing:

- Sharing or publishing a notebook that contains a locked note, and publishing a locked note, are refused before any request is sent or any local state is changed. Deleted notes count, since restoring one would otherwise publish it later.
- After unsharing or unpublishing, the deleted share leaves the local share state immediately, so locking works again right away even if the follow-up refresh fails.

Model level, so API, CLI and plugin routes are covered as requested on the issue:

- A check in `BaseItem.save`, next to the existing read-only share checks, refuses locking a note that is shared or published, moving a locked note into a shared or published notebook, moving a notebook containing locked notes into one, and turning a locked conflict back into a normal note under a shared ancestor.
- Sync saves are exempt so remote state always applies, and share marker propagation never triggers the check, so sync maintenance cannot fail on it.
- Dropping items onto a deleted folder re-parents through batch SQL that skips `BaseItem.save`, so `Note.batchDelete` and `Folder.batchDelete` validate the destination first. The folder check runs before any child is deleted, so a rejected drop cannot leave a partially trashed tree.

Data API:

- A locked note cannot gain `share_id` or `is_shared` through PUT, and neither can a folder that contains locked notes, mirroring the #16098 restrictions. Clearing these markers stays allowed as a recovery path.
- The CLI needed no change, `set` already refuses any modification of a locked note.

Moving a locked note, or a notebook containing one, is only refused when the destination is shared or published. All other moves, and removing a lock, keep working as before, so #15961 behaviour is otherwise unchanged. With the flag off, nothing changes.

Known limitations:

- A share or publish request already in flight when a lock happens in another window is not serialized against it. The preflights and the model check cover every deterministic path, and the state is recoverable since unlock and unshare stay available.
- "Also publish linked notes" can expose a locked note linked from a published note, and a later lock or link edit can create the same state. Being discussed separately, will be restricted in a follow-up here or handled on its own.
- Client-side checks cannot cover a caller using the Joplin Server API directly; the server side belongs to the #16304 work.

## Testing

- `yarn tsc` for lib, eslint on the changed files
- `yarn workspace @joplin/lib test` (noteLockShareGuard, setNoteLockState, ShareService, routes/notes, routes/folders, Folder, Note, onFolderDrop, trash, RevisionService, ResourceService, convertNoteToMarkdown, config-shared)
- `yarn workspace joplin test` (command-set, command-cat, command-edit)
- Manually tested against a local Joplin Server with two accounts:
  - Sharing a notebook with a locked note inside stops with the dialog error and no request reaches the server (checked the server log). After removing the lock the same share goes through and the recipient is added.
  - Locking a note in the shared notebook, moving a locked note into it, and dragging a locked note or a notebook containing one onto a deleted folder under it all stop with a popup, and nothing lands in the trash on the rejected drops.
  - Publishing a locked note stops; publishing a plain note works, and locking it afterwards stops.
  - Right after unsharing or unpublishing, locking works again without waiting for a sync.

## Screenshots

| Sharing refused | Locking in a shared notebook | Publishing a plain note works |
| --- | --- | --- |
| <img width="300" alt="Share notebook refused because it contains locked notes" src="https://github.com/user-attachments/assets/0e0bff44-2b5a-4592-98bb-d7ed23536371" /> | <img width="300" alt="Cannot lock a note in a shared notebook" src="https://github.com/user-attachments/assets/108d104e-0fe0-423d-9e1b-1fe3fc03943f" /> | <img width="300" alt="Publishing an unlocked note works" src="https://github.com/user-attachments/assets/ae2106ac-13e1-4109-8711-4d9bb93cc463" /> |

| Drop onto a deleted shared folder | Publishing a locked note | Locking a published note |
| --- | --- | --- |
| <img width="300" alt="Dropping a notebook with a locked note onto a deleted shared folder refused" src="https://github.com/user-attachments/assets/27f083b5-f41d-42e8-898a-7a1ac4ec3245" /> | <img width="300" alt="Publishing a locked note refused" src="https://github.com/user-attachments/assets/df49fe4f-9d85-49b9-bfbf-036b39002438" /> | <img width="300" alt="Locking a published note refused" src="https://github.com/user-attachments/assets/1fdeb4a0-35c2-4581-a325-b90d139abdb0" /> |

| Sharing works without locked notes | Moving a locked note |
| --- | --- |
| <img width="300" alt="Share succeeds after removing the lock" src="https://github.com/user-attachments/assets/c215068d-556a-4523-885e-3e515c1e607a" /> | <img width="420" alt="Moving a locked note into a shared notebook refused" src="https://github.com/user-attachments/assets/a3a82b47-cfc3-413a-9a8d-092ea7594a0f" /> |

The move popup screenshot predates a final wording tweak (the message now reads "This note cannot be moved to a shared or published notebook because it is locked"), behaviour unchanged.


## AI Assistance Disclosure

I used AI tools while working on this PR for code suggestions and review, testing support, and drafting parts of this description, including the disclosure. I reviewed the final changes and reran the tests listed above myself.