### PR TITLE
All: Translation: Update hu_HU.po

### DIFF
--- a/packages/tools/locales/hu_HU.po
+++ b/packages/tools/locales/hu_HU.po
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Joplin 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-09-06 11:47+0200\n"
 "Last-Translator: summoner <summoner@disroot.org>\n"
 "Language-Team: Hungarian <>\n"
 "Language: hu_HU\n"
@@ -13,27 +15,19 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Lokalize 26.08.0\n"
+"X-Generator: Poedit 3.9\n"
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:634
 msgid "- Camera: to allow taking a picture and attaching it to a note."
-msgstr ""
-"– Kamera: lehetővé teszi a képkészítést és a képek mellékelését a "
-"jegyzetekhez."
+msgstr "– Kamera: lehetővé teszi a képkészítést és a képek mellékelését a jegyzetekhez."
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:637
 msgid "- Location: to allow attaching geo-location information to a note."
-msgstr ""
-"– Hely: lehetővé teszi a földrajzi helymeghatározási adatok mellékelését a "
-"jegyzetekhez."
+msgstr "– Hely: lehetővé teszi a földrajzi helymeghatározási adatok mellékelését a jegyzetekhez."
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:631
-msgid ""
-"- Storage: to allow attaching files to notes and to enable filesystem "
-"synchronisation."
-msgstr ""
-"– Tárhely: lehetővé teszi a fájlrendszer szinkronizálását és a fájlok "
-"mellékelését a jegyzetekhez."
+msgid "- Storage: to allow attaching files to notes and to enable filesystem synchronisation."
+msgstr "– Tárhely: lehetővé teszi a fájlrendszer szinkronizálását és a fájlok mellékelését a jegyzetekhez."
 
 #: packages/app-desktop/gui/ChatPanel/ChatPanel.tsx:147
 msgid "— now viewing: %s —"
@@ -315,12 +309,8 @@ msgid "%s input / %s output tokens used."
 msgstr "%s bemeneti / %s kimeneti token felhasználva."
 
 #: packages/app-desktop/gui/SyncWizard/Dialog.tsx:292
-msgid ""
-"%s is not optimised for synchronising many small files so your initial "
-"synchronisation will be slow."
-msgstr ""
-"A(z) %s nincs optimalizálva több, kis fájl szinkronizálására, így a kezdeti "
-"szinkronizálás lassú lesz."
+msgid "%s is not optimised for synchronising many small files so your initial synchronisation will be slow."
+msgstr "A(z) %s nincs optimalizálva több, kis fájl szinkronizálására, így a kezdeti szinkronizálás lassú lesz."
 
 #: packages/app-mobile/components/EditorToolbar/ToolbarEditorDialog.tsx:221
 msgid "%s moved down"
@@ -378,30 +368,12 @@ msgid "+ Text"
 msgstr "+ Szöveg"
 
 #: packages/app-cli/app/command-tag.ts:15
-msgid ""
-"<tag-command> can be \"add\", \"remove\", \"list\", or \"notetags\" to "
-"assign or remove [tag] from [note], to list notes associated with [tag], or "
-"to list tags associated with [note]. The command `tag list` can be used to "
-"list all the tags (use -l for long option)."
-msgstr ""
-"A <tag-command> lehet „add” (hozzáadás), „remove” (eltávolítás), „list” "
-"(listázás) vagy „notetags” (jegyzetcímkék) a [tag] [note] jegyzethez történő "
-"hozzárendeléséhez vagy eltávolításához, a [tag] címkéhez társított jegyzetek "
-"listázásához, illetve a [note] jegyzethez kapcsolódó címkék listázásához. A "
-"`tag list` parancs az összes címke listázására használható (a -l opcióval "
-"részletesebb megjelenítés érhető el)."
+msgid "<tag-command> can be \"add\", \"remove\", \"list\", or \"notetags\" to assign or remove [tag] from [note], to list notes associated with [tag], or to list tags associated with [note]. The command `tag list` can be used to list all the tags (use -l for long option)."
+msgstr "A <tag-command> lehet „add” (hozzáadás), „remove” (eltávolítás), „list” (listázás) vagy „notetags” (jegyzetcímkék) a [tag] [note] jegyzethez történő hozzárendeléséhez vagy eltávolításához, a [tag] címkéhez társított jegyzetek listázásához, illetve a [note] jegyzethez kapcsolódó címkék listázásához. A `tag list` parancs az összes címke listázására használható (a -l opcióval részletesebb megjelenítés érhető el)."
 
 #: packages/app-cli/app/command-todo.ts:15
-msgid ""
-"<todo-command> can either be \"toggle\" or \"clear\". Use \"toggle\" to "
-"toggle the given to-do between completed and uncompleted state (If the "
-"target is a regular note it will be converted to a to-do). Use \"clear\" to "
-"convert the to-do back to a regular note."
-msgstr ""
-"A <todo-command> lehet „toggle” (váltás) vagy „clear” (törlés). A „toggle” "
-"használatával az adott teendőt válthatja az elvégzett és a nem elvégzett "
-"állapot között (ha a cél egy normál jegyzet, akkor az teendővé alakul). A "
-"„clear” segítségével a teendőt visszaalakíthatja normál jegyzetté."
+msgid "<todo-command> can either be \"toggle\" or \"clear\". Use \"toggle\" to toggle the given to-do between completed and uncompleted state (If the target is a regular note it will be converted to a to-do). Use \"clear\" to convert the to-do back to a regular note."
+msgstr "A <todo-command> lehet „toggle” (váltás) vagy „clear” (törlés). A „toggle” használatával az adott teendőt válthatja az elvégzett és a nem elvégzett állapot között (ha a cél egy normál jegyzet, akkor az teendővé alakul). A „clear” segítségével a teendőt visszaalakíthatja normál jegyzetté."
 
 #: packages/server/src/utils/time.ts:56
 msgid "1 day"
@@ -410,37 +382,24 @@ msgstr[0] "1 nap"
 msgstr[1] "%d nap"
 
 #: packages/lib/utils/joplinCloud/index.ts:732
-msgid ""
-"14-day free trial. Cancel anytime during the trial and you won't be charged."
-msgstr ""
-"14 napos ingyenes próbaidőszak. A próbaidőszak alatt bármikor lemondhatja a "
-"szolgáltatást használati díj felszámolása nélkül."
+msgid "14-day free trial. Cancel anytime during the trial and you won't be charged."
+msgstr "14 napos ingyenes próbaidőszak. A próbaidőszak alatt bármikor lemondhatja a szolgáltatást használati díj felszámolása nélkül."
 
 #: packages/editor/ProseMirror/plugins/imagePlugin.ts:148
 msgid "A brief description of the image:"
 msgstr "Kép rövid leírása:"
 
 #: packages/lib/models/settings/builtInMetadata.ts:2489
-msgid ""
-"A comma-separated list of words. May be used for uncommon words, to help "
-"voice typing spell them correctly."
-msgstr ""
-"Szavak vesszővel elválasztott listája. Használható a nem túl gyakori szavak "
-"esetében, hogy segítse a hangalapú gépelést a helyesírásban."
+msgid "A comma-separated list of words. May be used for uncommon words, to help voice typing spell them correctly."
+msgstr "Szavak vesszővel elválasztott listája. Használható a nem túl gyakori szavak esetében, hogy segítse a hangalapú gépelést a helyesírásban."
 
 #: packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx:37
 msgid "A new update (%s) is available"
 msgstr "Új frissítés (%s) érhető el"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1558
-msgid ""
-"A system-wide keyboard shortcut that toggles the Joplin window. Works even "
-"when Joplin is not focused. Example: CommandOrControl+Shift+J. Leave empty "
-"to disable."
-msgstr ""
-"Rendszerszintű billentyűkombináció a Joplin ablak megjelenítéséhez/"
-"elrejtéséhez. Akkor is működik, ha a Joplin nincs fókuszban. Például: (Cmd "
-"vagy Ctrl)+Shift+J. Hagyja üresen a letiltáshoz."
+msgid "A system-wide keyboard shortcut that toggles the Joplin window. Works even when Joplin is not focused. Example: CommandOrControl+Shift+J. Leave empty to disable."
+msgstr "Rendszerszintű billentyűkombináció a Joplin ablak megjelenítéséhez/elrejtéséhez. Akkor is működik, ha a Joplin nincs fókuszban. Például: (Cmd vagy Ctrl)+Shift+J. Hagyja üresen a letiltáshoz."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1876
 msgid "A3"
@@ -478,12 +437,8 @@ msgid "Accelerator \"%s\" is not valid."
 msgstr "A(z) „%s” hívóbetű nem érvényes."
 
 #: packages/lib/services/KeymapService.ts:382
-msgid ""
-"Accelerator \"%s\" is used for \"%s\" and \"%s\" commands. This may lead to "
-"unexpected behaviour."
-msgstr ""
-"A(z) „%s” hívóbetű a(z) „%s” és a(z) „%s” parancsokhoz van hozzárendelve. Ez "
-"váratlan viselkedést okozhat."
+msgid "Accelerator \"%s\" is used for \"%s\" and \"%s\" commands. This may lead to unexpected behaviour."
+msgstr "A(z) „%s” hívóbetű a(z) „%s” és a(z) „%s” parancsokhoz van hozzárendelve. Ez váratlan viselkedést okozhat."
 
 #: packages/app-desktop/gui/MainScreen.tsx:613
 #: packages/app-mobile/components/screens/ShareManager/IncomingShareItem.tsx:40
@@ -519,14 +474,8 @@ msgid "Accessible"
 msgstr "Akadálymentes"
 
 #: packages/lib/models/settings/builtInMetadata.ts:586
-msgid ""
-"Accessible mode saves additional information, enabling creation of "
-"accessible PDFs. It increases database size by approximately 10-20 KB per "
-"page."
-msgstr ""
-"Az akadálymentes mód további adatokat ment a jegyzethez, lehetővé téve az "
-"akadálymentes PDF-fájlok létrehozását. Ez oldalanként körülbelül 10–20 KB-"
-"tal növeli az adatbázis méretét."
+msgid "Accessible mode saves additional information, enabling creation of accessible PDFs. It increases database size by approximately 10-20 KB per page."
+msgstr "Az akadálymentes mód további adatokat ment a jegyzethez, lehetővé téve az akadálymentes PDF-fájlok létrehozását. Ez oldalanként körülbelül 10–20 KB-tal növeli az adatbázis méretét."
 
 #: packages/server/src/routes/admin/users.ts:159
 msgid "Account"
@@ -672,41 +621,27 @@ msgstr "MI-csevegés"
 #: packages/lib/services/ai/availability.ts:36
 #: packages/lib/services/ai/availability.ts:65
 msgid "AI features are disabled. Enable them in Settings → AI."
-msgstr ""
-"Az MI-funkciók le vannak tiltva. Engedélyezze őket a Beállítások → MI "
-"menüpontban."
+msgstr "Az MI-funkciók le vannak tiltva. Engedélyezze őket a Beállítások → MI menüpontban."
 
 #: packages/app-desktop/gui/ConfigScreen/controls/AiIndexStatus.tsx:24
 msgid "AI is disabled"
 msgstr "Az MI le van tiltva"
 
 #: packages/app-desktop/gui/AiDegradedNotice.tsx:15
-msgid ""
-"AI is running in reduced-quality mode — monthly allowance exceeded. Credits "
-"replenish on a rolling 30-day basis, or you can"
-msgstr ""
-"Az MI csökkentett módban fut, Ön túllépte a havi keretét. A kreditek 30 "
-"naponta megújulnak, vagy"
+msgid "AI is running in reduced-quality mode — monthly allowance exceeded. Credits replenish on a rolling 30-day basis, or you can"
+msgstr "Az MI csökkentett módban fut, Ön túllépte a havi keretét. A kreditek 30 naponta megújulnak, vagy"
 
 #: packages/app-desktop/services/aiStatusBridge.ts:62
-msgid ""
-"AI usage has exceeded your monthly allowance — responses are using a reduced-"
-"quality model. Credits replenish on a rolling 30-day basis. Buy more at %s."
-msgstr ""
-"Az MI csökkentett módban fut, Ön túllépte a havi keretét. A válaszadáshoz "
-"csökkentett minőségű modell van használatban. A kreditek 30 naponta "
-"megújulnak, vagy vásároljon többet itt: %s."
+msgid "AI usage has exceeded your monthly allowance — responses are using a reduced-quality model. Credits replenish on a rolling 30-day basis. Buy more at %s."
+msgstr "Az MI csökkentett módban fut, Ön túllépte a havi keretét. A válaszadáshoz csökkentett minőségű modell van használatban. A kreditek 30 naponta megújulnak, vagy vásároljon többet itt: %s."
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:18
 msgid "all"
 msgstr "összes"
 
 #: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:120
-msgid ""
-"All data, including notes, notebooks and tags will be permanently deleted."
-msgstr ""
-"Az összes adat, beleértve a jegyzeteket, jegyzetfüzeteket és címkéket, "
-"véglegesen törölve lesz."
+msgid "All data, including notes, notebooks and tags will be permanently deleted."
+msgstr "Az összes adat, beleértve a jegyzeteket, jegyzetfüzeteket és címkéket, véglegesen törölve lesz."
 
 #: packages/lib/services/ReportService.ts:229
 msgid "All item sync failures have been marked as \"ignored\"."
@@ -719,12 +654,8 @@ msgid "All notes"
 msgstr "Összes jegyzet"
 
 #: packages/app-mobile/components/screens/tags.tsx:176
-msgid ""
-"All notes associated with this tag will remain, but the tag will be removed "
-"from all notes."
-msgstr ""
-"Az ehhez a címkéhez kapcsolódó összes jegyzet megmarad, de a címke el lesz "
-"távolítva az összes jegyzetből."
+msgid "All notes associated with this tag will remain, but the tag will be removed from all notes."
+msgstr "Az ehhez a címkéhez kapcsolódó összes jegyzet megmarad, de a címke el lesz távolítva az összes jegyzetből."
 
 #: packages/lib/onedrive-api-node-utils.ts:58
 msgid "All potential ports are in use - please report the issue at %s"
@@ -748,8 +679,7 @@ msgstr "Címkék szerkesztésének engedélyezése a jegyzeteken"
 
 #: packages/lib/models/settings/builtInMetadata.ts:879
 msgid "Allow editing the current note (chat panel only)"
-msgstr ""
-"Jelenlegi jegyzet szerkesztésének engedélyezése (csak a csevegőpanelen)"
+msgstr "Jelenlegi jegyzet szerkesztésének engedélyezése (csak a csevegőpanelen)"
 
 #: packages/lib/models/settings/builtInMetadata.ts:924
 msgid "Allow listing notebooks"
@@ -789,9 +719,7 @@ msgstr "Jegyzetek frissítésének engedélyezése"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1433
 msgid "Allows debugging mobile plugins. See %s for details."
-msgstr ""
-"Lehetővé teszi a mobilalkalmazás bővítményeinek hibakeresését. További "
-"részletek: %s."
+msgstr "Lehetővé teszi a mobilalkalmazás bővítményeinek hibakeresését. További részletek: %s."
 
 #: packages/app-desktop/gui/SyncWizard/Dialog.tsx:267
 msgid "Already have an account? Log in"
@@ -826,27 +754,17 @@ msgid "Always resize"
 msgstr "Mindig méretezze át"
 
 #: packages/app-cli/app/command-mv.ts:36
-msgid ""
-"Ambiguous notebook \"%s\". Please use notebook id instead - press \"ti\" to "
-"see the short notebook id or use $b for current selected notebook"
-msgstr ""
-"Többértelmű jegyzetfüzet: „%s”. Használjon jegyzetfüzet-azonosítót helyette "
-"– nyomja meg a „ti” billentyűkombinációt a rövid azonosító megtekintéséhez, "
-"vagy használja a $b változót az jelenleg kijelölt jegyzetfüzethez"
+msgid "Ambiguous notebook \"%s\". Please use notebook id instead - press \"ti\" to see the short notebook id or use $b for current selected notebook"
+msgstr "Többértelmű jegyzetfüzet: „%s”. Használjon jegyzetfüzet-azonosítót helyette – nyomja meg a „ti” billentyűkombinációt a rövid azonosító megtekintéséhez, vagy használja a $b változót az jelenleg kijelölt jegyzetfüzethez"
 
 #: packages/app-cli/app/command-mkbook.ts:33
 #: packages/app-cli/app/command-mv.ts:29
-msgid ""
-"Ambiguous notebook \"%s\". Please use short notebook id instead - press "
-"\"ti\" to see the short notebook id"
-msgstr ""
-"Többértelmű jegyzetfüzet: „%s”. Használjon rövid jegyzetfüzet-azonosítót – "
-"nyomja meg a „ti” billentyűkombinációt a rövid azonosító megtekintéséhez"
+msgid "Ambiguous notebook \"%s\". Please use short notebook id instead - press \"ti\" to see the short notebook id"
+msgstr "Többértelmű jegyzetfüzet: „%s”. Használjon rövid jegyzetfüzet-azonosítót – nyomja meg a „ti” billentyűkombinációt a rövid azonosító megtekintéséhez"
 
 #: packages/app-mobile/components/NoteEditor/ImageEditor/promptRestoreAutosave.ts:13
 msgid "An autosaved drawing was found. Attach a copy of it to the note?"
-msgstr ""
-"Automatikusan mentett rajz megtalálva. Mellékeli a másolatát a jegyzethez?"
+msgstr "Automatikusan mentett rajz megtalálva. Mellékeli a másolatát a jegyzethez?"
 
 #: packages/app-desktop/ElectronAppWrapper.ts:185
 msgid "An error occurred: %s"
@@ -866,12 +784,8 @@ msgstr "Anthropic"
 
 #: packages/app-desktop/gui/JoplinCloudConfigScreen.tsx:48
 #: packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.tsx:24
-msgid ""
-"Any email sent to this address will be converted into a note and added to "
-"your collection. The note will be saved into the Inbox notebook"
-msgstr ""
-"Bármely erre a címre küldött e-mail jegyzetté lesz alakítva, és hozzáadódik "
-"a gyűjteményéhez. A jegyzet az „Inbox” nevű jegyzetfüzetbe lesz mentve"
+msgid "Any email sent to this address will be converted into a note and added to your collection. The note will be saved into the Inbox notebook"
+msgstr "Bármely erre a címre küldött e-mail jegyzetté lesz alakítva, és hozzáadódik a gyűjteményéhez. A jegyzet az „Inbox” nevű jegyzetfüzetbe lesz mentve"
 
 #: packages/lib/models/settings/builtInMetadata.ts:738
 msgid "API key"
@@ -903,28 +817,20 @@ msgstr ""
 "Ez a művelet nem vonható vissza."
 
 #: packages/lib/components/shared/NoteRevisionViewer/useDeleteHistoryClick.ts:17
-msgid ""
-"Are you sure you want to delete all history for this note? This cannot be "
-"undone."
-msgstr ""
-"Biztosan törölni szeretné ennek a jegyzetnek az összes előzményét? Ez a "
-"művelet nem vonható vissza."
+msgid "Are you sure you want to delete all history for this note? This cannot be undone."
+msgstr "Biztosan törölni szeretné ennek a jegyzetnek az összes előzményét? Ez a művelet nem vonható vissza."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:46
 msgid "Are you sure you want to renew the authorisation token?"
 msgstr "Biztosan meg akarja újítani a hitelesítési tokent?"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/resetLayout.ts:14
-msgid ""
-"Are you sure you want to return to the default layout? The current layout "
-"configuration will be lost."
-msgstr ""
-"Biztosan vissza szeretne térni az alapértelmezett elrendezéshez? A jelenlegi "
-"elrendezés konfigurációja elvész."
+msgid "Are you sure you want to return to the default layout? The current layout configuration will be lost."
+msgstr "Biztosan vissza szeretne térni az alapértelmezett elrendezéshez? A jelenlegi elrendezés konfigurációja elvész."
 
 #: packages/app-desktop/gui/ConfigScreen/controls/SettingComponent.tsx:242
 msgid "Arguments:"
-msgstr "Argumentumok:"
+msgstr "Argumentumok"
 
 #: packages/lib/models/settings/builtInMetadata.ts:82
 msgid "Aritim Dark"
@@ -943,25 +849,16 @@ msgid "Ask about this note, or request a change…"
 msgstr "Kérdezzen erről a jegyzetről, vagy kérjen módosítást…"
 
 #: packages/app-desktop/gui/ChatPanel/ChatPanel.tsx:363
-msgid ""
-"Ask about this note, or request changes. Select text in the editor first to "
-"scope the request to that selection."
-msgstr ""
-"Kérdezzen erről a jegyzetről, vagy kérjen módosításokat. Először jelöljön ki "
-"egy szöveget a szerkesztőben, ha a kérést csak arra a kijelölésre szeretné "
-"korlátozni."
+msgid "Ask about this note, or request changes. Select text in the editor first to scope the request to that selection."
+msgstr "Kérdezzen erről a jegyzetről, vagy kérjen módosításokat. Először jelöljön ki egy szöveget a szerkesztőben, ha a kérést csak arra a kijelölésre szeretné korlátozni."
 
 #: packages/app-mobile/components/TagEditor.tsx:188
 msgid "Associated tags:"
 msgstr "Kapcsolódó címkék:"
 
 #: packages/app-mobile/utils/lockToSingleInstance.ts:16
-msgid ""
-"At present, Joplin Web can only be open in one tab at a time. Please close "
-"the other instance of Joplin."
-msgstr ""
-"Jelenleg a Joplin Web egyszerre csak egy lapon nyitható meg. Zárja be a "
-"Joplin másik példányát."
+msgid "At present, Joplin Web can only be open in one tab at a time. Please close the other instance of Joplin."
+msgstr "Jelenleg a Joplin Web egyszerre csak egy lapon nyitható meg. Zárja be a Joplin másik példányát."
 
 #: packages/app-mobile/components/NoteEditor/ImageEditor/promptRestoreAutosave.ts:25
 msgid "Attach"
@@ -1016,32 +913,17 @@ msgid "Attachments that could not be downloaded"
 msgstr "Nem lehet letölteni a mellékleteket"
 
 #: packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx:221
-msgid ""
-"Attention: After resetting your password it will no longer be possible to "
-"decrypt any data encrypted with your current password. All encrypted shared "
-"notebooks will also be unshared, so please ask the notebook owner to share "
-"it again with you."
-msgstr ""
-"Figyelem: A jelszó visszaállítása után már nem lesz lehetséges a jelenlegi "
-"jelszavával titkosított adatok visszafejtése. Minden titkosított, megosztott "
-"jegyzetfüzet megosztása megszűnik, ezért kérje meg a jegyzetfüzet "
-"tulajdonosát, hogy ossza meg újra Önnel."
+msgid "Attention: After resetting your password it will no longer be possible to decrypt any data encrypted with your current password. All encrypted shared notebooks will also be unshared, so please ask the notebook owner to share it again with you."
+msgstr "Figyelem: A jelszó visszaállítása után már nem lesz lehetséges a jelenlegi jelszavával titkosított adatok visszafejtése. Minden titkosított, megosztott jegyzetfüzet megosztása megszűnik, ezért kérje meg a jegyzetfüzet tulajdonosát, hogy ossza meg újra Önnel."
 
 #: packages/lib/models/settings/builtInMetadata.ts:68
-msgid ""
-"Attention: If you change this location, make sure you copy all your content "
-"to it before syncing, otherwise all files will be removed! See the FAQ for "
-"more details: %s"
-msgstr ""
-"Figyelem: Ha módosítja ezt a helyet, győződjön meg arról, hogy az összes "
-"tartalmát átmásolta az új helyre a szinkronizálás előtt, különben minden "
-"fájl elvész! További részletekért tekintse meg a GYIK-et: %s"
+msgid "Attention: If you change this location, make sure you copy all your content to it before syncing, otherwise all files will be removed! See the FAQ for more details: %s"
+msgstr "Figyelem: Ha módosítja ezt a helyet, győződjön meg arról, hogy az összes tartalmát átmásolta az új helyre a szinkronizálás előtt, különben minden fájl elvész! További részletekért tekintse meg a GYIK-et: %s"
 
 #: packages/app-cli/app/command-sync.ts:70
 #: packages/app-cli/app/command-sync.ts:84
 #: packages/app-desktop/gui/OneDriveLoginScreen.tsx:56
-msgid ""
-"Authentication was not completed (did not receive an authentication token)."
+msgid "Authentication was not completed (did not receive an authentication token)."
 msgstr "Nem fejeződött be a hitelesítés (nem érkezett hitelesítési token)."
 
 #: packages/server/src/routes/index/applications.ts:32
@@ -1235,12 +1117,8 @@ msgid "Cancelling background synchronisation... Please wait."
 msgstr "A háttérben történő szinkronizálás megszakítása… Kis türelmet."
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:205
-msgid ""
-"Cancelling will discard the recording. This cannot be undone. Are you sure "
-"you want to proceed?"
-msgstr ""
-"A megszakítással az eddig rögzített hang törlődik. Ez a művelet nem vonható "
-"vissza. Biztosan folytatni szeretné?"
+msgid "Cancelling will discard the recording. This cannot be undone. Are you sure you want to proceed?"
+msgstr "A megszakítással az eddig rögzített hang törlődik. Ez a művelet nem vonható vissza. Biztosan folytatni szeretné?"
 
 #: packages/app-desktop/gui/TrashNotification/TrashNotificationMessage.tsx:23
 #: packages/lib/Synchronizer.ts:225
@@ -1327,15 +1205,11 @@ msgstr "Nem lehet előkészíteni a szinkronizálót."
 
 #: packages/lib/services/interop/InteropService.ts:278
 msgid "Cannot load \"%s\" module for format \"%s\" and output \"%s\""
-msgstr ""
-"Nem lehet betölteni a(z) „%s” modult a(z) „%s” formátumhoz és a(z) „%s” "
-"kimenethez."
+msgstr "Nem lehet betölteni a(z) „%s” modult a(z) „%s” formátumhoz és a(z) „%s” kimenethez."
 
 #: packages/lib/services/interop/InteropService.ts:291
 msgid "Cannot load \"%s\" module for format \"%s\" and target \"%s\""
-msgstr ""
-"Nem lehet betölteni a(z) „%s” modult a(z) „%s” formátumhoz és a(z) „%s” "
-"célhoz."
+msgstr "Nem lehet betölteni a(z) „%s” modult a(z) „%s” formátumhoz és a(z) „%s” célhoz."
 
 #: packages/lib/models/Note.ts:710
 msgid "Cannot move note to \"%s\" notebook"
@@ -1347,55 +1221,32 @@ msgid "Cannot move notebook to this location"
 msgstr "Nem lehet a jegyzetfüzetet áthelyezni erre a helyre"
 
 #: packages/lib/onedrive-api.ts:476
-msgid ""
-"Cannot refresh token: authentication data is missing. Starting the "
-"synchronisation again may fix the problem."
-msgstr ""
-"Nem lehet frissíteni a tokent: a hitelesítési adatok hiányoznak. A "
-"szinkronizálás újbóli elindítása megoldhatja a problémát."
+msgid "Cannot refresh token: authentication data is missing. Starting the synchronisation again may fix the problem."
+msgstr "Nem lehet frissíteni a tokent: a hitelesítési adatok hiányoznak. A szinkronizálás újbóli elindítása megoldhatja a problémát."
 
 #: packages/server/src/models/UserModel.ts:419
 msgid "Cannot save %s \"%s\" because it is larger than the allowed limit (%s)"
