### PR TITLE
Server: Improve logging for shared notebook maintenance

### DIFF
--- a/packages/server/src/models/ShareModel.ts
+++ b/packages/server/src/models/ShareModel.ts
@@ -433,11 +433,19 @@ export default class ShareModel extends BaseModel<Share> {
 					}
 
 					if (row.item_count < realShareItemCount) {
-						logger.warn(`checkForMissingUserItems: User is missing some items: Share ${share.id}: User ${row.user_id}`);
+						logger.warn(`checkForMissingUserItems: User is missing some items: Share ${share.id}: User ${row.user_id}: Has ${row.item_count} of ${realShareItemCount} items (share owner: ${share.owner_id})`);
 						await this.createSharedFolderUserItems(share.id, row.user_id);
+
+						// If the count doesn't move, the repair is a no-op and the next run will
+						// log exactly the same warning. Record it so we can tell a stuck share
+						// apart from one that is simply being repaired.
+						const newCount = await this.itemCountByUserAndShareId(share.id, row.user_id);
+						if (newCount === row.item_count) {
+							logger.warn(`checkForMissingUserItems: Repair had no effect: Share ${share.id}: User ${row.user_id}: Still has ${newCount} of ${realShareItemCount} items`);
+						}
 					} else if (row.item_count > realShareItemCount) {
 						// Shouldn't be possible but log it just in case
-						logger.warn(`checkForMissingUserItems: User has too many items (??): Share ${share.id}: User ${row.user_id}`);
+						logger.warn(`checkForMissingUserItems: User has too many items (??): Share ${share.id}: User ${row.user_id}: Has ${row.item_count} of ${realShareItemCount} items (share owner: ${share.owner_id})`);
 					}
 				}
 			}
