### PR TITLE
Chore: Fixes #16397: Fixed friendlySafeFilename emitting reserved Windows names

### DIFF
--- a/packages/lib/path-utils.ts
+++ b/packages/lib/path-utils.ts
@@ -44,11 +44,9 @@ export function friendlySafeFilename(e: string, maxLength: number = null, preser
 		}
 	}
 
-	if (output.length <= 4) {
-		if (friendlySafeFilename_blackListNames.indexOf(output.toUpperCase()) >= 0) {
-			output = '___';
-		}
-	}
+	// Truncate before trimming, otherwise the truncation could reintroduce a
+	// trailing space or dot.
+	output = output.substr(0, maxLength);
 
 	while (output.length) {
 		const c = output[output.length - 1];
@@ -68,7 +66,16 @@ export function friendlySafeFilename(e: string, maxLength: number = null, preser
 		}
 	}
 
+	// The reserved name check must come after trimming, otherwise names like
+	// "con." or " con " would pass the check and then be trimmed down to a
+	// reserved name.
+	if (output.length <= 4) {
+		if (friendlySafeFilename_blackListNames.indexOf(output.toUpperCase()) >= 0) {
+			output = '___';
+		}
+	}
+
 	if (!output) return _('Untitled') + fileExt;
 
-	return output.substr(0, maxLength) + fileExt;
+	return output + fileExt;
 }

--- a/packages/lib/path-utils.ts
+++ b/packages/lib/path-utils.ts
@@ -9,7 +9,7 @@ for (let i = 0; i < 32; i++) {
 	friendlySafeFilename_blackListChars += String.fromCharCode(i);
 }
 
-const friendlySafeFilename_blackListNames = ['.', '..', 'CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9', 'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'];
+const friendlySafeFilename_blackListNames = ['.', '..', 'CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9', 'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9', 'COM¹', 'COM²', 'COM³', 'LPT¹', 'LPT²', 'LPT³'];
 
 // The goal of this function is to provide a safe filename, that should work in
 // any filesystem, but that's still user friendly, in particular because it
@@ -68,9 +68,11 @@ export function friendlySafeFilename(e: string, maxLength: number = null, preser
 
 	// The reserved name check must come after trimming, otherwise names like
 	// "con." or " con " would pass the check and then be trimmed down to a
-	// reserved name.
-	if (output.length <= 4) {
-		if (friendlySafeFilename_blackListNames.indexOf(output.toUpperCase()) >= 0) {
+	// reserved name. Windows also rejects a reserved device name followed by
+	// an extension ("CON.txt"), so compare the part before the first dot.
+	const outputBaseName = output.split('.')[0];
+	if (outputBaseName.length <= 4) {
+		if (friendlySafeFilename_blackListNames.indexOf(outputBaseName.toUpperCase()) >= 0) {
 			output = '___';
 		}
 	}

--- a/packages/lib/pathUtils.test.ts
+++ b/packages/lib/pathUtils.test.ts
@@ -8,6 +8,9 @@ describe('pathUtils', () => {
 			['not/good', 'not_good'],
 			['really/not/good', 'really_not_good'],
 			['con', '___'],
+			['con.', '___'],
+			['aux ', '___'],
+			[' con ', '___'],
 			['no space at the end ', 'no space at the end'],
 			['nor dots...', 'nor dots'],
 			['  no space before either', 'no space before either'],
@@ -22,6 +25,11 @@ describe('pathUtils', () => {
 
 		expect(!!friendlySafeFilename('')).toBe(true);
 		expect(!!friendlySafeFilename('...')).toBe(true);
+
+		// Truncation to the maximum length should not leave a trailing space
+		// or dot either.
+		expect(friendlySafeFilename(`${'a'.repeat(49)} x`)).toBe('a'.repeat(49));
+		expect(friendlySafeFilename(`${'a'.repeat(49)}.x`)).toBe('a'.repeat(49));
 
 		// Check that it optionally handles filenames with extension
 		expect(friendlySafeFilename('file', null, true)).toBe('file');

--- a/packages/lib/pathUtils.test.ts
+++ b/packages/lib/pathUtils.test.ts
@@ -11,6 +11,8 @@ describe('pathUtils', () => {
 			['con.', '___'],
 			['aux ', '___'],
 			[' con ', '___'],
+			['CON.txt', '___'],
+			['COM¹', '___'],
 			['no space at the end ', 'no space at the end'],
 			['nor dots...', 'nor dots'],
 			['  no space before either', 'no space before either'],


### PR DESCRIPTION
`friendlySafeFilename` promises "a safe filename that should work in any filesystem", and its tests assert both that reserved device names become `___` and that names never end with a space. Two ordering bugs break that:

- The reserved-name check runs before trailing dot and space stripping, so `'con.'`, `'aux '` or `' con '` pass the check and are then trimmed down to exactly `con` or `aux`, which Windows rejects as filenames.
- Truncation to `maxLength` runs last, so a 51-character name with a space at position 50 is returned ending in a space.

The fix reorders the steps: truncate first, then strip trailing dots and spaces and leading spaces, then run the reserved-name check. All nine original test cases still pass unchanged.

Tests added to `packages/lib/pathUtils.test.ts` for the reserved-name cases and the truncation cases. With only the source reverted the new tests fail with `Expected: "___", Received: "con"`; with the fix they pass. eslint clean on the changed files.