-msgstr ""
-"Nem lehet menteni a következőt: %s „%s”, mert nagyobb, mint a megengedett "
-"határérték (%s)"
+msgstr "Nem lehet menteni a következőt: %s „%s”, mert nagyobb, mint a megengedett határérték (%s)"
 
 #: packages/server/src/models/UserModel.ts:436
-msgid ""
-"Cannot save %s \"%s\" because it would go over the total allowed size (%s) "
-"for this account"
-msgstr ""
-"Nem lehet menteni a következőt: %s „%s”, mert meghaladná a fiók megengedett "
-"teljes méretét (%s)"
+msgid "Cannot save %s \"%s\" because it would go over the total allowed size (%s) for this account"
+msgstr "Nem lehet menteni a következőt: %s „%s”, mert meghaladná a fiók megengedett teljes méretét (%s)"
 
 #: packages/app-mobile/root.tsx:636
 msgid "Cannot share"
 msgstr "Nem osztható meg"
 
 #: packages/lib/services/share/ShareService.ts:423
-msgid ""
-"Cannot share encrypted notebook with recipient %s because they have not "
-"enabled end-to-end encryption. They may do so from the screen Configuration "
-"> Encryption."
-msgstr ""
-"A titkosított jegyzetfüzetet nem lehet megosztani a következő címzettel: %s, "
-"mert az nem engedélyezte a végpontok közötti titkosítást. Ezt megteheti a "
-"Beállítások > Titkosítás menüben."
+msgid "Cannot share encrypted notebook with recipient %s because they have not enabled end-to-end encryption. They may do so from the screen Configuration > Encryption."
+msgstr "A titkosított jegyzetfüzetet nem lehet megosztani a következő címzettel: %s, mert az nem engedélyezte a végpontok közötti titkosítást. Ezt megteheti a Beállítások > Titkosítás menüben."
 
 #: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:340
 msgid "Case sensitive"
 msgstr "Kis- és nagybetűk megkülönböztetése"
 
 #: packages/lib/components/shared/NoteEditor/WarningBanner/useEditorTypeMigrationBanner.ts:22
-msgid ""
-"Certain Markdown formatting is now rendered in the editor by default. For "
-"example, **bold** will appear as actual bold text. You can change this "
-"behaviour in the \"Editor\" section of Settings."
-msgstr ""
-"Egyes Markdown formázások mostantól alapértelmezés szerint meg lesznek "
-"jelenítve a szerkesztőben. Például a **félkövér** ténylegesen félkövér "
-"szövegként jelenik meg. Ezt a viselkedést a Beállítások „Szerkesztő” "
-"menüpontban módosíthatja."
+msgid "Certain Markdown formatting is now rendered in the editor by default. For example, **bold** will appear as actual bold text. You can change this behaviour in the \"Editor\" section of Settings."
+msgstr "Egyes Markdown formázások mostantól alapértelmezés szerint meg lesznek jelenítve a szerkesztőben. Például a **félkövér** ténylegesen félkövér szövegként jelenik meg. Ezt a viselkedést a Beállítások „Szerkesztő” menüpontban módosíthatja."
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleLayoutMoveMode.ts:7
 msgid "Change application layout"
@@ -1515,31 +1366,20 @@ msgid "Clears the console output."
 msgstr "Törli a konzol kimenetét."
 
 #: packages/lib/components/shared/NoteRevisionViewer/getHelpMessage.ts:5
-msgid ""
-"Click \"%s\" to restore the note. It will be copied in the notebook named "
-"\"%s\". The current version of the note will not be replaced or modified."
-msgstr ""
-"Kattintson a(z) „%s” gombra a jegyzet visszaállításához. A jegyzet a(z) „%s” "
-"nevű jegyzetfüzetbe lesz másolva. A jegyzet jelenlegi verziója nem lesz "
-"lecserélve vagy módosítva."
+msgid "Click \"%s\" to restore the note. It will be copied in the notebook named \"%s\". The current version of the note will not be replaced or modified."
+msgstr "Kattintson a(z) „%s” gombra a jegyzet visszaállításához. A jegyzet a(z) „%s” nevű jegyzetfüzetbe lesz másolva. A jegyzet jelenlegi verziója nem lesz lecserélve vagy módosítva."
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:239
 msgid "Click \"start\" to attach a new voice memo to the note."
-msgstr ""
-"Kattintson a „Rögzítés indítása” gombra, ha új hangjegyzetet szeretne "
-"mellékelni a jegyzethez."
+msgstr "Kattintson a „Rögzítés indítása” gombra, ha új hangjegyzetet szeretne mellékelni a jegyzethez."
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/WhiteboardEditor.tsx:183
-msgid ""
-"Click the eye icon in the toolbar to switch to the Markdown editor and fix "
-"the JSON manually."
-msgstr ""
-"Kattintson a szem ikonra az eszköztáron a Markdown szerkesztőre való "
-"váltáshoz és a JSON-fájl kézi javításához."
+msgid "Click the eye icon in the toolbar to switch to the Markdown editor and fix the JSON manually."
+msgstr "Kattintson a szem ikonra az eszköztáron a Markdown szerkesztőre való váltáshoz és a JSON-fájl kézi javításához."
 
 #: packages/app-desktop/gui/NoteEditor/StatusBar.tsx:79
 msgid "Click to add tags..."
-msgstr "Kattintson ide a címkék hozzáadáshoz…"
+msgstr "Címkék hozzáadásához kattintson ide…"
 
 #: packages/lib/versionInfo.ts:99
 msgid "Client ID: %s"
@@ -1578,14 +1418,8 @@ msgid "Close side menu"
 msgstr "Oldalmenü bezárása"
 
 #: packages/lib/models/settings/settingValidations.ts:33
-msgid ""
-"Close the application, then delete your profile in \"%s\", and start the "
-"application again. Make sure you create a backup first by exporting all your "
-"notes as JEX."
-msgstr ""
-"Zárja be az alkalmazást, majd törölje a profilját a következőben: „%s”, és "
-"indítsa újra az alkalmazást. Először mindenképpen készítsen biztonsági "
-"mentést az összes jegyzetének JEX-fájlként történő exportálásával."
+msgid "Close the application, then delete your profile in \"%s\", and start the application again. Make sure you create a backup first by exporting all your notes as JEX."
+msgstr "Zárja be az alkalmazást, majd törölje a profilját a következőben: „%s”, és indítsa újra az alkalmazást. Először mindenképpen készítsen biztonsági mentést az összes jegyzetének JEX-fájlként történő exportálásával."
 
 #: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:26
 #: packages/app-desktop/gui/MenuBar.tsx:638
@@ -1645,17 +1479,8 @@ msgid "Coming alarms"
 msgstr "Következő riasztások"
 
 #: packages/lib/models/settings/builtInMetadata.ts:2050
-msgid ""
-"Comma-separated list of paths to directories to load the certificates from, "
-"or path to individual cert files. For example: /my/cert_dir, /other/"
-"custom.pem. Note that if you make changes to the TLS settings, you must save "
-"your changes before clicking on \"Check synchronisation configuration\"."
-msgstr ""
-"A tanúsítványok betöltéséhez használt könyvtárak elérési útvonalainak "
-"vesszővel elválasztott listája, vagy az egyes tanúsítványfájlok elérési "
-"útvonala. Például: /my/cert_dir, /other/custom.pem. Vegye figyelembe, hogy "
-"ha módosítja a TLS-beállításokat, mentse el a módosításokat, mielőtt a "
-"„Szinkronizálási konfiguráció ellenőrzése” gombra kattint."
+msgid "Comma-separated list of paths to directories to load the certificates from, or path to individual cert files. For example: /my/cert_dir, /other/custom.pem. Note that if you make changes to the TLS settings, you must save your changes before clicking on \"Check synchronisation configuration\"."
+msgstr "A tanúsítványok betöltéséhez használt könyvtárak elérési útvonalainak vesszővel elválasztott listája, vagy az egyes tanúsítványfájlok elérési útvonala. Például: /my/cert_dir, /other/custom.pem. Vegye figyelembe, hogy ha módosítja a TLS-beállításokat, mentse el a módosításokat, mielőtt a „Szinkronizálási konfiguráció ellenőrzése” gombra kattint."
 
 #: packages/lib/services/KeymapService.ts:350
 msgid "command"
@@ -1678,10 +1503,8 @@ msgid "Command palette..."
 msgstr "Parancspaletta…"
 
 #: packages/app-cli/app/command-share.ts:59
-msgid ""
-"Commands: `add`, `remove`, `list`, `delete`, `accept`, `leave`, and `reject`."
-msgstr ""
-"Parancsok: `add`, `remove`, `list`, `delete`, `accept`, `leave`, és `reject`."
+msgid "Commands: `add`, `remove`, `list`, `delete`, `accept`, `leave`, and `reject`."
+msgstr "Parancsok: `add`, `remove`, `list`, `delete`, `accept`, `leave`, és `reject`."
 
 #: packages/lib/services/noteList/defaultListRenderer.ts:35
 msgid "Compact"
@@ -1852,7 +1675,7 @@ msgstr "Másolás"
 
 #: packages/app-desktop/commands/copyDevCommand.ts:9
 msgid "Copy dev mode command to clipboard"
-msgstr "A „dev mode” parancs másolása a vágólapra"
+msgstr "„dev mode” parancs másolása a vágólapra"
 
 #: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:281
 #: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:295
@@ -1921,13 +1744,11 @@ msgstr ""
 
 #: packages/lib/JoplinServerApi.ts:128
 msgid ""
-"Could not connect to Joplin Server. Please check the Synchronisation options "
-"in the config screen. Full error was:\n"
+"Could not connect to Joplin Server. Please check the Synchronisation options in the config screen. Full error was:\n"
 "\n"
 "%s"
 msgstr ""
-"Nem sikerült kapcsolódni a Joplin Serverhez. Ellenőrizze a szinkronizálási "
-"beállításokat. A teljes hiba a következő volt:\n"
+"Nem sikerült kapcsolódni a Joplin Serverhez. Ellenőrizze a szinkronizálási beállításokat. A teljes hiba a következő volt:\n"
 "\n"
 "%s"
 
@@ -1949,13 +1770,11 @@ msgstr "Nem sikerült telepíteni a bővítményt: %s"
 
 #: packages/lib/services/share/invitationRespond.ts:24
 msgid ""
-"Could not respond to the invitation. Please try again, or check with the "
-"notebook owner if they are still sharing it.\n"
+"Could not respond to the invitation. Please try again, or check with the notebook owner if they are still sharing it.\n"
 "\n"
 "The error was: \"%s\""
 msgstr ""
-"Nem sikerült válaszolni a meghívásra. Próbálja újra vagy kérdezze meg a "
-"jegyzetfüzet tulajdonosát, hogy még mindig megosztja-e a jegyzetfüzetet.\n"
+"Nem sikerült válaszolni a meghívásra. Próbálja újra vagy kérdezze meg a jegyzetfüzet tulajdonosát, hogy még mindig megosztja-e a jegyzetfüzetet.\n"
 "\n"
 "A hiba a következő volt: „%s”"
 
@@ -1968,12 +1787,8 @@ msgid "Could not upgrade master key: %s"
 msgstr "Nem sikerült frissíteni a mesterkulcsot: %s"
 
 #: packages/lib/commands/leaveSharedFolder.ts:33
-msgid ""
-"Could not verify the share status of this notebook - aborting. Please try "
-"again when you are connected to the internet."
-msgstr ""
-"Nem sikerült ellenőrizni a jegyzetfüzet megosztási állapotát – megszakítás. "
-"Próbálja újra, amikor kapcsolódik az internethez."
+msgid "Could not verify the share status of this notebook - aborting. Please try again when you are connected to the internet."
+msgstr "Nem sikerült ellenőrizni a jegyzetfüzet megosztási állapotát – megszakítás. Próbálja újra, amikor kapcsolódik az internethez."
 
 #: packages/app-mobile/components/biometrics/biometricAuthenticate.ts:26
 msgid "Could not verify your identity: %s"
@@ -2196,9 +2011,7 @@ msgstr "Alapértelmezett"
 
 #: packages/lib/models/settings/builtInMetadata.ts:2500
 msgid "Default title to use for documents created by the scanner."
-msgstr ""
-"A dokumentumbeolvasó által létrehozott dokumentumokhoz használt "
-"alapértelmezett cím."
+msgstr "A dokumentumbeolvasó által létrehozott dokumentumokhoz használt alapértelmezett cím."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1681
 msgid "Default view / edit state"
@@ -2286,8 +2099,7 @@ msgid ""
 msgstr ""
 "Törli a(z) „%s” profilt?\n"
 "\n"
-"Az összes adat, beleértve a jegyzeteket, füzeteket és címkéket, véglegesen "
-"törölve lesznek."
+"Az összes adat, beleértve a jegyzeteket, füzeteket és címkéket, véglegesen törölve lesznek."
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:39
 #: packages/editor/CodeMirror/extensions/rendering/renderTables.ts:728
@@ -2308,21 +2120,15 @@ msgstr "Biztosan törli a(z) „%s” címkét?"
 msgid ""
 "Delete the Inbox notebook?\n"
 "\n"
-"If you delete the inbox notebook, any email that's recently been sent to it "
-"may be lost."
+"If you delete the inbox notebook, any email that's recently been sent to it may be lost."
 msgstr ""
 "Törli az „Inbox” nevű jegyzetfüzetet?\n"
 "\n"
-"Ha törli az „Inbox” nevű jegyzetfüzetet, az ide nemrég küldött e-mailek "
-"elveszhetnek."
+"Ha törli az „Inbox” nevű jegyzetfüzetet, az ide nemrég küldött e-mailek elveszhetnek."
 
 #: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:269
-msgid ""
-"Delete this invitation? The recipient will no longer have access to this "
-"shared notebook."
-msgstr ""
-"Törli ezt a meghívást? A címzett többé nem fér hozzá ehhez a megosztott "
-"jegyzetfüzethez."
+msgid "Delete this invitation? The recipient will no longer have access to this shared notebook."
+msgstr "Törli ezt a meghívást? A címzett többé nem fér hozzá ehhez a megosztott jegyzetfüzethez."
 
 #: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:119
 msgid "Delete this profile?"
@@ -2448,14 +2254,8 @@ msgstr "Letiltott billentyűk"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:413
 #: packages/app-mobile/components/screens/encryption-config.tsx:307
-msgid ""
-"Disabling encryption means *all* your notes and attachments are going to be "
-"re-synchronised and sent unencrypted to the sync target. Do you wish to "
-"continue?"
-msgstr ""
-"A titkosítás kikapcsolása azt jelenti, hogy az *összes* jegyzet és melléklet "
-"újra lesz szinkronizálva, és titkosítatlanul lesz elküldve a szinkronizálási "
-"célra. Folytatja?"
+msgid "Disabling encryption means *all* your notes and attachments are going to be re-synchronised and sent unencrypted to the sync target. Do you wish to continue?"
+msgstr "A titkosítás kikapcsolása azt jelenti, hogy az *összes* jegyzet és melléklet újra lesz szinkronizálva, és titkosítatlanul lesz elküldve a szinkronizálási célra. Folytatja?"
 
 #: packages/app-mobile/components/NoteEditor/ImageEditor/promptRestoreAutosave.ts:19
 msgid "Discard"
@@ -2485,14 +2285,8 @@ msgid "Displays only the first top <num> notes."
 msgstr "Csak az első <num> leggyakrabban használt jegyzetet jeleníti meg."
 
 #: packages/app-cli/app/command-ls.ts:31
-msgid ""
-"Displays only the items of the specific type(s). Can be `n` for notes, `t` "
-"for to-dos, or `nt` for notes and to-dos (eg. `-tt` would display only the "
-"to-dos, while `-tnt` would display notes and to-dos."
-msgstr ""
-"Csak a megadott típusú elemeket jeleníti meg. Lehet `n` a jegyzetekhez, `t` "
-"a teendőkhöz, vagy `nt` a jegyzetekhez és teendőkhöz (például: `-tt` csak a "
-"teendőket jeleníti meg, míg a `-tnt` a jegyzeteket és teendőket is)."
+msgid "Displays only the items of the specific type(s). Can be `n` for notes, `t` for to-dos, or `nt` for notes and to-dos (eg. `-tt` would display only the to-dos, while `-tnt` would display notes and to-dos."
+msgstr "Csak a megadott típusú elemeket jeleníti meg. Lehet `n` a jegyzetekhez, `t` a teendőkhöz, vagy `nt` a jegyzetekhez és teendőkhöz (például: `-tt` csak a teendőket jeleníti meg, míg a `-tnt` a jegyzeteket és teendőket is)."
 
 #: packages/app-cli/app/command-status.ts:13
 msgid "Displays summary about the notes and notebooks."
@@ -2511,12 +2305,8 @@ msgid "Displays the given note."
 msgstr "Megjeleníti a megadott jegyzetet."
 
 #: packages/app-cli/app/command-ls.ts:19
-msgid ""
-"Displays the notes in the current notebook. Use `ls /` to display the list "
-"of notebooks."
-msgstr ""
-"Megjeleníti a jegyzeteket a jelenlegi jegyzetfüzetben. Használja az `ls /` "
-"parancsot a jegyzetfüzetek listájának megjelenítéséhez."
+msgid "Displays the notes in the current notebook. Use `ls /` to display the list of notebooks."
+msgstr "Megjeleníti a jegyzeteket a jelenlegi jegyzetfüzetben. Használja az `ls /` parancsot a jegyzetfüzetek listájának megjelenítéséhez."
 
 #: packages/app-cli/app/command-help.ts:13
 msgid "Displays usage information."
@@ -2541,26 +2331,16 @@ msgid "Do not ask for user confirmation."
 msgstr "Ne kérjen felhasználói jóváhagyást."
 
 #: packages/lib/components/EncryptionConfigScreen/utils.ts:57
-msgid ""
-"Do not lose the password as, for security purposes, this will be the *only* "
-"way to decrypt the data! To enable encryption, please enter your password "
-"below."
-msgstr ""
-"Ne veszítse el a jelszót, mert biztonsági okokból ez lesz az *egyetlen* "
-"módja az adatok visszafejtésének! A titkosítás engedélyezéséhez adja meg a "
-"jelszavát alább."
+msgid "Do not lose the password as, for security purposes, this will be the *only* way to decrypt the data! To enable encryption, please enter your password below."
+msgstr "Ne veszítse el a jelszót, mert biztonsági okokból ez lesz az *egyetlen* módja az adatok visszafejtésének! A titkosítás engedélyezéséhez adja meg a jelszavát alább."
 
 #: packages/lib/models/settings/builtInMetadata.ts:2499
 msgid "Document scanner: Title template"
 msgstr "Dokumentumbeolvasó: Címsablon"
 
 #: packages/app-cli/app/command-share.ts:65
-msgid ""
-"Don't allow the share recipient to write to the shared notebook. Valid only "
-"for the `add` subcommand."
-msgstr ""
-"Ne engedélyezze, hogy a megosztás címzettje írjon a megosztott "
-"jegyzetfüzetbe. Csak az `add` alparancsra érvényes."
+msgid "Don't allow the share recipient to write to the shared notebook. Valid only for the `add` subcommand."
+msgstr "Ne engedélyezze, hogy a megosztás címzettje írjon a megosztott jegyzetfüzetbe. Csak az `add` alparancsra érvényes."
 
 #: packages/app-desktop/gui/JoplinCloudSignUpCallToAction.tsx:31
 msgid "Don't have an account yet?"
@@ -2588,11 +2368,8 @@ msgid "Done"
 msgstr "Kész"
 
 #: packages/app-mobile/components/screens/ResourceScreen.tsx:368
-msgid ""
-"Double tap to open this attachment. Long press to expand or collapse details."
-msgstr ""
-"Dupla koppintással nyithatja meg ezt a mellékletet. Nyomja hosszan a "
-"részletek kibontásához vagy összecsukásához."
+msgid "Double tap to open this attachment. Long press to expand or collapse details."
+msgstr "Dupla koppintással nyithatja meg ezt a mellékletet. Nyomja hosszan a részletek kibontásához vagy összecsukásához."
 
 #: packages/app-desktop/checkForUpdates.ts:116
 msgid "Download"
@@ -2697,13 +2474,8 @@ msgid "Duplicate selected notes"
 msgstr "Kijelölt jegyzetek duplikálása"
 
 #: packages/app-cli/app/command-cp.ts:13
-msgid ""
-"Duplicates the notes matching <note> to [notebook]. If no notebook is "
-"specified the note is duplicated in the current notebook."
-msgstr ""
-"A(z) <note> jegyzetnek megfelelő jegyzeteket duplikálja a(z) [notebook] "
-"jegyzetfüzetbe. Ha nincs megadva jegyzetfüzet, a jegyzet a jelenlegi "
-"jegyzetfüzetben lesz duplikálva."
+msgid "Duplicates the notes matching <note> to [notebook]. If no notebook is specified the note is duplicated in the current notebook."
+msgstr "A(z) <note> jegyzetnek megfelelő jegyzeteket duplikálja a(z) [notebook] jegyzetfüzetbe. Ha nincs megadva jegyzetfüzet, a jegyzet a jelenlegi jegyzetfüzetben lesz duplikálva."
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:229
 msgid "Duration: %s"
@@ -3013,40 +2785,20 @@ msgid "Enabled"
 msgstr "Engedélyezve"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1127
-msgid ""
-"Enables Markdown list continuation, auto-closing HTML tags, and other markup "
-"autocompletions."
-msgstr ""
-"Engedélyezi a Markdown lista folytatását, az automatikus HTML-címkék "
-"bezárását és egyéb automatikus jelölőkiegészítéseket."
+msgid "Enables Markdown list continuation, auto-closing HTML tags, and other markup autocompletions."
+msgstr "Engedélyezi a Markdown lista folytatását, az automatikus HTML-címkék bezárását és egyéb automatikus jelölőkiegészítéseket."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1160
-msgid ""
-"Enables Markdown pattern replacement in the Rich Text Editor. For example, "
-"when enabled, typing **bold** creates bold text."
-msgstr ""
-"Engedélyezi a Markdown minták cseréjét a formázott szöveges szerkesztőben. "
-"Ha például engedélyezve van, a **félkövér** beírása félkövér szöveget hoz "
-"létre."
+msgid "Enables Markdown pattern replacement in the Rich Text Editor. For example, when enabled, typing **bold** creates bold text."
+msgstr "Engedélyezi a Markdown minták cseréjét a formázott szöveges szerkesztőben. Ha például engedélyezve van, a **félkövér** beírása félkövér szöveget hoz létre."
 
 #: packages/lib/models/settings/builtInMetadata.ts:880
-msgid ""
-"Enables the default edit operations for notes with an open AI chat panel. "
-"When disabled, the chat panel can still read the open note. Does not apply "
-"to MCP."
-msgstr ""
-"Engedélyezi az alapértelmezett szerkesztési műveleteket a jegyzeteknél "
-"nyitott MI-csevegőpanel esetén. Letiltott állapotban a csevegőpanel továbbra "
-"is olvashatja a nyitott jegyzetet. Nem vonatkozik az MCP-re."
+msgid "Enables the default edit operations for notes with an open AI chat panel. When disabled, the chat panel can still read the open note. Does not apply to MCP."
+msgstr "Engedélyezi az alapértelmezett szerkesztési műveleteket a jegyzeteknél nyitott MI-csevegőpanel esetén. Letiltott állapotban a csevegőpanel továbbra is olvashatja a nyitott jegyzetet. Nem vonatkozik az MCP-re."
 
 #: packages/lib/components/EncryptionConfigScreen/utils.ts:52
-msgid ""
-"Enabling encryption means *all* your notes and attachments are going to be "
-"re-synchronised and sent encrypted to the sync target."
-msgstr ""
-"A titkosítás engedélyezése azt jelenti, hogy *minden* jegyzet és melléklet "
-"újra lesz szinkronizálva, és titkosítva lesz elküldve a szinkronizálási "
-"célra."
+msgid "Enabling encryption means *all* your notes and attachments are going to be re-synchronised and sent encrypted to the sync target."
+msgstr "A titkosítás engedélyezése azt jelenti, hogy *minden* jegyzet és melléklet újra lesz szinkronizálva, és titkosítva lesz elküldve a szinkronizálási célra."
 
 #: packages/lib/models/BaseItem.ts:960
 msgid "Encrypted"
@@ -3057,12 +2809,8 @@ msgid "Encrypted items cannot be modified"
 msgstr "A titkosított elemek nem módosíthatóak"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/enableNoteEncryption.ts:33
-msgid ""
-"Encrypting a note requires a note lock password, which has not yet been set. "
-"Set it up now?"
-msgstr ""
-"A jegyzet titkosításához jegyzetzárolási jelszó szükséges, amely még nincs "
-"beállítva. Beállítja most?"
+msgid "Encrypting a note requires a note lock password, which has not yet been set. Set it up now?"
+msgstr "A jegyzet titkosításához jegyzetzárolási jelszó szükséges, amely még nincs beállítva. Beállítja most?"
 
 #: packages/lib/models/Setting.ts:1366
 msgid "Encryption"
@@ -3084,12 +2832,8 @@ msgid "Encryption keys"
 msgstr "Titkosítási kulcsok"
 
 #: packages/app-mobile/components/screens/encryption-config.tsx:167
-msgid ""
-"Encryption was setup previously, but all keys have been disabled. To "
-"continue, please use the desktop app to enable a key."
-msgstr ""
-"A titkosítás korábban be lett állítva, de minden kulcs le lett tiltva. A "
-"folytatáshoz használja az asztali alkalmazást egy kulcs engedélyezéséhez."
+msgid "Encryption was setup previously, but all keys have been disabled. To continue, please use the desktop app to enable a key."
+msgstr "A titkosítás korábban be lett állítva, de minden kulcs le lett tiltva. A folytatáshoz használja az asztali alkalmazást egy kulcs engedélyezéséhez."
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:438
 msgid "Encryption:"
@@ -3134,11 +2878,8 @@ msgid "Enter the code:"
 msgstr "Adja meg a kódot:"
 
 #: packages/app-desktop/gui/NoteLockUnlockDialog/Dialog.tsx:68
-msgid ""
-"Enter the note lock password to unlock encrypted notes for this session."
-msgstr ""
-"Adja meg a jegyzetzárolási jelszót a titkosított jegyzetek feloldásához "
-"ebben a munkamenetben."
+msgid "Enter the note lock password to unlock encrypted notes for this session."
+msgstr "Adja meg a jegyzetzárolási jelszót a titkosított jegyzetek feloldásához ebben a munkamenetben."
 
 #: packages/app-mobile/components/NoteItem.tsx:156
 msgid "Entering selection mode"
@@ -3177,12 +2918,8 @@ msgid "Error: %s"
 msgstr "Hiba: %s"
 
 #: packages/lib/components/shared/config/config-shared.ts:108
-msgid ""
-"Error. Please check that URL, username, password, etc. are correct and that "
-"the sync target is accessible. The reported error was:"
-msgstr ""
-"Hiba. Ellenőrizze, hogy a webcím, felhasználónév, jelszó stb. helyesek-e, és "
-"hogy a szinkronizálási cél elérhető-e. A jelentett hiba a következő:"
+msgid "Error. Please check that URL, username, password, etc. are correct and that the sync target is accessible. The reported error was:"
+msgstr "Hiba. Ellenőrizze, hogy a webcím, felhasználónév, jelszó stb. helyesek-e, és hogy a szinkronizálási cél elérhető-e. A jelentett hiba a következő:"
 
 #: packages/lib/components/shared/config/config-shared.ts:154
 msgid "Error. The AI provider test failed:"