@@ -477,7 +485,11 @@ export default class ShareModel extends BaseModel<Share> {
 
 		perfTimer.push('Main');
 
+		let loopCount = 0;
+
 		while (true) {
+			loopCount++;
+
 			perfTimer.push('Get latestProcessedChange');
 			const latestProcessedChange = await this.models().keyValue().value<string>('ShareService::latestProcessedChange');
 			perfTimer.pop();
@@ -486,6 +498,13 @@ export default class ShareModel extends BaseModel<Share> {
 			const paginatedChanges = await this.models().change().allFromId(latestProcessedChange || '');
 			perfTimer.pop();
 			const changes = paginatedChanges.items;
+
+			// allFromId computes the cursor and has_more before filtering out changes for
+			// deleted items, so a batch can come back empty while has_more is still true. If
+			// that keeps happening the task is spinning without making progress.
+			if (loopCount % 100 === 0) {
+				logger.warn(`updateSharedItems3: Still looping after ${loopCount} iterations: cursor=${paginatedChanges.cursor} changes=${changes.length} hasMore=${paginatedChanges.has_more}`);
+			}
 
 			if (!changes.length) {
 				perfTimer.push('Set latestProcessedChange');
@@ -701,6 +720,18 @@ export default class ShareModel extends BaseModel<Share> {
 			.count('id', { as: 'item_count' })
 			.where('jop_share_id', '=', shareId);
 		return r[0].item_count;
+	}
+
+	public async itemCountByUserAndShareId(shareId: Uuid, userId: Uuid): Promise<number> {
+		const r = await this.db('user_items')
+			.count('item_id', { as: 'item_count' })
+			.where('user_id', '=', userId)
+			.whereIn('item_id',
+				this.db('items')
+					.select('id')
+					.where('jop_share_id', '=', shareId),
+			);
+		return Number(r[0].item_count);
 	}
 
 	public async itemCountByShareIdPerUser(shareId: Uuid): Promise<{ item_count: number; user_id: Uuid }[]> {

--- a/packages/server/src/models/UserItemModel.ts
+++ b/packages/server/src/models/UserItemModel.ts
@@ -142,7 +142,17 @@ export default class UserItemModel extends BaseModel<UserItem> {
 		perfTimer.push('Main');
 
 		const items: Item[] = Array.isArray(itemsQuery) ? itemsQuery : await itemsQuery.whereNotIn('id', this.db('user_items').select('item_id').where('user_id', '=', userId));
-		if (!items.length) return;
+
+		// Callers such as ShareModel::createSharedFolderUserItems only call this after
+		// determining that items are missing, so selecting nothing means the caller's view
+		// and this query disagree. Log it to tell that case apart from a failing insert.
+		if (!items.length) {
+			logger.info(`addMulti: No item to add for user ${userId} (caller passed ${Array.isArray(itemsQuery) ? 'an array' : 'a query'})`);
+			perfTimer.pop();
+			return;
+		}
+
+		logger.info(`addMulti: Adding ${items.length} items for user ${userId}: ${items.map(i => i.id).join(', ')}`);
 
 		perfTimer.push(`Processing ${items.length} items`);
 
@@ -171,6 +181,7 @@ export default class UserItemModel extends BaseModel<UserItem> {
 					if (!options.ignoreAlreadyExists || !isUniqueConstraintError(error)) {
 						throw error;
 					}
+					logger.info(`addMulti: Skipping already existing user item: user ${userId}, item ${item.id}`);
 				}
 			}, 'UserItemModel::addMulti');
 		}

--- a/packages/server/src/models/UserItemModel.ts
+++ b/packages/server/src/models/UserItemModel.ts
@@ -9,6 +9,15 @@ import { isUniqueConstraintError } from '../db';
 
 const logger = Logger.create('UserItemModel');
 
+// addMulti can process a whole notebook at once, so item IDs are only ever logged
+// as a sample.
+const maxLoggedItemIds = 20;
+
+const itemIdSample = (itemIds: Uuid[]) => {
+	const sample = itemIds.slice(0, maxLoggedItemIds).join(', ');
+	return itemIds.length > maxLoggedItemIds ? `${sample}, ... (${itemIds.length - maxLoggedItemIds} more)` : sample;
+};
+
 interface DeleteByShare {
 	id: Uuid;
 	owner_id: Uuid;
@@ -152,9 +161,11 @@ export default class UserItemModel extends BaseModel<UserItem> {
 			return;
 		}
 
-		logger.info(`addMulti: Adding ${items.length} items for user ${userId}: ${items.map(i => i.id).join(', ')}`);
+		logger.info(`addMulti: Adding ${items.length} items for user ${userId}: ${itemIdSample(items.map(i => i.id))}`);
 
 		perfTimer.push(`Processing ${items.length} items`);
+
+		const skippedItemIds: Uuid[] = [];
 
 		for (const item of items) {
 			if (!('name' in item) || !('id' in item)) throw new Error('item.id and item.name must be set');
@@ -181,9 +192,13 @@ export default class UserItemModel extends BaseModel<UserItem> {
 					if (!options.ignoreAlreadyExists || !isUniqueConstraintError(error)) {
 						throw error;
 					}
-					logger.info(`addMulti: Skipping already existing user item: user ${userId}, item ${item.id}`);
+					skippedItemIds.push(item.id);
 				}
 			}, 'UserItemModel::addMulti');
+		}
+
+		if (skippedItemIds.length) {
+			logger.info(`addMulti: Skipped ${skippedItemIds.length} already existing user items for user ${userId}: ${itemIdSample(skippedItemIds)}`);
 		}
 
 		perfTimer.pop();


### PR DESCRIPTION
Some accounts produce a continuous stream of warnings about shared notebooks with missing items, repeating every second without ever resolving. The warnings say which share and user are affected, but not enough to work out why the automatic repair isn't fixing anything.

This adds the missing detail: the warnings now include how many items the user actually has versus how many the share contains, and a separate message is logged when a repair attempt runs but leaves the count unchanged — which distinguishes a share that is genuinely healing from one that is permanently stuck. The code that adds items to a user's collection now also reports whether it found anything to add, and the maintenance task reports when it has been looping unusually long.

No behaviour changes for users; this is diagnostic only, and is a prerequisite for tracking down the underlying issue.

Log sample:

> 2026-09-02T21:28:55.715Z	21:28:55 1|index | 2026-09-02 21:28:55: [warn] ShareModel: checkForMissingUserItems: User is missing some items: Share XXXXXXXX: User YYYYYYYY	backend-app