### PR TITLE
Desktop: Fixes #16290: Insert HTML link syntax in HTML notes for linkToNote command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -528,6 +528,7 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/commands/gotoAnything.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/hideModalMessage.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/index.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.test.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/lockEncryptedNotes.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/moveToFolder.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -554,6 +554,7 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/commands/gotoAnything.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/hideModalMessage.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/index.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.test.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/lockEncryptedNotes.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/moveToFolder.js

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.test.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.test.ts
@@ -1,0 +1,171 @@
+import { runtime } from './linkToNote';
+import CommandService, { CommandContext } from '@joplin/lib/services/CommandService';
+import Note from '@joplin/lib/models/Note';
+import { ModelType } from '@joplin/lib/BaseModel';
+import { MarkupLanguage } from '@joplin/renderer';
+import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
+
+describe('linkToNote', () => {
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	test('should insert a markdown link when current note is markdown', async () => {
+		const mdNote = await Note.save({ title: 'Markdown Note', body: 'some content' });
+		const targetNote = { id: 'target_note_123', title: 'Target Note' };
+
+		let insertedText = '';
+		jest.spyOn(CommandService.instance(), 'execute').mockImplementation(async (commandName: string, ...args: unknown[]) => {
+			if (commandName === 'gotoAnything') {
+				return {
+					type: ModelType.Note,
+					item: targetNote,
+				};
+			}
+			if (commandName === 'insertText') {
+				insertedText = args[0] as string;
+				return null;
+			}
+			return null;
+		});
+
+		const context = {
+			state: {
+				selectedNoteIds: [mdNote.id],
+			},
+		} as unknown as CommandContext;
+
+		await runtime().execute(context);
+		expect(insertedText).toBe('[Target Note](:/target_note_123)');
+	});
+
+	test('should insert an HTML link when current note is HTML format', async () => {
+		const htmlNote = await Note.save({
+			title: 'HTML Note',
+			body: '<p>some content</p>',
+			markup_language: MarkupLanguage.Html,
+		});
+		const targetNote = { id: 'target_note_456', title: 'Target Note' };
+
+		let insertedText = '';
+		jest.spyOn(CommandService.instance(), 'execute').mockImplementation(async (commandName: string, ...args: unknown[]) => {
+			if (commandName === 'gotoAnything') {
+				return {
+					type: ModelType.Note,
+					item: targetNote,
+				};
+			}
+			if (commandName === 'insertText') {
+				insertedText = args[0] as string;
+				return null;
+			}
+			return null;
+		});
+
+		const context = {
+			state: {
+				selectedNoteIds: [htmlNote.id],
+			},
+		} as unknown as CommandContext;
+
+		await runtime().execute(context);
+		expect(insertedText).toBe('<a href=":/target_note_456">Target Note</a>');
+	});
+
+	test('should escape special characters in HTML link title', async () => {
+		const htmlNote = await Note.save({
+			title: 'HTML Note',
+			body: '<p>some content</p>',
+			markup_language: MarkupLanguage.Html,
+		});
+		const targetNote = { id: 'target_note_789', title: '<Special & "Title">' };
+
+		let insertedText = '';
+		jest.spyOn(CommandService.instance(), 'execute').mockImplementation(async (commandName: string, ...args: unknown[]) => {
+			if (commandName === 'gotoAnything') {
+				return {
+					type: ModelType.Note,
+					item: targetNote,
+				};
+			}
+			if (commandName === 'insertText') {
+				insertedText = args[0] as string;
+				return null;
+			}
+			return null;
+		});
+
+		const context = {
+			state: {
+				selectedNoteIds: [htmlNote.id],
+			},
+		} as unknown as CommandContext;
+
+		await runtime().execute(context);
+		expect(insertedText).toBe('<a href=":/target_note_789">&lt;Special &amp; &quot;Title&quot;&gt;</a>');
+	});
+
+	test('should fall back to note id if target note title is empty in HTML notes', async () => {
+		const htmlNote = await Note.save({
+			title: 'HTML Note',
+			body: '<p>some content</p>',
+			markup_language: MarkupLanguage.Html,
+		});
+		const targetNote = { id: 'target_note_000', title: '' };
+
+		let insertedText = '';
+		jest.spyOn(CommandService.instance(), 'execute').mockImplementation(async (commandName: string, ...args: unknown[]) => {
+			if (commandName === 'gotoAnything') {
+				return {
+					type: ModelType.Note,
+					item: targetNote,
+				};
+			}
+			if (commandName === 'insertText') {
+				insertedText = args[0] as string;
+				return null;
+			}
+			return null;
+		});
+
+		const context = {
+			state: {
+				selectedNoteIds: [htmlNote.id],
+			},
+		} as unknown as CommandContext;
+
+		await runtime().execute(context);
+		expect(insertedText).toBe('<a href=":/target_note_000">target_note_000</a>');
+	});
+
+	test('should default to markdown syntax when no note is selected', async () => {
+		const targetNote = { id: 'target_note_123', title: 'Target Note' };
+
+		let insertedText = '';
+		jest.spyOn(CommandService.instance(), 'execute').mockImplementation(async (commandName: string, ...args: unknown[]) => {
+			if (commandName === 'gotoAnything') {
+				return {
+					type: ModelType.Note,
+					item: targetNote,
+				};
+			}
+			if (commandName === 'insertText') {
+				insertedText = args[0] as string;
+				return null;
+			}
+			return null;
+		});
+
+		const context = {
+			state: {},
+		} as unknown as CommandContext;
+
+		await runtime().execute(context);
+		expect(insertedText).toBe('[Target Note](:/target_note_123)');
+	});
+});

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.ts
@@ -5,6 +5,10 @@ import { GotoAnythingOptions, UiType } from './gotoAnything';
 import { ModelType } from '@joplin/lib/BaseModel';
 import Logger from '@joplin/utils/Logger';
 import markdownUtils from '@joplin/lib/markdownUtils';
