### PR TITLE
Desktop: Fixes #16290: Insert HTML links in HTML notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -527,6 +527,7 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/commands/gotoAnything.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/hideModalMessage.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/index.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.test.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/lockEncryptedNotes.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/moveToFolder.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -553,6 +553,7 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/commands/gotoAnything.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/hideModalMessage.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/index.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.test.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/lockEncryptedNotes.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/moveToFolder.js

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.test.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.test.ts
@@ -1,0 +1,16 @@
+import { MarkupLanguage } from '@joplin/renderer';
+import { noteLinkMarkup } from './linkToNote';
+
+describe('linkToNote', () => {
+	test('should create a Markdown link for Markdown notes', () => {
+		expect(noteLinkMarkup('Target [note]', 'abc123', MarkupLanguage.Markdown)).toBe('[Target \\[note\\]](:/abc123)');
+	});
+
+	test('should create an HTML link for HTML notes', () => {
+		expect(noteLinkMarkup('Target note', 'abc123', MarkupLanguage.Html)).toBe('<a href=":/abc123">Target note</a>');
+	});
+
+	test('should escape HTML in note titles', () => {
+		expect(noteLinkMarkup('A <note> & "quote"', 'abc123', MarkupLanguage.Html)).toBe('<a href=":/abc123">A &lt;note&gt; &amp; &quot;quote&quot;</a>');
+	});
+});

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.ts
@@ -5,8 +5,17 @@ import { GotoAnythingOptions, UiType } from './gotoAnything';
 import { ModelType } from '@joplin/lib/BaseModel';
 import Logger from '@joplin/utils/Logger';
 import markdownUtils from '@joplin/lib/markdownUtils';
+import { stateUtils } from '@joplin/lib/reducer';
+import { escapeHtml } from '@joplin/lib/string-utils';
+import { MarkupLanguage } from '@joplin/renderer';
 
 const logger = Logger.create('linkToNote');
+
+export const noteLinkMarkup = (title: string, id: string, markupLanguage: number) => {
+	const escapedLinkUrl = markdownUtils.escapeLinkUrl(id);
+	if (markupLanguage === MarkupLanguage.Html) return `<a href=":/${escapedLinkUrl}">${escapeHtml(title)}</a>`;
+	return `[${markdownUtils.escapeTitleText(title)}](:/${escapedLinkUrl})`;
+};
 
 export const declaration: CommandDeclaration = {
 	name: 'linkToNote',
@@ -16,7 +25,7 @@ export const declaration: CommandDeclaration = {
 
 export const runtime = (): CommandRuntime => {
 	return {
-		execute: async (_context: CommandContext) => {
+		execute: async (context: CommandContext) => {
 			const options: GotoAnythingOptions = {
 				mode: Mode.TitleOnly,
 				alwaysShowHelp: true,
@@ -29,7 +38,8 @@ export const runtime = (): CommandRuntime => {
 				return null;
 			}
 
-			const link = `[${markdownUtils.escapeTitleText(result.item.title)}](:/${markdownUtils.escapeLinkUrl(result.item.id)})`;
+			const selectedNote = stateUtils.selectedNote(context.state);
+			const link = noteLinkMarkup(result.item.title, result.item.id, selectedNote?.markup_language ?? MarkupLanguage.Markdown);
 			await CommandService.instance().execute('insertText', link);
 			return result;
 		},


### PR DESCRIPTION
## AI Assistance Disclosure

I used ChatGPT (GPT-5.6 Sol) to help with codebase exploration, implementation support, testing, and verification.

I personally reviewed the final implementation and understand how it works.

Gemini 3.1 Pro was used as a read-only second reviewer, while ChatGPT was the primary assistant. Gemini did not modify the repository.

## Problem

In HTML notes, the "Link to note" command currently inserts:

`[Target note](:/note-id)`

This does not render correctly because:

HTML notes contain HTML source, so inserting Markdown link syntax there does not produce the correct link markup and may not render properly in the note viewer.

## Solution

The change now checks:

the selected note's `markup_language`

`stateUtils.selectedNote(context.state)?.markup_language`

For Markdown notes:

The existing Markdown link behavior is kept unchanged, using Markdown syntax like `[Target note](:/note-id)`.

For HTML notes:

The command generates an HTML anchor instead, for example:

`<a href=":/note-id">Target note</a>`

HTML note titles use `escapeHtml()`.

Markdown note titles continue to use `markdownUtils.escapeTitleText()`.

The note ID/link URL continues to use `markdownUtils.escapeLinkUrl()`.

The selected note's `markup_language` determines whether Markdown or HTML syntax is generated.

## Test Plan

I verified:

1. **Markdown notes still generate Markdown links correctly.**
2. **HTML notes generate HTML anchor links.**
3. **Special HTML characters in note titles are escaped correctly.**

Results:

3/3 focused tests passed

42/42 desktop suites passed

240/240 tests passed

ESLint passed

TypeScript passed

generated-file checks passed

pre-commit checks passed

I also verified the behavior in the Electron app:

I opened an HTML note, used “Link to note...” to select another note, and verified that Joplin inserted an HTML `<a>` link in the source editor and rendered it correctly as a clickable link in the viewer.

The test confirmed both the generated HTML source and the rendered clickable link.

UI demo video attached.

https://github.com/user-attachments/assets/2475e661-64ac-4e8f-8e98-47dc6d979a64