@@ -3279,13 +3016,8 @@ msgid "Exporting..."
 msgstr "Exportálás…"
 
 #: packages/app-cli/app/command-export.ts:14
-msgid ""
-"Exports Joplin data to the given path. By default, it will export the "
-"complete database including notebooks, notes, tags and resources."
-msgstr ""
-"A Joplin adatainak exportálása a megadott elérési útra. Alapértelmezés "
-"szerint az egész adatbázis exportálva lesz, beleértve a jegyzetfüzeteket, "
-"jegyzeteket, címkéket és erőforrásokat."
+msgid "Exports Joplin data to the given path. By default, it will export the complete database including notebooks, notes, tags and resources."
+msgstr "A Joplin adatainak exportálása a megadott elérési útra. Alapértelmezés szerint az egész adatbázis exportálva lesz, beleértve a jegyzetfüzeteket, jegyzeteket, címkéket és erőforrásokat."
 
 #: packages/app-cli/app/command-export.ts:24
 msgid "Exports only the given note."
@@ -3296,40 +3028,20 @@ msgid "Exports only the given notebook."
 msgstr "Csak a megadott jegyzetfüzet exportálása."
 
 #: packages/lib/models/settings/builtInMetadata.ts:663
-msgid ""
-"Exposes Joplin notes to external AI applications (Claude Desktop, Cursor, "
-"etc.) via the Model Context Protocol. Requires the Web Clipper service to be "
-"running. Connected AI tools can read your note content; any text they "
-"retrieve may be sent to the external LLM provider those tools use."
-msgstr ""
-"A Model Context Protocol segítségével elérhetővé teszi a Joplin jegyzeteket "
-"a külső MI-alkalmazások (Claude Desktop, Cursor stb.) számára. Ehhez a Web "
-"Clipper szolgáltatás futtatása szükséges. A kapcsolódott MI-eszközök "
-"olvashatják a jegyzetei tartalmát; bármely általuk lekért szöveg elküldhető "
-"a külső MI-szolgáltatónak, amelyet ezek az eszközök használnak."
+msgid "Exposes Joplin notes to external AI applications (Claude Desktop, Cursor, etc.) via the Model Context Protocol. Requires the Web Clipper service to be running. Connected AI tools can read your note content; any text they retrieve may be sent to the external LLM provider those tools use."
+msgstr "A Model Context Protocol segítségével elérhetővé teszi a Joplin jegyzeteket a külső MI-alkalmazások (Claude Desktop, Cursor stb.) számára. Ehhez a Web Clipper szolgáltatás futtatása szükséges. A kapcsolódott MI-eszközök olvashatják a jegyzetei tartalmát; bármely általuk lekért szöveg elküldhető a külső MI-szolgáltatónak, amelyet ezek az eszközök használnak."
 
 #: packages/lib/models/settings/builtInMetadata.ts:2115
 msgid "Fail-safe"
 msgstr "Hibabiztos"
 
 #: packages/lib/models/settings/builtInMetadata.ts:2116
-msgid ""
-"Fail-safe: Do not wipe out local data when sync target is empty (often the "
-"result of a misconfiguration or bug)"
-msgstr ""
-"Hibabiztos: Ne törölje a helyi adatokat, ha a szinkronizálási cél üres (ami "
-"gyakran helytelen konfiguráció vagy hiba következménye)."
+msgid "Fail-safe: Do not wipe out local data when sync target is empty (often the result of a misconfiguration or bug)"
+msgstr "Hibabiztos: Ne törölje a helyi adatokat, ha a szinkronizálási cél üres (ami gyakran helytelen konfiguráció vagy hiba következménye)."
 
 #: packages/lib/services/synchronizer/syncInfoUtils.ts:177
-msgid ""
-"Fail-safe: Sync was interrupted to prevent data loss, because the sync "
-"target is empty or damaged. To override this behaviour disable the fail-safe "
-"in the sync settings."
-msgstr ""
-"Hibabiztos: A szinkronizálás megszakadt az adatvesztés elkerülése érdekében, "
-"mert a szinkronizálás célpontja üres vagy sérült. Ennek a viselkedésnek a "
-"felülírásához tiltsa le a „hibabiztos” funkciót a szinkronizálási "
-"beállításokban."
+msgid "Fail-safe: Sync was interrupted to prevent data loss, because the sync target is empty or damaged. To override this behaviour disable the fail-safe in the sync settings."
+msgstr "Hibabiztos: A szinkronizálás megszakadt az adatvesztés elkerülése érdekében, mert a szinkronizálás célpontja üres vagy sérült. Ennek a viselkedésnek a felülírásához tiltsa le a „hibabiztos” funkciót a szinkronizálási beállításokban."
 
 #: packages/app-desktop/gui/SsoLoginScreen/SsoLoginScreen.tsx:29
 #: packages/app-mobile/components/screens/SsoLoginScreen.tsx:54
@@ -3444,25 +3156,15 @@ msgstr "Például: „%s”"
 
 #: packages/app-cli/app/command-help.ts:36
 msgid "For information on how to customise the shortcuts please visit %s"
-msgstr ""
-"A gyorsbillentyűk testreszabásával kapcsolatos további tudnivalókért "
-"látogasson el a következő oldalra: %s"
+msgstr "A gyorsbillentyűk testreszabásával kapcsolatos további tudnivalókért látogasson el a következő oldalra: %s"
 
 #: packages/app-mobile/components/screens/encryption-config.tsx:369
-msgid ""
-"For more information about End-To-End Encryption (E2EE) and advice on how to "
-"enable it please check the documentation:"
-msgstr ""
-"További tudnivalókért a végpontok közötti titkosításról (E2EE) és annak "
-"engedélyezésével kapcsolatos tanácsokért, tekintse meg a következő "
-"dokumentációt:"
+msgid "For more information about End-To-End Encryption (E2EE) and advice on how to enable it please check the documentation:"
+msgstr "További tudnivalókért a végpontok közötti titkosításról (E2EE) és annak engedélyezésével kapcsolatos tanácsokért, tekintse meg a következő dokumentációt:"
 
 #: packages/app-cli/app/command-help.ts:84
-msgid ""
-"For the list of keyboard shortcuts and config options, type `help keymap`"
-msgstr ""
-"A billentyűparancsok és konfigurációs beállítások listájához írja be a "
-"következőt: `help keymap`"
+msgid "For the list of keyboard shortcuts and config options, type `help keymap`"
+msgstr "A billentyűparancsok és konfigurációs beállítások listájához írja be a következőt: `help keymap`"
 
 #: packages/lib/models/settings/builtInMetadata.ts:335
 msgid "Force path style"
@@ -3525,14 +3227,8 @@ msgid "Get pre-releases when checking for updates"
 msgstr "Előzetes verziók letöltése a frissítések ellenőrzésekor"
 
 #: packages/app-cli/app/command-config.ts:14
-msgid ""
-"Gets or sets a config value. If [value] is not provided, it will show the "
-"value of [name]. If neither [name] nor [value] is provided, it will list the "
-"current configuration."
-msgstr ""
-"Beállít egy konfigurációs értéket, vagy lekéri azt. Ha a [value] nincs "
-"megadva, akkor megjeleníti a [name] értékét. Ha sem a [name], sem a [value] "
-"nincs megadva, akkor felsorolja a jelenlegi konfigurációt."
+msgid "Gets or sets a config value. If [value] is not provided, it will show the value of [name]. If neither [name] nor [value] is provided, it will list the current configuration."
+msgstr "Beállít egy konfigurációs értéket, vagy lekéri azt. Ha a [value] nincs megadva, akkor megjeleníti a [name] értékét. Ha sem a [name], sem a [value] nincs megadva, akkor felsorolja a jelenlegi konfigurációt."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1557
 msgid "Global shortcut to show/hide Joplin"
@@ -3695,28 +3391,16 @@ msgid "Idle"
 msgstr "Tétlen"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1958
-msgid ""
-"If an image attachment is on its own line and followed by a blank line, it "
-"will be rendered just below its Markdown source."
-msgstr ""
-"Ha egy képmelléklet a saját sorában található, és egy üres sor követi, akkor "
-"a Markdown forrása alatt fog megjelenni."
+msgid "If an image attachment is on its own line and followed by a blank line, it will be rendered just below its Markdown source."
+msgstr "Ha egy képmelléklet a saját sorában található, és egy üres sor követi, akkor a Markdown forrása alatt fog megjelenni."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1139
-msgid ""
-"If enabled, opening an HTML note displays a prompt to convert the note to "
-"Markdown."
-msgstr ""
-"Ha engedélyezve van, akkor egy HTML-jegyzet megnyitásakor az alkalmazás "
-"rákérdez a jegyzet Markdown formátumra való átalakítására."
+msgid "If enabled, opening an HTML note displays a prompt to convert the note to Markdown."
+msgstr "Ha engedélyezve van, akkor egy HTML-jegyzet megnyitásakor az alkalmazás rákérdez a jegyzet Markdown formátumra való átalakítására."
 
 #: packages/lib/services/joplinCloudUtils.ts:39
-msgid ""
-"If you have already authorised, please wait for the application to sync to "
-"Joplin Cloud."
-msgstr ""
-"Ha már engedélyezte, várja meg, amíg az alkalmazás szinkronizálódik a Joplin "
-"Clouddal."
+msgid "If you have already authorised, please wait for the application to sync to Joplin Cloud."
+msgstr "Ha már engedélyezte, várja meg, amíg az alkalmazás szinkronizálódik a Joplin Clouddal."
 
 #: packages/app-desktop/ElectronAppWrapper.ts:179
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:561
@@ -3745,12 +3429,8 @@ msgid "Import"
 msgstr "Importálás"
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:603
-msgid ""
-"Import a note from a text file (%s). The note will be imported into notebook "
-"'%s'."
-msgstr ""
-"Jegyzet importálása szöveges fájlból (%s). A jegyzet a(z) „%s” "
-"jegyzetfüzetbe lesz importálva."
+msgid "Import a note from a text file (%s). The note will be imported into notebook '%s'."
+msgstr "Jegyzet importálása szöveges fájlból (%s). A jegyzet a(z) „%s” jegyzetfüzetbe lesz importálva."
 
 #: packages/lib/models/Setting.ts:1372
 msgid "Import and Export"
@@ -3765,8 +3445,7 @@ msgid ""
 "Import failed. Make sure a %s file was selected.\n"
 "Details: %s"
 msgstr ""
-"Nem sikerült az importálás. Győződjön meg arról, hogy egy %s fájlt "
-"választott ki.\n"
+"Nem sikerült az importálás. Győződjön meg arról, hogy egy %s fájlt választott ki.\n"
 "Részletek: %s"
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:593
@@ -3814,54 +3493,34 @@ msgid "Imports data into Joplin."
 msgstr "Adatok importálása a Joplin alkalmazásba."
 
 #: packages/lib/models/settings/builtInMetadata.ts:467
-msgid ""
-"In \"Manual\" mode, attachments are downloaded only when you click on them. "
-"In \"Auto\", they are downloaded when you open the note. In \"Always\", all "
-"the attachments are downloaded whether you open the note or not."
-msgstr ""
-"„Kézi” módban a mellékletek csak akkor töltődnek le, ha rájuk kattint. "
-"„Automatikus” módban a mellékletek akkor töltődnek le, amikor megnyitja a "
-"jegyzetet. „Mindig” módban az összes melléklet le lesz töltve, függetlenül "
-"attól, hogy megnyitja-e a jegyzetet, vagy sem."
+msgid "In \"Manual\" mode, attachments are downloaded only when you click on them. In \"Auto\", they are downloaded when you open the note. In \"Always\", all the attachments are downloaded whether you open the note or not."
+msgstr "„Kézi” módban a mellékletek csak akkor töltődnek le, ha rájuk kattint. „Automatikus” módban a mellékletek akkor töltődnek le, amikor megnyitja a jegyzetet. „Mindig” módban az összes melléklet le lesz töltve, függetlenül attól, hogy megnyitja-e a jegyzetet, vagy sem."
 
 #: packages/app-cli/app/command-help.ts:77
-msgid ""
-"In any command, a note or notebook can be referred to by title or ID, or "
-"using the shortcuts `$n` or `$b` for, respectively, the currently selected "
-"note or notebook. `$c` can be used to refer to the currently selected item."
-msgstr ""
-"Bármely parancsban egy jegyzet vagy jegyzetfüzet hivatkozható cím vagy "
-"azonosító alapján, illetve a jelenleg kijelölt jegyzet vagy jegyzetfüzet "
-"esetén a `$n` vagy `$b` parancs használatával. A jelenlegi kijelölt elemre a "
-"`$c` paranccsal hivatkozhat."
+msgid "In any command, a note or notebook can be referred to by title or ID, or using the shortcuts `$n` or `$b` for, respectively, the currently selected note or notebook. `$c` can be used to refer to the currently selected item."
+msgstr "Bármely parancsban egy jegyzet vagy jegyzetfüzet hivatkozható cím vagy azonosító alapján, illetve a jelenleg kijelölt jegyzet vagy jegyzetfüzet esetén a `$n` vagy `$b` parancs használatával. A jelenlegi kijelölt elemre a `$c` paranccsal hivatkozhat."
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:547
 msgid ""
-"In order to do so, your entire data set will have to be encrypted and "
-"synchronised, so it is best to run it overnight.\n"
+"In order to do so, your entire data set will have to be encrypted and synchronised, so it is best to run it overnight.\n"
 "\n"
 "To start, please follow these instructions:\n"
 "\n"
 "1. Synchronise all your devices.\n"
 "2. Click \"%s\".\n"
-"3. Let it run to completion. While it runs, avoid changing any note on your "
-"other devices, to avoid conflicts.\n"
-"4. Once sync is done on this device, sync all your other devices and let it "
-"run to completion.\n"
+"3. Let it run to completion. While it runs, avoid changing any note on your other devices, to avoid conflicts.\n"
+"4. Once sync is done on this device, sync all your other devices and let it run to completion.\n"
 "\n"
 "Important: you only need to run this ONCE on one device."
 msgstr ""
-"Ehhez az összes adatának titkosítása és szinkronizálása szükséges, ezért a "
-"folyamatot érdemes éjszakára időzíteni.\n"
+"Ehhez az összes adatának titkosítása és szinkronizálása szükséges, ezért a folyamatot érdemes éjszakára időzíteni.\n"
 "\n"
 "A kezdéshez kövesse az alábbi lépéseket:\n"
 "\n"
 "1. Szinkronizálja az összes eszközét.  \n"
 "2. Kattintson a(z) „%s” gombra.  \n"
-"3. Várja meg, amíg a folyamat befejeződik. Amíg fut, kerülje a jegyzetek "
-"módosítását más eszközein, hogy elkerülje az ütközéseket.  \n"
-"4. Miután a szinkronizálás ezen az eszközön befejeződött, szinkronizálja a "
-"többi eszközt, és várja meg, amíg ott is befejeződik.  \n"
+"3. Várja meg, amíg a folyamat befejeződik. Amíg fut, kerülje a jegyzetek módosítását más eszközein, hogy elkerülje az ütközéseket.  \n"
+"4. Miután a szinkronizálás ezen az eszközön befejeződött, szinkronizálja a többi eszközt, és várja meg, amíg ott is befejeződik.  \n"
 "\n"
 "Fontos: ezt a folyamatot ELÉG egyszer lefuttatni egyetlen eszközön."
 
@@ -3871,39 +3530,25 @@ msgstr "A szinkronizáláshoz frissítse az alkalmazást a(z) %s verzióra"
 
 #: packages/app-desktop/gui/MainScreen.tsx:655
 #: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:74
-msgid ""
-"In order to synchronise, Please upgrade your application to version %s: %s"
+msgid "In order to synchronise, Please upgrade your application to version %s: %s"
 msgstr "A szinkronizáláshoz frissítse az alkalmazást a(z) %s verzióra: %s"
 
 #: packages/app-desktop/gui/MainScreen.tsx:643
-msgid ""
-"In order to synchronise, Please upgrade your application to version %s: %s "
-"or update it using your package manager"
-msgstr ""
-"A szinkronizáláshoz frissítse az alkalmazást a(z) %s verzióra: %s, vagy "
-"frissítse a csomagkezelőjével"
+msgid "In order to synchronise, Please upgrade your application to version %s: %s or update it using your package manager"
+msgstr "A szinkronizáláshoz frissítse az alkalmazást a(z) %s verzióra: %s, vagy frissítse a csomagkezelőjével"
 
 #: packages/app-desktop/gui/MainScreen.tsx:635
-msgid ""
-"In order to synchronise, Please upgrade your application to version %s. "
-"Joplin could not check update information."
-msgstr ""
-"A szinkronizáláshoz frissítse az alkalmazást a(z) %s verzióra. A Joplin nem "
-"tudta ellenőrizni a frissítési adatokat."
+msgid "In order to synchronise, Please upgrade your application to version %s. Joplin could not check update information."
+msgstr "A szinkronizáláshoz frissítse az alkalmazást a(z) %s verzióra. A Joplin nem tudta ellenőrizni a frissítési adatokat."
 
 #: packages/lib/services/synchronizer/syncInfoUtils.ts:617
 msgid "In order to synchronise, please upgrade your application to version %s+"
-msgstr ""
-"A szinkronizáláshoz frissítse az alkalmazást a(z) %s vagy újabb verzióra"
+msgstr "A szinkronizáláshoz frissítse az alkalmazást a(z) %s vagy újabb verzióra"
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:150
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:256
-msgid ""
-"In order to use file system synchronisation your permission to write to "
-"external storage is required."
-msgstr ""
-"A fájlrendszer szinkronizálásának használatához engedélyeznie kell az írást "
-"a külső tárhelyre."
+msgid "In order to use file system synchronisation your permission to write to external storage is required."
+msgstr "A fájlrendszer szinkronizálásának használatához engedélyeznie kell az írást a külső tárhelyre."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:140
 msgid "In order to use the web clipper, you need to do the following:"
@@ -4076,12 +3721,8 @@ msgid "Invalid password"
 msgstr "Érvénytelen jelszó: %s"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:343
-msgid ""
-"Invalid password. Please try again. If you have forgotten your password you "
-"will need to reset it."
-msgstr ""
-"Érvénytelen jelszó. Próbálja újra. Ha elfelejtette a jelszavát, vissza kell "
-"állítania."
+msgid "Invalid password. Please try again. If you have forgotten your password you will need to reset it."
+msgstr "Érvénytelen jelszó. Próbálja újra. Ha elfelejtette a jelszavát, vissza kell állítania."
 
 #: packages/lib/services/plugins/PluginService.ts:600
 msgid "Invalid plugin manifest: %s"
@@ -4130,12 +3771,8 @@ msgid "Join us on %s"
 msgstr "Csatlakozzon hozzánk a(z) %s felületen"
 
 #: packages/app-mobile/components/SyncWizard/SyncWizard.tsx:138
-msgid ""
-"Joplin can synchronise your notes using various providers. Select one from "
-"the list below."
-msgstr ""
-"A Joplin különböző szolgáltatók segítségével tudja szinkronizálni a "
-"jegyzeteit. Jelöljön ki egyet az alábbi listából."
+msgid "Joplin can synchronise your notes using various providers. Select one from the list below."
+msgstr "A Joplin különböző szolgáltatók segítségével tudja szinkronizálni a jegyzeteit. Jelöljön ki egyet az alábbi listából."
 
 #: packages/app-mobile/components/SyncWizard/SyncWizard.tsx:142
 #: packages/lib/models/Setting.ts:1370 packages/lib/SyncTargetJoplinCloud.ts:31
@@ -4149,13 +3786,8 @@ msgstr "Joplin Cloud MI (béta)"
 
 #: packages/lib/models/settings/builtInMetadata.ts:694
 #: packages/lib/services/ai/availability.ts:44
-msgid ""
-"Joplin Cloud AI requires Joplin Cloud sync. Pick a different provider or "
-"restore Joplin Cloud sync."
-msgstr ""
-"A Joplin Cloud MI szolgáltatáshoz Joplin Cloud szinkronizáció szükséges. "
-"Válasszon egy másik szolgáltatót, vagy állítsa vissza a Joplin Cloud "
-"szinkronizációt."
+msgid "Joplin Cloud AI requires Joplin Cloud sync. Pick a different provider or restore Joplin Cloud sync."
+msgstr "A Joplin Cloud MI szolgáltatáshoz Joplin Cloud szinkronizáció szükséges. Válasszon egy másik szolgáltatót, vagy állítsa vissza a Joplin Cloud szinkronizációt."
 
 #: packages/app-desktop/gui/Root.tsx:165
 #: packages/app-mobile/components/screens/JoplinCloudLoginScreen.tsx:149
@@ -4167,12 +3799,8 @@ msgid "Joplin Desktop"
 msgstr "Joplin asztali alkalmazás"
 
 #: packages/app-desktop/bridge.ts:521
-msgid ""
-"Joplin doesn't recognise the %s extension. Opening this file could be "
-"dangerous. What would you like to do?"
-msgstr ""
-"A Joplin nem ismeri fel a(z) %s nevű bővítményt. Ennek a fájlnak a "
-"megnyitása veszélyes lehet. Mit szeretne tenni?"
+msgid "Joplin doesn't recognise the %s extension. Opening this file could be dangerous. What would you like to do?"
+msgstr "A Joplin nem ismeri fel a(z) %s nevű bővítményt. Ennek a fájlnak a megnyitása veszélyes lehet. Mit szeretne tenni?"
 
 #: packages/lib/services/interop/InteropService.ts:174
 #: packages/lib/services/interop/InteropService.ts:70
@@ -4185,14 +3813,8 @@ msgid "Joplin Export File"
 msgstr "Joplin exportálási fájl"
 
 #: packages/lib/services/ReportService.ts:256
-msgid ""
-"Joplin failed to decrypt these items multiple times, possibly because they "
-"are corrupted or too large. These items will remain on the device but Joplin "
-"will no longer attempt to decrypt them."
-msgstr ""
-"A Joplinnak többszöri próbálkozás után sem sikerült visszafejteni ezeket az "
-"elemeket, valószínűleg azért, mert sérültek vagy túl nagyok. Ezek az elemek "
-"az eszközön maradnak, de a Joplin többé nem próbálja visszafejteni őket."
+msgid "Joplin failed to decrypt these items multiple times, possibly because they are corrupted or too large. These items will remain on the device but Joplin will no longer attempt to decrypt them."
+msgstr "A Joplinnak többszöri próbálkozás után sem sikerült visszafejteni ezeket az elemeket, valószínűleg azért, mert sérültek vagy túl nagyok. Ezek az elemek az eszközön maradnak, de a Joplin többé nem próbálja visszafejteni őket."
 
 #: packages/app-desktop/gui/MenuBar.tsx:914
 msgid "Joplin Forum"
@@ -4207,12 +3829,8 @@ msgid "Joplin Mobile"
 msgstr "Joplin mobilalkalmazás"
 
 #: packages/server/src/routes/index/applications.ts:33
-msgid ""
-"Joplin needs your permission to access your %s account and to synchronise "
-"data with it."
-msgstr ""
-"A Joplinnak engedélyre van szüksége a saját %s fiókjához való hozzáféréshez "
-"és az adatok szinkronizálásához."
+msgid "Joplin needs your permission to access your %s account and to synchronise data with it."
+msgstr "A Joplinnak engedélyre van szüksége a saját %s fiókjához való hozzáféréshez és az adatok szinkronizálásához."
 
 #: packages/lib/SyncTargetJoplinServer.ts:64
 msgid "Joplin Server"
@@ -4249,25 +3867,16 @@ msgid "Joplin SSO Authentication"
 msgstr "Joplin SSO-hitelesítés"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:573
-msgid ""
-"Joplin supports saving the location at which notes are saved or created. Do "
-"you want to enable it? This can be changed at any time in settings."
-msgstr ""
-"A Joplin támogatja a jegyzetek mentési vagy létrehozási helyének mentését. "
-"Engedélyezni szeretné ezt a funkciót? Ez a beállításokban bármikor "
-"módosítható."
+msgid "Joplin supports saving the location at which notes are saved or created. Do you want to enable it? This can be changed at any time in settings."
+msgstr "A Joplin támogatja a jegyzetek mentési vagy létrehozási helyének mentését. Engedélyezni szeretné ezt a funkciót? Ez a beállításokban bármikor módosítható."
 
 #: packages/lib/utils/joplinCloud/index.ts:309
 msgid "Joplin Web App"
 msgstr "Joplin Web App"
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:139
-msgid ""
-"Joplin Web Clipper allows saving web pages and screenshots from your browser "
-"to Joplin."
-msgstr ""
-"A Joplin Web Clipper lehetővé teszi weboldalak és képernyőképek mentését a "
-"böngészőből a Joplin alkalmazásba."
+msgid "Joplin Web Clipper allows saving web pages and screenshots from your browser to Joplin."
+msgstr "A Joplin Web Clipper lehetővé teszi weboldalak és képernyőképek mentését a böngészőből a Joplin alkalmazásba."
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:646
 msgid "Joplin website"
@@ -4275,13 +3884,8 @@ msgstr "Joplin weboldala"
 
 #: packages/app-mobile/components/SyncWizard/SyncWizard.tsx:144
 #: packages/lib/SyncTargetJoplinCloud.ts:35
-msgid ""
-"Joplin's own sync service. Also gives access to Joplin-specific features "
-"such as publishing notes or collaborating on notebooks with others."
-msgstr ""
-"A Joplin saját szinkronizálási szolgáltatása. Emellett hozzáférést biztosít "
-"a Joplin speciális funkcióihoz, például jegyzetek közzétételéhez vagy a "
-"jegyzetfüzetek megosztása másokkal a közös használathoz."
+msgid "Joplin's own sync service. Also gives access to Joplin-specific features such as publishing notes or collaborating on notebooks with others."
+msgstr "A Joplin saját szinkronizálási szolgáltatása. Emellett hozzáférést biztosít a Joplin speciális funkcióihoz, például jegyzetek közzétételéhez vagy a jegyzetfüzetek megosztása másokkal a közös használathoz."
 
 #: packages/lib/components/shared/NoteEditor/WarningBanner/useEditorTypeMigrationBanner.ts:33
 msgid "Keep it enabled"
@@ -4377,9 +3981,7 @@ msgstr "Tudjon meg többet"
 
 #: packages/lib/models/settings/builtInMetadata.ts:2458
 msgid "Leave it blank to download the language files from the default website"
-msgstr ""
-"Hagyja üresen, hogy a nyelvi fájlok az alapértelmezett webhelyről "
-"töltődjenek le"
+msgstr "Hagyja üresen, hogy a nyelvi fájlok az alapértelmezett webhelyről töltődjenek le"
 
 #: packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx:90
 msgid "Leave notebook"
@@ -4402,12 +4004,8 @@ msgid "Light"
 msgstr "Világos"
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:110
-msgid ""
-"Like any software you install, plugins can potentially cause security issues "
-"or data loss."
-msgstr ""
-"Mint minden telepített szoftver, a bővítmények is okozhatnak biztonsági "
-"problémákat vagy adatvesztést."
+msgid "Like any software you install, plugins can potentially cause security issues or data loss."
+msgstr "Mint minden telepített szoftver, a bővítmények is okozhatnak biztonsági problémákat vagy adatvesztést."
 
 #: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:117
 msgid "Lines"
@@ -4486,28 +4084,16 @@ msgid "Lock encrypted notes"
 msgstr "Titkosított jegyzetek zárolása"
 
 #: packages/app-cli/app/command-sync.ts:152
