### PR TITLE
Chore: Trying to fix flaky Goto Anything and editor plugin saving integration tests

### DIFF
--- a/packages/app-desktop/integration-tests/models/GoToAnything.ts
+++ b/packages/app-desktop/integration-tests/models/GoToAnything.ts
@@ -3,7 +3,6 @@ import { ElectronApplication, expect, Locator, Page } from '@playwright/test';
 import MainScreen from './MainScreen';
 import activateMainMenuItem from '../util/activateMainMenuItem';
 import { msleep } from '@joplin/utils/time';
-import retryOnFailure from '../util/retryOnFailure';
 
 export default class GoToAnything {
 	public readonly containerLocator: Locator;
@@ -20,14 +19,26 @@ export default class GoToAnything {
 
 	public async open(electronApp: ElectronApplication) {
 		await this.mainScreen.waitFor();
-		const openFromMenu = async () => {
+
+		// The menu item toggles the dialog, so retrying unconditionally would close a dialog
+		// that a previous slow attempt had just opened.
+		await expect.poll(async () => {
+			if (await this.containerLocator.isVisible()) return true;
+
 			await activateMainMenuItem(electronApp, 'Goto Anything...');
-			// Use a shorter per-attempt timeout so multiple retries fit within the
-			// overall test timeout — otherwise a slow CI runner can exhaust the
-			// per-test budget mid-retry and force a hard worker teardown.
-			await this.waitFor(10_000);
-		};
-		await retryOnFailure(openFromMenu, { maxRetries: 3 });
+			try {
+				await this.waitFor(5_000);
+			} catch (error) {
+				return false;
+			}
+			return true;
+		}, {
+			timeout: 30_000,
+			message: 'should open the Goto Anything dialog',
+		}).toBe(true);
+
+		// Filling the controlled input before React attaches onChange silently drops the text.
+		await this.inputLocator.waitFor();
 	}
 
 	public async openLinkToNote(electronApp: ElectronApplication) {

--- a/packages/app-desktop/integration-tests/pluginApi.spec.ts
+++ b/packages/app-desktop/integration-tests/pluginApi.spec.ts
@@ -169,6 +169,9 @@ test.describe('pluginApi', () => {
 		const pluginFrameContent = pluginFrame.contentFrame();
 		await expect(pluginFrameContent.getByText('Loaded!')).toBeAttached();
 
+		// The plugin only knows which note to save after its first onUpdate event.
+		await expect(pluginFrameContent.locator('#note-id')).not.toBeEmpty();
+
 		// Editor plugin tests should pass
 		await mainScreen.goToAnything.runCommand(app, 'testEditorPluginSave-test-editor-plugin');
 

--- a/packages/app-desktop/integration-tests/resources/test-plugins/editorPluginSaving.js
+++ b/packages/app-desktop/integration-tests/resources/test-plugins/editorPluginSaving.js
@@ -29,12 +29,18 @@ const registerEditorPlugin = async (editorViewId) => {
 			);
 
 			let noteId;
-			await editors.onUpdate(viewHandle, event => {
+			// The note ID is exposed in the DOM so tests can wait for the first update.
+			await editors.onUpdate(viewHandle, async event => {
 				noteId = event.noteId;
+				await editors.setHtml(
+					viewHandle,
+					`<code>Loaded!</code><code id="note-id">${noteId}</code>`,
+				);
 			});
 
-			saveCallbacks.push(() => {
-				void editors.saveNote(viewHandle, {
+			saveCallbacks.push(async () => {
+				if (!noteId) throw new Error('saveNote called before the first onUpdate event');
+				await editors.saveNote(viewHandle, {
 					noteId,
 					body: `Changed by ${editorViewId}`,
 				});
@@ -53,7 +59,7 @@ const registerEditorPlugin = async (editorViewId) => {
 		iconName: 'fas fa-music',
 		execute: async () => {
 			for (const saveCallback of saveCallbacks) {
-				saveCallback();
+				await saveCallback();
 			}
 		},
 	});


### PR DESCRIPTION
Fixes two recurring CI failures in the desktop integration tests.

**Goto Anything fails to open**

`GoToAnything.open()` retried menu activation via `retryOnFailure`, but the menu item *toggles* the dialog. On a slow runner, an attempt that timed out at 10s could still have opened the dialog — the next retry then closed it again. Replaced with an `expect.poll` that only re-activates the menu when the dialog isn't already visible, and lowered the per-attempt wait to 5s so the retries fit within the 70s per-test budget.

Also waits for the input before returning: it's a controlled component, and filling it before React attaches `onChange` silently drops the text.

**Editor plugin saving saves nothing**

The test waited for `Loaded!` (set in `onSetup`) before running the save command, but the plugin only learns the note ID from `onUpdate`. If the command ran first, `saveNote` was called with `noteId === undefined`, and the `void`-ed promise swallowed the rejection — so the failure surfaced as stale note content rather than an error. This one failed identically on all three retries, so it was a real ordering bug rather than a timing tolerance issue.

The plugin now exposes the note ID in the DOM, the test waits for it, and the save callback throws instead of failing silently.

Log:

```
2026-09-08T10:51:51.9449466Z [10:51:51] Finished 'before-start' after 8.41 s
2026-09-08T10:51:54.9186366Z
2026-09-08T10:51:54.9186897Z Running 86 tests using 1 worker
2026-09-08T10:52:26.1948579Z ··retry failed: locator.waitFor: Timeout 10000ms exceeded.
2026-09-08T10:52:26.1949155Z Call log:
2026-09-08T10:52:26.1949632Z   - waiting for locator('.go-to-anything-dialog[open]') to be visible
2026-09-08T10:52:26.1949852Z
2026-09-08T10:52:26.1950337Z     at GoToAnything.waitFor (/home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/models/GoToAnything.ts:18:31)
2026-09-08T10:52:26.1951124Z     at openFromMenu (/home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/models/GoToAnything.ts:28:15)
2026-09-08T10:52:26.1951826Z     at retryOnFailure (/home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/util/retryOnFailure.ts:10:11)
2026-09-08T10:52:26.1952529Z     at GoToAnything.open (/home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/models/GoToAnything.ts:30:3)
2026-09-08T10:52:26.1953165Z     at /home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/goToAnything.spec.ts:28:4 {
2026-09-08T10:52:26.1953550Z   name: 'TimeoutError',
2026-09-08T10:52:26.1953978Z   Symbol(step): {
2026-09-08T10:52:26.1954150Z     location: {
2026-09-08T10:52:26.1954554Z       file: '/home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/models/GoToAnything.ts',
2026-09-08T10:52:26.1954975Z       line: 18,
2026-09-08T10:52:26.1955164Z       column: 31,
2026-09-08T10:52:26.1955393Z       function: 'GoToAnything.waitFor'
2026-09-08T10:52:26.1955596Z     },
2026-09-08T10:52:26.1955787Z     category: 'pw:api',
2026-09-08T10:52:26.1956112Z     title: "Wait for selector locator('.go-to-anything-dialog[open]')",
2026-09-08T10:52:26.1956424Z     apiName: 'locator.waitFor',
2026-09-08T10:52:26.1956606Z     params: {
2026-09-08T10:52:26.1956830Z       selector: '.go-to-anything-dialog[open]',
2026-09-08T10:52:26.1957065Z       strict: true,
2026-09-08T10:52:26.1957287Z       omitReturnValue: true,
2026-09-08T10:52:26.1957504Z       timeout: 10000
2026-09-08T10:52:26.1957663Z     },
2026-09-08T10:52:26.1957835Z     group: undefined,
2026-09-08T10:52:26.1958047Z     stepId: 'pw:api@59',
2026-09-08T10:52:26.1958263Z     boxedStack: undefined,
2026-09-08T10:52:26.1958953Z     steps: [],
2026-09-08T10:52:26.1959141Z     attachmentIndices: [],
2026-09-08T10:52:26.1959363Z     info: TestStepInfoImpl {
2026-09-08T10:52:26.1959580Z       annotations: [],
2026-09-08T10:52:26.1959842Z       _testInfo: [TestInfoImpl],
2026-09-08T10:52:26.1960118Z       _stepId: 'pw:api@59',
2026-09-08T10:52:26.1960509Z       _title: "Wait for selector locator('.go-to-anything-dialog[open]')",
2026-09-08T10:52:26.1960850Z       _parentStep: undefined,
2026-09-08T10:52:26.1961130Z       skip: [Function (anonymous)]
2026-09-08T10:52:26.1961381Z     },
2026-09-08T10:52:26.1961613Z     complete: [Function: complete],
2026-09-08T10:52:26.1961915Z     endWallTime: 1788864746192,
2026-09-08T10:52:26.1962135Z     error: {
2026-09-08T10:52:26.1962500Z       message: 'TimeoutError: locator.waitFor: Timeout 10000ms exceeded.\n' +
2026-09-08T10:52:26.1962878Z         'Call log:\n' +
2026-09-08T10:52:26.1963351Z         "\x1B[2m  - waiting for locator('.go-to-anything-dialog[open]') to be visible\x1B[22m\n",
2026-09-08T10:52:26.1964128Z       stack: 'TimeoutError: locator.waitFor: Timeout 10000ms exceeded.\n' +
2026-09-08T10:52:26.1964776Z         'Call log:\n' +
2026-09-08T10:52:26.1965257Z         "\x1B[2m  - waiting for locator('.go-to-anything-dialog[open]') to be visible\x1B[22m\n" +
2026-09-08T10:52:26.1965655Z         '\n' +
2026-09-08T10:52:26.1966381Z         '    at GoToAnything.waitFor (/home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/models/GoToAnything.ts:18:31)\n' +
2026-09-08T10:52:26.1967348Z         '    at openFromMenu (/home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/models/GoToAnything.ts:28:15)\n' +
2026-09-08T10:52:26.1968260Z         '    at retryOnFailure (/home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/util/retryOnFailure.ts:10:11)\n' +
2026-09-08T10:52:26.1969129Z         '    at GoToAnything.open (/home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/models/GoToAnything.ts:30:3)\n' +
2026-09-08T10:52:26.1969962Z         '    at /home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/goToAnything.spec.ts:28:4',
2026-09-08T10:52:26.1970446Z       cause: undefined
2026-09-08T10:52:26.1970657Z     }
2026-09-08T10:52:26.1970805Z   }
2026-09-08T10:52:26.1970991Z } Retrying... 1/3
2026-09-08T11:02:48.3878853Z ·································°°············××F····························
2026-09-08T11:03:42.1398968Z ········
2026-09-08T11:03:42.1406654Z
2026-09-08T11:03:42.1416626Z   1) integration-tests/pluginApi.spec.ts:154:6 › pluginApi › should be possible to save changes to a note using the editor plugin API
2026-09-08T11:03:42.1417174Z
2026-09-08T11:03:42.1417590Z     Error: expect(received).toBe(expected) // Object.is equality
2026-09-08T11:03:42.1418005Z
2026-09-08T11:03:42.1418192Z     Expected: "Changed by test-editor-plugin"
2026-09-08T11:03:42.1418508Z     Received: "Initial content."
2026-09-08T11:03:42.1418742Z
2026-09-08T11:03:42.1418832Z     Call Log:
2026-09-08T11:03:42.1419069Z     - Timeout 15000ms exceeded while waiting on the predicate
2026-09-08T11:03:42.1419241Z
2026-09-08T11:03:42.1419358Z        at models/NoteEditor/NoteEditorScreen.ts:162
2026-09-08T11:03:42.1419496Z
2026-09-08T11:03:42.1419675Z       160 | // Allow `expected` to be either an exact match (a string) or a pattern
2026-09-08T11:03:42.1420019Z       161 | if (typeof expected === 'string') {
2026-09-08T11:03:42.1420247Z     > 162 | await expectResult.toBe(expected);
2026-09-08T11:03:42.1420442Z           | ^
2026-09-08T11:03:42.1420601Z       163 | } else {
2026-09-08T11:03:42.1420798Z       164 | await expectResult.toMatch(expected);
2026-09-08T11:03:42.1420989Z       165 | }
2026-09-08T11:03:42.1421746Z         at NoteEditorScreen.expectToHaveText (/home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/models/NoteEditor/NoteEditorScreen.ts:162:4)
2026-09-08T11:03:42.1422389Z         at /home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/pluginApi.spec.ts:184:3
2026-09-08T11:03:42.1422695Z
2026-09-08T11:03:42.1423096Z     attachment #1: log.txt (text/plain) ────────────────────────────────────────────────────────────
2026-09-08T11:03:42.1426969Z     2026-09-08 10:57:55: Performance: main: Start at 0.92s
2026-09-08T11:03:42.1427328Z     2026-09-08 10:57:55: Performance: app/start: Start at 0.94s
2026-09-08T11:03:42.1427635Z     2026-09-08 10:57:55: Performance: BaseApplication/start: Start at 0.94s
2026-09-08T11:03:42.1428085Z     2026-09-08 10:57:55: App: Profile directory: /home/runner/work/joplin/joplin/packages/app-desktop/integration-tes...
2026-09-08T11:03:42.1428633Z     ────────────────────────────────────────────────────────────────────────────────────────────────
2026-09-08T11:03:42.1428848Z
2026-09-08T11:03:42.1429124Z     Error Context: test-results/pluginApi-pluginApi-should-800d9-using-the-editor-plugin-API/error-context.md
2026-09-08T11:03:42.1429595Z
2026-09-08T11:03:42.1429820Z     Retry #1 ───────────────────────────────────────────────────────────────────────────────────────
2026-09-08T11:03:42.1430018Z
2026-09-08T11:03:42.1430368Z     Error: expect(received).toBe(expected) // Object.is equality
2026-09-08T11:03:42.1430616Z
2026-09-08T11:03:42.1430768Z     Expected: "Changed by test-editor-plugin"
2026-09-08T11:03:42.1431036Z     Received: "Initial content."
2026-09-08T11:03:42.1431164Z
2026-09-08T11:03:42.1431223Z     Call Log:
2026-09-08T11:03:42.1431429Z     - Timeout 15000ms exceeded while waiting on the predicate
2026-09-08T11:03:42.1431584Z
2026-09-08T11:03:42.1431694Z        at models/NoteEditor/NoteEditorScreen.ts:162
2026-09-08T11:03:42.1431836Z
2026-09-08T11:03:42.1432003Z       160 | // Allow `expected` to be either an exact match (a string) or a pattern
2026-09-08T11:03:42.1432285Z       161 | if (typeof expected === 'string') {
2026-09-08T11:03:42.1432527Z     > 162 | await expectResult.toBe(expected);
2026-09-08T11:03:42.1432716Z           | ^
2026-09-08T11:03:42.1432857Z       163 | } else {
2026-09-08T11:03:42.1433047Z       164 | await expectResult.toMatch(expected);
2026-09-08T11:03:42.1433238Z       165 | }
2026-09-08T11:03:42.1433878Z         at NoteEditorScreen.expectToHaveText (/home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/models/NoteEditor/NoteEditorScreen.ts:162:4)
2026-09-08T11:03:42.1434519Z         at /home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/pluginApi.spec.ts:184:3
2026-09-08T11:03:42.1434769Z
2026-09-08T11:03:42.1435031Z     attachment #1: log.txt (text/plain) ────────────────────────────────────────────────────────────
2026-09-08T11:03:42.1435376Z     2026-09-08 10:58:18: Performance: main: Start at 0.89s
2026-09-08T11:03:42.1435651Z     2026-09-08 10:58:18: Performance: app/start: Start at 0.91s
2026-09-08T11:03:42.1435961Z     2026-09-08 10:58:18: Performance: BaseApplication/start: Start at 0.91s
2026-09-08T11:03:42.1436398Z     2026-09-08 10:58:18: App: Profile directory: /home/runner/work/joplin/joplin/packages/app-desktop/integration-tes...
2026-09-08T11:03:42.1436898Z     ────────────────────────────────────────────────────────────────────────────────────────────────
2026-09-08T11:03:42.1437092Z
2026-09-08T11:03:42.1437389Z     Error Context: test-results/pluginApi-pluginApi-should-800d9-using-the-editor-plugin-API-retry1/error-context.md
2026-09-08T11:03:42.1437706Z
2026-09-08T11:03:42.1437958Z     attachment #3: trace (application/zip) ─────────────────────────────────────────────────────────
2026-09-08T11:03:42.1438415Z     test-results/pluginApi-pluginApi-should-800d9-using-the-editor-plugin-API-retry1/trace.zip
2026-09-08T11:03:42.1438742Z     Usage:
2026-09-08T11:03:42.1438910Z
2026-09-08T11:03:42.1439225Z         yarn playwright show-trace test-results/pluginApi-pluginApi-should-800d9-using-the-editor-plugin-API-retry1/trace.zip
2026-09-08T11:03:42.1439710Z
2026-09-08T11:03:42.1440162Z     ────────────────────────────────────────────────────────────────────────────────────────────────
2026-09-08T11:03:42.1440370Z
2026-09-08T11:03:42.1440658Z     Retry #2 ───────────────────────────────────────────────────────────────────────────────────────
2026-09-08T11:03:42.1440854Z
2026-09-08T11:03:42.1441174Z     Error: expect(received).toBe(expected) // Object.is equality
2026-09-08T11:03:42.1441429Z
2026-09-08T11:03:42.1441580Z     Expected: "Changed by test-editor-plugin"
2026-09-08T11:03:42.1441845Z     Received: "Initial content."
2026-09-08T11:03:42.1441975Z
2026-09-08T11:03:42.1442036Z     Call Log:
2026-09-08T11:03:42.1442243Z     - Timeout 15000ms exceeded while waiting on the predicate
2026-09-08T11:03:42.1442414Z
2026-09-08T11:03:42.1442527Z        at models/NoteEditor/NoteEditorScreen.ts:162
2026-09-08T11:03:42.1442664Z
2026-09-08T11:03:42.1442835Z       160 | // Allow `expected` to be either an exact match (a string) or a pattern
2026-09-08T11:03:42.1443133Z       161 | if (typeof expected === 'string') {
2026-09-08T11:03:42.1443362Z     > 162 | await expectResult.toBe(expected);
2026-09-08T11:03:42.1443556Z           | ^
2026-09-08T11:03:42.1443937Z       163 | } else {
2026-09-08T11:03:42.1444138Z       164 | await expectResult.toMatch(expected);
2026-09-08T11:03:42.1444337Z       165 | }
2026-09-08T11:03:42.1444809Z         at NoteEditorScreen.expectToHaveText (/home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/models/NoteEditor/NoteEditorScreen.ts:162:4)
2026-09-08T11:03:42.1445429Z         at /home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/pluginApi.spec.ts:184:3
2026-09-08T11:03:42.1445691Z
2026-09-08T11:03:42.1445956Z     attachment #1: log.txt (text/plain) ────────────────────────────────────────────────────────────
2026-09-08T11:03:42.1446290Z     2026-09-08 10:58:41: Performance: main: Start at 0.86s
2026-09-08T11:03:42.1446575Z     2026-09-08 10:58:41: Performance: app/start: Start at 0.88s
2026-09-08T11:03:42.1446878Z     2026-09-08 10:58:41: Performance: BaseApplication/start: Start at 0.88s
2026-09-08T11:03:42.1447320Z     2026-09-08 10:58:41: App: Profile directory: /home/runner/work/joplin/joplin/packages/app-desktop/integration-tes...
2026-09-08T11:03:42.1447868Z     ────────────────────────────────────────────────────────────────────────────────────────────────
2026-09-08T11:03:42.1448052Z
2026-09-08T11:03:42.1448348Z     Error Context: test-results/pluginApi-pluginApi-should-800d9-using-the-editor-plugin-API-retry2/error-context.md
2026-09-08T11:03:42.1448667Z
2026-09-08T11:03:42.1448738Z   1 failed
2026-09-08T11:03:42.1449247Z     integration-tests/pluginApi.spec.ts:154:6 › pluginApi › should be possible to save changes to a note using the editor plugin API
2026-09-08T11:03:42.1449615Z   2 skipped
2026-09-08T11:03:42.1449758Z   83 passed (11.8m)
2026-09-08T11:03:42.4728320Z ##[error]Process completed with exit code 1.
2026-09-08T11:03:42.5056512Z ##[group]Run actions/upload-artifact@v6
2026-09-08T11:03:42.5056763Z with:
2026-09-08T11:03:42.5056948Z   name: playwright-report-ubuntu-22.04
2026-09-08T11:03:42.5057241Z   path: packages/app-desktop/playwright-report/
2026-09-08T11:03:42.5057482Z   retention-days: 7
2026-09-08T11:03:42.5057670Z   if-no-files-found: warn
2026-09-08T11:03:42.5057867Z   compression-level: 6
2026-09-08T11:03:42.5058027Z   overwrite: false
2026-09-08T11:03:42.5058213Z   include-hidden-files: false
```