### PR TITLE
Chore: Fixes #16396: Fixed URIError when a link anchor contains a raw percent sign

### DIFF
--- a/packages/lib/urlUtils.test.ts
+++ b/packages/lib/urlUtils.test.ts
@@ -34,6 +34,10 @@ describe('urlUtils', () => {
 			['joplin://1234abcd1234abcd1234abcd1234abcd#hash', { itemId: '1234abcd1234abcd1234abcd1234abcd', hash: 'hash' }],
 			[':/1234abcd1234abcd1234abcd1234abc', null],
 			['joplin://1234abcd1234abcd1234abcd1234abc', null],
+			// Anchors that are not valid percent-encoding should be kept
+			// as-is instead of making decoding throw.
+			[':/1234abcd1234abcd1234abcd1234abcd#50%', { itemId: '1234abcd1234abcd1234abcd1234abcd', hash: '50%' }],
+			['joplin://1234abcd1234abcd1234abcd1234abcd#C%20%%20E', { itemId: '1234abcd1234abcd1234abcd1234abcd', hash: 'C%20%%20E' }],
 		];
 
 		for (const t of testCases) {
@@ -85,6 +89,12 @@ describe('urlUtils', () => {
 			),
 		).toMatchObject(expected);
 	});
+
+	it('should not throw when a link anchor contains a raw percent sign', (async () => {
+		const body = 'Progress: [half done](:/1234abcd1234abcd1234abcd1234abcd#50%-done)';
+		expect(() => urlUtils.extractResourceUrls(body)).not.toThrow();
+		expect(urlUtils.extractResourceUrls(body)).toEqual([{ itemId: '1234abcd1234abcd1234abcd1234abcd', hash: '50%-done' }]);
+	}));
 
 	it('should extract resource URLs', (async () => {
 		const testCases: [string, string[]][] = [

--- a/packages/lib/urlUtils.ts
+++ b/packages/lib/urlUtils.ts
@@ -63,7 +63,15 @@ export const parseResourceUrl = (url: string) => {
 	// In general we want the hash to be decoded so that non-alphabetical languages
 	// appear as-is without being encoded with %.
 	// Fixes https://github.com/laurent22/joplin/issues/1870
-	if (hash) hash = urlDecode(hash.substr(1)); // Remove the first #
+	if (hash) {
+		hash = hash.substr(1); // Remove the first #
+		try {
+			hash = urlDecode(hash);
+		} catch (error) {
+			// If the hash is not valid percent-encoding (eg. it contains a
+			// literal "%"), keep it as-is instead of throwing.
+		}
+	}
 
 	return {
 		itemId: itemId,

--- a/packages/renderer/urlUtils.ts
+++ b/packages/renderer/urlUtils.ts
@@ -24,7 +24,15 @@ export const parseResourceUrl = (url: string): ParsedResourceUrl | null => {
 	// In general we want the hash to be decoded so that non-alphabetical languages
 	// appear as-is without being encoded with %.
 	// Fixes https://github.com/laurent22/joplin/issues/1870
-	if (hash) hash = urlDecode(hash.substr(1)); // Remove the first #
+	if (hash) {
+		hash = hash.substr(1); // Remove the first #
+		try {
+			hash = urlDecode(hash);
+		} catch (error) {
+			// If the hash is not valid percent-encoding (eg. it contains a
+			// literal "%"), keep it as-is instead of throwing.
+		}
+	}
 
 	return {
 		itemId: itemId,


### PR DESCRIPTION
`parseResourceUrl` decodes a resource link's anchor with `decodeURIComponent`, which throws `URIError: URI malformed` on a raw `%` that is not valid percent-encoding. `Note.linkedItemIds` runs `extractResourceUrls` over every note body on save, sync and indexing, so a note containing a link like `[x](:/<32-char-id>#50%-done)` throws.

This is the root cause behind #5051 ("URIError causing revision service to fail"): the fix there (097e49d7) wrapped the revision service caller in try/catch, but the throw itself remained, in both `packages/lib/urlUtils.ts` and the duplicated `packages/renderer/urlUtils.ts`.

The decode is now wrapped and the raw hash is kept when decoding fails; valid encodings still decode (a Cyrillic `#%D0%9A...` anchor test decodes to the expected text).

Tests added to `packages/lib/urlUtils.test.ts`. With only the source reverted, the new test fails with `Error name: "URIError", Error message: "URI malformed"` from both `parseResourceUrl` and `extractResourceUrls`; with the fix the suite passes. eslint clean on the changed files.