-msgid ""
-"Lock file is already being hold. If you know that no synchronisation is "
-"taking place, you may delete the lock file at \"%s\" and resume the "
-"operation."
-msgstr ""
-"A zárolási fájl már használatban van. Ha meggyőződött arról, hogy nem "
-"történik szinkronizálás a háttérben, akkor törölheti a zárolási fájlt itt: "
-"„%s”, és folytathatja a műveletet."
+msgid "Lock file is already being hold. If you know that no synchronisation is taking place, you may delete the lock file at \"%s\" and resume the operation."
+msgstr "A zárolási fájl már használatban van. Ha meggyőződött arról, hogy nem történik szinkronizálás a háttérben, akkor törölheti a zárolási fájlt itt: „%s”, és folytathatja a műveletet."
 
 #: packages/app-desktop/gui/NoteEditor/NoteLockPanel/NoteLockPanel.tsx:83
 msgid "Locked note"
 msgstr "Zárolt jegyzet"
 
 #: packages/lib/models/Setting.ts:1390
-msgid ""
-"Locked notes are encrypted on this device and can only be read after "
-"entering your note lock password. The password is required again after "
-"locking or restarting Joplin."
-msgstr ""
-"Ezen az eszközön titkosítva vannak a zárolt jegyzetek, és csak a "
-"jegyzetzárolási jelszó megadása után olvashatók. A jelszóra újra szükség van "
-"a Joplin zárolása vagy újraindítása után."
+msgid "Locked notes are encrypted on this device and can only be read after entering your note lock password. The password is required again after locking or restarting Joplin."
+msgstr "Ezen az eszközön titkosítva vannak a zárolt jegyzetek, és csak a jegyzetzárolási jelszó megadása után olvashatók. A jelszóra újra szükség van a Joplin zárolása vagy újraindítása után."
 
 #: packages/app-desktop/commands/startExternalEditing.ts:24
 msgid "Locked notes cannot be opened in an external editor"
@@ -4586,8 +4172,7 @@ msgstr "Megosztott jegyzetfüzetek kezelése"
 
 #: packages/server/src/middleware/notificationHandler.ts:116
 msgid "Manage this server's license from the [admin dashboard](%s)."
-msgstr ""
-"Ezen kiszolgáló licencének kezelése az [adminisztrációs vezérlőpultról](%s)."
+msgstr "Ezen kiszolgáló licencének kezelése az [adminisztrációs vezérlőpultról](%s)."
 
 #: packages/app-mobile/components/EditorToolbar/ToolbarEditorDialog.tsx:384
 msgid "Manage toolbar options"
@@ -4598,23 +4183,13 @@ msgid "Manage your plugins"
 msgstr "Bővítmények kezelése"
 
 #: packages/app-desktop/gui/ProfileEditor.tsx:217
-msgid ""
-"Manage your profiles. You can rename or delete profiles. The active profile "
-"cannot be deleted."
-msgstr ""
-"Profilok kezelése. Átnevezheti vagy törölheti a profilokat. Az aktív profil "
-"nem törölhető."
+msgid "Manage your profiles. You can rename or delete profiles. The active profile cannot be deleted."
+msgstr "Profilok kezelése. Átnevezheti vagy törölheti a profilokat. Az aktív profil nem törölhető."
 
 #. `generate-ppk`
 #: packages/app-cli/app/command-e2ee.ts:19
-msgid ""
-"Manages E2EE configuration. Commands are `enable`, `disable`, `decrypt`, "
-"`status`, `decrypt-file`, and `target-status`."
-msgstr ""
-"Végpontok közötti titkosításbeállítások kezelése (E2EE). A parancsok a "
-"következők: `enable` (engedélyezés), `disable` (letiltás), `decrypt` "
-"(visszafejtés), `status` (állapot), `decrypt-file` (fájl visszafejtése) és "
-"`target-status` (cél állapota)."
+msgid "Manages E2EE configuration. Commands are `enable`, `disable`, `decrypt`, `status`, `decrypt-file`, and `target-status`."
+msgstr "Végpontok közötti titkosításbeállítások kezelése (E2EE). A parancsok a következők: `enable` (engedélyezés), `disable` (letiltás), `decrypt` (visszafejtés), `status` (állapot), `decrypt-file` (fájl visszafejtése) és `target-status` (cél állapota)."
 
 #: packages/lib/models/settings/builtInMetadata.ts:471
 msgid "Manual"
@@ -4640,11 +4215,11 @@ msgstr "Markdown szerkesztő"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1968
 msgid "Markdown editor: Highlight active line"
-msgstr "Markdown szerkesztő: Aktív sor kiemelése"
+msgstr "Markdown szerkesztő: aktív sor kiemelése"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1947
 msgid "Markdown editor: Interactive table editing"
-msgstr "Markdown szerkesztő: Interaktív táblázatszerkesztés"
+msgstr "Markdown szerkesztő: interaktív táblázatszerkesztés"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1957
 msgid "Markdown editor: Render images"
@@ -4652,7 +4227,7 @@ msgstr "Markdown szerkesztő: képek megjelenítése"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1937
 msgid "Markdown editor: Render markup in editor"
-msgstr "Markdown szerkesztő: Formázás megjelenítése a szerkesztőben"
+msgstr "Markdown szerkesztő: formázás megjelenítése a szerkesztőben"
 
 #: packages/app-cli/app/command-done.ts:15
 msgid "Marks a to-do as done."
@@ -4710,11 +4285,8 @@ msgid "Max Total Size"
 msgstr "Legnagyobb összméret"
 
 #: packages/lib/services/ai/availability.ts:87
-msgid ""
-"MCP requires the Web Clipper service. Enable it in Settings → Web Clipper."
-msgstr ""
-"Az MCP-hez a Web Clipper szolgáltatás szükséges. Engedélyezze a Beállítások "
-"→ Web Clipper menüpontban."
+msgid "MCP requires the Web Clipper service. Enable it in Settings → Web Clipper."
+msgstr "Az MCP-hez a Web Clipper szolgáltatás szükséges. Engedélyezze a Beállítások → Web Clipper menüpontban."
 
 #: packages/lib/models/Setting.ts:1410
 msgid "Media player, math, diagrams, table of contents"
@@ -4774,14 +4346,11 @@ msgstr "További információ"
 
 #: packages/app-cli/app/app.ts:67
 msgid "More than one item match \"%s\". Please narrow down your query."
-msgstr ""
-"Több elem is megfelel a(z) „%s” kifejezésnek. Pontosítsa a lekérdezést."
+msgstr "Több elem is megfelel a(z) „%s” kifejezésnek. Pontosítsa a lekérdezést."
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:115
-msgid ""
-"Most plugins have source code available for review on the plugin website."
-msgstr ""
-"A legtöbb bővítmény forráskódja elérhető átnézésre a bővítmény weboldalán."
+msgid "Most plugins have source code available for review on the plugin website."
+msgstr "A legtöbb bővítmény forráskódja elérhető átnézésre a bővítmény weboldalán."
 
 #: packages/app-mobile/components/ScreenHeader/index.tsx:609
 msgid "Move %d note to notebook \"%s\"?"
@@ -4793,13 +4362,11 @@ msgstr[1] "Áthelyezi a(z) %d jegyzetet a(z) „%s” jegyzetfüzetbe?"
 msgid ""
 "Move %d notebooks to the trash?\n"
 "\n"
-"All notes and sub-notebooks within these notebooks will also be moved to the "
-"trash."
+"All notes and sub-notebooks within these notebooks will also be moved to the trash."
 msgstr ""
 "Áthelyez %d jegyzetfüzetet a kukába?\n"
 "\n"
-"A jegyzetfüzetekben lévő összes jegyzet és aljegyzetfüzet is a kukába lesz "
-"áthelyezve."
+"A jegyzetfüzetekben lévő összes jegyzet és aljegyzetfüzet is a kukába lesz áthelyezve."
 
 #: packages/app-mobile/components/EditorToolbar/ToolbarEditorDialog.tsx:259
 msgid "Move %s down"
@@ -4833,13 +4400,11 @@ msgstr "Mozgatás balra"
 msgid ""
 "Move notebook \"%s\" to the trash?\n"
 "\n"
-"All notes and sub-notebooks within this notebook will also be moved to the "
-"trash."
+"All notes and sub-notebooks within this notebook will also be moved to the trash."
 msgstr ""
 "Áthelyezi a(z) „%s” nevű jegyzetfüzetet a kukába?\n"
 "\n"
-"A jegyzetfüzetben található összes jegyzet és almappa szintén a kukába lesz "
-"áthelyezve."
+"A jegyzetfüzetben található összes jegyzet és almappa szintén a kukába lesz áthelyezve."
 
 #: packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx:75
 msgid "Move right"
@@ -4873,9 +4438,7 @@ msgstr "Mozgatás felfelé"
 
 #: packages/app-cli/app/command-mv.ts:14
 msgid "Moves the given <item> to [notebook]"
-msgstr ""
-"Áthelyezi a következő elemmel egyezőket: <item> a(z) [notebook] nevű "
-"jegyzetfüzetbe"
+msgstr "Áthelyezi a következő elemmel egyezőket: <item> a(z) [notebook] nevű jegyzetfüzetbe"
 
 #: packages/app-cli/app/cli-utils.ts:209
 #: packages/app-cli/app/setupCommand.ts:30
@@ -4933,10 +4496,8 @@ msgid "New Notebook"
 msgstr "Új jegyzetfüzet"
 
 #: packages/app-desktop/gui/ImportScreen.tsx:81
-msgid ""
-"New notebook \"%s\" will be created and file \"%s\" will be imported into it"
-msgstr ""
-"Új „%s” nevű jegyzetfüzet jön létre, és a(z) „%s” fájl ebbe lesz importálva"
+msgid "New notebook \"%s\" will be created and file \"%s\" will be imported into it"
+msgstr "Új „%s” nevű jegyzetfüzet jön létre, és a(z) „%s” fájl ebbe lesz importálva"
 
 #: packages/app-mobile/components/FolderPicker.tsx:71
 msgid "New notebook title"
@@ -5042,12 +4603,8 @@ msgid "No colour"
 msgstr "Nincs szín"
 
 #: packages/lib/services/ai/availability.ts:74
-msgid ""
-"No embedding model is installed. It is downloaded automatically on first use "
-"— check Settings → AI for progress."
-msgstr ""
-"Nincs telepítve beágyazási modell. Az első használatkor automatikusan "
-"letöltődik — ellenőrizze a folyamatot a Beállítások → MI menüpontban."
+msgid "No embedding model is installed. It is downloaded automatically on first use — check Settings → AI for progress."
+msgstr "Nincs telepítve beágyazási modell. Az első használatkor automatikusan letöltődik — ellenőrizze a folyamatot a Beállítások → MI menüpontban."
 
 #: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:538
 #: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:552
@@ -5068,8 +4625,7 @@ msgstr "Nincs kijelölve jegyzetfüzet."
 
 #: packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts:15
 msgid "No notes in here. Create one by clicking on \"New note\"."
-msgstr ""
-"Nincs itt jegyzet. Hozzon létre egyet az „Új jegyzet” gombra kattintva."
+msgstr "Nincs itt jegyzet. Hozzon létre egyet az „Új jegyzet” gombra kattintva."
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx:197
 msgid "No plugins are installed."
@@ -5105,11 +4661,8 @@ msgid "No tags"
 msgstr "Nincsenek címkék"
 
 #: packages/app-cli/app/command-edit.ts:30
-msgid ""
-"No text editor is defined. Please set it using `config editor <editor-path>`"
-msgstr ""
-"Nincs megadva szövegszerkesztő. Adjon meg egyet a `config editor <editor-"
-"path>` parancs használatával"
+msgid "No text editor is defined. Please set it using `config editor <editor-path>`"
+msgstr "Nincs megadva szövegszerkesztő. Adjon meg egyet a `config editor <editor-path>` parancs használatával"
 
 #: packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx:63
 msgid "No updates available"
@@ -5120,12 +4673,8 @@ msgid "No URL for SAML authentication set."
 msgstr "Nincs beállítva webcím a SAML-hitelesítéshez."
 
 #: packages/app-mobile/root.tsx:637
-msgid ""
-"No valid notebook is available. Please create or select a notebook and try "
-"again."
-msgstr ""
-"Nem érhető el érvényes jegyzetfüzet. Hozzon létre vagy válasszon ki egy "
-"jegyzetfüzetet, majd próbálja újra."
+msgid "No valid notebook is available. Please create or select a notebook and try again."
+msgstr "Nem érhető el érvényes jegyzetfüzet. Hozzon létre vagy válasszon ki egy jegyzetfüzetet, majd próbálja újra."
 
 #: packages/app-cli/app/command-share.ts:188
 #: packages/app-cli/app/command-share.ts:208
@@ -5143,9 +4692,7 @@ msgstr "Normál"
 
 #: packages/app-cli/app/command-sync.ts:121
 msgid "Not authenticated with %s. Please provide any missing credentials."
-msgstr ""
-"Nincs hitelesítve a(z) %s szolgáltatással. Adja meg a hiányzó hitelesítő "
-"adatokat."
+msgstr "Nincs hitelesítve a(z) %s szolgáltatással. Adja meg a hiányzó hitelesítő adatokat."
 
 #: packages/app-desktop/gui/SyncWizard/Dialog.tsx:207
 msgid "Not checked"
@@ -5305,11 +4852,8 @@ msgid "Note: Does not work in all desktop environments."
 msgstr "Megjegyzés: Nem működik minden asztali környezetben."
 
 #: packages/lib/components/shared/ShareNoteDialog/useEncryptionWarningMessage.ts:6
-msgid ""
-"Note: When a note is shared, it will no longer be encrypted on the server."
-msgstr ""
-"Megjegyzés: Amikor egy jegyzet meg van osztva, többé nem lesz titkosítva a "
-"kiszolgálón."
+msgid "Note: When a note is shared, it will no longer be encrypted on the server."
+msgstr "Megjegyzés: Amikor egy jegyzet meg van osztva, többé nem lesz titkosítva a kiszolgálón."
 
 #: packages/app-desktop/gui/MenuBar.tsx:856
 msgid "Note&book"
@@ -5342,9 +4886,7 @@ msgstr "Jegyzetfüzetek"
 
 #: packages/lib/models/Folder.ts:1100
 msgid "Notebooks cannot be named \"%s\", which is a reserved title."
-msgstr ""
-"A jegyzetfüzetek nem nevezhetők el a következő néven: „%s”, mivel ez egy "
-"fenntartott cím."
+msgstr "A jegyzetfüzetek nem nevezhetők el a következő néven: „%s”, mivel ez egy fenntartott cím."
 
 #: packages/app-desktop/gui/NoteList/NoteList2.tsx:310
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleNotesSortOrderField.ts:8
@@ -5375,25 +4917,15 @@ msgstr "Obsidian Vault"
 
 #: packages/app-desktop/commands/createAccessibleDocument.ts:57
 msgid "OCR has been queued. Please wait for it to complete and then try again."
-msgstr ""
-"Sorba lett állítva az OCR-ezési művelet. Várja meg, amíg befejeződik, majd "
-"próbálja újra."
+msgstr "Sorba lett állítva az OCR-ezési művelet. Várja meg, amíg befejeződik, majd próbálja újra."
 
 #: packages/app-desktop/commands/createAccessibleDocument.ts:33
-msgid ""
-"OCR is not complete. Please wait for OCR to finish before creating an "
-"accessible document."
-msgstr ""
-"Még nem fejeződött be az OCR-ezési művelet. Várja meg a művelet befejezését "
-"az akadálymentes dokumentum létrehozása előtt."
+msgid "OCR is not complete. Please wait for OCR to finish before creating an accessible document."
+msgstr "Még nem fejeződött be az OCR-ezési művelet. Várja meg a művelet befejezését az akadálymentes dokumentum létrehozása előtt."
 
 #: packages/app-desktop/commands/createAccessibleDocument.ts:42
-msgid ""
-"OCR needs to run to generate an accessible document. This may take a moment. "
-"Would you like to continue?"
-msgstr ""
-"Az akadálymentes dokumentum létrehozásához OCR-ezési művelet futtatása "
-"szükséges. Ez eltarthat egy ideig. Folytatja?"
+msgid "OCR needs to run to generate an accessible document. This may take a moment. Would you like to continue?"
+msgstr "Az akadálymentes dokumentum létrehozásához OCR-ezési művelet futtatása szükséges. Ez eltarthat egy ideig. Folytatja?"
 
 #: packages/lib/models/settings/builtInMetadata.ts:632
 msgid "OCR: Clear cache and re-download language data files"
@@ -5460,16 +4992,8 @@ msgid "One of your master keys use an obsolete encryption method."
 msgstr "Az egyik mesterkulcsa elavult titkosítási módszert használ."
 
 #: packages/app-cli/app/gui/NoteWidget.ts:56
-msgid ""
-"One or more items are currently encrypted and you may need to supply a "
-"master password. To do so please type `e2ee decrypt`. If you have already "
-"supplied the password, the encrypted items are being decrypted in the "
-"background and will be available soon."
-msgstr ""
-"Jelenleg egy vagy több elem titkosítva van, és szükség lehet egy "
-"mesterjelszó megadása. Ehhez írja be az `e2ee decrypt` (e2ee visszafejtése) "
-"parancsot. Ha már megadta a jelszót, a titkosított elemek a háttérben "
-"visszafejtődnek, és hamarosan elérhetők lesznek."
+msgid "One or more items are currently encrypted and you may need to supply a master password. To do so please type `e2ee decrypt`. If you have already supplied the password, the encrypted items are being decrypted in the background and will be available soon."
+msgstr "Jelenleg egy vagy több elem titkosítva van, és szükség lehet egy mesterjelszó megadása. Ehhez írja be az `e2ee decrypt` (e2ee visszafejtése) parancsot. Ha már megadta a jelszót, a titkosított elemek a háttérben visszafejtődnek, és hamarosan elérhetők lesznek."
 
 #: packages/app-desktop/gui/MainScreen.tsx:626
 msgid "One or more master keys need a password."
@@ -5488,14 +5012,8 @@ msgid "OneNote Notebook"
 msgstr "OneNote jegyzetfüzet"
 
 #: packages/app-desktop/gui/ConfigScreen/controls/NoteLockSettings.tsx:49
-msgid ""
-"Only do this if you've forgotten your current password. A new password will "
-"be created, and any notes locked with the old one will become permanently "
-"unreadable."
-msgstr ""
-"Csak akkor tegye ezt, ha elfelejtette a jelenlegi jelszavát. Egy új jelszó "
-"jön létre, és a régi jelszóval zárolt jegyzetek végleg olvashatatlanná "
-"válnak."
+msgid "Only do this if you've forgotten your current password. A new password will be created, and any notes locked with the old one will become permanently unreadable."
+msgstr "Csak akkor tegye ezt, ha elfelejtette a jelenlegi jelszavát. Egy új jelszó jön létre, és a régi jelszóval zárolt jegyzetek végleg olvashatatlanná válnak."
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/print.ts:18
 msgid "Only one note can be printed at a time."
@@ -5600,12 +5118,8 @@ msgid "Options"
 msgstr "Beállítások"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1522
-msgid ""
-"Options that should be used whenever rendering ABC code. It must be a JSON5 "
-"object. The full list of options is available at: %s"
-msgstr ""
-"Az ABC-kód megjelenítésekor használandó beállítások. Egy JSON5 objektumnak "
-"kell lennie. A beállítások teljes listája itt érhető el: %s"
+msgid "Options that should be used whenever rendering ABC code. It must be a JSON5 object. The full list of options is available at: %s"
+msgstr "Az ABC-kód megjelenítésekor használandó beállítások. Egy JSON5 objektumnak kell lennie. A beállítások teljes listája itt érhető el: %s"
 
 #: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:102
 msgid "Ordered list"
@@ -5696,7 +5210,7 @@ msgstr "Beillesztés szövegként"
 #: packages/app-desktop/gui/ConfigScreen/controls/SettingComponent.tsx:268
 #: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportProfileButton.tsx:54
 msgid "Path:"
-msgstr "Útvonal:"
+msgstr "Útvonal"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/exportPdf.ts:11
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/exportPdf.ts:25
@@ -5723,8 +5237,7 @@ msgid ""
 msgstr ""
 "Véglegesen törli a(z) „%s” nevű jegyzetfüzetet?\n"
 "\n"
-"Az ebben a jegyzetfüzetben található összes jegyzet és aljegyzetfüzet "
-"véglegesen törlődik."
+"Az ebben a jegyzetfüzetben található összes jegyzet és aljegyzetfüzet véglegesen törlődik."
 
 #: packages/lib/models/Note.ts:1068
 msgid "Permanently delete this note?"
@@ -5741,66 +5254,34 @@ msgid "Photo %d"
 msgstr "Kép: %d"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:462
-msgid ""
-"Please click on \"%s\" to proceed, or set the passwords in the \"%s\" list "
-"below."
-msgstr ""
-"Kattintson a(z) „%s” elemre a folytatáshoz, vagy állítsa be a jelszavakat az "
-"alábbi „%s” listában."
+msgid "Please click on \"%s\" to proceed, or set the passwords in the \"%s\" list below."
+msgstr "Kattintson a(z) „%s” elemre a folytatáshoz, vagy állítsa be a jelszavakat az alábbi „%s” listában."
 
 #: packages/lib/components/EncryptionConfigScreen/utils.ts:66
-msgid ""
-"Please confirm that you would like to re-encrypt your complete database."
+msgid "Please confirm that you would like to re-encrypt your complete database."
 msgstr "Erősítse meg, hogy újra szeretné titkosítani a teljes adatbázisát."
 
 #: packages/server/src/middleware/notificationHandler.ts:99
-msgid ""
-"Please disable users from the [admin dashboard](%s) to bring this server "
-"under the limit."
-msgstr ""
-"Tiltsa le a felhasználókat az [adminisztrációs vezérlőpulton](%s), hogy ez a "
-"kiszolgáló a korlát alá kerüljön."
+msgid "Please disable users from the [admin dashboard](%s) to bring this server under the limit."
+msgstr "Tiltsa le a felhasználókat az [adminisztrációs vezérlőpulton](%s), hogy ez a kiszolgáló a korlát alá kerüljön."
 
 #: packages/lib/components/EncryptionConfigScreen/utils.ts:227
-msgid ""
-"Please enter your password in the master key list below before upgrading the "
-"key."
-msgstr ""
-"Adja meg a jelszavát az alábbi mesterkulcslistában, mielőtt frissítené a "
-"kulcsot."
+msgid "Please enter your password in the master key list below before upgrading the key."
+msgstr "Adja meg a jelszavát az alábbi mesterkulcslistában, mielőtt frissítené a kulcsot."
 
 #: packages/app-desktop/gui/ConfigScreen/controls/NoteLockSettings.tsx:200
 #: packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx:204
 #: packages/app-mobile/components/screens/ConfigScreen/NoteLockConfig.tsx:135
-msgid ""
-"Please make sure you remember your password. It cannot be recovered if lost, "
-"and any data encrypted with it will become inaccessible."
-msgstr ""
-"Győződjön meg arról, hogy emlékszik a jelszavára. Jelszavának elvesztése "
-"esetén az nem állítható vissza, és a vele titkosított adatok elérhetetlenné "
-"válnak."
+msgid "Please make sure you remember your password. It cannot be recovered if lost, and any data encrypted with it will become inaccessible."
+msgstr "Győződjön meg arról, hogy emlékszik a jelszavára. Jelszavának elvesztése esetén az nem állítható vissza, és a vele titkosított adatok elérhetetlenné válnak."
 
 #: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:411
-msgid ""
-"Please note that if it is a large notebook, it may take a few minutes for "
-"all the notes to show up on the recipient's device."
-msgstr ""
-"Vegye figyelembe, hogy ha a jegyzetfüzet nagy méretű, akkor eltarthat néhány "
-"percig, amíg az összes jegyzet megjelenik a címzett eszközén."
+msgid "Please note that if it is a large notebook, it may take a few minutes for all the notes to show up on the recipient's device."
+msgstr "Vegye figyelembe, hogy ha a jegyzetfüzet nagy méretű, akkor eltarthat néhány percig, amíg az összes jegyzet megjelenik a címzett eszközén."
 
 #: packages/lib/onedrive-api-node-utils.ts:130
-msgid ""
-"Please open the following URL in your browser to authenticate the "
-"application. The application will create a directory in \"Apps/Joplin\" and "
-"will only read and write files in this directory. It will have no access to "
-"any files outside this directory nor to any other personal data. No data "
-"will be shared with any third party."
-msgstr ""
-"Nyissa meg az alábbi webcímet a böngészőjében az alkalmazás hitelesítéséhez. "
-"Az alkalmazás létrehoz egy könyvtárat az „Apps/Joplin” mappában, és "
-"kizárólag ebben a könyvtárban fog fájlokat olvasni és írni. Nem fér hozzá "
-"semmilyen fájlhoz ezen a könyvtáron kívül, és nem fér hozzá más személyes "
-"adatokhoz sem. Az adatok nem lesznek megosztva harmadik felekkel."
+msgid "Please open the following URL in your browser to authenticate the application. The application will create a directory in \"Apps/Joplin\" and will only read and write files in this directory. It will have no access to any files outside this directory nor to any other personal data. No data will be shared with any third party."
+msgstr "Nyissa meg az alábbi webcímet a böngészőjében az alkalmazás hitelesítéséhez. Az alkalmazás létrehoz egy könyvtárat az „Apps/Joplin” mappában, és kizárólag ebben a könyvtárban fog fájlokat olvasni és írni. Nem fér hozzá semmilyen fájlhoz ezen a könyvtáron kívül, és nem fér hozzá más személyes adatokhoz sem. Az adatok nem lesznek megosztva harmadik felekkel."
 
 #: packages/lib/services/share/ShareService.ts:417
 msgid "Please provide the recipient email"
@@ -5836,16 +5317,11 @@ msgstr "Frissítse a licenckulcsot az [adminisztrációs vezérlőpultról](%s).
 
 #: packages/lib/services/plugins/PluginService.ts:607
 msgid "Please upgrade Joplin to version %s or later to use this plugin."
-msgstr ""
-"Frissítse a Joplint a(z) %s vagy újabb verzióra a bővítmény használatához."
+msgstr "Frissítse a Joplint a(z) %s vagy újabb verzióra a bővítmény használatához."
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx:1672
-msgid ""
-"Please wait for all attachments to be downloaded and decrypted. You may also "
-"switch to %s to edit the note."
-msgstr ""
-"Várjon, amíg minden melléklet letöltődik és visszafejtődik. A jegyzet "
-"szerkesztéséhez a(z) %s nézetre is válthat."
+msgid "Please wait for all attachments to be downloaded and decrypted. You may also switch to %s to edit the note."
+msgstr "Várjon, amíg minden melléklet letöltődik és visszafejtődik. A jegyzet szerkesztéséhez a(z) %s nézetre is válthat."
 
 #: packages/server/src/utils/saml.ts:58
 msgid "Please wait while we load your organisation sign-in page..."
@@ -5893,13 +5369,8 @@ msgid "Plugins"
 msgstr "Bővítmények"
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:103
-msgid ""
-"Plugins extend Joplin with features that are not present by default. Plugins "
-"can extend Joplin's editor, viewer, and more."
-msgstr ""
-"A bővítmények további funkciókkal egészítik ki a Joplint, amelyek "
-"alapértelmezetten nem érhetők el. A bővítmények kiterjeszthetik a Joplin "
-"szerkesztőjét, megjelenítőjét és egyéb részeit."
+msgid "Plugins extend Joplin with features that are not present by default. Plugins can extend Joplin's editor, viewer, and more."
+msgstr "A bővítmények további funkciókkal egészítik ki a Joplint, amelyek alapértelmezetten nem érhetők el. A bővítmények kiterjeszthetik a Joplin szerkesztőjét, megjelenítőjét és egyéb részeit."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1884
 msgid "Portrait"
