### PR TITLE
Web: Fixes #16379: Fix menu animation in Safari

### DIFF
--- a/packages/app-mobile/components/Modal.tsx
+++ b/packages/app-mobile/components/Modal.tsx
@@ -240,6 +240,9 @@ const ModalComponent = Platform.OS === 'web' ? (props: ModalElementProps) => {
 		open={props.visible}
 		onCancel={props.onClose}
 		onShow={props.onShow}
+		// 2026-09-03: Work around dialog display issues on Safari by autofocusing
+		// the root dialog element.
+		onBeforeShow={dialog => dialog.setAttribute('autofocus', 'true')}
 		preventAutoCloseOnCancel={true}
 	>
 		{props.children}

--- a/packages/lib/components/Dialog.tsx
+++ b/packages/lib/components/Dialog.tsx
@@ -8,11 +8,13 @@ const { useEffect, useRef, useState } = shim.react();
 
 type OnCancelListener = ()=> void;
 type OnShowListener = ()=> void;
+type OnBeforeShowListener = (dialog: HTMLDialogElement)=> void;
 
 interface Props {
 	className?: string;
 	onCancel?: OnCancelListener;
 	onShow?: OnShowListener;
+	onBeforeShow?: OnBeforeShowListener;
 	contentStyle?: CSSProperties;
 	open?: boolean;
 	preventAutoCloseOnCancel?: boolean;
@@ -38,17 +40,20 @@ const Dialog: FC<Props> = props => {
 
 	const [contentRendered, setContentRendered] = useState(false);
 
+	const propsRef = useRef(props);
+
 	useEffect(() => {
 		if (!dialogElement || !contentRendered) return;
 
 		const open = props.open ?? true;
 		if (!dialogElement.open && open) {
+			propsRef.current.onBeforeShow?.(dialogElement);
 			dialogElement.showModal();
-			props.onShow?.();
+			propsRef.current.onShow?.();
 		} else if (dialogElement.open && !open) {
 			dialogElement.close();
 		}
-	}, [dialogElement, contentRendered, props.open, props.onShow]);
+	}, [dialogElement, contentRendered, props.open]);
 
 	useEffect(() => {
 		if (!dialogElement) return;

--- a/packages/lib/components/Dialog.tsx
+++ b/packages/lib/components/Dialog.tsx
@@ -41,6 +41,7 @@ const Dialog: FC<Props> = props => {
 	const [contentRendered, setContentRendered] = useState(false);
 
 	const propsRef = useRef(props);
+	propsRef.current = props;
 
 	useEffect(() => {
 		if (!dialogElement || !contentRendered) return;


### PR DESCRIPTION
# Problem

Safari auto-scrolls to the first focusable element in the new long-press dialogs. This breaks the slide-in animation.

> [!NOTE]
>
> This pull request targets `release-3.7`.

# Solution

Add the `autofocus` attribute to the container `<dialog>` element.

MDN provides the following guidance for setting `autofocus`:
> Explicitly indicating the initial focus placement by using the [autofocus](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/autofocus) attribute will help ensure initial focus is set on the element deemed the best initial focus placement for any particular dialog. When in doubt, as it may not always be known where initial focus could be set within a dialog, particularly for instances where a dialog's content is dynamically rendered when invoked, the <dialog> element itself may provide the best initial focus placement.
> – https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#accessibility

Fixes #16379.

# Screen recording

https://github.com/user-attachments/assets/ffc913f8-cf09-488a-988f-25a280ca2d43



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
