### PR TITLE
Web: Fix incorrect "Only one copy of Joplin can be open at a time" warning in Safari and Firefox

### DIFF
--- a/packages/app-mobile/web/public/info-page.css
+++ b/packages/app-mobile/web/public/info-page.css
@@ -23,6 +23,14 @@ main {
 	margin-right: auto;
 }
 
+main.-loading > #only-one-copy-message {
+	display: none;
+}
+
+main:not(.-loading) > #loading-message {
+	display: none;
+}
+
 @media screen and (prefers-color-scheme: dark) {
 	:root {
 		--bg-secondary: black;

--- a/packages/app-mobile/web/public/just-one-client.html
+++ b/packages/app-mobile/web/public/just-one-client.html
@@ -55,10 +55,13 @@
 				// where a previous tab already has access.
 				// Retry once to work around this issue: 
 				setTimeout(() => {
-					main.classList.remove('-loading');
-
-					url.searchParams.set('no-retry', '1');
-					location.replace(url);
+					try {
+						url.searchParams.set('no-retry', '1');
+						location.replace(url);
+					} catch (error) {
+						main.classList.remove('-loading');
+						throw error;
+					}
 				}, 150);
 			} else {
 				main.classList.remove('-loading');

--- a/packages/app-mobile/web/public/just-one-client.html
+++ b/packages/app-mobile/web/public/just-one-client.html
@@ -11,30 +11,61 @@
 		<link rel="stylesheet" href="./info-page.css"/>
 	</head>
 	<body>
-		<main>
-			<h1>⚠️ Error: Only one copy of Joplin can be open at a time ⚠️</h1>
-			<p>
-				At present, the Joplin web client only supports one open copy at a time in the same browser. This restriction is present to keep your data safe.
-			</p>
-			<p>
-				To use Joplin in this tab, please <button id="close-all-other-web-clients">close all other Joplin web client tabs</button>,
-				then <button id="refresh-this-page">refresh</button> this page.
-			</p>
+		<main class="-loading">
+			<div id="only-one-copy-message">
+				<h1>⚠️ Error: Only one copy of Joplin can be open at a time ⚠️</h1>
+				<p>
+					At present, the Joplin web client only supports one open copy at a time in the same browser. This restriction is present to keep your data safe.
+				</p>
+				<p>
+					To use Joplin in this tab, please <button id="close-all-other-web-clients">close all other Joplin web client tabs</button>,
+					then <button id="refresh-this-page">refresh</button> this page.
+				</p>
+			</div>
+			<div id="loading-message">
+				<p>Loading...</p>
+			</div>
 		</main>
 	</body>
 	<script>
-		for (const refreshLink of document.querySelectorAll('#refresh-this-page')) {
-			refreshLink.onclick = () => location.reload();
-		}
+		function setUpButtons() {
+			for (const refreshLink of document.querySelectorAll('#refresh-this-page')) {
+				refreshLink.onclick = () => location.reload();
+			}
 
-		for (const closeLink of document.querySelectorAll('#close-all-other-web-clients')) {
-			if (navigator.serviceWorker) {
-				closeLink.onclick = () => {
-					window.navigator.serviceWorker.controller.postMessage({ type: 'closeAllJoplinWebTabs' });
-				};
-			} else {
-				closeLink.replaceWith(document.createTextNode(closeLink.textContent));
+			for (const closeLink of document.querySelectorAll('#close-all-other-web-clients')) {
+				if (navigator.serviceWorker) {
+					closeLink.onclick = () => {
+						window.navigator.serviceWorker.controller.postMessage({ type: 'closeAllJoplinWebTabs' });
+					};
+				} else {
+					closeLink.replaceWith(document.createTextNode(closeLink.textContent));
+				}
 			}
 		}
+
+		function handleRetry() {
+			const main = document.querySelector('main');
+			const url = new URL(location.href);
+			if (!url.searchParams.has('no-retry')) {
+				main.classList.add('-loading');
+
+				// In some browsers (e.g. Firefox, Safari), the service worker incorrectly
+				// detects reloading the web app (or the first load) as a new browser tab accessing Joplin,
+				// where a previous tab already has access.
+				// Retry once to work around this issue: 
+				setTimeout(() => {
+					main.classList.remove('-loading');
+
+					url.searchParams.set('no-retry', '1');
+					location.replace(url);
+				}, 150);
+			} else {
+				main.classList.remove('-loading');
+			}
+		}
+
+		setUpButtons();
+		handleRetry();
 	</script>
 </html>


### PR DESCRIPTION
# Problem

Safari and Firefox usually show a warning that "only one copy of Joplin can be open at a time" when opening or reloading the web app.

# Solution

Retry loading the web app once if the initial load fails. Firefox and Safari don't detect the reload *from the "only one copy of Joplin" page* as a second client attempting to access the web app.

> [!NOTE]
>
> This change targets `release-3.7`.

# Screen recording


https://github.com/user-attachments/assets/1558b422-1949-4d4e-95ec-c985d593393b



<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