@@ -5935,26 +5406,19 @@ msgstr "Előnyben részesített világos téma"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1149
 msgid "Preserve colours when pasting text in Rich Text Editor"
-msgstr ""
-"Színek megőrzése a szöveg beillesztésekor a formázott szöveges szerkesztőben"
+msgstr "Színek megőrzése a szöveg beillesztésekor a formázott szöveges szerkesztőben"
 
 #: packages/app-cli/app/app-gui.ts:801
 msgid "Press Ctrl+D or type \"exit\" to exit the application"
-msgstr ""
-"Nyomja meg a Ctrl+D billentyűkombinációt, vagy írja be az „exit” parancsot "
-"az alkalmazás bezárásához"
+msgstr "Nyomja meg a Ctrl+D billentyűkombinációt, vagy írja be az „exit” parancsot az alkalmazás bezárásához"
 
 #: packages/app-desktop/gui/KeymapConfig/ShortcutRecorder.tsx:77
 msgid "Press the shortcut"
 msgstr "Nyomja meg a billentyűparancsot"
 
 #: packages/app-desktop/gui/KeymapConfig/ShortcutRecorder.tsx:76
-msgid ""
-"Press the shortcut and then press ENTER. Or, press BACKSPACE to clear the "
-"shortcut."
-msgstr ""
-"Nyomja meg a billentyűparancsot, majd nyomja meg az entert, vagy nyomja meg "
-"a backspace-t a billentyűparancs törléséhez."
+msgid "Press the shortcut and then press ENTER. Or, press BACKSPACE to clear the shortcut."
+msgstr "Nyomja meg a billentyűparancsot, majd nyomja meg az entert, vagy nyomja meg a backspace-t a billentyűparancs törléséhez."
 
 #: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:111
 msgid "Press to set the decryption password."
@@ -6186,16 +5650,11 @@ msgstr "Olvasási idő: %s perc"
 
 #: packages/app-cli/app/command-batch.ts:45
 msgid "Reading commands from standard input is only available in CLI mode."
-msgstr ""
-"A parancsok általános bemenetről történő olvasása csak CLI-módban érhető el."
+msgstr "A parancsok általános bemenetről történő olvasása csak CLI-módban érhető el."
 
 #: packages/app-desktop/gui/NoteEditor/NoteLockPanel/NoteLockPanel.tsx:59
-msgid ""
-"Reading this note requires the note lock password, which has not been set up "
-"on this device yet."
-msgstr ""
-"A jegyzet elolvasásához szükség van a jegyzetzárolási jelszóra, amely ezen "
-"az eszközön még nem lett beállítva."
+msgid "Reading this note requires the note lock password, which has not been set up on this device yet."
+msgstr "A jegyzet elolvasásához szükség van a jegyzetzárolási jelszóra, amely ezen az eszközön még nem lett beállítva."
 
 #: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:344
 msgid "Recipient has accepted the invitation"
@@ -6274,8 +5733,7 @@ msgstr "Eltávolítás"
 
 #: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:166
 msgid "Remove %d tags from all notes? This cannot be undone."
-msgstr ""
-"Eltávolít %d címkét az összes jegyzetből? Ez a művelet nem vonható vissza."
+msgstr "Eltávolít %d címkét az összes jegyzetből? Ez a művelet nem vonható vissza."
 
 #: packages/app-mobile/components/TagEditor.tsx:136
 msgid "Remove %s"
@@ -6332,8 +5790,7 @@ msgstr "A megadott <item> (jegyzet vagy jegyzetfüzet) átnevezése <name> névr
 
 #: packages/lib/models/settings/builtInMetadata.ts:1938
 msgid "Renders markup on all lines that don't include the cursor."
-msgstr ""
-"Megjeleníti a formázást minden olyan sorban, amely nem tartalmazza a kurzort."
+msgstr "Megjeleníti a formázást minden olyan sorban, amely nem tartalmazza a kurzort."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:169
 msgid "Renew token"
@@ -6402,13 +5859,8 @@ msgid "Reports"
 msgstr "Jelentések"
 
 #: packages/lib/models/settings/builtInMetadata.ts:675
-msgid ""
-"Required to use cloud-hosted AI models, including Joplin Cloud AI. When "
-"disabled, only on-device providers can be used."
-msgstr ""
-"Szükséges a felhőben futtatott MI-modellek használatához, beleértve a Joplin "
-"Cloud MI-t is. Ha le van tiltva, akkor csak az eszközön lévő szolgáltatók "
-"használhatók."
+msgid "Required to use cloud-hosted AI models, including Joplin Cloud AI. When disabled, only on-device providers can be used."
+msgstr "Szükséges a felhőben futtatott MI-modellek használatához, beleértve a Joplin Cloud MI-t is. Ha le van tiltva, akkor csak az eszközön lévő szolgáltatók használhatók."
 
 #: packages/app-desktop/gui/ChatPanel/ChatPanel.tsx:416
 msgid "Reset"
@@ -6438,7 +5890,7 @@ msgstr "Tokenhasználat visszaállítása"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1374
 msgid "Resize large images:"
-msgstr "Nagy méretű képek átméretezése:"
+msgstr "Nagy méretű képek átméretezése"
 
 #: packages/app-desktop/commands/createAccessibleDocument.ts:21
 msgid "Resource not found"
@@ -6550,21 +6002,15 @@ msgstr "Formázott szöveg"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx:734
 msgid "Rich Text editor. Press Escape then Tab to escape focus."
-msgstr ""
-"Formázott szöveges szerkesztő. Nyomja meg az ESC, majd a Tab billentyűt a "
-"fókusz elhagyásához."
+msgstr "Formázott szöveges szerkesztő. Nyomja meg az ESC, majd a Tab billentyűt a fókusz elhagyásához."
 
 #: packages/app-desktop/commands/createAccessibleDocument.ts:43
 msgid "Run OCR"
 msgstr "OCR futtatása"
 
 #: packages/app-cli/app/command-batch.ts:29
-msgid ""
-"Runs the commands contained in the text file. There should be one command "
-"per line."
-msgstr ""
-"A szöveges fájlban található parancsok futtatása. Minden sorban egy "
-"parancsnak kell szerepelnie."
+msgid "Runs the commands contained in the text file. There should be one command per line."
+msgstr "A szöveges fájlban található parancsok futtatása. Minden sorban egy parancsnak kell szerepelnie."
 
 #: packages/lib/SyncTargetAmazonS3.js:28
 msgid "S3"
@@ -6591,12 +6037,8 @@ msgid "S3 URL"
 msgstr "S3 webcím"
 
 #: packages/app-desktop/gui/MainScreen.tsx:573
-msgid ""
-"Safe mode is currently active. Note rendering and all plugins are "
-"temporarily disabled."
-msgstr ""
-"A biztonságos mód jelenleg aktív. A jegyzetek megjelenítése és az összes "
-"bővítmény ideiglenesen le van tiltva."
+msgid "Safe mode is currently active. Note rendering and all plugins are temporarily disabled."
+msgstr "A biztonságos mód jelenleg aktív. A jegyzetek megjelenítése és az összes bővítmény ideiglenesen le van tiltva."
 
 #: packages/app-desktop/gui/ConfigScreen/controls/NoteLockSettings.tsx:126
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:197
@@ -6794,13 +6236,8 @@ msgid "Self-hosted"
 msgstr "Saját üzemeltetésű"
 
 #: packages/app-mobile/components/SyncWizard/SyncWizard.tsx:110
-msgid ""
-"Self-hosted instances of the Joplin web app cannot sync with Joplin Cloud. "
-"Open the official web app?"
-msgstr ""
-"A Joplin webalkalmazás saját üzemeltetésű példányai nem tudnak "
-"szinkronizálni a Joplin Cloud szolgáltatással. Megnyitja a hivatalos "
-"webalkalmazást?"
+msgid "Self-hosted instances of the Joplin web app cannot sync with Joplin Cloud. Open the official web app?"
+msgstr "A Joplin webalkalmazás saját üzemeltetésű példányai nem tudnak szinkronizálni a Joplin Cloud szolgáltatással. Megnyitja a hivatalos webalkalmazást?"
 
 #: packages/app-desktop/gui/ChatPanel/ChatPanel.tsx:410
 msgid "Send"
@@ -6838,12 +6275,8 @@ msgid "Set alarm:"
 msgstr "Riasztás beállítása:"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1716
-msgid ""
-"Set it to 0 to make it take the complete available space. Recommended width "
-"is 600."
-msgstr ""
-"Állítsa 0-ra, hogy a teljes rendelkezésre álló helyet elfoglalja. Az "
-"ajánlott szélesség 600."
+msgid "Set it to 0 to make it take the complete available space. Recommended width is 600."
+msgstr "Állítsa 0-ra, hogy a teljes rendelkezésre álló helyet elfoglalja. Az ajánlott szélesség 600."
 
 #: packages/app-desktop/gui/MainScreen.tsx:580
 #: packages/app-desktop/gui/MainScreen.tsx:627
@@ -6856,13 +6289,11 @@ msgstr "Jegyzetzárolás beállítása"
 
 #: packages/app-cli/app/command-set.ts:23
 msgid ""
-"Sets the property <name> of the given <note> to the given [value]. Possible "
-"properties are:\n"
+"Sets the property <name> of the given <note> to the given [value]. Possible properties are:\n"
 "\n"
 "%s"
 msgstr ""
-"A megadott <note> jegyzet <name> név tulajdonságát a megadott [value] "
-"értékre állítja. A lehetséges tulajdonságok a következők:\n"
+"A megadott <note> jegyzet <name> név tulajdonságát a megadott [value] értékre állítja. A lehetséges tulajdonságok a következők:\n"
 "\n"
 "%s"
 
@@ -6878,12 +6309,8 @@ msgid "Share"
 msgstr "Megosztás"
 
 #: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteExportButton.tsx:21
-msgid ""
-"Share a copy of all notes in a file format that can be imported by Joplin on "
-"a computer."
-msgstr ""
-"Az összes jegyzet másolatának megosztása olyan fájlformátumban, amelyet egy "
-"számítógépen importálni lehet a Joplinba."
+msgid "Share a copy of all notes in a file format that can be imported by Joplin on a computer."
+msgstr "Az összes jegyzet másolatának megosztása olyan fájlformátumban, amelyet egy számítógépen importálni lehet a Joplinba."
 
 #: packages/lib/utils/joplinCloud/index.ts:251
 msgid "Share a notebook with others"
@@ -6915,12 +6342,8 @@ msgid "Shares"
 msgstr "Megosztások"
 
 #: packages/app-cli/app/command-share.ts:58
-msgid ""
-"Shares or unshares the specified [notebook] with [user]. Requires Joplin "
-"Cloud or Joplin Server."
-msgstr ""
-"Engedélyezi vagy megszünteti a megadott [jegyzetfüzet] megosztását a "
-"[felhasználóval]. Joplin Cloud vagy Joplin Server szükséges hozzá."
+msgid "Shares or unshares the specified [notebook] with [user]. Requires Joplin Cloud or Joplin Server."
+msgstr "Engedélyezi vagy megszünteti a megadott [jegyzetfüzet] megosztását a [felhasználóval]. Joplin Cloud vagy Joplin Server szükséges hozzá."
 
 #: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:395
 msgid "Sharing notebook..."
@@ -7045,9 +6468,7 @@ msgstr "Ezen verzió kihagyása"
 
 #: packages/app-cli/app/command-e2ee.ts:65
 msgid "Skipped items: %d (use --retry-failed-items to retry decrypting them)"
-msgstr ""
-"Kihagyott elemek: %d (használja a --retry-failed-items opciót a visszafejtés "
-"megismétléséhez)"
+msgstr "Kihagyott elemek: %d (használja a --retry-failed-items opciót a visszafejtés megismétléséhez)"
 
 #: packages/app-cli/app/command-import.ts:55
 #: packages/app-desktop/gui/ImportScreen.tsx:100
@@ -7067,18 +6488,12 @@ msgid "Solarised Light"
 msgstr "Solarised világos"
 
 #: packages/lib/models/settings/settingValidations.ts:21
-msgid ""
-"Some attachments could not be downloaded. Please try to download them again."
-msgstr ""
-"Néhány mellékletet nem sikerült letölteni. Próbálja újraletölteni őket."
+msgid "Some attachments could not be downloaded. Please try to download them again."
+msgstr "Néhány mellékletet nem sikerült letölteni. Próbálja újraletölteni őket."
 
 #: packages/lib/models/settings/settingValidations.ts:18
-msgid ""
-"Some attachments need to be downloaded. Set the attachment download mode to "
-"\"always\" and try again."
-msgstr ""
-"Néhány mellékletet le kell tölteni. Állítsa a mellékletek letöltési módját "
-"„mindig” értékre, és próbálja újra."
+msgid "Some attachments need to be downloaded. Set the attachment download mode to \"always\" and try again."
+msgstr "Néhány mellékletet le kell tölteni. Állítsa a mellékletek letöltési módját „mindig” értékre, és próbálja újra."
 
 #: packages/app-desktop/gui/MainScreen.tsx:591
 #: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:123
@@ -7091,16 +6506,11 @@ msgstr "Néhány elemet nem sikerült szinkronizálni."
 
 #: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:114
 msgid "Some items cannot be synchronised. Press for more info."
-msgstr ""
-"Néhány elemet nem sikerült szinkronizálni. Kattintson ide a további "
-"adatokért."
+msgstr "Néhány elemet nem sikerült szinkronizálni. Kattintson ide a további adatokért."
 
 #: packages/lib/models/settings/settingValidations.ts:24
-msgid ""
-"Some items could not be synchronised. Please try to synchronise them first."
-msgstr ""
-"Néhány elemet nem sikerült szinkronizálni. Először próbálja meg "
-"szinkronizálni őket."
+msgid "Some items could not be synchronised. Please try to synchronise them first."
+msgstr "Néhány elemet nem sikerült szinkronizálni. Először próbálja meg szinkronizálni őket."
 
 #: packages/app-desktop/gui/ChatPanel/ChatPanel.tsx:308
 msgid "Something went wrong."
@@ -7139,9 +6549,7 @@ msgstr "Kijelölt sorok rendezése"
 
 #: packages/app-cli/app/command-ls.ts:29
 msgid "Sorts the item by <field> (eg. title, updated_time, created_time)."
-msgstr ""
-"Elem rendezése a(z) <field> szerint (például: title (cím), updated_time "
-"(frissítés dátuma), created_time (létrehozás dátuma))"
+msgstr "Elem rendezése a(z) <field> szerint (például: title (cím), updated_time (frissítés dátuma), created_time (létrehozás dátuma))"
 
 #: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:10
 msgid "Source"
@@ -7168,12 +6576,8 @@ msgid "Spacer"
 msgstr "Elválasztó"
 
 #: packages/lib/models/settings/builtInMetadata.ts:2134
-msgid ""
-"Specify the port that should be used by the API server. If not set, a "
-"default will be used."
-msgstr ""
-"Adja meg az API-kiszolgáló által használt portot. Ha nincs megadva, az "
-"alapértelmezettet fogja használni."
+msgid "Specify the port that should be used by the API server. If not set, a default will be used."
+msgstr "Adja meg az API-kiszolgáló által használt portot. Ha nincs megadva, az alapértelmezettet fogja használni."
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/showSpellCheckerMenu.ts:11
 #: packages/lib/services/spellChecker/SpellCheckerService.ts:218
@@ -7203,21 +6607,12 @@ msgid "Start recording"
 msgstr "Rögzítés indítása"
 
 #: packages/app-cli/app/command-server.ts:19
-msgid ""
-"Start, stop or check the API server. To specify on which port it should run, "
-"set the api.port config variable. Commands are (%s)."
-msgstr ""
-"Az API-kiszolgáló elindítása, leállítása vagy állapotának ellenőrzése. A "
-"futtatáshoz szükséges port megadásához állítsa be az api.port konfigurációs "
-"változót. A parancsok a következők: (%s)."
+msgid "Start, stop or check the API server. To specify on which port it should run, set the api.port config variable. Commands are (%s)."
+msgstr "Az API-kiszolgáló elindítása, leállítása vagy állapotának ellenőrzése. A futtatáshoz szükséges port megadásához állítsa be az api.port konfigurációs változót. A parancsok a következők: (%s)."
 
 #: packages/app-cli/app/command-e2ee.ts:56
-msgid ""
-"Starting decryption... Please wait as it may take several minutes depending "
-"on how much there is to decrypt."
-msgstr ""
-"Visszafejtés indítása… Kis türelmet, ez több percet is igénybe vehet, attól "
-"függően, hogy mennyi visszafejtendő adat van."
+msgid "Starting decryption... Please wait as it may take several minutes depending on how much there is to decrypt."
+msgstr "Visszafejtés indítása… Kis türelmet, ez több percet is igénybe vehet, attól függően, hogy mennyi visszafejtendő adat van."
 
 #: packages/app-cli/app/command-sync.ts:228
 msgid "Starting synchronisation..."
@@ -7225,9 +6620,7 @@ msgstr "Szinkronizálás indítása…"
 
 #: packages/app-cli/app/command-edit.ts:75
 msgid "Starting to edit note. Close the editor to get back to the prompt."
-msgstr ""
-"Jegyzet szerkesztésének indítása. Zárja be a szerkesztőt, hogy visszatérjen "
-"a prompthoz."
+msgstr "Jegyzet szerkesztésének indítása. Zárja be a szerkesztőt, hogy visszatérjen a prompthoz."
 
 #: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:173
 msgid "Statistics"
@@ -7260,9 +6653,7 @@ msgstr "1. lépés: Engedélyezze a Web Clipper szolgáltatást"
 #: packages/app-desktop/gui/DropboxLoginScreen.tsx:53
 #: packages/app-mobile/components/screens/dropbox-login.tsx:77
 msgid "Step 1: Open this URL in your browser to authorise the application:"
-msgstr ""
-"1. lépés: Nyissa meg ezt a webcímet a böngészőben, hogy hitelesítse az "
-"alkalmazást:"
+msgstr "1. lépés: Nyissa meg ezt a webcímet a böngészőben, hogy hitelesítse az alkalmazást:"
 
 #: packages/app-cli/app/command-sync.ts:82
 #: packages/app-desktop/gui/DropboxLoginScreen.tsx:57
@@ -7393,12 +6784,8 @@ msgid "Switched notes: %s"
 msgstr "Átváltott jegyzet: %s"
 
 #: packages/app-cli/app/command-use.ts:13
-msgid ""
-"Switches to [notebook] - all further operations will happen within this "
-"notebook."
-msgstr ""
-"Váltás a(z) [notebook] jegyzetfüzetre – minden további művelet ebben a "
-"jegyzetfüzetben történik."
+msgid "Switches to [notebook] - all further operations will happen within this notebook."
+msgstr "Váltás a(z) [notebook] jegyzetfüzetre – minden további művelet ebben a jegyzetfüzetben történik."
 
 #: packages/lib/utils/joplinCloud/index.ts:294
 msgid "Sync as many devices as you want"
@@ -7418,9 +6805,7 @@ msgstr "Szinkronizálási állapot (szinkronizált elemek / összes elem)"
 
 #: packages/app-cli/app/command-sync.ts:266
 msgid "Sync target must be upgraded! Run `%s` to proceed."
-msgstr ""
-"A szinkronizálási célpontot frissíteni kell! A folytatáshoz futtassa a(z) "
-"`%s` parancsot."
+msgstr "A szinkronizálási célpontot frissíteni kell! A folytatáshoz futtassa a(z) `%s` parancsot."
 
 #: packages/app-mobile/components/screens/UpgradeSyncTargetScreen.tsx:63
 msgid "Sync Target Upgrade"
@@ -7432,9 +6817,7 @@ msgstr "Szinkronizálási cél: %s"
 
 #: packages/app-cli/app/command-sync.ts:40
 msgid "Sync to provided target (defaults to sync.target config value)"
-msgstr ""
-"Szinkronizálás a megadott célra (alapértelmezés a sync.target beállítás "
-"értékre)"
+msgstr "Szinkronizálás a megadott célra (alapértelmezés a sync.target beállítás értékre)"
 
 #: packages/lib/versionInfo.ts:100
 msgid "Sync Version: %s"
@@ -7446,13 +6829,8 @@ msgid "Sync your notes"
 msgstr "Szinkronizálja a jegyzeteit"
 
 #: packages/app-desktop/gui/SyncWizard/Dialog.tsx:386
-msgid ""
-"Sync your notes with Joplin Cloud to access them on all your devices. Other "
-"sync options are also available."
-msgstr ""
-"Szinkronizálja saját jegyzeteit a Joplin Cloud segítségével, hogy elérje "
-"őket az összes eszközén. Egyéb szinkronizálási lehetőségek is rendelkezésre "
-"állnak."
+msgid "Sync your notes with Joplin Cloud to access them on all your devices. Other sync options are also available."
+msgstr "Szinkronizálja saját jegyzeteit a Joplin Cloud segítségével, hogy elérje őket az összes eszközén. Egyéb szinkronizálási lehetőségek is rendelkezésre állnak."
 
 #: packages/lib/models/Setting.ts:1406
 msgid "Sync, encryption, proxy"
@@ -7573,8 +6951,7 @@ msgstr "Címkék"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/setTags.ts:26
 msgid "Tags cannot be changed for locked notes while the session is locked"
-msgstr ""
-"Zárolt jegyzeteknél nem módosíthatójk a címkék, amíg a munkamenet zárolva van"
+msgstr "Zárolt jegyzeteknél nem módosíthatójk a címkék, amíg a munkamenet zárolva van"
 
 #: packages/app-mobile/components/CameraView/ActionButtons.tsx:111
 #: packages/app-mobile/components/screens/Note/commands/attachFile.ts:96
@@ -7612,11 +6989,8 @@ msgstr "Szövegszerkesztő-parancs"
 
 #: packages/app-desktop/gui/ProfileEditor.tsx:143
 #: packages/app-mobile/components/ProfileSwitcher/utils/deleteProfile.ts:21
-msgid ""
-"The active profile cannot be deleted. Switch to a different profile and try "
-"again."
-msgstr ""
-"Nem törölhető az aktív profil. Váltson másik profilra, és próbálja újra."
+msgid "The active profile cannot be deleted. Switch to a different profile and try again."
+msgstr "Nem törölhető az aktív profil. Váltson másik profilra, és próbálja újra."
 
 #: packages/lib/services/ai/availability.ts:48
 #: packages/lib/services/ai/availability.ts:51
@@ -7624,15 +6998,12 @@ msgid "The API key is missing. Set it in Settings → AI."
 msgstr "Hiányzik az API-kulcs. Állítsa be a Beállítások → MI menüpontban."
 
 #: packages/app-desktop/bridge.ts:649
-msgid ""
-"The app is now going to close. Please relaunch it to complete the process."
+msgid "The app is now going to close. Please relaunch it to complete the process."
 msgstr "Az alkalmazás most bezárul. Indítsa újra a folyamat befejezéséhez."
 
 #: packages/lib/onedrive-api-node-utils.ts:99
-msgid ""
-"The application has been authorised - you may now close this browser tab."
-msgstr ""
-"Az alkalmazás hitelesítve lett – most már bezárhatja ezt a böngészőfület."
+msgid "The application has been authorised - you may now close this browser tab."
+msgstr "Az alkalmazás hitelesítve lett – most már bezárhatja ezt a böngészőfület."
 
 #: packages/lib/components/shared/dropbox-login-shared.ts:76
 msgid "The application has been authorised!"
@@ -7647,9 +7018,7 @@ msgid "The application must be restarted for these changes to take effect."
 msgstr "Az alkalmazást újra kell indítani a módosítások érvényesítéséhez."
 
 #: packages/app-desktop/gui/NoteEditor/NoteEditor.tsx:689
-msgid ""
-"The attachments will no longer be watched when you switch to a different "
-"note."
+msgid "The attachments will no longer be watched when you switch to a different note."
 msgstr "A mellékletek figyelése megszűnik, ha egy másik jegyzetre vált."
 
 #: packages/app-cli/app/app.ts:284
@@ -7658,33 +7027,19 @@ msgstr "A(z) „%s” parancs csak GUI módban érhető el"
 
 #: packages/server/src/middleware/notificationHandler.ts:43
 msgid "The default admin password has not been changed! [Change it now](%s)"
-msgstr ""
-"Az alapértelmezett adminisztrátori jelszó nem lett megváltoztatva! "
-"[Változtassa meg most](%s)"
+msgstr "Az alapértelmezett adminisztrátori jelszó nem lett megváltoztatva! [Változtassa meg most](%s)"
 
 #: packages/server/src/middleware/notificationHandler.ts:41
-msgid ""
-"The default admin password is insecure and has not been changed! [Change it "
-"now](%s)"
-msgstr ""
-"Az alapértelmezett adminisztrátori jelszó nem biztonságos és nem lett "
-"módosítva! [Módosítsa most](%s)"
+msgid "The default admin password is insecure and has not been changed! [Change it now](%s)"
+msgstr "Az alapértelmezett adminisztrátori jelszó nem biztonságos és nem lett módosítva! [Módosítsa most](%s)"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:545
-msgid ""
-"The default encryption method has been changed to a more secure one and it "
-"is recommended that you apply it to your data."
-msgstr ""
-"Az alapértelmezett titkosítási módszer biztonságosabbra módosult, és "
-"ajánlott, hogy ezt alkalmazza az adataira."
+msgid "The default encryption method has been changed to a more secure one and it is recommended that you apply it to your data."
+msgstr "Az alapértelmezett titkosítási módszer biztonságosabbra módosult, és ajánlott, hogy ezt alkalmazza az adataira."
 
 #: packages/app-desktop/gui/MainScreen.tsx:603
-msgid ""
-"The default encryption method has been changed, you should re-encrypt your "
-"data."
-msgstr ""
-"Az alapértelmezett titkosítási módszer módosult, ezért újra kell "
-"titkosítania az adatait."
+msgid "The default encryption method has been changed, you should re-encrypt your data."
+msgstr "Az alapértelmezett titkosítási módszer módosult, ezért újra kell titkosítania az adatait."
 
 #: packages/app-desktop/gui/ProfileEditor.tsx:209
 #: packages/app-mobile/components/ProfileSwitcher/utils/deleteProfile.ts:79
@@ -7692,28 +7047,14 @@ msgid "The default profile has been reset."
 msgstr "Az alapértelmezett profil vissza lett állítva."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1871
-msgid ""
-"The editor command (may include arguments) that will be used to open a note. "
-"If none is provided it will try to auto-detect the default editor."
-msgstr ""
-"A jegyzet megnyitásához használt szerkesztőparancs (tartalmazhat "
-"argumentumokat). Ha nincs megadva, a program megpróbálja automatikusan "
-"felismerni az alapértelmezett szerkesztőt."
+msgid "The editor command (may include arguments) that will be used to open a note. If none is provided it will try to auto-detect the default editor."
+msgstr "A jegyzet megnyitásához használt szerkesztőparancs (tartalmazhat argumentumokat). Ha nincs megadva, a program megpróbálja automatikusan felismerni az alapértelmezett szerkesztőt."
 
 #: packages/lib/models/settings/builtInMetadata.ts:2192
 #: packages/lib/models/settings/builtInMetadata.ts:2207
 #: packages/lib/models/settings/builtInMetadata.ts:2222
