### PR TITLE
Chore: Fixes #16392: Fixed fetchWithRetry never retrying due to missing await

### DIFF
--- a/packages/utils/net.test.ts
+++ b/packages/utils/net.test.ts
@@ -1,0 +1,44 @@
+jest.mock('node-fetch');
+
+import fetch from 'node-fetch';
+import { fetchWithRetry } from './net';
+
+const mockedFetch = fetch as unknown as jest.Mock;
+
+describe('net', () => {
+
+	beforeEach(() => {
+		mockedFetch.mockReset();
+	});
+
+	it('should retry a failing request until it succeeds', async () => {
+		const response = { ok: true };
+		let callCount = 0;
+		mockedFetch.mockImplementation(() => {
+			callCount++;
+			if (callCount < 3) return Promise.reject(new Error(`Failed ${callCount}`));
+			return Promise.resolve(response);
+		});
+
+		const retries: number[] = [];
+		const actual = await fetchWithRetry('http://example.com', {
+			retry: 5,
+			pause: 1,
+			callback: (retry: number) => retries.push(retry),
+		});
+
+		expect(callCount).toBe(3);
+		expect(retries).toEqual([5, 4]);
+		expect(actual).toBe(response);
+	});
+
+	it('should throw after the last retry', async () => {
+		mockedFetch.mockImplementation(() => Promise.reject(new Error('Always failing')));
+
+		await expect(fetchWithRetry('http://example.com', { retry: 2, pause: 1 }))
+			.rejects.toThrow('Always failing');
+
+		expect(mockedFetch).toHaveBeenCalledTimes(2);
+	});
+
+});

--- a/packages/utils/net.ts
+++ b/packages/utils/net.ts
@@ -15,7 +15,7 @@ export const fetchWithRetry = async (url: string, opts: FetchWithRetryOptions | 
 
 	while (retry > 0) {
 		try {
-			return fetch(url, opts);
+			return await fetch(url, opts);
 		} catch (e) {
 			if (opts && opts.callback) {
 				opts.callback(retry);


### PR DESCRIPTION
`fetchWithRetry` in `packages/utils/net.ts` never retries. The call inside the `try` block is:

```ts
return fetch(url, opts);
```

Without `await`, the promise is returned rather than settled inside the `try`, so a rejection escapes the surrounding `catch`. The loop exits on its first iteration and the `retry`, `callback` and `pause` options are all dead code.

### Repro

Against a mocked endpoint that fails twice and then succeeds, asking for `retry: 5`:

```
fetch call count      = 1        (expected 3)
callback invocations  = []       (expected [5, 4])
threw                 = "boom 1" (expected the successful response)
```

### Fix

`return await fetch(url, opts);`

The sibling retry loop in `packages/utils/execCommand.ts` already uses `return await runOnce()`, so this restores the pattern the package uses elsewhere.

### Tests

Added `packages/utils/net.test.ts` with two cases: retrying until success, and throwing after the last attempt. Reverting only `net.ts` and keeping the tests fails both with `Failed 1` and `Expected number of calls: 2, Received number of calls: 1`, the exact symptom above. Restoring it passes.

`npx jest` in `packages/utils` passes, `npx tsc --noEmit` exits 0, and eslint is clean on both changed files.

### Note on scope

`@joplin/utils/net` has no in-repo callers today, but it is a published export of `@joplin/utils`, so this is public API. Happy to drop the module instead if you would rather retire it than fix it.