### PR TITLE
Desktop, Mobile: Fixes #16407: Fix keyboard navigation issues related to level-1 headings

### DIFF
--- a/packages/editor/CodeMirror/theme.ts
+++ b/packages/editor/CodeMirror/theme.ts
@@ -200,10 +200,10 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 		},
 		// Only underline level 1 headings not in block quotes. The underline overlaps with the blockquote border.
 		'& .cm-h1:not(.cm-blockQuote)': {
-			// Use a background image and transparent borderBottom in place of a solid border with a margin.
+			// Use a background image in place of a solid border with a margin.
 			// Margins between lines aren't supported in CodeMirror and can break selection.
 			// See https://discuss.codemirror.net/t/css-causing-inability-to-click-on-a-line/8919/5, https://github.com/laurent22/joplin/issues/16407
-			borderBottom: '0.1em solid transparent',
+			paddingBottom: '0.3em',
 			backgroundPositionY: 'bottom 0.1em',
 			backgroundSize: '100% 1px',
 			backgroundRepeat: 'no-repeat',

--- a/packages/editor/CodeMirror/theme.ts
+++ b/packages/editor/CodeMirror/theme.ts
@@ -204,8 +204,10 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 			// Margins between lines aren't supported in CodeMirror and can break selection.
 			// See https://discuss.codemirror.net/t/css-causing-inability-to-click-on-a-line/8919/5, https://github.com/laurent22/joplin/issues/16407
 			borderBottom: '0.1em solid transparent',
-			backgroundImage: `linear-gradient(0deg, ${theme.dividerColor} 1px, transparent 0, transparent 90%)`,
+			backgroundPositionY: 'bottom 0.1em',
+			backgroundSize: '100% 1px',
 			backgroundRepeat: 'no-repeat',
+			backgroundImage: `linear-gradient(${theme.dividerColor})`,
 		},
 		'& .cm-h2': {
 			...baseHeadingStyle,

--- a/packages/editor/CodeMirror/theme.ts
+++ b/packages/editor/CodeMirror/theme.ts
@@ -200,8 +200,12 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 		},
 		// Only underline level 1 headings not in block quotes. The underline overlaps with the blockquote border.
 		'& .cm-h1:not(.cm-blockQuote)': {
-			borderBottom: `1px solid ${theme.dividerColor}`,
-			marginBottom: '0.1em',
+			// Use a background image and transparent borderBottom in place of a solid border with a margin.
+			// Margins between lines aren't supported in CodeMirror and can break selection.
+			// See https://discuss.codemirror.net/t/css-causing-inability-to-click-on-a-line/8919/5, https://github.com/laurent22/joplin/issues/16407
+			borderBottom: '0.1em solid transparent',
+			backgroundImage: `linear-gradient(0deg, ${theme.dividerColor} 1px, transparent 0, transparent 90%)`,
+			backgroundRepeat: 'no-repeat',
 		},
 		'& .cm-h2': {
 			...baseHeadingStyle,


### PR DESCRIPTION
# Problem

In certain notes, pressing the <kbd>up</kbd> arrow key skips multiple lines and jumps to the previous level-1 heading.

**Why this happens**: Joplin uses a 0.1em margin below level-1 heading lines to separate the header's border from the next line. However, margins between lines are [not officially supported by CodeMirror](https://discuss.codemirror.net/t/css-causing-inability-to-click-on-a-line/8919/5) and known to cause selection issues. Since [a recent CodeMirror upgrade](https://github.com/laurent22/joplin/commit/698b59b8fc35278546609f8a7a2d87746d4bf272), margins between lines also break keyboard navigation in some cases. As a result, notes with many level-1 headings near the viewport cause issues with keyboard navigation.

For example, in this [note imported from MDN](https://github.com/mdn/content/blob/f0179562ad8e2a4dd1f0916c529792198d7e06b2/files/en-us/web/api/xsltprocessor/importstylesheet/index.md?plain=1#L69), after replacing all headings with level-1 headings and zooming out such that enough headings are near the viewport, <kbd>up</kbd> sometimes causes the cursor to skip multiple lines:

https://github.com/user-attachments/assets/1f404e2a-7efa-4f5b-bf56-e4bc7456b4eb

<!--MDN note license: https://github.com/mdn/content/tree/f0179562ad8e2a4dd1f0916c529792198d7e06b2?tab=License-1-ov-file-->


# Solution

This pull request keeps roughly the same visual behavior while removing the margin between lines. The underline is simulated using a `background-image` and the margin by increasing padding and adjusting the `background-image`'s position.

Fixes #16407, #16413.

> [!NOTE]
>
> The solution implemented here isn't ideal. It may be better to remove the 0.1em margin below level-1 headings.
>
> Since #16407 is a regression since v3.6, **this pull request targets `release-3.7`.**

# Screenshots

|Platform| Before | After   |
|--------|--------|---------|
|Desktop| <img width="640" height="431" alt="Desktop: Before" src="https://github.com/user-attachments/assets/8da7ae1f-ae6b-4570-a90c-ca1eb5a71218" /> |<img width="640" height="431" alt="desktop: After" src="https://github.com/user-attachments/assets/f42df188-a9d7-42e5-b26c-4f64860e94dc" /> |
|iOS (simulator)| <img width="312" height="586" alt="image" src="https://github.com/user-attachments/assets/9c722b34-f585-47fe-82fb-f360a5d04ea9" />| <img width="312" height="586" alt="image" src="https://github.com/user-attachments/assets/aff61235-4716-4f32-a9e7-8edc9a0fb790" /> |
| Android 13 VM (dark mode) | <img width="457" height="545" alt="Android: Before, note with multiple headings of the same level" src="https://github.com/user-attachments/assets/3b074475-e837-41bd-b609-9af90e88acb4" /> | <img width="457" height="545" alt="Android: After, same note" src="https://github.com/user-attachments/assets/3fb64913-9931-4e8f-b7a9-06a31da22722" /> |









# Screen recording

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/2e75e0c2-65d3-4594-beca-5280b3e99f82" alt="Shows navigation with the arrow keys in a note with 6 level-1 headings and an unordered list. The cursor jumps several lines when pressing the up arrow key near the end of the note"></video> | <video src="https://github.com/user-attachments/assets/b94673f7-05a4-4072-9065-93dc5a3ba5ad" alt="shows navigation with the arrow keys in the same note, but the cursor no longer jumps multiple lines near the end of the note"></video> |








<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