-msgid ""
-"The factor property sets how the item will grow or shrink to fit the "
-"available space in its container with respect to the other items. Thus an "
-"item with a factor of 2 will take twice as much space as an item with a "
-"factor of 1.Restart app to see changes."
-msgstr ""
-"A faktortulajdonság határozza meg, hogy az elem a többi elemhez képest "
-"hogyan fog nőni vagy zsugorodni, hogy elférjen a tárolójában rendelkezésre "
-"álló helyhez képest. Így egy 2-es faktorú elem kétszer annyi helyet foglal "
-"el, mint egy 1-es faktorú elem. A módosítások megtekintéséhez indítsa újra "
-"az alkalmazást."
+msgid "The factor property sets how the item will grow or shrink to fit the available space in its container with respect to the other items. Thus an item with a factor of 2 will take twice as much space as an item with a factor of 1.Restart app to see changes."
+msgstr "A faktortulajdonság határozza meg, hogy az elem a többi elemhez képest hogyan fog nőni vagy zsugorodni, hogy elférjen a tárolójában rendelkezésre álló helyhez képest. Így egy 2-es faktorú elem kétszer annyi helyet foglal el, mint egy 1-es faktorú elem. A módosítások megtekintéséhez indítsa újra az alkalmazást."
 
 #: packages/app-desktop/gui/NoteEditor/NoteEditor.tsx:704
 msgid "The following attachment matches your search query:"
@@ -7726,96 +7067,53 @@ msgid "The following attachments are being watched for changes:"
 msgstr "A következő mellékletek módosítása figyelve van:"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:143
-msgid ""
-"The following keys use an out-dated encryption algorithm and it is "
-"recommended to upgrade them. The upgraded key will still be able to decrypt "
-"and encrypt your data as usual."
-msgstr ""
-"A következő kulcsok elavult titkosítási algoritmust használnak, ezért "
-"ajánlott frissíteni őket. A frissített kulcs továbbra is képes lesz a "
-"szokásos módon visszafejteni és titkosítani az adatokat."
+msgid "The following keys use an out-dated encryption algorithm and it is recommended to upgrade them. The upgraded key will still be able to decrypt and encrypt your data as usual."
+msgstr "A következő kulcsok elavult titkosítási algoritmust használnak, ezért ajánlott frissíteni őket. A frissített kulcs továbbra is képes lesz a szokásos módon visszafejteni és titkosítani az adatokat."
 
 #: packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx:96
 msgid "The following plugins may not support the current markdown editor:"
-msgstr ""
-"A következő bővítmények nem feltétlenül támogatják a jelenlegi Markdown "
-"szerkesztőt:"
+msgstr "A következő bővítmények nem feltétlenül támogatják a jelenlegi Markdown szerkesztőt:"
 
 #: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx:256
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/RecommendedBadge.tsx:49
-msgid ""
-"The Joplin team has vetted this plugin and it meets our standards for "
-"security and performance."
-msgstr ""
-"A Joplin csapata ellenőrizte ezt a bővítményt, és megfelel a biztonsági és "
-"teljesítménybeli szabványainknak."
+msgid "The Joplin team has vetted this plugin and it meets our standards for security and performance."
+msgstr "A Joplin csapata ellenőrizte ezt a bővítményt, és megfelel a biztonsági és teljesítménybeli szabványainknak."
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:522
-msgid ""
-"The keys with these IDs are used to encrypt some of your items, however the "
-"application does not currently have access to them. It is likely they will "
-"eventually be downloaded via synchronisation."
-msgstr ""
-"Az ezekkel az azonosítókkal rendelkező kulcsok néhány elem titkosítására "
-"szolgálnak, azonban az alkalmazásnak jelenleg nincs hozzáférése ezekhez. "
-"Valószínűleg idővel le lesznek töltve egy szinkronizációt követően."
+msgid "The keys with these IDs are used to encrypt some of your items, however the application does not currently have access to them. It is likely they will eventually be downloaded via synchronisation."
+msgstr "Az ezekkel az azonosítókkal rendelkező kulcsok néhány elem titkosítására szolgálnak, azonban az alkalmazásnak jelenleg nincs hozzáférése ezekhez. Valószínűleg idővel le lesznek töltve egy szinkronizációt követően."
 
 #: packages/app-desktop/gui/ErrorBoundary.tsx:55
-msgid ""
-"The legacy Markdown editor appears to have crashed due to an incompatibility "
-"with a plugin. We recommend using the new editor."
-msgstr ""
-"Úgy tűnik, hogy a régi Markdown szerkesztő egy bővítménnyel való "
-"inkompatibilitás miatt összeomlott. Javasoljuk az új szerkesztő használatát."
+msgid "The legacy Markdown editor appears to have crashed due to an incompatibility with a plugin. We recommend using the new editor."
+msgstr "Úgy tűnik, hogy a régi Markdown szerkesztő egy bővítménnyel való inkompatibilitás miatt összeomlott. Javasoljuk az új szerkesztő használatát."
 
 #: packages/server/src/middleware/notificationHandler.ts:113
 msgid "The license for this server failed to refresh."
 msgstr "Ennek a kiszolgálónak a licencét nem sikerült frissíteni."
 
 #: packages/server/src/middleware/notificationHandler.ts:68
-msgid ""
-"The license key for this Joplin Server Business instance has expired and "
-"needs to be renewed."
-msgstr ""
-"Ennek a Joplin Server Business példánynak a licenckulcsa lejárt, és "
-"megújítást igényel."
+msgid "The license key for this Joplin Server Business instance has expired and needs to be renewed."
+msgstr "Ennek a Joplin Server Business példánynak a licenckulcsa lejárt, és megújítást igényel."
 
 #: packages/server/src/middleware/notificationHandler.ts:80
-msgid ""
-"The license key for this Joplin Server Business instance has expired or is "
-"invalid. Uploading items has been disabled until the license is renewed."
-msgstr ""
-"Ennek a Joplin Server Business példánynak a licenckulcsa lejárt vagy "
-"érvénytelen. Az elemek feltöltése le lett tiltva a licenc megújításáig."
+msgid "The license key for this Joplin Server Business instance has expired or is invalid. Uploading items has been disabled until the license is renewed."
+msgstr "Ennek a Joplin Server Business példánynak a licenckulcsa lejárt vagy érvénytelen. Az elemek feltöltése le lett tiltva a licenc megújításáig."
 
 #: packages/lib/components/EncryptionConfigScreen/utils.ts:236
 msgid "The master key has been upgraded successfully!"
 msgstr "A mesterkulcs frissítése sikeresen megtörtént!"
 
 #: packages/app-mobile/components/screens/encryption-config.tsx:339
-msgid ""
-"The master keys with these IDs are used to encrypt some of your items, "
-"however the application does not currently have access to them. It is likely "
-"they will eventually be downloaded via synchronisation."
-msgstr ""
-"Az ezekkel az azonosítókkal rendelkező mesterkulcsok néhány elem "
-"titkosítására szolgálnak, azonban az alkalmazásnak jelenleg nincs "
-"hozzáférése ezekhez. Valószínűleg idővel le lesznek töltve egy "
-"szinkronizációt követően."
+msgid "The master keys with these IDs are used to encrypt some of your items, however the application does not currently have access to them. It is likely they will eventually be downloaded via synchronisation."
+msgstr "Az ezekkel az azonosítókkal rendelkező mesterkulcsok néhány elem titkosítására szolgálnak, azonban az alkalmazásnak jelenleg nincs hozzáférése ezekhez. Valószínűleg idővel le lesznek töltve egy szinkronizációt követően."
 
 #: packages/lib/services/ai/availability.ts:84
 msgid "The MCP server is disabled. Enable it in Settings → MCP."
-msgstr ""
-"Az MCP-kiszolgáló le van tiltva. Engedélyezze a Beállítások → MCP "
-"menüpontban."
+msgstr "Az MCP-kiszolgáló le van tiltva. Engedélyezze a Beállítások → MCP menüpontban."
 
 #: packages/lib/models/settings/builtInMetadata.ts:750
-msgid ""
-"The model identifier to use, for example gpt-4o-mini or claude-3-5-sonnet-"
-"latest."
-msgstr ""
-"A használandó modellazonosító, például gpt-4o-mini vagy claude-3-5-sonnet-"
-"latest."
+msgid "The model identifier to use, for example gpt-4o-mini or claude-3-5-sonnet-latest."
+msgstr "A használandó modellazonosító, például gpt-4o-mini vagy claude-3-5-sonnet-latest."
 
 #: packages/lib/services/ai/availability.ts:49
 #: packages/lib/services/ai/availability.ts:52
@@ -7824,41 +7122,21 @@ msgstr "A modell neve hiányzik. Állítsa be a Beállítások → MI menüpontb
 
 #: packages/lib/services/RevisionService.ts:291
 msgid "The note \"%s\" has been successfully restored to the notebook \"%s\"."
-msgstr ""
-"A(z) „%s” nevű jegyzet sikeresen vissza lett állítva a(z) „%s” nevű "
-"jegyzetfüzetbe."
+msgstr "A(z) „%s” nevű jegyzet sikeresen vissza lett állítva a(z) „%s” nevű jegyzetfüzetbe."
 
 #: packages/lib/services/ai/noteChat.ts:350
-msgid ""
-"The note changed while the request was running; edits were not applied. Try "
-"again."
-msgstr ""
-"A jegyzet megváltozott a kérés futása közben; a módosítások nem lettek "
-"használatba véve. Próbálja újra."
+msgid "The note changed while the request was running; edits were not applied. Try again."
+msgstr "A jegyzet megváltozott a kérés futása közben; a módosítások nem lettek használatba véve. Próbálja újra."
 
 #: packages/lib/commands/convertNoteToMarkdown.ts:82
-msgid ""
-"The note has been converted to Markdown and the original note has been moved "
-"to the trash"
-msgid_plural ""
-"The notes have been converted to Markdown and the original notes have been "
-"moved to the trash"
-msgstr[0] ""
-"A jegyzet Markdown formátumba lett átalakítva, az eredeti jegyzet pedig a "
-"kukába lett áthelyezve"
-msgstr[1] ""
-"A jegyzetek Markdown formátumba lettek átalakítva, az eredeti jegyzetek "
-"pedig a kukába lettek áthelyezve"
+msgid "The note has been converted to Markdown and the original note has been moved to the trash"
+msgid_plural "The notes have been converted to Markdown and the original notes have been moved to the trash"
+msgstr[0] "A jegyzet Markdown formátumba lett átalakítva, az eredeti jegyzet pedig a kukába lett áthelyezve"
+msgstr[1] "A jegyzetek Markdown formátumba lettek átalakítva, az eredeti jegyzetek pedig a kukába lettek áthelyezve"
 
 #: packages/app-desktop/gui/ConfigScreen/controls/NoteLockSettings.tsx:211
-msgid ""
-"The note lock key uses an out-dated encryption algorithm and it is "
-"recommended to upgrade it. The upgraded key will still be able to decrypt "
-"and encrypt your data as usual."
-msgstr ""
-"A jegyzetzárolási kulcs elavult titkosítási algoritmust használ, és ajánlott "
-"a frissítése. A frissített kulcs továbbra is képes lesz a szokásos módon "
-"visszafejteni és titkosítani az adatait."
+msgid "The note lock key uses an out-dated encryption algorithm and it is recommended to upgrade it. The upgraded key will still be able to decrypt and encrypt your data as usual."
+msgstr "A jegyzetzárolási kulcs elavult titkosítási algoritmust használ, és ajánlott a frissítése. A frissített kulcs továbbra is képes lesz a szokásos módon visszafejteni és titkosítani az adatait."
 
 #: packages/app-cli/app/command-set.ts:40
 msgid "The note lock state cannot be changed from the command line"
@@ -7884,31 +7162,20 @@ msgid "The notes have been imported: %s"
 msgstr "A következő jegyzetek importálva lettek: %s"
 
 #: packages/lib/models/settings/builtInMetadata.ts:726
-msgid ""
-"The OpenAI-compatible API endpoint. For example, https://api.openai.com/v1 "
-"or http://localhost:11434/v1 for Ollama."
-msgstr ""
-"Az OpenAI-kompatibilis API-végpont. Például https://api.openai.com/v1 vagy "
-"http://localhost:11434/v1 az Ollama esetén."
+msgid "The OpenAI-compatible API endpoint. For example, https://api.openai.com/v1 or http://localhost:11434/v1 for Ollama."
+msgstr "Az OpenAI-kompatibilis API-végpont. Például https://api.openai.com/v1 vagy http://localhost:11434/v1 az Ollama esetén."
 
 #: packages/lib/services/ai/availability.ts:47
-msgid ""
-"The OpenAI-compatible provider needs a base URL. Set it in Settings → AI."
-msgstr ""
-"Az OpenAI-kompatibilis szolgáltatónak alap webcímre van szüksége. Állítsa be "
-"a Beállítások → MI menüpontban."
+msgid "The OpenAI-compatible provider needs a base URL. Set it in Settings → AI."
+msgstr "Az OpenAI-kompatibilis szolgáltatónak alap webcímre van szüksége. Állítsa be a Beállítások → MI menüpontban."
 
 #: packages/app-cli/app/command-help.ts:73
 msgid "The possible commands are:"
 msgstr "A lehetséges parancsok a következők:"
 
 #: packages/lib/components/shared/config/config-shared.ts:132
-msgid ""
-"The provider returned an empty response. Check that the base URL ends with /"
-"v1 and that a model is loaded."
-msgstr ""
-"A szolgáltató üres választ adott. Ellenőrizze, hogy az alap webcím /v1-re "
-"végződik-e, és hogy a modell be van-e töltve."
+msgid "The provider returned an empty response. Check that the base URL ends with /v1 and that a model is loaded."
+msgstr "A szolgáltató üres választ adott. Ellenőrizze, hogy az alap webcím /v1-re végződik-e, és hogy a modell be van-e töltve."
 
 #: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:275
 msgid ""
@@ -7924,33 +7191,23 @@ msgstr ""
 msgid ""
 "The sync target cannot be changed for the following reason: %s\n"
 "\n"
-"If the issue cannot be resolved, you may need to clear your data first by "
-"following these instructions:\n"
+"If the issue cannot be resolved, you may need to clear your data first by following these instructions:\n"
 "\n"
 "%s"
 msgstr ""
 "A szinkronizálás célpontja nem módosítható a következő okból: %s\n"
 "\n"
-"Ha a probléma nem oldható meg, akkor először törölnie kell az adatokat az "
-"alábbi utasítások szerint:\n"
+"Ha a probléma nem oldható meg, akkor először törölnie kell az adatokat az alábbi utasítások szerint:\n"
 "\n"
 "%s"
 
 #: packages/app-desktop/gui/MainScreen.tsx:585
-msgid ""
-"The sync target needs to be upgraded before Joplin can sync. The operation "
-"may take a few minutes to complete and the app needs to be restarted. To "
-"proceed please click on the link."
-msgstr ""
-"A szinkronizálás célpontját frissíteni kell, mielőtt a Joplin szinkronizálni "
-"tudna. A művelet eltarthat néhány percig, és az alkalmazást újra kell "
-"indítani. A folytatáshoz kattintson a hivatkozásra."
+msgid "The sync target needs to be upgraded before Joplin can sync. The operation may take a few minutes to complete and the app needs to be restarted. To proceed please click on the link."
+msgstr "A szinkronizálás célpontját frissíteni kell, mielőtt a Joplin szinkronizálni tudna. A művelet eltarthat néhány percig, és az alkalmazást újra kell indítani. A folytatáshoz kattintson a hivatkozásra."
 
 #: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:117
 msgid "The sync target needs to be upgraded. Press this banner to proceed."
-msgstr ""
-"A szinkronizálási célt frissíteni kell. Az elfogadáshoz nyomja meg ezt a "
-"gombot."
+msgstr "A szinkronizálási célt frissíteni kell. Az elfogadáshoz nyomja meg ezt a gombot."
 
 #: packages/app-desktop/gui/MainScreen.tsx:579
 msgid "The synchronisation password is missing."
@@ -7961,55 +7218,38 @@ msgid "The tag \"%s\" already exists. Please choose a different name."
 msgstr "A(z) „%s” nevű címke már létezik. Válasszon másik nevet neki."
 
 #: packages/lib/models/settings/builtInMetadata.ts:140
-msgid ""
-"The target to synchronise to. Each sync target may have additional "
-"parameters which are named as `sync.NUM.NAME` (all documented below)."
-msgstr ""
-"A szinkronizálási cél. Minden szinkronizációs célnak további paraméterei "
-"lehetnek, amelyek a `sync.NUM.NAME` nevet kapják (ezek mindegyike alább "
-"dokumentálva van)."
+msgid "The target to synchronise to. Each sync target may have additional parameters which are named as `sync.NUM.NAME` (all documented below)."
+msgstr "A szinkronizálási cél. Minden szinkronizációs célnak további paraméterei lehetnek, amelyek a `sync.NUM.NAME` nevet kapják (ezek mindegyike alább dokumentálva van)."
 
 #: packages/lib/services/share/invitationRespond.ts:22
 msgid ""
-"The web client does not support accepting encrypted shared notebooks. Please "
-"switch to the desktop or mobile app before accepting the share.\n"
+"The web client does not support accepting encrypted shared notebooks. Please switch to the desktop or mobile app before accepting the share.\n"
 "\n"
 "Error: \"%s\""
 msgstr ""
-"A webes kliens nem támogatja a titkosított, megosztott jegyzetfüzetek "
-"elfogadását. A megosztás elfogadása előtt váltson át asztali vagy "
-"mobilalkalmazásra.\n"
+"A webes kliens nem támogatja a titkosított, megosztott jegyzetfüzetek elfogadását. A megosztás elfogadása előtt váltson át asztali vagy mobilalkalmazásra.\n"
 "\n"
 "Hiba: „%s”"
 
 #: packages/app-desktop/gui/Root.tsx:130
 msgid "The Web Clipper needs your authorisation to access your data."
-msgstr ""
-"A Web Clipper szolgáltatásnak engedélyre van szüksége, hogy hozzáférjen az "
-"adatokhoz."
+msgstr "A Web Clipper szolgáltatásnak engedélyre van szüksége, hogy hozzáférjen az adatokhoz."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:111
 msgid "The web clipper service cannot be enabled in this instance of Joplin."
-msgstr ""
-"A Web Clipper szolgáltatás nem engedélyezhető a Joplin ezen példányában."
+msgstr "A Web Clipper szolgáltatás nem engedélyezhető a Joplin ezen példányában."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:86
 msgid "The web clipper service is enabled and set to auto-start."
-msgstr ""
-"A Web Clipper szolgáltatás engedélyezve van, és automatikus indításra van "
-"állítva."
+msgstr "A Web Clipper szolgáltatás engedélyezve van, és automatikus indításra van állítva."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:117
 msgid "The web clipper service is not enabled."
 msgstr "A Web Clipper szolgáltatás nincs engedélyezve."
 
 #: packages/lib/utils/webDAVUtils.ts:28
-msgid ""
-"The WebDAV implementation of %s is incompatible with Joplin, and as such is "
-"no longer supported. Please use a different sync method."
-msgstr ""
-"A WebDAV %s megvalósítása nem kompatibilis a Joplinnal, és mint ilyen, már "
-"nem támogatott. Használjon más szinkronizálási módszert."
+msgid "The WebDAV implementation of %s is incompatible with Joplin, and as such is no longer supported. Please use a different sync method."
+msgstr "A WebDAV %s megvalósítása nem kompatibilis a Joplinnal, és mint ilyen, már nem támogatott. Használjon más szinkronizálási módszert."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1014
 msgid "Theme"
@@ -8021,8 +7261,7 @@ msgstr "Témák, jegyzetfüzet rendezési sorrendje"
 
 #: packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts:17
 msgid "There are currently no notes. Create one by clicking on the (+) button."
-msgstr ""
-"Jelenleg nincsenek jegyzetek. Hozzon létre egyet a „+” gombra kattintva."
+msgstr "Jelenleg nincsenek jegyzetek. Hozzon létre egyet a „+” gombra kattintva."
 
 #: packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts:9
 msgid "There are no notes in the trash folder."
@@ -8051,55 +7290,20 @@ msgid "There was an error downloading this attachment:"
 msgstr "Hiba történt a melléklet letöltésekor:"
 
 #: packages/lib/services/ReportService.ts:239
-msgid ""
-"These items failed to sync, but have been marked as \"ignored\". They won't "
-"cause the sync warning to appear, but still aren't synced. To unignore, "
-"click \"retry\"."
-msgstr ""
-"Ezeket az elemeket nem sikerült szinkronizálni, ezért „mellőzöttként” lettek "
-"megjelölve. Ezek nem okozzák a szinkronizálási figyelmeztetés megjelenését, "
-"de mégsem szinkronizálódnak. A mellőzés megszüntetéséhez kattintson az "
-"„újrapróbálás” gombra."
+msgid "These items failed to sync, but have been marked as \"ignored\". They won't cause the sync warning to appear, but still aren't synced. To unignore, click \"retry\"."
+msgstr "Ezeket az elemeket nem sikerült szinkronizálni, ezért „mellőzöttként” lettek megjelölve. Ezek nem okozzák a szinkronizálási figyelmeztetés megjelenését, de mégsem szinkronizálódnak. A mellőzés megszüntetéséhez kattintson az „újrapróbálás” gombra."
 
 #: packages/lib/services/ReportService.ts:189
-msgid ""
-"These items will remain on the device but will not be uploaded to the sync "
-"target. In order to find these items, either search for the title or the ID "
-"(which is displayed in brackets above)."
-msgstr ""
-"Ezek az elemek az eszközön maradnak, de nem lesznek feltöltve a "
-"szinkronizálási célra. Ezen elemek megtalálásához vagy a címre vagy az "
-"azonosítóra (amely a fenti zárójelben látható) kell keresni."
+msgid "These items will remain on the device but will not be uploaded to the sync target. In order to find these items, either search for the title or the ID (which is displayed in brackets above)."
+msgstr "Ezek az elemek az eszközön maradnak, de nem lesznek feltöltve a szinkronizálási célra. Ezen elemek megtalálásához vagy a címre vagy az azonosítóra (amely a fenti zárójelben látható) kell keresni."
 
 #: packages/lib/models/Setting.ts:1384
-msgid ""
-"These plugins enhance the Markdown renderer with additional features. Please "
-"note that, while these features might be useful, they are not standard "
-"Markdown and thus most of them will only work in Joplin. Additionally, some "
-"of them are *incompatible* with the WYSIWYG editor. If you open a note that "
-"uses one of these plugins in that editor, you will lose the plugin "
-"formatting. It is indicated below which plugins are compatible or not with "
-"the WYSIWYG editor."
-msgstr ""
-"Ezek a bővítmények további funkciókkal egészítik ki a Markdown megjelenítőt. "
-"Vegye figyelembe, hogy bár ezek a funkciók hasznosak lehetnek, nem részei a "
-"szabványos Markdownnak, így legtöbbjük csak a Joplinban fog működni. "
-"Emellett némelyikük nem kompatibilis a WYSIWYG (vizuális) szerkesztővel. Ha "
-"olyan jegyzetet nyit meg abban a szerkesztőben, amely használja ezen "
-"bővítmények egyikét, a bővítmény által nyújtott formázás elvész. Alább "
-"látható, hogy mely bővítmények kompatibilisek a WYSIWYG szerkesztővel, és "
-"melyek nem."
+msgid "These plugins enhance the Markdown renderer with additional features. Please note that, while these features might be useful, they are not standard Markdown and thus most of them will only work in Joplin. Additionally, some of them are *incompatible* with the WYSIWYG editor. If you open a note that uses one of these plugins in that editor, you will lose the plugin formatting. It is indicated below which plugins are compatible or not with the WYSIWYG editor."
+msgstr "Ezek a bővítmények további funkciókkal egészítik ki a Markdown megjelenítőt. Vegye figyelembe, hogy bár ezek a funkciók hasznosak lehetnek, nem részei a szabványos Markdownnak, így legtöbbjük csak a Joplinban fog működni. Emellett némelyikük nem kompatibilis a WYSIWYG (vizuális) szerkesztővel. Ha olyan jegyzetet nyit meg abban a szerkesztőben, amely használja ezen bővítmények egyikét, a bővítmény által nyújtott formázás elvész. Alább látható, hogy mely bővítmények kompatibilisek a WYSIWYG szerkesztővel, és melyek nem."
 
 #: packages/lib/utils/joplinCloud/index.ts:319
-msgid ""
-"This allows another user to share a notebook with you, and you can then both "
-"collaborate on it. It does not however allow you to share a notebook with "
-"someone else, unless you have the feature \"%s\"."
-msgstr ""
-"Ez lehetővé teszi egy másik felhasználónak, hogy megosszon Önnel egy "
-"jegyzetfüzetet, és mindketten együtt dolgozhassanak rajta. Nem teszi azonban "
-"lehetővé, hogy Ön osszon meg egy jegyzetfüzetet valaki mással, kivéve, ha Ön "
-"rendelkezik a(z) „%s” funkcióval."
+msgid "This allows another user to share a notebook with you, and you can then both collaborate on it. It does not however allow you to share a notebook with someone else, unless you have the feature \"%s\"."
+msgstr "Ez lehetővé teszi egy másik felhasználónak, hogy megosszon Önnel egy jegyzetfüzetet, és mindketten együtt dolgozhassanak rajta. Nem teszi azonban lehetővé, hogy Ön osszon meg egy jegyzetfüzetet valaki mással, kivéve, ha Ön rendelkezik a(z) „%s” funkcióval."
 
 #: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:207
 msgid "This attachment does not have OCR data (Status: %s)"
@@ -8111,24 +7315,16 @@ msgid "This attachment is not downloaded or not decrypted yet"
 msgstr "Ez a melléklet még nincs letöltve vagy visszafejtve"
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:166
-msgid ""
-"This authorisation token is only needed to allow third-party applications to "
-"access Joplin."
-msgstr ""
-"Erre az engedélyezési tokenre csak ahhoz van szükség, hogy harmadik fél "
-"alkalmazásai hozzáférhessenek a Joplinhoz."
+msgid "This authorisation token is only needed to allow third-party applications to access Joplin."
+msgstr "Erre az engedélyezési tokenre csak ahhoz van szükség, hogy harmadik fél alkalmazásai hozzáférhessenek a Joplinhoz."
 
 #: packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx:45
 msgid "This drawing may have unsaved changes."
 msgstr "Ez a rajz mentetlen módosításokat tartalmazhat."
 
 #: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:173
-msgid ""
-"This feature is disabled by default, you need to manually enable it by "
-"turning on the option to 'Enable handwritten transcription'."
-msgstr ""
-"Ez a funkció alapértelmezetten ki van kapcsolva, kézzel kell engedélyezni a "
-"„Kézzel írt átírás engedélyezése” beállítás bekapcsolásával."
+msgid "This feature is disabled by default, you need to manually enable it by turning on the option to 'Enable handwritten transcription'."
+msgstr "Ez a funkció alapértelmezetten ki van kapcsolva, kézzel kell engedélyezni a „Kézzel írt átírás engedélyezése” beállítás bekapcsolásával."
 
 #: packages/app-desktop/commands/createAccessibleDocument.ts:28
 msgid "This feature is only available for PDF files."
@@ -8136,9 +7332,7 @@ msgstr "Ez a funkció csak PDF-fájlokhoz érhető el."
 
 #: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:168
 msgid "This feature is only available on Joplin Cloud and Joplin Server."
