### PR TITLE
Desktop: Fixes #16457: Whiteboard: Add missing "Add note to whiteboard" menu item

### DIFF
--- a/packages/app-desktop/app.reducer.ts
+++ b/packages/app-desktop/app.reducer.ts
@@ -299,10 +299,9 @@ export default function(state: AppState, action: any) {
 		}
 
 		case 'WHITEBOARD_ACTIVE_NOTE_SET':
-			newState = {
-				...state,
-				activeNoteIsWhiteboard: !!action.value,
-			};
+			newState = withWindowStateUpdated(
+				state, action.windowId, 'activeNoteIsWhiteboard', () => !!action.value,
+			);
 			break;
 
 		case 'AI_CHAT_APPEND':

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -532,6 +532,7 @@ function useMenu(props: Props) {
 			// the following menu items will be available for all OS under Tools
 			const toolsItemsAll = [
 				menuItemDic.newWhiteboard,
+				menuItemDic.addNoteToWhiteboard,
 				separator(),
 				{
 					label: _('Note attachments...'),

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -579,8 +579,8 @@ function NoteEditorContent(props: NoteEditorProps) {
 	// show the editor toggle. We can't compute this from the redux note list
 	// because note bodies aren't in the preview fields.
 	useEffect(() => {
-		props.dispatch({ type: 'WHITEBOARD_ACTIVE_NOTE_SET', value: noteHasWhiteboardFence });
-	}, [noteHasWhiteboardFence, props.dispatch]);
+		props.dispatch({ type: 'WHITEBOARD_ACTIVE_NOTE_SET', value: noteHasWhiteboardFence, windowId });
+	}, [noteHasWhiteboardFence, windowId, props.dispatch]);
 
 	if (useWhiteboardEditor) {
 		editor = <WhiteboardEditor key={formNote.id} {...editorProps}/>;

--- a/readme/apps/whiteboard.md
+++ b/readme/apps/whiteboard.md
@@ -19,8 +19,9 @@ A whiteboard note opens directly in the editor. The view supports panning (click
 ### Adding cards
 
 - **+ Text** (top-right action panel) — adds a new text card near the centre of the visible viewport. Double-click the card or press **Enter** when it's focused to edit; the body supports Markdown, including headings, lists, code blocks, and checkboxes.
-- **Drag and drop from Joplin** — drag a note from the note list, or an attachment, onto the whiteboard to create a card linking to it.
-- **Tools → Add note to whiteboard** — opens the note picker and adds a card linking to the chosen Joplin note. The card shows the note's title and a live preview of its body, with working checkboxes.
+- **Drag and drop from Joplin** — drag a note from the note list onto the whiteboard to create a card linking to it.
+- **Drag and drop a file** — drag a file, such as an image, from your computer onto the whiteboard.
+- **Tools → Add note to whiteboard** — opens the note picker and adds a card linking to the chosen Joplin note.
 
 ### Connecting cards
 


### PR DESCRIPTION
The `addNoteToWhiteboard` command was implemented and registered in `menuCommandNames`, but never inserted into a menu — so it was unreachable. Added it to the Tools menu next to "Create whiteboard".

Also fixes `activeNoteIsWhiteboard` being written to root state instead of window state. It's declared on `AppWindowState` and read via `windowStateById`, so it worked in the main window by accident and silently failed in secondary windows — leaving the new menu item (and the toolbar's editor toggle) permanently disabled there.