### PR TITLE
Server: Fix notification read-state being updatable by non-owner

### DIFF
--- a/packages/server/src/models/NotificationModel.ts
+++ b/packages/server/src/models/NotificationModel.ts
@@ -148,6 +148,14 @@ export default class NotificationModel extends BaseModel<Notification> {
 			.first();
 	}
 
+	public loadByUserId(userId: Uuid, id: Uuid): Promise<Notification> {
+		return this.db(this.tableName)
+			.select(this.defaultFields)
+			.where('id', '=', id)
+			.andWhere('owner_id', '=', userId)
+			.first();
+	}
+
 	public async deleteByUserId(userId: Uuid) {
 		await this.db(this.tableName).where('owner_id', '=', userId).delete();
 	}

--- a/packages/server/src/routes/index/notifications.test.ts
+++ b/packages/server/src/routes/index/notifications.test.ts
@@ -44,4 +44,31 @@ describe('notifications', () => {
 		expect((await model.loadByKey(user.id, NotificationKey.EmailConfirmed)).read).toBe(1);
 	});
 
+	test('should not allow updating the notification of another user', async () => {
+		const { user: user1 } = await createUserAndSession(1);
+		const { session: session2 } = await createUserAndSession(2);
+
+		const model = models().notification();
+
+		await model.add(user1.id, NotificationKey.EmailConfirmed, NotificationLevel.Normal, 'testing notification');
+
+		const notification = await model.loadByKey(user1.id, NotificationKey.EmailConfirmed);
+
+		const context = await koaAppContext({
+			sessionId: session2.id,
+			request: {
+				method: 'PATCH',
+				url: `/notifications/${notification.id}`,
+				body: {
+					read: 1,
+				},
+			},
+		});
+
+		await routeHandler(context);
+
+		expect(context.response.status).toBe(404);
+		expect((await model.loadByKey(user1.id, NotificationKey.EmailConfirmed)).read).toBe(0);
+	});
+
 });

--- a/packages/server/src/routes/index/notifications.ts
+++ b/packages/server/src/routes/index/notifications.ts
@@ -12,7 +12,7 @@ router.patch('notifications/:id', async (path: SubPath, ctx: AppContext) => {
 	const fields: Notification = await bodyFields(ctx.req);
 	const notificationId = path.id;
 	const model = ctx.joplin.models.notification();
-	const existingNotification = await model.load(notificationId);
+	const existingNotification = await model.loadByUserId(ctx.joplin.owner.id, notificationId);
 	if (!existingNotification) throw new ErrorNotFound();
 
 	const toSave: Notification = {};


### PR DESCRIPTION
The `PATCH /notifications/:id` route loaded the notification by id alone, so any authenticated user could toggle the `read` flag on another user's notification if they knew its id.

Added `NotificationModel.loadByUserId()` and used it in the route, so a notification belonging to someone else now falls through to the existing 404 rather than being modified.

Impact is limited: only the `read` flag is writable, no content is disclosed, and ids are random and not exposed.