-msgstr ""
-"Ez a funkció csak a Joplin Cloud és a Joplin Server szolgáltatásokban érhető "
-"el."
+msgstr "Ez a funkció csak a Joplin Cloud és a Joplin Server szolgáltatásokban érhető el."
 
 #: packages/app-mobile/components/screens/ResourceScreen.tsx:290
 msgid "This file could not be opened: %s"
@@ -8150,35 +7344,22 @@ msgstr "Ezt a képtípust nem támogatja a képfelismerő rendszer."
 
 #: packages/app-desktop/gui/ResourceScreen.tsx:301
 #: packages/app-mobile/components/screens/ResourceScreen.tsx:409
-msgid ""
-"This is an advanced tool to show the attachments that are linked to your "
-"notes. Please be careful when deleting one of them as they cannot be "
-"restored afterwards."
-msgstr ""
-"Ez egy fejlett eszköz a jegyzetekhez kapcsolódó mellékletek megjelenítésére. "
-"Legyen óvatos, amikor törli valamelyiket, mert utólag nem lehet "
-"visszaállítani."
+msgid "This is an advanced tool to show the attachments that are linked to your notes. Please be careful when deleting one of them as they cannot be restored afterwards."
+msgstr "Ez egy fejlett eszköz a jegyzetekhez kapcsolódó mellékletek megjelenítésére. Legyen óvatos, amikor törli valamelyiket, mert utólag nem lehet visszaállítani."
 
 #: packages/server/src/middleware/notificationHandler.ts:92
 msgid "This Joplin Server Business instance is only licensed for %d user."
-msgid_plural ""
-"This Joplin Server Business instance is only licensed for %d users."
-msgstr[0] ""
-"Ez a Joplin Server Business példány csak %d felhasználóra van licencelve."
-msgstr[1] ""
-"Ez a Joplin Server Business példány csak %d felhasználóra van licencelve."
+msgid_plural "This Joplin Server Business instance is only licensed for %d users."
+msgstr[0] "Ez a Joplin Server Business példány csak %d felhasználóra van licencelve."
+msgstr[1] "Ez a Joplin Server Business példány csak %d felhasználóra van licencelve."
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/WhiteboardEditor/nodes/FileNode.tsx:202
 msgid "This linked item has been deleted."
 msgstr "Ez a hivatkozott elem törölve lett."
 
 #: packages/app-desktop/gui/NoteEditor/NoteLockPanel/NoteLockPanel.tsx:53
-msgid ""
-"This note could not be decrypted. If it was encrypted prior to a password "
-"reset, the contents are no longer recoverable."
-msgstr ""
-"Ezt a jegyzetet nem sikerült visszafejteni. Ha a jelszó visszaállítása előtt "
-"lett titkosítva, a tartalma már nem állítható helyre."
+msgid "This note could not be decrypted. If it was encrypted prior to a password reset, the contents are no longer recoverable."
+msgstr "Ezt a jegyzetet nem sikerült visszafejteni. Ha a jelszó visszaállítása előtt lett titkosítva, a tartalma már nem állítható helyre."
 
 #: packages/app-mobile/components/ScreenHeader/index.tsx:275
 msgid "This note could not be deleted: %s"
@@ -8208,12 +7389,8 @@ msgstr "Ez a jegyzet módosítva lett:"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx:654
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx:214
-msgid ""
-"This note has no content. Click on \"%s\" to toggle the editor and edit the "
-"note."
-msgstr ""
-"Ennek a jegyzetnek nincs tartalma. Kattintson a(z) „%s” gombra a szerkesztő "
-"be-/kikapcsolásához és a jegyzet szerkesztéséhez."
+msgid "This note has no content. Click on \"%s\" to toggle the editor and edit the note."
+msgstr "Ennek a jegyzetnek nincs tartalma. Kattintson a(z) „%s” gombra a szerkesztő be-/kikapcsolásához és a jegyzet szerkesztéséhez."
 
 #: packages/app-desktop/gui/NoteRevisionViewer.tsx:74
 msgid "This note has no history"
@@ -8222,73 +7399,44 @@ msgstr "Ennek a jegyzetnek nincsenek előzményei"
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/disableNoteEncryption.ts:23
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/enableNoteEncryption.ts:28
 msgid "This note is currently being saved. Please try again in a moment."
-msgstr ""
-"Ez a jegyzet jelenleg mentés alatt áll. Próbálja újra egy pár perc múlva."
+msgstr "Ez a jegyzet jelenleg mentés alatt áll. Próbálja újra egy pár perc múlva."
 
 #: packages/app-desktop/gui/ChatPanel/ChatPanel.tsx:350
 msgid "This note is encrypted and cannot be used with AI Chat."
 msgstr "Ez a jegyzet titkosítva van, és nem használható az MI-csevegéssel."
 
 #: packages/app-desktop/gui/NoteEditor/NoteLockPanel/NoteLockPanel.tsx:67
-msgid ""
-"This note is encrypted. Enter the note lock password to unlock encrypted "
-"notes for this session."
-msgstr ""
-"Ez a jegyzet titkosítva van. Adja meg a jegyzetzárolási jelszót a "
-"titkosított jegyzetek feloldásához ebben a munkamenetben."
+msgid "This note is encrypted. Enter the note lock password to unlock encrypted notes for this session."
+msgstr "Ez a jegyzet titkosítva van. Adja meg a jegyzetzárolási jelszót a titkosított jegyzetek feloldásához ebben a munkamenetben."
 
 #: packages/app-desktop/gui/NoteEditor/NoteEditor.tsx:807
-msgid ""
-"This note is in HTML format. Convert it to Markdown to edit it more easily."
-msgstr ""
-"Ez a jegyzet HTML-formátumban van. Alakítsa át Markdown formátumba, hogy "
-"könnyebben szerkeszthesse."
+msgid "This note is in HTML format. Convert it to Markdown to edit it more easily."
+msgstr "Ez a jegyzet HTML-formátumban van. Alakítsa át Markdown formátumba, hogy könnyebben szerkeszthesse."
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts:111
-msgid ""
-"This notebook contains Windows-specific files. For maximum compatibility, "
-"consider importing the notebook from Windows."
-msgstr ""
-"Ez a jegyzetfüzet Windows-specifikus fájlokat tartalmaz. A maximális "
-"kompatibilitás érdekében fontolja meg a jegyzetfüzet Windowsból történő "
-"importálását."
+msgid "This notebook contains Windows-specific files. For maximum compatibility, consider importing the notebook from Windows."
+msgstr "Ez a jegyzetfüzet Windows-specifikus fájlokat tartalmaz. A maximális kompatibilitás érdekében fontolja meg a jegyzetfüzet Windowsból történő importálását."
 
 #: packages/lib/services/plugins/PluginService.ts:615
 msgid "This plugin doesn't support %s."
 msgstr "Ez a bővítmény nem támogatja a következőt: %s."
 
 #: packages/lib/services/ai/availability.ts:57
-msgid ""
-"This provider sends data off your device. Turn on \"Allow remote AI "
-"providers\" in Settings → AI."
-msgstr ""
-"Ez a szolgáltató adatokat küld ki az Ön eszközéről. Kapcsolja be a „Távoli "
-"MI-szolgáltatók engedélyezése” beállítást a Beállítások → MI menüpontban."
+msgid "This provider sends data off your device. Turn on \"Allow remote AI providers\" in Settings → AI."
+msgstr "Ez a szolgáltató adatokat küld ki az Ön eszközéről. Kapcsolja be a „Távoli MI-szolgáltatók engedélyezése” beállítást a Beállítások → MI menüpontban."
 
 #: packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx:65
 #: packages/app-mobile/components/NoteEditor/WarningBanner.tsx:37
-msgid ""
-"This Rich Text editor has a number of limitations and it is recommended to "
-"be aware of them before using it."
-msgstr ""
-"Ennek a formázott szöveges szerkesztőnek számos korlátozása van, és ajánlott "
-"tisztában lennie velük, mielőtt használná."
+msgid "This Rich Text editor has a number of limitations and it is recommended to be aware of them before using it."
+msgstr "Ennek a formázott szöveges szerkesztőnek számos korlátozása van, és ajánlott tisztában lennie velük, mielőtt használná."
 
 #: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:516
 msgid "This section opens in its own screen and is matched by section title."
-msgstr ""
-"Ez a szakasz a képernyőjén nyílik meg, és a szakasz címe alapján van "
-"párosítva."
+msgstr "Ez a szakasz a képernyőjén nyílik meg, és a szakasz címe alapján van párosítva."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:144
-msgid ""
-"This service allows the browser extension to communicate with Joplin. When "
-"enabling it your firewall may ask you to give permission to Joplin to listen "
-"to a particular port."
-msgstr ""
-"Ez a szolgáltatás lehetővé teszi, hogy a böngészőbővítmény kommunikáljon a "
-"Joplinnal. Engedélyezéskor a tűzfal megkérheti, hogy engedélyezze a "
-"Joplinnak egy adott port figyelését."
+msgid "This service allows the browser extension to communicate with Joplin. When enabling it your firewall may ask you to give permission to Joplin to listen to a particular port."
+msgstr "Ez a szolgáltatás lehetővé teszi, hogy a böngészőbővítmény kommunikáljon a Joplinnal. Engedélyezéskor a tűzfal megkérheti, hogy engedélyezze a Joplinnak egy adott port figyelését."
 
 #: packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts:11
 msgid "This subfolder of the trash has no notes."
@@ -8299,14 +7447,8 @@ msgid "This whiteboard could not be loaded"
 msgstr "Ezt a tervezőtáblát nem sikerült betölteni"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1536
-msgid ""
-"This will allow Joplin to run in the background. It is recommended to enable "
-"this setting so that your notes are constantly being synchronised, thus "
-"reducing the number of conflicts."
-msgstr ""
-"Ez lehetővé teszi, hogy a Joplin a háttérben fusson. Ajánlott engedélyezni "
-"ezt a beállítást, hogy a jegyzetek folyamatosan szinkronizálódjanak, így "
-"csökkentve a konfliktusok számát."
+msgid "This will allow Joplin to run in the background. It is recommended to enable this setting so that your notes are constantly being synchronised, thus reducing the number of conflicts."
+msgstr "Ez lehetővé teszi, hogy a Joplin a háttérben fusson. Ajánlott engedélyezni ezt a beállítást, hogy a jegyzetek folyamatosan szinkronizálódjanak, így csökkentve a konfliktusok számát."
 
 #: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:182
 msgid "This will open a new screen. Save your current changes?"
@@ -8319,12 +7461,8 @@ msgstr "Ez véglegesen törli az összes elemet a kukából. Folytatja?"
 
 #: packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx:60
 #: packages/lib/commands/leaveSharedFolder.ts:22
-msgid ""
-"This will remove the notebook from your collection and you will no longer "
-"have access to its content. Do you wish to continue?"
-msgstr ""
-"Ezzel eltávolítja a jegyzetfüzetet a gyűjteményéből, és többé nem férhet "
-"hozzá a tartalmához. Folytatja?"
+msgid "This will remove the notebook from your collection and you will no longer have access to its content. Do you wish to continue?"
+msgstr "Ezzel eltávolítja a jegyzetfüzetet a gyűjteményéből, és többé nem férhet hozzá a tartalmához. Folytatja?"
 
 #: packages/lib/models/settings/builtInMetadata.ts:555
 msgid "Time format"
@@ -8351,39 +7489,25 @@ msgid "Title (Z-A)"
 msgstr "Cím (Z-A)"
 
 #: packages/server/src/routes/index/recovery_codes.ts:29
-msgid ""
-"To access your recovery codes please enter an authentication code or your "
-"password."
-msgstr ""
-"Helyreállítási kódok eléréséhez adja meg a hitelesítési kódot vagy a "
-"jelszavát."
+msgid "To access your recovery codes please enter an authentication code or your password."
+msgstr "Helyreállítási kódok eléréséhez adja meg a hitelesítési kódot vagy a jelszavát."
 
 #: packages/app-cli/app/command-sync.ts:79
 #: packages/app-desktop/gui/DropboxLoginScreen.tsx:52
 #: packages/app-mobile/components/screens/dropbox-login.tsx:76
-msgid ""
-"To allow Joplin to synchronise with Dropbox, please follow the steps below:"
-msgstr ""
-"Ahhoz, hogy a Joplin szinkronizálódhasson a Dropboxszal, kövesse az alábbi "
-"lépéseket:"
+msgid "To allow Joplin to synchronise with Dropbox, please follow the steps below:"
+msgstr "Ahhoz, hogy a Joplin szinkronizálódhasson a Dropboxszal, kövesse az alábbi lépéseket:"
 
 #: packages/app-cli/app/command-sync.ts:108
 #: packages/app-desktop/gui/JoplinCloudLoginScreen.tsx:87
 #: packages/app-mobile/components/screens/JoplinCloudLoginScreen.tsx:154
-msgid ""
-"To allow Joplin to synchronise with Joplin Cloud, please login using this "
-"URL:"
-msgstr ""
-"Ahhoz, hogy a Joplin szinkronizálódhasson a Joplin Clouddal, Jelentkezzen be "
-"ezen a webcímen:"
+msgid "To allow Joplin to synchronise with Joplin Cloud, please login using this URL:"
+msgstr "Ahhoz, hogy a Joplin szinkronizálódhasson a Joplin Clouddal, Jelentkezzen be ezen a webcímen:"
 
 #: packages/app-desktop/gui/SsoLoginScreen/SsoLoginScreen.tsx:36
 #: packages/app-mobile/components/screens/SsoLoginScreen.tsx:64
-msgid ""
-"To allow Joplin to synchronise with your account, please follow these steps:"
-msgstr ""
-"Ahhoz, hogy a Joplin szinkronizálódhasson a fiókjával, kövesse az alábbi "
-"lépéseket:"
+msgid "To allow Joplin to synchronise with your account, please follow these steps:"
+msgstr "Ahhoz, hogy a Joplin szinkronizálódhasson a fiókjával, kövesse az alábbi lépéseket:"
 
 #: packages/lib/components/EncryptionConfigScreen/utils.ts:55
 msgid "To continue, please enter your master password below."
@@ -8391,9 +7515,7 @@ msgstr "A folytatáshoz adja meg a mesterjelszót alább."
 
 #: packages/app-mobile/components/ComboBox.tsx:580
 msgid "To create a new tag, type the name and press enter."
-msgstr ""
-"Új címke létrehozásához írja be a címke nevét, majd nyomja meg az enter "
-"billentyűt."
+msgstr "Új címke létrehozásához írja be a címke nevét, majd nyomja meg az enter billentyűt."
 
 #: packages/app-cli/app/app-gui.ts:497
 msgid "To delete a tag, untag the associated notes."
@@ -8412,12 +7534,8 @@ msgid "To exit command line mode, press ESCAPE"
 msgstr "Parancssori módból való kilépéshez nyomja meg az „ESC” billentyűt"
 
 #: packages/app-desktop/gui/NoteList/utils/canManuallySortNotes.ts:10
-msgid ""
-"To manually sort the notes, the sort order must be changed to \"%s\" in the "
-"menu \"%s\" > \"%s\""
-msgstr ""
-"Jegyzetek kézi rendezéséhez a(z) „%s” > „%s” menüben a rendezési sorrendet a "
-"következőre kell módosítania:„%s”"
+msgid "To manually sort the notes, the sort order must be changed to \"%s\" in the menu \"%s\" > \"%s\""
+msgstr "Jegyzetek kézi rendezéséhez a(z) „%s” > „%s” menüben a rendezési sorrendet a következőre kell módosítania:„%s”"
 
 #: packages/app-cli/app/command-help.ts:81
 msgid "To maximise/minimise the console, press \"tc\"."
@@ -8425,29 +7543,19 @@ msgstr "Konzol maximalizálásához/minimalizálásához nyomja meg a „tc” g
 
 #: packages/app-cli/app/command-help.ts:79
 msgid "To move from one pane to another, press Tab or Shift+Tab."
-msgstr ""
-"Egyik ablaktábláról a másikra való áttéréshez nyomja le a Tab vagy a "
-"Shift+Tab billentyűkombinációt."
+msgstr "Egyik ablaktábláról a másikra való áttéréshez nyomja le a Tab vagy a Shift+Tab billentyűkombinációt."
 
 #: packages/app-cli/app/command-status.ts:44
-msgid ""
-"To retry decryption of these items. Run `e2ee decrypt --retry-failed-items`"
-msgstr ""
-"Ezeknek az elemeknek a visszafejtését újra meg kell próbálni. Futtassa az "
-"`e2ee decrypt --retry-failed-items` parancsot"
+msgid "To retry decryption of these items. Run `e2ee decrypt --retry-failed-items`"
+msgstr "Ezeknek az elemeknek a visszafejtését újra meg kell próbálni. Futtassa az `e2ee decrypt --retry-failed-items` parancsot"
 
 #: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:72
 msgid "To switch the profile, the app is going to restart."
 msgstr "Profilváltáshoz az alkalmazás újra fog indulni."
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:628
-msgid ""
-"To work correctly, the app needs the following permissions. Please enable "
-"them in your phone settings, in Apps > Joplin > Permissions"
-msgstr ""
-"A megfelelő működéshez az alkalmazásnak a következő engedélyekre van "
-"szüksége. Engedélyezze ezeket a telefon beállításaiban, az Alkalmazások > "
-"Joplin > Engedélyek menüpontban"
+msgid "To work correctly, the app needs the following permissions. Please enable them in your phone settings, in Apps > Joplin > Permissions"
+msgstr "A megfelelő működéshez az alkalmazásnak a következő engedélyekre van szüksége. Engedélyezze ezeket a telefon beállításaiban, az Alkalmazások > Joplin > Engedélyek menüpontban"
 
 #: packages/app-desktop/gui/NoteListControls/NoteListControls.tsx:123
 #: packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx:71
@@ -8551,13 +7659,8 @@ msgid "Tools"
 msgstr "Eszközök"
 
 #: packages/lib/models/Setting.ts:1393
-msgid ""
-"Tools and services to expose to AI. AI agents can use these tools either via "
-"the note chat panel or Joplin's MCP server (if enabled)."
-msgstr ""
-"Az MI számára elérhetővé tehető eszközök és szolgáltatások. Az MI-ügynökök "
-"használhatják ezeket az eszközöket a jegyzet-csevegőpanelen vagy a Joplin "
-"MCP-kiszolgálóján keresztül (ha engedélyezve van)."
+msgid "Tools and services to expose to AI. AI agents can use these tools either via the note chat panel or Joplin's MCP server (if enabled)."
+msgstr "Az MI számára elérhetővé tehető eszközök és szolgáltatások. Az MI-ügynökök használhatják ezeket az eszközöket a jegyzet-csevegőpanelen vagy a Joplin MCP-kiszolgálóján keresztül (ha engedélyezve van)."
 
 #: packages/server/src/routes/admin/users.ts:167
 msgid "Total Size"
@@ -8581,28 +7684,16 @@ msgid "TYPE"
 msgstr "TÍPUS"
 
 #: packages/app-cli/app/command-help.ts:71
-msgid ""
-"Type `help [command]` for more information about a command; or type `help "
-"all` for the complete usage information."
-msgstr ""
-"A paranccsal kapcsolatos további tudnivalókért írja be a `help [command]` "
-"parancsot; vagy a teljes használati információért írja be a `help all` "
-"parancsot."
+msgid "Type `help [command]` for more information about a command; or type `help all` for the complete usage information."
+msgstr "A paranccsal kapcsolatos további tudnivalókért írja be a `help [command]` parancsot; vagy a teljes használati információért írja be a `help all` parancsot."
 
 #: packages/app-cli/app/main.js:105
 msgid "Type `joplin help` for usage information."
-msgstr ""
-"A használati útmutató megtekintéséhez írja be a `joplin help` parancsot."
+msgstr "A használati útmutató megtekintéséhez írja be a `joplin help` parancsot."
 
 #: packages/app-desktop/plugins/GotoAnything.tsx:723
-msgid ""
-"Type a note title or part of its content to jump to it. Or type # followed "
-"by a tag name, or @ followed by a notebook name. Or type : to search for "
-"commands."
-msgstr ""
-"A jegyzet címének vagy tartalmának egy részének beírásával ugorhat a "
-"jegyzetre. Vagy írja be a „#” a címke neve után, vagy a „@” a jegyzetfüzet "
-"neve után. Vagy írja be a „:” billentyűt a parancsok kereséséhez."
+msgid "Type a note title or part of its content to jump to it. Or type # followed by a tag name, or @ followed by a notebook name. Or type : to search for commands."
+msgstr "A jegyzet címének vagy tartalmának egy részének beírásával ugorhat a jegyzetre. Vagy írja be a „#” a címke neve után, vagy a „@” a jegyzetfüzet neve után. Vagy írja be a „:” billentyűt a parancsok kereséséhez."
 
 #: packages/app-desktop/plugins/GotoAnything.tsx:721
 msgid "Type a note title to search for it."
@@ -8652,13 +7743,8 @@ msgid "Undo"
 msgstr "Visszavonás"
 
 #: packages/lib/models/settings/settingValidations.ts:32
-msgid ""
-"Uninstall and reinstall the application. Make sure you create a backup first "
-"by exporting all your notes as JEX from the desktop application."
-msgstr ""
-"Távolítsa el és telepítse újra az alkalmazást. Győződjön meg arról, hogy "
-"készített-e biztonsági mentést az összes jegyzet JEX-fájlként történő "
-"exportálásával az asztali alkalmazásból."
+msgid "Uninstall and reinstall the application. Make sure you create a backup first by exporting all your notes as JEX from the desktop application."
+msgstr "Távolítsa el és telepítse újra az alkalmazást. Győződjön meg arról, hogy készített-e biztonsági mentést az összes jegyzet JEX-fájlként történő exportálásával az asztali alkalmazásból."
 
 #: packages/app-mobile/utils/getVersionInfoText.ts:13
 #: packages/app-mobile/utils/getVersionInfoText.ts:14
@@ -8674,10 +7760,8 @@ msgid "Unknown flag: %s"
 msgstr "Ismeretlen jelző: %s"
 
 #: packages/lib/Synchronizer.ts:1229
-msgid ""
-"Unknown item type downloaded - please upgrade Joplin to the latest version"
-msgstr ""
-"Ismeretlen elemtípus lett letöltve – frissítse a Joplint a legújabb verzióra"
+msgid "Unknown item type downloaded - please upgrade Joplin to the latest version"
+msgstr "Ismeretlen elemtípus lett letöltve – frissítse a Joplint a legújabb verzióra"
 
 #: packages/app-mobile/utils/getVersionInfoText.ts:28
 msgid "Unknown platform"
@@ -8718,29 +7802,19 @@ msgstr "Jegyzetfüzet közzétételének visszavonása"
 
 #: packages/app-cli/app/command-unpublish.ts:24
 msgid "Unpublishes a note from Joplin Server or Joplin Cloud"
-msgstr ""
-"Visszavonja egy jegyzet közzétételét a Joplin Serverről vagy a Joplin "
-"Cloudról"
+msgstr "Visszavonja egy jegyzet közzétételét a Joplin Serverről vagy a Joplin Cloudról"
 
 #: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:431
 msgid "Unshare"
 msgstr "Megosztás visszavonása"
 
 #: packages/app-cli/app/command-share.ts:244
-msgid ""
-"Unshare notebook \"%s\"? This may cause other users to lose access to the "
-"notebook."
-msgstr ""
-"Megszünteti a(z) „%s” nevű jegyzetfüzet megosztását? Ez azt eredményezheti, "
-"hogy más felhasználók elveszítik a jegyzetfüzethez való hozzáférést."
+msgid "Unshare notebook \"%s\"? This may cause other users to lose access to the notebook."
+msgstr "Megszünteti a(z) „%s” nevű jegyzetfüzet megosztását? Ez azt eredményezheti, hogy más felhasználók elveszítik a jegyzetfüzethez való hozzáférést."
 
 #: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:418
-msgid ""
-"Unshare this notebook? The recipients will no longer have access to its "
-"content."
-msgstr ""
-"Visszavonja a jegyzetfüzet megosztását? A címzettek többé nem férnek hozzá a "
-"tartalmához."
+msgid "Unshare this notebook? The recipients will no longer have access to its content."
+msgstr "Visszavonja a jegyzetfüzet megosztását? A címzettek többé nem férnek hozzá a tartalmához."
 
 #: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx:79
 msgid "Unsupported file extension. Expected: %s"
@@ -8764,12 +7838,8 @@ msgstr ""
 "Hiba: %s"
 
 #: packages/lib/services/e2ee/ppk/ppk.ts:68
-msgid ""
-"Unsupported public key format. Please check that Joplin is updated to the "
-"latest version and try again."
-msgstr ""
-"Nem támogatott nyilvános kulcs formátum. Ellenőrizze, hogy a Joplin a "
-"legújabb verzióra van-e frissítve, majd próbálja újra."
+msgid "Unsupported public key format. Please check that Joplin is updated to the latest version and try again."
+msgstr "Nem támogatott nyilvános kulcs formátum. Ellenőrizze, hogy a Joplin a legújabb verzióra van-e frissítve, majd próbálja újra."
 
 #: packages/app-desktop/gui/ProfileEditor.tsx:54
 #: packages/app-desktop/gui/ResourceScreen.tsx:127
@@ -8893,16 +7963,11 @@ msgstr "Használat: %s"
 
 #: packages/lib/models/settings/builtInMetadata.ts:2278
 msgid "Use biometrics to secure access to the app"
-msgstr ""
-"Biometrikus adatok használata az alkalmazáshoz való hozzáférés biztosításához"
+msgstr "Biometrikus adatok használata az alkalmazáshoz való hozzáférés biztosításához"
 
 #: packages/app-cli/app/command-ls.ts:33 packages/app-cli/app/command-tag.ts:19
-msgid ""
-"Use long list format. Format is ID, NOTE_COUNT (for notebook), DATE, "
-"TODO_CHECKED (for to-dos), TITLE"
-msgstr ""
-"Használjon hosszú listaformátumot. A formátum: ID, NOTE_COUNT (jegyzetfüzet "
-"esetén), DATE, TODO_CHECKED (teendő esetén), TITLE"
+msgid "Use long list format. Format is ID, NOTE_COUNT (for notebook), DATE, TODO_CHECKED (for to-dos), TITLE"
+msgstr "Használjon hosszú listaformátumot. A formátum: ID, NOTE_COUNT (jegyzetfüzet esetén), DATE, TODO_CHECKED (teendő esetén), TITLE"
 
 #: packages/app-mobile/components/screens/Notes/Notes.tsx:113
 msgid "Use own sort order"
@@ -8913,61 +7978,36 @@ msgid "Use spell checker"
 msgstr "Helyesírás-ellenőrző használata"
 
 #: packages/app-cli/app/command-help.ts:80
-msgid ""
-"Use the arrows and page up/down to scroll the lists and text areas "
-"(including this console)."
-msgstr ""
-"A nyilakkal és a PgUp/PgDn lapozással görgetheti a listákat és a szöveges "
-"területeket (beleértve ezt a konzolt is)."
+msgid "Use the arrows and page up/down to scroll the lists and text areas (including this console)."
+msgstr "A nyilakkal és a PgUp/PgDn lapozással görgetheti a listákat és a szöveges területeket (beleértve ezt a konzolt is)."
 
 #: packages/app-desktop/gui/MainScreen.tsx:788
 msgid "Use the arrows to move the layout items. Press \"Escape\" to exit."
