### PR TITLE
Desktop: Fixes #16444: Allow OpenAI reasoning models to be used with tools

### DIFF
--- a/packages/lib/services/ai/providers/OpenAiCompatible.ts
+++ b/packages/lib/services/ai/providers/OpenAiCompatible.ts
@@ -171,6 +171,14 @@ export default class OpenAiCompatibleProvider extends ChatProviderBase {
 			({ response, json } = await doFetch());
 		}
 
+		// Reasoning models apply a reasoning_effort default server-side, which OpenAI then rejects
+		// alongside tools on /chat/completions. Opt out of the default to keep tools working.
+		if (response.status === 400 && 'tools' in body && /reasoning_effort/i.test(errorMessage())) {
+			logger.warn(`Model ${this.model_} rejected function tools with reasoning; retrying with reasoning disabled.`);
+			body.reasoning_effort = 'none';
+			({ response, json } = await doFetch());
+		}
+
 		// Older OpenAI models might reject `response_format` json_schema (see https://stackoverflow.com/q/79039544).
 		// For compatibility, retry without response_format on failure:
 		if (response.status === 400 && 'response_format' in body && /json_schema|response_format/i.test(errorMessage())) {


### PR DESCRIPTION
Using a reasoning model (e.g. `gpt-5.6-luna`) with the OpenAI-compatible provider failed with:

> AI provider returned 400: Function tools with reasoning_effort are not supported for gpt-5.6-luna in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.

Joplin never sends `reasoning_effort` — reasoning models apply a default server-side, and OpenAI rejects that default alongside function tools on `/chat/completions`. Since AI chat always sends tools, these models were unusable.

This adds a retry that sets `reasoning_effort: 'none'` and re-sends once when a 400 names the parameter, following the same pattern as the existing `max_tokens` and `response_format` shims in `doChat()`. The retry is gated on `tools` being present so it won't fire on unrelated errors.

Proper fix should be https://github.com/laurent22/joplin/issues/16450