### PR TITLE
Server: Add rate limiting to the signup and password reset endpoints

### DIFF
--- a/packages/server/src/routes/index/password.ts
+++ b/packages/server/src/routes/index/password.ts
@@ -5,7 +5,8 @@ import { AppContext } from '../../utils/types';
 import { ErrorNotFound } from '../../utils/errors';
 import defaultView from '../../utils/defaultView';
 import { forgotPasswordUrl, resetPasswordUrl } from '../../utils/urlUtils';
-import { bodyFields } from '../../utils/requestUtils';
+import { bodyFields, userIp } from '../../utils/requestUtils';
+import { limiterForgotPasswordBruteForce } from '../../utils/request/limiterAccountBruteForce';
 import Logger from '@joplin/utils/Logger';
 
 const logger = Logger.create('index/password');
@@ -27,6 +28,8 @@ const subRoutes: Record<string, RouteHandler> = {
 		let confirmationMessage = '';
 
 		if (ctx.method === 'POST') {
+			await limiterForgotPasswordBruteForce(userIp(ctx));
+
 			const fields = await bodyFields<ForgotPasswordFields>(ctx.req);
 			try {
 				await ctx.joplin.models.user().sendResetPasswordEmail(fields.email || '');

--- a/packages/server/src/routes/index/signup.ts
+++ b/packages/server/src/routes/index/signup.ts
@@ -2,7 +2,8 @@ import { SubPath, redirect, makeUrl, UrlType } from '../../utils/routeUtils';
 import Router from '../../utils/Router';
 import { RouteType } from '../../utils/types';
 import { AppContext } from '../../utils/types';
-import { bodyFields } from '../../utils/requestUtils';
+import { bodyFields, userIp } from '../../utils/requestUtils';
+import { limiterSignupBruteForce } from '../../utils/request/limiterAccountBruteForce';
 import config from '../../config';
 import defaultView from '../../utils/defaultView';
 import { View } from '../../services/MustacheService';
@@ -38,6 +39,8 @@ router.get('signup', async (_path: SubPath, _ctx: AppContext) => {
 
 router.post('signup', async (_path: SubPath, ctx: AppContext) => {
 	if (!config().signupEnabled) throw new ErrorForbidden('Signup is not enabled');
+
+	await limiterSignupBruteForce(userIp(ctx));
 
 	try {
 		const formUser = await bodyFields<FormUser>(ctx.req);

--- a/packages/server/src/utils/request/limiterAccountBruteForce.ts
+++ b/packages/server/src/utils/request/limiterAccountBruteForce.ts
@@ -1,0 +1,11 @@
+import bruteForceLimiter from './bruteForceLimiter';
+
+export const limiterSignupBruteForce = bruteForceLimiter(
+	10,
+	'Too many sign up attempts',
+);
+
+export const limiterForgotPasswordBruteForce = bruteForceLimiter(
+	10,
+	'Too many password reset requests',
+);


### PR DESCRIPTION
`limiterLoginBruteForce` was only applied to the login routes, so `POST /signup` and `POST /password/forgot` could be called without any limit. Both now use a brute force limiter with the same 10 requests per minute per IP as login.