### PR TITLE
Chore: Allow the "Web" prefix in pull request titles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -26,6 +26,7 @@ Valid prefixes:
 - `Mobile` — the mobile app (both Android and iOS)
 - `Android` — only the Android app
 - `iOS` — only the iOS app
+- `Web` — only the web app
 - `Windows` — Windows-specific changes
 - `Linux` — Linux-specific changes
 - `macOS` — macOS-specific changes

--- a/.github/scripts/check_pr_title.js
+++ b/.github/scripts/check_pr_title.js
@@ -25,7 +25,7 @@ module.exports = async ({ github, context, core }) => {
 	// the changelog generator. Non-product prefixes (Tools, Chore, CI, Doc,
 	// Plugin Repo) are administrative categories for changes that do not
 	// ship to users and so do not appear in the changelog.
-	const prefix = '(Desktop|Mobile|Android|iOS|Windows|Linux|macOS|Cli|Clipper|Server|Transcribe|Plugins|Api|Cloud|Tools|Chore|CI|Doc)';
+	const prefix = '(Desktop|Mobile|Android|iOS|Web|Windows|Linux|macOS|Cli|Clipper|Server|Transcribe|Plugins|Api|Cloud|Tools|Chore|CI|Doc)';
 	const prefixList = `${prefix}(,\\s*${prefix})*`;
 	const strictRegex = new RegExp(`^${prefixList}: (Fixes|Resolves) #[0-9]+: .+`);
 	const softRegex = new RegExp(`^${prefixList}: ((Fixes|Resolves) #[0-9]+: )?.+`);

--- a/packages/tools/git-changelog.test.ts
+++ b/packages/tools/git-changelog.test.ts
@@ -9,6 +9,7 @@ describe('git-changelog', () => {
 		const testCases: TestCase[] = [
 			[['packages/app-mobile/package.json'], 'ios', true],
 			[['packages/app-mobile/package.json'], 'android', true],
+			[['packages/app-mobile/package.json'], 'web', true],
 			[['packages/app-mobile/package.json'], 'desktop', false],
 			[[], 'desktop', false],
 			[['packages/server/package.json'], 'server', true],
@@ -19,6 +20,7 @@ describe('git-changelog', () => {
 			[['packages/lib/package.json'], 'server', true],
 			[['packages/lib/package.json'], 'desktop', true],
 			[['packages/lib/package.json'], 'android', true],
+			[['packages/lib/package.json'], 'web', true],
 			[['packages/lib/package.json'], 'clipper', false],
 			[['packages/app-clipper/package.json'], 'clipper', true],
 		];

--- a/packages/tools/git-changelog.ts
+++ b/packages/tools/git-changelog.ts
@@ -19,6 +19,7 @@ enum Platform {
 	MacOs = 'macos',
 	Linux = 'linux',
 	Ios = 'ios',
+	Web = 'web',
 	Desktop = 'desktop',
 	Clipper = 'clipper',
 	Server = 'server',
@@ -102,6 +103,7 @@ function platformFromTag(tagName: string): Platform {
 	if (tagName.indexOf('linux') >= 0) return Platform.Linux;
 	if (tagName.indexOf('macos') >= 0) return Platform.MacOs;
 	if (tagName.indexOf('ios') >= 0) return Platform.Ios;
+	if (tagName.indexOf('web') >= 0) return Platform.Web;
 	if (tagName.indexOf('clipper') === 0) return Platform.Clipper;
 	if (tagName.indexOf('cli') === 0) return Platform.Cli;
 	if (tagName.indexOf('server') === 0) return Platform.Server;
@@ -115,7 +117,7 @@ function platformFromTag(tagName: string): Platform {
 
 export const filesApplyToPlatform = (files: string[], platform: string): boolean => {
 	const isMainApp = ['android', 'ios', 'windows', 'linux', 'macos', 'desktop', 'cli', 'server'].includes(platform);
-	const isMobile = ['android', 'ios'].includes(platform);
+	const isMobile = ['android', 'ios', 'web'].includes(platform);
 
 	for (const file of files) {
 		if (file.startsWith('packages/app-cli') && platform === 'cli') return true;
@@ -262,6 +264,7 @@ function filterLogs(logs: LogEntry[], platform: Platform) {
 		if ((platform === 'android' || platform === 'ios') && prefix.indexOf('mobile') >= 0) addIt = true;
 		if (platform === 'android' && prefix.indexOf('android') >= 0) addIt = true;
 		if (platform === 'ios' && prefix.indexOf('ios') >= 0) addIt = true;
+		if (platform === 'web' && prefix.indexOf('web') >= 0) addIt = true;
 		if (platform === 'desktop' && prefix.indexOf('desktop') >= 0) addIt = true;
 		if (platform === 'desktop' && (prefix.indexOf('desktop') >= 0 || prefix.indexOf('api') >= 0 || prefix.indexOf('plugins') >= 0 || prefix.indexOf('macos') >= 0 || prefix.indexOf('windows') >= 0 || prefix.indexOf('linux') >= 0)) addIt = true;
 		if (platform === 'cli' && prefix.indexOf('cli') >= 0) addIt = true;
@@ -323,7 +326,7 @@ function formatCommitMessage(commit: string, msg: string, author: Author, option
 	const isPlatformPrefix = (prefixString: string) => {
 		const prefix = prefixString.split(',').map(p => p.trim().toLowerCase());
 		for (const p of prefix) {
-			if (['android', 'mobile', 'ios', 'desktop', 'windows', 'linux', 'macos', 'cli', 'clipper', 'all', 'api', 'plugins', 'server', 'transcribe', 'cloud'].indexOf(p) >= 0) return true;
+			if (['android', 'mobile', 'ios', 'web', 'desktop', 'windows', 'linux', 'macos', 'cli', 'clipper', 'all', 'api', 'plugins', 'server', 'transcribe', 'cloud'].indexOf(p) >= 0) return true;
 		}
 		return false;
 	};

--- a/packages/tools/git-changelog.ts
+++ b/packages/tools/git-changelog.ts
@@ -116,8 +116,8 @@ function platformFromTag(tagName: string): Platform {
 }
 
 export const filesApplyToPlatform = (files: string[], platform: string): boolean => {
-	const isMainApp = ['android', 'ios', 'windows', 'linux', 'macos', 'desktop', 'cli', 'server'].includes(platform);
 	const isMobile = ['android', 'ios', 'web'].includes(platform);
+	const isMainApp = isMobile || ['windows', 'linux', 'macos', 'desktop', 'cli', 'server'].includes(platform);
 
 	for (const file of files) {
 		if (file.startsWith('packages/app-cli') && platform === 'cli') return true;


### PR DESCRIPTION
# Problem

The "Web" prefix [isn't an allowed pull request title prefix.](https://github.com/laurent22/joplin/pull/16405#issuecomment-5529868269)

# Solution

- Allow the `Web` prefix in `check_pr_title.js`.
- Document that `Web` is a supported prefix via the pull request template.
- Update the `git-changelog.ts` script to support the `Web` prefix.

# Testing

Manual regression testing:
1. Rebuild `packages/tools` with `yarn tsc`.
2. Modify the built `tool-utils.js` to not require an OAuth token.
3. Run `node packages/tools/git-changelog.js v3.7.13`. Verify that this generates a changelog for the desktop app.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
