### PR TITLE
Chore: Fixes #16398: Fixed front matter export corrupting titles starting with a dash

### DIFF
--- a/packages/lib/utils/frontMatter.test.ts
+++ b/packages/lib/utils/frontMatter.test.ts
@@ -1,0 +1,44 @@
+import { noteToFrontMatter, parse } from './frontMatter';
+import { NoteEntity } from '../services/database/types';
+
+const testNote = (title: string): NoteEntity => {
+	return { title, latitude: '0.00000000', longitude: '0.00000000', altitude: '0.0000' };
+};
+
+// Export a note to front matter, then re-import it the way
+// InteropService_Importer_Md_frontmatter does.
+const roundTripTitle = (title: string) => {
+	const md = noteToFrontMatter(testNote(title), []);
+	const note = `---\n${md}---\n\nbody`;
+	return parse(note).metadata.title;
+};
+
+describe('frontMatter', () => {
+
+	it('should round-trip titles that start with a dash', () => {
+		const testCases = [
+			// If the quotes added by the yaml library were trimmed, the
+			// doubled inner quote would remain ("-5 o''clock"), the ": "
+			// would make the header invalid YAML, and the " #" would start a
+			// comment.
+			'-5 o\'clock',
+			'-5: totals',
+			'-5 #hot',
+			'-60',
+			'- title with dash',
+		];
+
+		for (const title of testCases) {
+			expect(roundTripTitle(title)).toBe(title);
+		}
+	});
+
+	it('should not quote a plain negative number', () => {
+		expect(noteToFrontMatter(testNote('-60'), [])).toContain('title: -60');
+	});
+
+	it('should keep quoting a title that looks like a list item', () => {
+		expect(noteToFrontMatter(testNote('- title with dash'), [])).toContain('title: \'- title with dash\'');
+	});
+
+});

--- a/packages/lib/utils/frontMatter.test.ts
+++ b/packages/lib/utils/frontMatter.test.ts
@@ -2,7 +2,7 @@ import { noteToFrontMatter, parse } from './frontMatter';
 import { NoteEntity } from '../services/database/types';
 
 const testNote = (title: string): NoteEntity => {
-	return { title, latitude: '0.00000000', longitude: '0.00000000', altitude: '0.0000' };
+	return { title, latitude: 0, longitude: 0, altitude: 0 };
 };
 
 // Export a note to front matter, then re-import it the way

--- a/packages/lib/utils/frontMatter.ts
+++ b/packages/lib/utils/frontMatter.ts
@@ -33,23 +33,13 @@ export const fieldOrder = ['title', 'id', 'updated', 'created', 'source', 'autho
 // These need to be stripped
 function trimQuotes(rawOutput: string): string {
 	return rawOutput.split('\n').map(line => {
-		const index = line.indexOf(': \'-');
-		const indexWithSpace = line.indexOf(': \'- ');
-
-		// We don't apply this processing if the string starts with a dash
-		// followed by a space. Those should actually be in quotes, otherwise
-		// they are detected as invalid list items when we later try to import
-		// the file.
-		if (index === indexWithSpace) return line;
-
-		if (index >= 0) {
-			// The plus 2 eats the : and space characters
-			const start = line.substring(0, index + 2);
-			// The plus 3 eats the quote character
-			const end = line.substring(index + 3, line.length - 1);
-			return start + end;
-		}
-
+		// Only unquote when the whole value is a plain negative number.
+		// Anything else must stay quoted to parse back to the same string:
+		// for example "- " would otherwise be detected as an invalid list
+		// item, an inner "'" would remain doubled ('-5 o''clock'), ": "
+		// would make the line invalid YAML, and " #" would start a comment.
+		const match = line.match(/^([^:]+: )'(-\d+(?:\.\d+)?)'$/);
+		if (match) return match[1] + match[2];
 		return line;
 	}).join('\n');
 }


### PR DESCRIPTION
`trimQuotes` in `packages/lib/utils/frontMatter.ts` strips yaml's outer quotes from any `: '-...'` value when exporting MD with front matter. That ignores that yaml doubles inner quotes and that the resulting unquoted scalar may not be valid yaml. Exporting and re-importing (exactly what `InteropService_Importer_Md_frontmatter.importFile` does with an exported note):

- title `-5 o'clock` round-trips as `-5 o''clock` (silent corruption);
- title `-5: totals` makes the exported note unimportable: `YAMLException: incomplete explicit mapping pair ... title: -5: totals`;
- title `-5 #hot` round-trips as `-5`, since ` #` starts a yaml comment.

The function's comment says it "only trims quotes associated with a negative number", so the fix restricts it to exactly that: unquote only when the whole value is a plain negative number. Existing exporter expectations are preserved (`title: -60` stays unquoted, `title: '- title with dash'` stays quoted, `latitude: '-94.51350100'`-style values still unquote).

Tests: a round-trip test through export and `parse`. With only the source reverted it fails with `Expected: "-5 o'clock", Received: "-5 o''clock"`; with the fix it passes. eslint clean on the changed files.