### PR TITLE
Mobile: Fixes #16442: Fixed sync target selection modal closing when tapping 'Other'

### DIFF
--- a/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
+++ b/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
@@ -13,6 +13,7 @@ import CardButton from '../buttons/CardButton';
 import Setting from '@joplin/lib/models/Setting';
 import shim from '@joplin/lib/shim';
 import SyncTargetRegistry from '@joplin/lib/SyncTargetRegistry';
+import Logger from '@joplin/utils/Logger';
 
 interface Props {
 	dispatch: Dispatch;
@@ -21,6 +22,7 @@ interface Props {
 }
 
 const iconSize = 24;
+const logger = Logger.create('SyncWizard');
 const styles = StyleSheet.create({
 	titleContainer: {
 		flexDirection: 'row',
@@ -162,15 +164,20 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 		// Persist the selection so that it is kept even if the user cancels the
 		// login or configuration step that follows.
 		Setting.setValue('sync.target', info.id);
-		await Setting.saveAll();
 
-		onDismiss();
+		try {
+			await Setting.saveAll();
 
-		const routeName = syncTargetRoutes[name];
-		if (routeName) {
-			await NavService.go(routeName);
-		} else {
-			await NavService.go('Config', { sectionName: 'sync' });
+			onDismiss();
+
+			const routeName = syncTargetRoutes[name];
+			if (routeName) {
+				await NavService.go(routeName);
+			} else {
+				await NavService.go('Config', { sectionName: 'sync' });
+			}
+		} catch (error) {
+			logger.error('Failed to save sync target setting:', error);
 		}
 	}, [onDismiss]);
 

--- a/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
+++ b/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
@@ -3,7 +3,7 @@ import DismissibleDialog, { DialogVariant } from '../DismissibleDialog';
 import { AppState } from '../../utils/types';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
-import { useCallback } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Icon, Text } from 'react-native-paper';
 import { _ } from '@joplin/lib/locale';
 import JoplinCloudIcon from './JoplinCloudIcon';
@@ -12,6 +12,7 @@ import { Platform, StyleSheet, View } from 'react-native';
 import CardButton from '../buttons/CardButton';
 import Setting from '@joplin/lib/models/Setting';
 import shim from '@joplin/lib/shim';
+import SyncTargetRegistry from '@joplin/lib/SyncTargetRegistry';
 
 interface Props {
 	dispatch: Dispatch;
@@ -50,6 +51,38 @@ const styles = StyleSheet.create({
 
 const isAppJoplinCloud = () => {
 	return Setting.value('isJoplinCloudWebApp');
+};
+
+// Sync targets that have a dedicated login screen are shown as cards and, once
+// selected, redirect to that screen. The others (self-hosted, WebDAV, file
+// system, etc.) redirect to the sync settings so the user can enter the
+// connection details.
+const syncTargetRoutes: Record<string, string> = {
+	'dropbox': 'DropboxLogin',
+	'onedrive': 'OneDriveLogin',
+	'joplinCloud': 'JoplinCloudLogin',
+};
+
+const syncTargetIcon = (name: string) => {
+	switch (name) {
+		case 'joplinServer':
+		case 'joplinServerSaml':
+			return <JoplinCloudIcon width={iconSize} height={iconSize}/>;
+		case 'dropbox':
+			return <Icon size={iconSize} source='dropbox'/>;
+		case 'onedrive':
+			return <Icon size={iconSize} source='microsoft-onedrive'/>;
+		case 'nextcloud':
+			return <Icon size={iconSize} source='cloud'/>;
+		case 'webdav':
+			return <Icon size={iconSize} source='folder-network'/>;
+		case 'amazon_s3':
+			return <Icon size={iconSize} source='cloud-upload-outline'/>;
+		case 'filesystem':
+			return <Icon size={iconSize} source='folder'/>;
+		default:
+			return <Icon size={iconSize} source='dots-horizontal-circle'/>;
+	}
 };
 
 const useShouldShowOtherButton = () => {
@@ -91,6 +124,8 @@ const SyncProvider: React.FC<SyncProviderProps> = props => {
 };
 
 const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
+	const [showAllSyncTargets, setShowAllSyncTargets] = useState(false);
+
 	const onDismiss = useCallback(() => {
 		dispatch({
 			type: 'SYNC_WIZARD_VISIBLE_CHANGE',
@@ -116,10 +151,37 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 		}
 	}, [onDismiss]);
 
-	const onSelectOtherTarget = useCallback(async () => {
+	const onSelectOtherTarget = useCallback(() => {
+		// Keep the dialog open and expand it to show the full list of sync targets.
+		setShowAllSyncTargets(true);
+	}, []);
+
+	const onSelectSyncTarget = useCallback(async (name: string) => {
+		const info = SyncTargetRegistry.infoByName(name);
+
+		// Persist the selection so that it is kept even if the user cancels the
+		// login or configuration step that follows.
+		Setting.setValue('sync.target', info.id);
+		await Setting.saveAll();
+
 		onDismiss();
-		await NavService.go('Config', { sectionName: 'sync' });
+
+		const routeName = syncTargetRoutes[name];
+		if (routeName) {
+			await NavService.go(routeName);
+		} else {
+			await NavService.go('Config', { sectionName: 'sync' });
+		}
 	}, [onDismiss]);
+
+	const otherSyncTargets = useMemo(() => {
+		const excludedTargetNames = ['none', 'joplinCloud'];
+		return SyncTargetRegistry.allIds()
+			.map(id => SyncTargetRegistry.idToName(id))
+			.filter(name => !excludedTargetNames.includes(name))
+			.map(name => SyncTargetRegistry.infoByName(name))
+			.filter(info => info.classRef.unsupportedPlatforms().indexOf(Platform.OS) < 0);
+	}, []);
 
 	const showOther = useShouldShowOtherButton();
 
@@ -133,34 +195,52 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 		heading={_('Synchronisation')}
 	>
 		<Text variant='bodyLarge' role='heading' style={styles.subheading}>{
-			isJoplinCloud
-				? _('You can synchronise your notes using Joplin Cloud, which also gives access to Joplin-specific features such as publishing notes or collaborating on notebooks with others.')
-				: _('Joplin can synchronise your notes using various providers. Select one from the list below.')
+			showAllSyncTargets
+				? _('Select one of the other supported sync targets.')
+				: isJoplinCloud
+					? _('You can synchronise your notes using Joplin Cloud, which also gives access to Joplin-specific features such as publishing notes or collaborating on notebooks with others.')
+					: _('Joplin can synchronise your notes using various providers. Select one from the list below.')
 		}</Text>
-		<View style={styles.syncProviderList}>
-			<SyncProvider
-				title={isJoplinCloud ? _('Synchronise with Joplin Cloud') : _('Joplin Cloud')}
-				description={
-					isJoplinCloud ? null : _('Joplin\'s own sync service. Also gives access to Joplin-specific features such as publishing notes or collaborating on notebooks with others.')
-				}
-				featuresList={[
-					_('Sync your notes'),
-					_('Publish notes to the internet'),
-					_('Collaborate on notebooks with others'),
-				]}
-				icon={() => <JoplinCloudIcon width={iconSize} height={iconSize}/>}
-				onPress={onSelectJoplinCloud}
-				disabled={false}
-			/>
-			{showOther && <SyncProvider
-				title={_('Other')}
-				description={_('Select one of the other supported sync targets.')}
-				icon={() => <Icon size={iconSize} source='dots-horizontal-circle'/>}
-				featuresList={[]}
-				onPress={onSelectOtherTarget}
-				disabled={false}
-			/>}
-		</View>
+		{showAllSyncTargets ? (
+			<View style={styles.syncProviderList}>
+				{otherSyncTargets.map(info => (
+					<SyncProvider
+						key={info.name}
+						title={info.label}
+						description={info.description}
+						icon={() => syncTargetIcon(info.name)}
+						featuresList={[]}
+						onPress={() => void onSelectSyncTarget(info.name)}
+						disabled={false}
+					/>
+				))}
+			</View>
+		) : (
+			<View style={styles.syncProviderList}>
+				<SyncProvider
+					title={isJoplinCloud ? _('Synchronise with Joplin Cloud') : _('Joplin Cloud')}
+					description={
+						isJoplinCloud ? null : _('Joplin\'s own sync service. Also gives access to Joplin-specific features such as publishing notes or collaborating on notebooks with others.')
+					}
+					featuresList={[
+						_('Sync your notes'),
+						_('Publish notes to the internet'),
+						_('Collaborate on notebooks with others'),
+					]}
+					icon={() => <JoplinCloudIcon width={iconSize} height={iconSize}/>}
+					onPress={onSelectJoplinCloud}
+					disabled={false}
+				/>
+				{showOther && <SyncProvider
+					title={_('Other')}
+					description={_('Select one of the other supported sync targets.')}
+					icon={() => <Icon size={iconSize} source='dots-horizontal-circle'/>}
+					featuresList={[]}
+					onPress={onSelectOtherTarget}
+					disabled={false}
+				/>}
+			</View>
+		)}
 	</DismissibleDialog>;
 };
 


### PR DESCRIPTION
Fixes #16442

### Summary of Changes

On Joplin Mobile, tapping the **"Other"** option in the Sync Wizard modal previously closed the dialog without allowing users to select an alternative sync target (e.g., Dropbox, OneDrive, Nextcloud, WebDAV, Amazon S3, File System).

This PR fixes the issue by keeping the Sync Wizard modal open upon selecting "Other", expanding it to display all supported sync target providers for the platform, and correctly navigating the user to the corresponding login or setup screen once selected.

### Key Changes

1. **Expanded Target List:** Added `showAllSyncTargets` state in `SyncWizard.tsx` so selecting "Other" keeps the dialog open and renders alternative sync targets instead of dismissing the modal.
2. **Dynamic Target Resolution:** Used `SyncTargetRegistry` to dynamically list valid sync targets supported by the user's mobile platform and added provider icons.
3. **Target Selection & Routing:** Implemented `onSelectSyncTarget()` to persist the selected target (`Setting.setValue('sync.target', info.id)`) with error logging, dismiss the modal, and navigate to the relevant login screen (`DropboxLogin`, `OneDriveLogin`, `JoplinCloudLogin`) or configuration page.

---

### Testing Done

- [x] Verified tapping **"Other"** in the mobile Sync Wizard keeps the dialog open and lists all supported sync options with appropriate icons.
- [x] Verified selecting a sync provider correctly saves `sync.target` setting.
- [x] Verified navigation to dedicated login screens (Dropbox, OneDrive, Joplin Cloud) and configuration page works properly.