-msgstr ""
-"Az elrendezéshez mozgassa az elemeket a nyilak segítségével. A kilépéshez "
-"nyomja meg az „ESC” gombot."
+msgstr "Az elrendezéshez mozgassa az elemeket a nyilak segítségével. A kilépéshez nyomja meg az „ESC” gombot."
 
 #: packages/lib/models/settings/builtInMetadata.ts:2012
 msgid "Use the legacy Markdown editor"
 msgstr "Régi Markdown szerkesztő használata"
 
 #: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:581
-msgid ""
-"Use this to rebuild the search index if there is a problem with search. It "
-"may take a long time depending on the number of notes."
-msgstr ""
-"Használja ezt a keresési index újjáépítéséhez, ha probléma van a kereséssel. "
-"Ez a jegyzetek számától függően sokáig tarthat."
+msgid "Use this to rebuild the search index if there is a problem with search. It may take a long time depending on the number of notes."
+msgstr "Használja ezt a keresési index újjáépítéséhez, ha probléma van a kereséssel. Ez a jegyzetek számától függően sokáig tarthat."
 
 #: packages/app-mobile/components/biometrics/BiometricPopup.tsx:84
-msgid ""
-"Use your biometrics to secure access to your application. You can always set "
-"it up later in Settings."
-msgstr ""
-"Használja biometrikus adatait az alkalmazáshoz való hozzáférés "
-"biztosításához. Ezt később bármikor beállíthatja a beállításokban."
+msgid "Use your biometrics to secure access to your application. You can always set it up later in Settings."
+msgstr "Használja biometrikus adatait az alkalmazáshoz való hozzáférés biztosításához. Ezt később bármikor beállíthatja a beállításokban."
 
 #: packages/server/src/routes/index/recovery_codes.ts:65
 msgid "Used"
 msgstr "Használt"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1669
-msgid ""
-"Used for most text in the markdown editor. If not found, a generic "
-"proportional (variable width) font is used."
-msgstr ""
-"A Markdown szerkesztő legtöbb szövegéhez használható. Ha nem található, "
-"akkor egy általános, arányos (változó szélességű) betűtípus lesz használva."
+msgid "Used for most text in the markdown editor. If not found, a generic proportional (variable width) font is used."
+msgstr "A Markdown szerkesztő legtöbb szövegéhez használható. Ha nem található, akkor egy általános, arányos (változó szélességű) betűtípus lesz használva."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1699
-msgid ""
-"Used where a fixed width font is needed to lay out text legibly (e.g. "
-"tables, checkboxes, code). If not found, a generic monospace (fixed width) "
-"font is used."
-msgstr ""
-"Ott használatos, ahol a szöveg olvasható elrendezéséhez fix szélességű "
-"betűtípusra van szükség (például: táblázatok, jelölőnégyzetek, kódok). Ha "
-"nem található, akkor egy általános monospace (fix szélességű) betűtípus lesz "
-"használva."
+msgid "Used where a fixed width font is needed to lay out text legibly (e.g. tables, checkboxes, code). If not found, a generic monospace (fixed width) font is used."
+msgstr "Ott használatos, ahol a szöveg olvasható elrendezéséhez fix szélességű betűtípusra van szükség (például: táblázatok, jelölőnégyzetek, kódok). Ha nem található, akkor egy általános monospace (fix szélességű) betűtípus lesz használva."
 
 #: packages/server/src/services/MustacheService.ts:124
 msgid "User deletions"
@@ -8990,12 +8030,8 @@ msgid "Vector search is not available on this platform"
 msgstr "Nem érhető el ezen a platformon a vektoros keresés"
 
 #: packages/lib/services/ai/availability.ts:71
-msgid ""
-"Vector search is unavailable on this platform (sqlite-vec extension not "
-"loaded)."
-msgstr ""
-"Nem érhető el ezen a platformon a vektoros keresés (a sqlite-vec bővítmény "
-"nincs betöltve)."
+msgid "Vector search is unavailable on this platform (sqlite-vec extension not loaded)."
+msgstr "Nem érhető el ezen a platformon a vektoros keresés (a sqlite-vec bővítmény nincs betöltve)."
 
 #: packages/app-mobile/components/biometrics/biometricAuthenticate.ts:9
 msgid "Verify your identity"
@@ -9084,21 +8120,15 @@ msgstr "Figyelmeztetés:"
 
 #: packages/app-desktop/gui/ResourceScreen.tsx:319
 msgid "Warning: not all resources shown for performance reasons (limit: %s)."
-msgstr ""
-"Figyelmeztetés: a teljesítmény miatt nem minden erőforrás jelenik meg "
-"(korlát: %s)."
+msgstr "Figyelmeztetés: a teljesítmény miatt nem minden erőforrás jelenik meg (korlát: %s)."
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:116
 msgid "We have a system for reporting and removing problematic plugins."
 msgstr "Van rendszerünk a problémás bővítmények jelentésére és eltávolítására."
 
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:114
-msgid ""
-"We mark plugins developed by trusted Joplin community members as "
-"\"recommended\"."
-msgstr ""
-"A Joplin közösség megbízható tagjai által fejlesztett bővítményeket "
-"„ajánlottként” jelöljük."
+msgid "We mark plugins developed by trusted Joplin community members as \"recommended\"."
+msgstr "A Joplin közösség megbízható tagjai által fejlesztett bővítményeket „ajánlottként” jelöljük."
 
 #: packages/lib/models/Setting.ts:1368
 msgid "Web Clipper"
@@ -9137,18 +8167,15 @@ msgstr "WebView verziója: %s"
 msgid ""
 "Welcome to Joplin!\n"
 "\n"
-"Type `:help shortcuts` for the list of keyboard shortcuts, or just `:help` "
-"for usage information.\n"
+"Type `:help shortcuts` for the list of keyboard shortcuts, or just `:help` for usage information.\n"
 "\n"
 "For example, to create a notebook press `mb`; to create a note press `mn`."
 msgstr ""
 "Üdvözöljük a Joplinban!\n"
 "\n"
-"A billentyűparancsok listázásához írja be a `:help shortcuts` parancsot, "
-"vagy csak a `:help` parancsot a súgó megjelenítéséhez.\n"
+"A billentyűparancsok listázásához írja be a `:help shortcuts` parancsot, vagy csak a `:help` parancsot a súgó megjelenítéséhez.\n"
 "\n"
-"Például egy jegyzetfüzet létrehozásához írja be az `mb` parancsot; egy "
-"jegyzet létrehozásához pedig írja be az `mn` parancsot."
+"Például egy jegyzetfüzet létrehozásához írja be az `mb` parancsot; egy jegyzet létrehozásához pedig írja be az `mn` parancsot."
 
 #: packages/lib/WelcomeUtils.ts:81
 msgid "Welcome!"
@@ -9160,47 +8187,27 @@ msgstr "Mik azok a bővítmények?"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1357
 msgid "When creating a new note:"
-msgstr "Új jegyzet létrehozásakor:"
+msgstr "Új jegyzet létrehozásakor"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1340
 msgid "When creating a new to-do:"
-msgstr "Új teendő létrehozásakor:"
+msgstr "Új teendő létrehozásakor"
 
 #: packages/lib/models/settings/builtInMetadata.ts:652
-msgid ""
-"When enabled, plugins and built-in features can use AI models to generate or "
-"analyse text."
-msgstr ""
-"Ha engedélyezve van, a bővítmények és a beépített funkciók MI-modelleket "
-"használhatnak szöveg előállítására vagy elemzésére."
+msgid "When enabled, plugins and built-in features can use AI models to generate or analyse text."
+msgstr "Ha engedélyezve van, a bővítmények és a beépített funkciók MI-modelleket használhatnak szöveg előállítására vagy elemzésére."
 
 #: packages/app-mobile/components/screens/DocumentScanner/NotePreview.tsx:167
-msgid ""
-"When enabled, requests that the images in the note be transcribed with a "
-"higher-quality on-server transcription service. Requires sync with a copy of "
-"the desktop app."
-msgstr ""
-"Ha engedélyezve van, akkor a jegyzetben lévő képek átírása egy jobb "
-"minőségű, kiszolgálóoldali átírási szolgáltatással történik. Ehhez "
-"szinkronizáció szükséges az asztali alkalmazással."
+msgid "When enabled, requests that the images in the note be transcribed with a higher-quality on-server transcription service. Requires sync with a copy of the desktop app."
+msgstr "Ha engedélyezve van, akkor a jegyzetben lévő képek átírása egy jobb minőségű, kiszolgálóoldali átírási szolgáltatással történik. Ehhez szinkronizáció szükséges az asztali alkalmazással."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1948
-msgid ""
-"When enabled, tables are rendered as an interactive widget in the editor. "
-"Disable this if you prefer to edit tables as raw Markdown."
-msgstr ""
-"Ha engedélyezve van, a táblázatok interaktív vezérlőelemként jelennek meg a "
-"szerkesztőben. Tiltsa le, ha a táblázatokat inkább nyers Markdownként "
-"szeretné szerkeszteni."
+msgid "When enabled, tables are rendered as an interactive widget in the editor. Disable this if you prefer to edit tables as raw Markdown."
+msgstr "Ha engedélyezve van, a táblázatok interaktív vezérlőelemként jelennek meg a szerkesztőben. Tiltsa le, ha a táblázatokat inkább nyers Markdownként szeretné szerkeszteni."
 
 #: packages/lib/models/settings/builtInMetadata.ts:574
-msgid ""
-"When enabled, the application will scan your attachments and extract the "
-"text from it. This will allow you to search for text in these attachments."
-msgstr ""
-"Ha engedélyezve van, az alkalmazás beolvassa a mellékleteket, és kivonatolja "
-"belőlük a szöveget. Ez lehetővé teszi a szöveg keresését ezekben a "
-"mellékletekben."
+msgid "When enabled, the application will scan your attachments and extract the text from it. This will allow you to search for text in these attachments."
+msgstr "Ha engedélyezve van, az alkalmazás beolvassa a mellékleteket, és kivonatolja belőlük a szöveget. Ez lehetővé teszi a szöveg keresését ezekben a mellékletekben."
 
 #: packages/app-desktop/ElectronAppWrapper.ts:320
 msgid "Window unresponsive."
@@ -9235,18 +8242,12 @@ msgstr "Igen"
 
 #: packages/app-mobile/components/screens/Note/Note.tsx:912
 #: packages/lib/shim-init-node.ts:291
-msgid ""
-"You are about to attach a large image (%dx%d pixels). Would you like to "
-"resize it down to %d pixels before attaching it?"
-msgstr ""
-"Nagy méretű képet (%dx%d pixel) készül mellékelni. Szeretné átméretezni a "
-"képet %d pixelre, mielőtt mellékelné?"
+msgid "You are about to attach a large image (%dx%d pixels). Would you like to resize it down to %d pixels before attaching it?"
+msgstr "Nagy méretű képet (%dx%d pixel) készül mellékelni. Szeretné átméretezni a képet %d pixelre, mielőtt mellékelné?"
 
 #: packages/lib/services/joplinCloudUtils.ts:47
 msgid "You are logged in into Joplin Cloud, you can leave this screen now."
-msgstr ""
-"Sikeresen bejelentkezett a Joplin Cloudba, most már elhagyhatja ezt a "
-"képernyőt."
+msgstr "Sikeresen bejelentkezett a Joplin Cloudba, most már elhagyhatja ezt a képernyőt."
 
 #: packages/app-desktop/gui/SsoLoginScreen/SsoLoginScreen.tsx:24
 #: packages/app-mobile/components/screens/SsoLoginScreen.tsx:48
@@ -9258,23 +8259,12 @@ msgid "You are now using the latest version of the Markdown editor."
 msgstr "Ön most a Markdown szerkesztő legújabb verzióját használja."
 
 #: packages/app-desktop/gui/MainScreen.tsx:668
-msgid ""
-"You are running the Intel version of Joplin on an Apple Silicon processor. "
-"Download the Apple Silicon one for better performance."
-msgstr ""
-"A Joplin egy Intel processzorokra optimalizált verzióját futtatja Apple "
-"Silicon processzoron. Töltse le az Apple Silicon processzorokra optimalizált "
-"változatot a jobb teljesítmény érdekében."
+msgid "You are running the Intel version of Joplin on an Apple Silicon processor. Download the Apple Silicon one for better performance."
+msgstr "A Joplin egy Intel processzorokra optimalizált verzióját futtatja Apple Silicon processzoron. Töltse le az Apple Silicon processzorokra optimalizált változatot a jobb teljesítmény érdekében."
 
 #: packages/app-mobile/components/SyncWizard/SyncWizard.tsx:137
-msgid ""
-"You can synchronise your notes using Joplin Cloud, which also gives access "
-"to Joplin-specific features such as publishing notes or collaborating on "
-"notebooks with others."
-msgstr ""
-"A saját jegyzeteit a Joplin Cloud segítségével szinkronizálhatja, amely "
-"hozzáférést biztosít a Joplin-specifikus funkciókhoz is, mint például "
-"jegyzetek közzététele vagy a jegyzetfüzetekben való közös munka másokkal."
+msgid "You can synchronise your notes using Joplin Cloud, which also gives access to Joplin-specific features such as publishing notes or collaborating on notebooks with others."
+msgstr "A saját jegyzeteit a Joplin Cloud segítségével szinkronizálhatja, amely hozzáférést biztosít a Joplin-specifikus funkciókhoz is, mint például jegyzetek közzététele vagy a jegyzetfüzetekben való közös munka másokkal."
 
 #: packages/app-mobile/components/NoteList.tsx:98
 msgid "You currently have no notebooks."
@@ -9293,28 +8283,16 @@ msgid "You may also type `status` for more information."
 msgstr "További adatokért beírhatja a `status` (állapot) parancsot is."
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:545
-msgid ""
-"You may use the tool below to re-encrypt your data, for example if you know "
-"that some of your notes are encrypted with an obsolete encryption method."
-msgstr ""
-"Az alábbi eszközzel újratitkosíthatja adatait, például ha tudja, hogy néhány "
-"jegyzete elavult titkosítási módszerrel van titkosítva."
+msgid "You may use the tool below to re-encrypt your data, for example if you know that some of your notes are encrypted with an obsolete encryption method."
+msgstr "Az alábbi eszközzel újratitkosíthatja adatait, például ha tudja, hogy néhány jegyzete elavult titkosítási módszerrel van titkosítva."
 
 #: packages/app-desktop/gui/ChatPanel/ChatPanel.tsx:266
-msgid ""
-"You switched notes while the request was running; edits were not applied. "
-"Try again."
-msgstr ""
-"Jegyzetet váltott a kérés futása közben; a módosítások nem lettek "
-"alkalmazva. Próbálja újra."
+msgid "You switched notes while the request was running; edits were not applied. Try again."
+msgstr "Jegyzetet váltott a kérés futása közben; a módosítások nem lettek alkalmazva. Próbálja újra."
 
 #: packages/lib/services/joplinCloudUtils.ts:55
-msgid ""
-"You were unable to connect to Joplin Cloud. Please check your credentials "
-"and try again. Error:"
-msgstr ""
-"Nem lehetett kapcsolódni a Joplin Cloudhoz. Ellenőrizze a "
-"hitelesítőadatokat, és próbálja újra. Hiba:"
+msgid "You were unable to connect to Joplin Cloud. Please check your credentials and try again. Error:"
+msgstr "Nem lehetett kapcsolódni a Joplin Cloudhoz. Ellenőrizze a hitelesítőadatokat, és próbálja újra. Hiba:"
 
 #: packages/app-desktop/gui/JoplinCloudConfigScreen.tsx:55
 #: packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.tsx:70
@@ -9335,16 +8313,8 @@ msgid "Your Joplin Cloud credentials are invalid, please login."
 msgstr "A Joplin Cloud hitelesítő adatai érvénytelenek, jelentkezzen be."
 
 #: packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx:228
-msgid ""
-"Your master password is used to protect sensitive information. In "
-"particular, it is used to encrypt your notes when end-to-end encryption "
-"(E2EE) is enabled, or to share and encrypt notes with someone who has E2EE "
-"enabled."
-msgstr ""
-"A mesterjelszó az érzékeny adatok védelmére szolgál. Különösen a saját "
-"jegyzeteinek titkosítására használatos, ha a végpontok közötti titkosítás "
-"(E2EE) engedélyezve van, vagy jegyzet megosztására és titkosítására "
-"valakivel, akinél engedélyezve van az E2EE."
+msgid "Your master password is used to protect sensitive information. In particular, it is used to encrypt your notes when end-to-end encryption (E2EE) is enabled, or to share and encrypt notes with someone who has E2EE enabled."
+msgstr "A mesterjelszó az érzékeny adatok védelmére szolgál. Különösen a saját jegyzeteinek titkosítására használatos, ha a végpontok közötti titkosítás (E2EE) engedélyezve van, vagy jegyzet megosztására és titkosítására valakivel, akinél engedélyezve van az E2EE."
 
 #: packages/app-desktop/gui/ChatPanel/ChatPanel.tsx:379
 msgid "Your note will be sent to the configured AI provider (%s)."
@@ -9355,12 +8325,8 @@ msgid "Your password is needed to decrypt some of your data."
 msgstr "Jelszó szükséges az adatok visszafejtéséhez."
 
 #: packages/app-cli/app/command-sync.ts:257
-msgid ""
-"Your password is needed to decrypt some of your data. Type `:e2ee decrypt` "
-"to set it."
-msgstr ""
-"A jelszóra az adatok egy részének visszafejtéséhez van szükség. A "
-"beállításához írja be az `:e2ee decrypt` parancsot."
+msgid "Your password is needed to decrypt some of your data. Type `:e2ee decrypt` to set it."
+msgstr "A jelszóra az adatok egy részének visszafejtéséhez van szükség. A beállításához írja be az `:e2ee decrypt` parancsot."
 
 #: packages/app-desktop/checkForUpdates.ts:115
 msgid "Your version: %s"
@@ -9376,13 +8342,10 @@ msgid "Zoom Out"
 msgstr "Kicsinyítés"
 
 #~ msgid ""
-#~ "An error occurred while sending the response. This can happen if the app "
-#~ "is offline or cannot connect to the server.\n"
+#~ "An error occurred while sending the response. This can happen if the app is offline or cannot connect to the server.\n"
 #~ "Error: %s"
 #~ msgstr ""
-#~ "Hiba történt a válasz elküldésekor. Ez akkor fordulhat elő, ha az "
-#~ "alkalmazás offline állapotban van, vagy nem tud csatlakozni a "
-#~ "kiszolgálóhoz.\n"
+#~ "Hiba történt a válasz elküldésekor. Ez akkor fordulhat elő, ha az alkalmazás offline állapotban van, vagy nem tud csatlakozni a kiszolgálóhoz.\n"
 #~ "Hiba: %s"
 
 #~ msgid "Do you find the Joplin web app useful?"
@@ -9417,13 +8380,11 @@ msgstr "Kicsinyítés"
 #~ msgstr "Kód:"
 
 #~ msgid ""
-#~ "In order to associate a geo-location with the note, the app needs your "
-#~ "permission to access your location.\n"
+#~ "In order to associate a geo-location with the note, the app needs your permission to access your location.\n"
 #~ "\n"
 #~ "You may turn off this option at any time in the Configuration screen."
 #~ msgstr ""
-#~ "Ahhoz, hogy a jegyzethez földrajzi helyet társíthasson, engedélyt kell "
-#~ "adnia az alkalmazásnak a helyadatokhoz való hozzáféréshez.\n"
+#~ "Ahhoz, hogy a jegyzethez földrajzi helyet társíthasson, engedélyt kell adnia az alkalmazásnak a helyadatokhoz való hozzáféréshez.\n"
 #~ "\n"
 #~ "Ezt az engedélyt bármikor kikapcsolhatja a „Beállítások” menüben."
 
@@ -9499,19 +8460,11 @@ msgstr "Kicsinyítés"
 #~ msgid "Type new tags or select from list"
 #~ msgstr "Írjon be új címkéket vagy válasszon a listából"
 
-#~ msgid ""
-#~ "The [Web Clipper](%s) is a browser extension that allows you to save web "
-#~ "pages and screenshots from your browser."
-#~ msgstr ""
-#~ "A [Web Clipper](%s) egy böngészőbővítmény, amely lehetővé teszi "
-#~ "weboldalak és képernyőképek mentését a böngészőből."
+#~ msgid "The [Web Clipper](%s) is a browser extension that allows you to save web pages and screenshots from your browser."
+#~ msgstr "A [Web Clipper](%s) egy böngészőbővítmény, amely lehetővé teszi weboldalak és képernyőképek mentését a böngészőből."
 
-#~ msgid ""
-#~ "The application did not close properly. Would you like to start in safe "
-#~ "mode?"
-#~ msgstr ""
-#~ "Az alkalmazás nem zárult be megfelelően. Szeretné biztonságos módban "
-#~ "elindítani?"
+#~ msgid "The application did not close properly. Would you like to start in safe mode?"
+#~ msgstr "Az alkalmazás nem zárult be megfelelően. Szeretné biztonságos módban elindítani?"
 
 #~ msgid "%d hours"
 #~ msgstr "%d óránként"
@@ -9598,12 +8551,8 @@ msgstr "Kicsinyítés"
 #~ msgid "Database v%s"
 #~ msgstr "Adatbázis v%s"
 
-#~ msgid ""
-#~ "There is currently no notebook. Create one by clicking on \"New "
-#~ "notebook\"."
-#~ msgstr ""
-#~ "Jelenleg nincs jegyzetfüzete. Hozzon létre egyet kattintva az \"Új "
-#~ "jegyzetfüzet\"-re."
+#~ msgid "There is currently no notebook. Create one by clicking on \"New notebook\"."
+#~ msgstr "Jelenleg nincs jegyzetfüzete. Hozzon létre egyet kattintva az \"Új jegyzetfüzet\"-re."
 
 #, fuzzy
 #~ msgid ""
@@ -9612,12 +8561,8 @@ msgstr "Kicsinyítés"
 #~ msgstr "Figyelmeztetés"
 
 #, fuzzy
-#~ msgid ""
-#~ "To allow Joplin to synchronise with Joplin Cloud, open this URL in your "
-#~ "browser to authorise the application:"
-#~ msgstr ""
-#~ "1. lépés: Nyissa meg ezt az URL-t a böngészőben, hogy hitelesítse az "
-#~ "alkalmazást:"
+#~ msgid "To allow Joplin to synchronise with Joplin Cloud, open this URL in your browser to authorise the application:"
+#~ msgstr "1. lépés: Nyissa meg ezt az URL-t a böngészőben, hogy hitelesítse az alkalmazást:"
 
 #~ msgid "Delete note?"
 #~ msgstr "Jegyzet törlése?"
@@ -9696,26 +8641,11 @@ msgstr "Kicsinyítés"
 #~ msgid "Master keys that need upgrading"
 #~ msgstr "Mester kulcsok amiket frissíteni kell"
 
-#~ msgid ""
-#~ "The following master keys use an out-dated encryption algorithm and it is "
-#~ "recommended to upgrade them. The upgraded master key will still be able "
-#~ "to decrypt and encrypt your data as usual."
-#~ msgstr ""
-#~ "A következő mester kulcsok elavult titkosítási algoritmust használnak és "
-#~ "javasolt frissíteni őket. A frissített mester kulcs továbbra is képes "
-#~ "lesz dekódolni és titkosítani az adatait."
+#~ msgid "The following master keys use an out-dated encryption algorithm and it is recommended to upgrade them. The upgraded master key will still be able to decrypt and encrypt your data as usual."
+#~ msgstr "A következő mester kulcsok elavult titkosítási algoritmust használnak és javasolt frissíteni őket. A frissített mester kulcs továbbra is képes lesz dekódolni és titkosítani az adatait."
 
-#~ msgid ""
-#~ "Enabling encryption means *all* your notes and attachments are going to "
-#~ "be re-synchronised and sent encrypted to the sync target. Do not lose the "
-#~ "password as, for security purposes, this will be the *only* way to "
-#~ "decrypt the data! To enable encryption, please enter your password below."
-#~ msgstr ""
-#~ "Titkosítás engedélyezése azt jelenti, az *összes* jegyzete és "
-#~ "csatolmányai együtt, újra lesznek szinkronizálva és titkosítva utaznak a "
-#~ "cél eszközre. Őrizze meg a jelszót, mivel biztonsági okok miatt ez az "
-#~ "*egyetlen* mód az adatai dekódolására! A titkosítás engedélyezéséhez, "
-#~ "kérem adja meg a jelszót lent."
+#~ msgid "Enabling encryption means *all* your notes and attachments are going to be re-synchronised and sent encrypted to the sync target. Do not lose the password as, for security purposes, this will be the *only* way to decrypt the data! To enable encryption, please enter your password below."
+#~ msgstr "Titkosítás engedélyezése azt jelenti, az *összes* jegyzete és csatolmányai együtt, újra lesznek szinkronizálva és titkosítva utaznak a cél eszközre. Őrizze meg a jelszót, mivel biztonsági okok miatt ez az *egyetlen* mód az adatai dekódolására! A titkosítás engedélyezéséhez, kérem adja meg a jelszót lent."
 
 #~ msgid "Master Keys"
 #~ msgstr "Mester Kulcsok"
@@ -9723,15 +8653,8 @@ msgstr "Kicsinyítés"
 #~ msgid "Password OK"
 #~ msgstr "Jelszó OK"
 
-#~ msgid ""
-#~ "Note: Only one master key is going to be used for encryption (the one "
-#~ "marked as \"active\"). Any of the keys might be used for decryption, "
-#~ "depending on how the notes or notebooks were originally encrypted."
-#~ msgstr ""
-#~ "Megjegyzés: A titkosításhoz, csak egy mester kulcs lesz felhasználva "
-#~ "(amelyik \"aktív\"-ként van jelölve). Elvileg bármelyik kulcsa "
-#~ "felhasználható dekódolásra, függően attól, hogy jegyzetei vagy "
-#~ "jegyzetfüzetei hogyan voltak eredetileg titkosítva."
+#~ msgid "Note: Only one master key is going to be used for encryption (the one marked as \"active\"). Any of the keys might be used for decryption, depending on how the notes or notebooks were originally encrypted."
+#~ msgstr "Megjegyzés: A titkosításhoz, csak egy mester kulcs lesz felhasználva (amelyik \"aktív\"-ként van jelölve). Elvileg bármelyik kulcsa felhasználható dekódolásra, függően attól, hogy jegyzetei vagy jegyzetfüzetei hogyan voltak eredetileg titkosítva."
 
 #~ msgid "Encryption is:"
 #~ msgstr "Titkosítás:"
@@ -9774,12 +8697,8 @@ msgstr "Kicsinyítés"
 #~ msgid "Checking..."
 #~ msgstr "Ellenőrzés..."
 
-#~ msgid ""
-#~ "The Joplin Nextcloud App is either not installed or misconfigured. Please "
-#~ "see the full error message below:"
-#~ msgstr ""
-#~ "A Joplin Nextcloud App vagy nincs telepítve vagy nincs beállítva. Kérem "
-#~ "ellenőrizze a lenti teljes hibaüzenetet:"
+#~ msgid "The Joplin Nextcloud App is either not installed or misconfigured. Please see the full error message below:"
+#~ msgstr "A Joplin Nextcloud App vagy nincs telepítve vagy nincs beállítva. Kérem ellenőrizze a lenti teljes hibaüzenetet:"
 
 #~ msgid "Joplin Nextcloud App status:"
 #~ msgstr "Joplin Nextcloud App statusz:"


### PR DESCRIPTION
Fix mistakes after testing the localization in the app.

Note:
POEdit is working fine now and cleaned up the po-file correctly, because lokalize wrapped lines in to 80 chars.