### PR TITLE
Linux: Fixes #16434: Fix missing window icon with certain system setups

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -310,13 +310,7 @@ if [[ $DESKTOP =~ .*gnome.*|.*kde.*|.*xfce.*|.*mate.*|.*lxqt.*|.*unity.*|.*x-cin
   DATA_HOME=${XDG_DATA_HOME:-~/.local/share}
   DESKTOP_FILE_LOCATION="$DATA_HOME/applications"
 
-  # Only later versions of Joplin default to Wayland
-  IS_WAYLAND_BY_DEFAULT=$(compareVersions "$RELEASE_VERSION" "3.5.6")
-  # Joplin has a different startup WM class on Wayland and X11:
-  STARTUP_WM_CLASS=Joplin
-  if [[ $XDG_SESSION_TYPE != "x11" && $IS_WAYLAND_BY_DEFAULT == "1" ]]; then
-    STARTUP_WM_CLASS=@joplin/app-desktop
-  fi
+  STARTUP_WM_CLASS=appimagekit-joplin
 
   # Only delete the desktop file if it will be replaced
   rm -f "$DESKTOP_FILE_LOCATION/appimagekit-joplin.desktop"
@@ -332,8 +326,6 @@ Name=Joplin
 Comment=Joplin for Desktop
 Exec=env APPIMAGELAUNCHER_DISABLE=TRUE "${INSTALL_DIR}/Joplin.AppImage" ${SANDBOXPARAM} %u
 Icon=joplin
-# This will be different between Wayland and X11. On Wayland, the startup
-# WM class is "@joplin/app-desktop". On X11, it's "Joplin".
 StartupWMClass=${STARTUP_WM_CLASS}
 Type=Application
 Categories=Office;


### PR DESCRIPTION
# Problem

Joplin's `.desktop` file sets an incorrect `StartupWMClass`. This seems to cause window display issues in some environments (see #16434).

According to [the desktop entry spec](https://specifications.freedesktop.org/desktop-entry/latest/recognized-keys.html), a `StartupWMClass` means that
> \[...\] it is known that the application will map at least one window with the given string as its WM class or WM name hint (see the [Startup Notification Protocol Specification](http://www.freedesktop.org/Standards/startup-notification-spec) for more details).

Since https://github.com/laurent22/joplin/pull/15043, the WM class for the Joplin window is `appimagekit-joplin`. This can be confirmed by using:
- On GNOME: [GNOME looking glass](https://github.com/GNOME/gnome-shell/blob/main/docs/looking-glass.md):
  <img width="547" height="457" alt="screenshot: Joplin is shown as having window class appimagekit-joplin" src="https://github.com/user-attachments/assets/84c6a23d-8fca-4347-a0b0-9849a4751d19" />
- On X11 (XFCE): `xprop` ([ref](https://superuser.com/a/142451))
  <img width="686" height="456" alt="screenshot: xprop reports Joplin's WM class as appimagekit-joplin" src="https://github.com/user-attachments/assets/840ae783-b9a3-4879-9520-a8c7e8a81d7c" />



# Solution

Adjust the install script to correctly set `StartupWMClass`.

May fix #16434.

# Notes

I have so far been unable to reproduce #16434 locally on Ubuntu 26.04 (GNOME/Wayland). For me, Joplin's icon is shown correctly both before and after this change. However, according to the [spec](https://specifications.freedesktop.org/desktop-entry/latest/recognized-keys.html), Joplin should not set `StartupWMClass` to a value that does not match at least one of Joplin's windows.

# Testing

- [x] On Ubuntu 26.04 (ARM): On a system with no previous Joplin installation
   1. Patch the install script to install a local ARM build of the AppImage. (ARM/Linux AppImages are currently not built/released in CI).
   2. Run the install script.
   3. Start Joplin from the just-created launcher (search for "Joplin" in the applications list and start it).
   4. Verify that the Joplin window is shown in the taskbar with the "Joplin" icon.
   5. Log out and log in to XFCE (X11).
   6. Start Joplin from the launcher created in step 2 (Applications > Office > Joplin).
   7. Verify that the Joplin window shows the correct icon.


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Web` — only the web app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