+import { stateUtils } from '@joplin/lib/reducer';
+import Note from '@joplin/lib/models/Note';
+import { MarkupLanguage } from '@joplin/renderer';
+import { htmlentities } from '@joplin/utils/html';
 
 const logger = Logger.create('linkToNote');
 
@@ -16,7 +20,7 @@ export const declaration: CommandDeclaration = {
 
 export const runtime = (): CommandRuntime => {
 	return {
-		execute: async (_context: CommandContext) => {
+		execute: async (context: CommandContext) => {
 			const options: GotoAnythingOptions = {
 				mode: Mode.TitleOnly,
 				alwaysShowHelp: true,
@@ -29,7 +33,14 @@ export const runtime = (): CommandRuntime => {
 				return null;
 			}
 
-			const link = `[${markdownUtils.escapeTitleText(result.item.title)}](:/${markdownUtils.escapeLinkUrl(result.item.id)})`;
+			const noteId = context?.state?.selectedNoteIds?.length ? stateUtils.selectedNoteId(context.state) : null;
+			const currentNote = noteId ? await Note.load(noteId) : null;
+			const isHtml = currentNote && currentNote.markup_language === MarkupLanguage.Html;
+
+			const link = isHtml
+				? `<a href=":/${markdownUtils.escapeLinkUrl(result.item.id)}">${htmlentities(result.item.title || result.item.id)}</a>`
+				: `[${markdownUtils.escapeTitleText(result.item.title)}](:/${markdownUtils.escapeLinkUrl(result.item.id)})`;
+
 			await CommandService.instance().execute('insertText', link);
 			return result;
 		},


### PR DESCRIPTION
### Summary

This PR fixes #16290 where clicking the "Link to note" toolbar button in the Desktop editor always inserted Markdown link syntax (`[Title](:/noteId)`), even when editing an HTML note (`markup_language === MarkupLanguage.Html`). This resulted in raw Markdown syntax appearing within HTML notes and failing to render as a clickable hyperlink in the viewer.

### Proposed Changes

1. In `packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.ts`:
   - Inspect the current note's markup language via `stateUtils.selectedNoteId(context?.state)` and `Note.load(noteId)`.
   - If the active note is an HTML note (`currentNote?.markup_language === MarkupLanguage.Html`), insert an HTML anchor tag:
     `<a href=":/${markdownUtils.escapeLinkUrl(result.item.id)}">${htmlentities(result.item.title || result.item.id)}</a>`
   - If the active note is a Markdown note (or no note is selected), preserve the existing Markdown link format:
     `[${markdownUtils.escapeTitleText(result.item.title)}](:/${markdownUtils.escapeLinkUrl(result.item.id)})`
2. Added Jest unit tests in `packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.test.ts`:
   - Verify Markdown note generates Markdown link syntax `[Title](:/id)`.
   - Verify HTML note generates HTML link syntax `<a href=":/id">Title</a>`.
   - Verify special characters in HTML note title are properly HTML-entity escaped.
   - Verify fallback to note ID when target note title is empty in HTML notes.
   - Verify default Markdown format when no note is selected.

### Testing Plan

#### Automated Tests
- Ran unit tests in `packages/app-desktop`:
  ```sh
  yarn test linkToNote
  ```
  All 5 tests pass.
- TypeScript check:
  ```sh
  yarn tsc --noEmit
  ```
  Passed with 0 errors.
- Linter:
  ```sh
  yarn linter packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.ts packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.test.ts
  ```
  Passed with 0 errors.
- Spellcheck and git pre-commit hooks passed.

#### Manual Testing
1. Select or create a standard Markdown note.
2. Click "Link to note" in the toolbar and select a target note.
3. Verify that `[Target Note](:/target-note-id)` is inserted.
4. Select or create an HTML format note.
5. Click "Link to note" in the toolbar and select a target note.
6. Verify that `<a href=":/target-note-id">Target Note</a>` is inserted.
7. Check the viewer pane to ensure the link renders and functions as a clickable internal link.