### PR TITLE
Mobile: Resolves #16442: Remove sync wizard button from config screen

### DIFF
--- a/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
+++ b/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
@@ -118,12 +118,7 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 
 	const onSelectOtherTarget = useCallback(async () => {
 		onDismiss();
-		await NavService.go('Config', {
-			sectionName: 'sync',
-			// Showing the sync wizard button after selecting "Other" can be confusing
-			// See #16442.
-			hideSyncWizardButton: true,
-		});
+		await NavService.go('Config', { sectionName: 'sync' });
 	}, [onDismiss]);
 
 	const showOther = useShouldShowOtherButton();

--- a/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
+++ b/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
@@ -118,7 +118,12 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 
 	const onSelectOtherTarget = useCallback(async () => {
 		onDismiss();
-		await NavService.go('Config', { sectionName: 'sync' });
+		await NavService.go('Config', {
+			sectionName: 'sync',
+			// Showing the sync wizard button after selecting "Other" can be confusing
+			// See #16442.
+			hideSyncWizardButton: true,
+		});
 	}, [onDismiss]);
 
 	const showOther = useShouldShowOtherButton();

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -67,7 +67,7 @@ interface ConfigScreenProps {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See ConfigScreenState.settings — same reason
 	settings: Record<string, any>;
 	themeId: number;
-	navigation: { state?: { sectionName?: string; hideSyncWizardButton?: boolean } };
+	navigation: { state?: { sectionName?: string } };
 	dispatch: Dispatch;
 }
 
@@ -133,13 +133,6 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 
 	private e2eeConfig_ = () => {
 		void NavService.go('EncryptionConfig');
-	};
-
-	private onShowSyncWizard_ = () => {
-		this.props.dispatch({
-			type: 'SYNC_WIZARD_VISIBLE_CHANGE',
-			visible: true,
-		});
 	};
 
 	private saveButton_press = async () => {
@@ -549,9 +542,6 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 		}
 
 		if (section.name === 'sync') {
-			if (settings['sync.target'] === 0 && !this.props.navigation?.state?.hideSyncWizardButton) {
-				addSettingButton('sync_wizard_button', _('Open Sync Wizard...'), this.onShowSyncWizard_);
-			}
 			addSettingButton('e2ee_config_button', _('Encryption Config'), this.e2eeConfig_);
 		}
 

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Platform, Linking, View, ScrollView, Text, TouchableOpacity, Alert, PermissionsAndroid, Dimensions, AccessibilityInfo, LayoutChangeEvent } from 'react-native';
-import Setting, { AppType, SettingMetadataSection } from '@joplin/lib/models/Setting';
+import Setting, { AppType, SettingMetadataSection, SettingsRecord } from '@joplin/lib/models/Setting';
 import NavService from '@joplin/lib/services/NavService';
 import SearchEngine from '@joplin/lib/services/search/SearchEngine';
 import checkPermissions from '../../../utils/checkPermissions';
@@ -67,7 +67,7 @@ interface ConfigScreenProps {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See ConfigScreenState.settings — same reason
 	settings: Record<string, any>;
 	themeId: number;
-	navigation: { state?: { sectionName?: string } };
+	navigation: { state?: { sectionName?: string; hideSyncWizardButton?: boolean } };
 	dispatch: Dispatch;
 }
 
@@ -381,8 +381,7 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 		);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See ConfigScreenState.settings — same reason
-	public sectionToComponent(key: string, section: SettingMetadataSection, settings: Record<string, any>, isSelected: boolean) {
+	public sectionToComponent(key: string, section: SettingMetadataSection, settings: SettingsRecord, isSelected: boolean) {
 		const settingComps: ReactElement[] = [];
 		const advancedSettingComps: ReactElement[] = [];
 
@@ -550,7 +549,9 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 		}
 
 		if (section.name === 'sync') {
-			addSettingButton('sync_wizard_button', _('Open Sync Wizard...'), this.onShowSyncWizard_);
+			if (settings['sync.target'] === 0 && !this.props.navigation?.state?.hideSyncWizardButton) {
+				addSettingButton('sync_wizard_button', _('Open Sync Wizard...'), this.onShowSyncWizard_);
+			}
 			addSettingButton('e2ee_config_button', _('Encryption Config'), this.e2eeConfig_);
 		}
 

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Platform, Linking, View, ScrollView, Text, TouchableOpacity, Alert, PermissionsAndroid, Dimensions, AccessibilityInfo, LayoutChangeEvent } from 'react-native';
-import Setting, { AppType, SettingMetadataSection, SettingsRecord } from '@joplin/lib/models/Setting';
+import Setting, { AppType, SettingMetadataSection } from '@joplin/lib/models/Setting';
 import NavService from '@joplin/lib/services/NavService';
 import SearchEngine from '@joplin/lib/services/search/SearchEngine';
 import checkPermissions from '../../../utils/checkPermissions';
@@ -374,7 +374,8 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 		);
 	}
 
-	public sectionToComponent(key: string, section: SettingMetadataSection, settings: SettingsRecord, isSelected: boolean) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See ConfigScreenState.settings — same reason
+	public sectionToComponent(key: string, section: SettingMetadataSection, settings: Record<string, any>, isSelected: boolean) {
 		const settingComps: ReactElement[] = [];
 		const advancedSettingComps: ReactElement[] = [];
 


### PR DESCRIPTION
# Problem

On mobile, showing the "Sync wizard" button in settings can be confusing since the "Other" option links directly back to settings, with no visible effect.

This is less of an issue on desktop, since the sync wizard offers more options than just Joplin Cloud.

> [!NOTE]
>
> Since #16442 is tagged with `v3.7`, this pull request targets `release-3.7`.

# Solution

Remove the "Sync wizard" button from settings.

# Screen recordings

## Web


https://github.com/user-attachments/assets/78e62423-4aab-42c2-8488-b4952c5fab57


