### PR TITLE
Desktop, Mobile, Cli: Fixes #16426: Prevent silent exit with unsynced changes if sync is cancelled

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -1315,9 +1315,19 @@ export default class Synchronizer {
 		// that the user will close or minimise the app when there are un-synced changes, because the sync is reported as completed.
 		// IMPORTANT: This must be the very last step in the sync, to avoid any window to allow an un-synced change to get missed
 		if (!hasErrors && !hasCaughtError && !cancelledBeforeClearedState && !this.cancelling()) {
-			const result = await BaseItem.itemsThatNeedSync(syncTargetId, 100, () => this.cancelling());
+			const cancellingDuringFinalCheck = () => {
+				// Simulates the user cancelling while this check is still running, which the
+				// synchronous cancelling_ flag can't otherwise reproduce in a test.
+				if (this.testingHooks_.indexOf('cancelFinalOutgoingChangesCheck') >= 0) this.cancelling_ = true;
+				return this.cancelling();
+			};
+			const result = await BaseItem.itemsThatNeedSync(syncTargetId, 100, cancellingDuringFinalCheck);
 
-			if (result.items.length > 0) {
+			if (this.cancelling()) {
+				// The check was interrupted before it could confirm there's nothing left to
+				// sync, so don't report the sync as fully up to date.
+				hasOutgoingChanges = true;
+			} else if (result.items.length > 0) {
 				logger.info('There are more outgoing changes to sync, schedule the sync again');
 				void reg.scheduleSync(reg.syncAsYouTypeInterval(), { syncSteps }, true);
 				hasOutgoingChanges = true;

--- a/packages/lib/services/synchronizer/Synchronizer.basics.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.basics.test.ts
@@ -310,6 +310,21 @@ describe('Synchronizer.basics', () => {
 		expect(notes.length).toBe(1);
 	}));
 
+	it('should not report the sync as fully up to date when the final outgoing-changes check is cancelled', (async () => {
+		const folder1 = await Folder.save({ title: 'folder1' });
+		await Note.save({ title: 'un', parent_id: folder1.id });
+
+		const dispatchedActions: { type: string; value?: unknown }[] = [];
+		synchronizer().dispatch = (action: { type: string; value?: unknown }) => dispatchedActions.push(action);
+
+		synchronizer().testingHooks_ = ['cancelFinalOutgoingChangesCheck'];
+		await synchronizerStart();
+		synchronizer().testingHooks_ = [];
+
+		const syncPendingUpdates = dispatchedActions.filter(a => a.type === 'SYNC_PENDING_UPDATE');
+		expect(syncPendingUpdates.every(a => a.value !== false)).toBe(true);
+	}));
+
 	it('should skip items that cannot be synced', (async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'un', is_todo: 1, parent_id: folder1.id });


### PR DESCRIPTION
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Web` — only the web app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
## Problem

When a user cancels a sync operation during the `BaseItem.itemsThatNeedSync` check the app mistakenly believes there are no opending changes left. It clears the `syncPending` flag by dispatching `SYNC_PENDING_UPDATE: false`.

If the user then quits the application it closes without showing the warning that was expected about unsynced changes and this can lead to data loss. This behavior was introduced as an effect in commit `5ae6b7b6c` which improved cancellation handling during long finish steps but accidentally broke this safety check.

## Solution

This PR modifies the sync safety check in `packages/lib/Synchronizer.ts`. When the `itemsThatNeedSync` query is interrupted due to a cancellation (detected via `this.cancelling()` being true) the code now treats `hasOutgoingChanges` as `true` of assuming zero pending items.

This keeps the `syncPending` flag avoiding unintended rescheduling of syncs right after the user clicks cancel. It ensures that `ElectronAppWrapper.quitWithSyncCheck()` will properly prompt the user with a warning if unsynced changes still exist.

## Testing

**Automated Tests:**

- Added a testing hook `cancelFinalOutgoingChangesCheck` to simulate cancellations mid-check in a controlled way.

- Added a regression test in `packages/lib/services/synchronizer/Synchronizer.basics.test.ts`: `"should not report the sync as up to date when the final outgoing-changes check is cancelled"`.

- Confirmed all sync-related test suites pass locally using `yarn test`.

**Manual Testing Plan:**

1. Open the desktop app. Make a local edit to a note.

2. Start a sync.

3. Quickly click "Cancel" during the sync process— during the finish step.

4. Try to quit the application

5. **Expected result:** The app should show the warning prompt about changes, before closing. Before this fix it would quit without any warning.