### PR TITLE
resolve search bar keyboard dismiss failure

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -380,10 +380,11 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			{
 				attachFile: this.attachFile.bind(this),
 				hideKeyboard: () => {
+					// The search panel is a native TextInput outside the editor WebView.
+					// Dismiss the native keyboard regardless of which editor is enabled.
+					Keyboard.dismiss();
 					if (this.useEditorBeta()) {
 						this.editorRef?.current?.hideKeyboard();
-					} else {
-						Keyboard.dismiss();
 					}
 				},
 				insertText: this.insertText.bind(this),


### PR DESCRIPTION
Fixes: #16462

## Description
This PR fixes issue #16462 where the "Dismiss keyboard" button does nothing when the search entry field is focused.

## Cause of the Bug
Previously, the `hideKeyboard` function conditionally called `Keyboard.dismiss()` only if the Beta Editor was disabled. However, the search panel is a native `TextInput` component outside the editor's WebView. When the Beta Editor is enabled and the search panel is focused, the function tried to call `this.editorRef?.current?.hideKeyboard()`, which failed to dismiss the native keyboard of the search field.

## Solution
Updated the `hideKeyboard` handler in `Note.tsx` to always call `Keyboard.dismiss()`, ensuring that the native keyboard is hidden regardless of which editor is enabled or where the focus lies (editor vs. search bar).

## Proposed Changes
* **Modified:** `packages/app-mobile/components/screens/Note/Note.tsx`
* Explicitly added `Keyboard.dismiss()` before checking the editor type so that the native keyboard is always dismissed.

## Note for Maintainers / Reviewers
> [!IMPORTANT]
> I do not have access to an iOS device or an iOS simulator to test this change locally.
> The fix is based on code logic and the description provided in the issue. Could a maintainer or reviewer please test this on an iOS device/simulator and verify if the keyboard dismisses properly when the search panel is focused?

## Related Issues
Closes #16462
