### PR TITLE
Mobile: Fixes #15982: Mobile: Tag list design should be consistent with the note list

### DIFF
--- a/packages/app-mobile/components/screens/tags.tsx
+++ b/packages/app-mobile/components/screens/tags.tsx
@@ -14,7 +14,7 @@ import useQueuedAsyncEffect from '@joplin/lib/hooks/useQueuedAsyncEffect';
 import { getCollator, getCollatorLocale } from '@joplin/lib/models/utils/getCollator';
 import { DialogContext } from '../DialogManager';
 import useOnLongPressProps from '../../utils/hooks/useOnLongPressProps';
-import { substrWithEllipsis } from '@joplin/lib/string-utils';
+import { escapeRegExp, substrWithEllipsis } from '@joplin/lib/string-utils';
 import { PromptButtonSpec } from '../DialogManager/types';
 import MultiTouchableOpacity from '../buttons/MultiTouchableOpacity';
 import SearchBar from './SearchScreen/SearchBar';
@@ -27,40 +27,51 @@ interface Props {
 	themeId: number;
 }
 
-const useStyles = (themeId: number) => {
+const useStyles = (themeId: number, showTopBorder = false) => {
 	return useMemo(() => {
 		const theme = themeStyle(themeId);
 
 		return StyleSheet.create({
-			listItem: {
-				flexDirection: 'row',
-				borderBottomWidth: 1,
-				borderBottomColor: theme.dividerColor,
-				alignItems: 'flex-start',
+			listItemDivider: {
+				borderTopWidth: showTopBorder ? 1 : 0,
+				borderTopColor: theme.dividerColor,
+				marginLeft: theme.marginLeft,
+				marginRight: theme.marginRight,
+			},
+			listItemPressable: {
 				paddingLeft: theme.marginLeft,
 				paddingRight: theme.marginRight,
-				paddingTop: theme.itemMarginTop,
-				paddingBottom: theme.itemMarginBottom,
+				paddingTop: theme.marginTop,
+				paddingBottom: theme.marginBottom,
 			},
 			listItemText: {
-				flex: 1,
+				flexShrink: 1,
 				color: theme.color,
 				fontSize: theme.fontSize,
 			},
+			highlightedText: {
+				backgroundColor: theme.searchMarkerBackgroundColor,
+				color: theme.searchMarkerColor,
+			},
 			rootStyle: theme.rootStyle,
 		});
-	}, [themeId]);
+	}, [themeId, showTopBorder]);
 };
 
 interface TagItemProps {
 	tag: TagEntity;
+	index: number;
+	highlightedWord: string;
 	themeId: number;
 	onPress: (id: string)=> void;
 	onLongPress: (tag: TagEntity)=> void;
 }
 
-const TagItem: React.FC<TagItemProps> = ({ tag, themeId, onPress, onLongPress }) => {
-	const styles = useStyles(themeId);
+const TagItem: React.FC<TagItemProps> = ({ tag, index, highlightedWord, themeId, onPress, onLongPress }) => {
+	const styles = useStyles(themeId, index !== 0);
+	const displayedTagTitle = highlightedWord ? tag.title.split(new RegExp(`(${escapeRegExp(highlightedWord)})`, 'i')).map((part, partIndex) => {
+		return part.toLowerCase() === highlightedWord.toLowerCase() ? <Text key={partIndex} style={styles.highlightedText}>{part}</Text> : part;
+	}) : tag.title;
 	const onLongPressProps = useOnLongPressProps({ onLongPress: () => onLongPress(tag), actionDescription: _('Edit tag') });
 	const accessibilityRole: AccessibilityRole = 'button';
 	const pressableProps = {
@@ -70,18 +81,17 @@ const TagItem: React.FC<TagItemProps> = ({ tag, themeId, onPress, onLongPress })
 	};
 
 	return (
-		<MultiTouchableOpacity
-			{...pressableProps}
-			containerProps={{
-				style: {},
-			}}
-			onPress={() => onPress(tag.id)}
-			beforePressable={null}
-		>
-			<View style={styles.listItem}>
-				<Text style={styles.listItemText}>{tag.title}</Text>
-			</View>
-		</MultiTouchableOpacity>
+		<View>
+			<View style={styles.listItemDivider}/>
+			<MultiTouchableOpacity
+				{...pressableProps}
+				style={styles.listItemPressable}
+				onPress={() => onPress(tag.id)}
+				beforePressable={null}
+			>
+				<Text style={styles.listItemText}>{displayedTagTitle}</Text>
+			</MultiTouchableOpacity>
+		</View>
 	);
 };
 
@@ -214,17 +224,19 @@ const TagsScreenComponent: React.FC<Props> = props => {
 		);
 	}, [dialogs]);
 
-	type RenderItemEvent = { item: TagEntity };
-	const onRenderItem = useCallback(({ item }: RenderItemEvent) => {
+	type RenderItemEvent = { item: TagEntity; index: number };
+	const onRenderItem = useCallback(({ item, index }: RenderItemEvent) => {
 		return (
 			<TagItem
 				tag={item}
+				index={index}
+				highlightedWord={searchQuery.trim()}
 				themeId={props.themeId}
 				onPress={(id) => onTagItemPress({ id })}
 				onLongPress={onTagItemLongPress}
 			/>
 		);
-	}, [onTagItemPress, onTagItemLongPress, props.themeId]);
+	}, [onTagItemPress, onTagItemLongPress, props.themeId, searchQuery]);
 
 	return (
 		<View style={styles.rootStyle}>
@@ -243,7 +255,7 @@ const TagsScreenComponent: React.FC<Props> = props => {
 					onClearButtonPress={clearButton_press}
 				/>
 			)}
-			<FlatList style={{ flex: 1 }} data={tags} renderItem={onRenderItem} keyExtractor={tag => tag.id} />
+			<FlatList style={{ flex: 1 }} data={showSearch && !searchQuery.trim() ? [] : tags} renderItem={onRenderItem} keyExtractor={tag => tag.id} />
 		</View>
 	);
 };


### PR DESCRIPTION
Fixes #15982

- [X] I Made the tag list UI similar to the note list UI.

- [X] Also I hide tags when the search input is empty 
Before:
<img width="430" height="786" alt="image" src="https://github.com/user-attachments/assets/ef567d88-8de8-43f5-82c3-e7361633e7ac" />

Now:
<img width="430" height="786" alt="image" src="https://github.com/user-attachments/assets/12f7a93d-8dc2-4b0a-b26e-0bceb91f8552" />



- [X] I also added highlighting to tag search results.

Tag list:

<img width="430" height="786" alt="Screenshot 2026-09-02 at 12 48 54 PM" src="https://github.com/user-attachments/assets/d02b6acc-4dae-45c1-a0b8-2e7606ec34af" />

Tag search:
<img width="430" height="786" alt="Screenshot 2026-09-02 at 12 48 59 PM" src="https://github.com/user-attachments/assets/b4fccd6d-7af9-4c12-8d9d-dc4433379947" />

- [X] Also I made Video that demonstrate that clickable area of the tag is correct (We had a problem with note padding before https://github.com/laurent22/joplin/pull/15987):

https://github.com/user-attachments/assets/640136bf-da11-4fca-b783-d2f6e2dfef6c