### PR TITLE
Desktop, Mobile, Cli: Fixes #16422: Fix WebDAV sync failing with 409 errors after 3.7 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1365,6 +1365,7 @@ packages/lib/SyncTargetWebDAV.js
 packages/lib/Synchronizer.js
 packages/lib/TaskQueue.test.js
 packages/lib/TaskQueue.js
+packages/lib/WebDavApi.test.js
 packages/lib/WebDavApi.js
 packages/lib/WelcomeUtils.test.js
 packages/lib/WelcomeUtils.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1391,6 +1391,7 @@ packages/lib/SyncTargetWebDAV.js
 packages/lib/Synchronizer.js
 packages/lib/TaskQueue.test.js
 packages/lib/TaskQueue.js
+packages/lib/WebDavApi.test.js
 packages/lib/WebDavApi.js
 packages/lib/WelcomeUtils.test.js
 packages/lib/WelcomeUtils.js

--- a/packages/lib/WebDavApi.test.ts
+++ b/packages/lib/WebDavApi.test.ts
@@ -1,0 +1,99 @@
+import WebDavApi from './WebDavApi';
+import shim, { FetchOptions } from './shim';
+
+const makeApi = () => {
+	return new WebDavApi({
+		baseUrl: () => 'https://example.com/dav',
+		username: () => 'user',
+		password: () => 'password',
+	});
+};
+
+const makeResponse = (status: number, text = '') => {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		text: async () => text,
+	};
+};
+
+describe('WebDavApi', () => {
+
+	let originalFetch: typeof shim.fetch;
+
+	beforeEach(() => {
+		originalFetch = shim.fetch;
+	});
+
+	afterEach(() => {
+		shim.fetch = originalFetch;
+	});
+
+	test.each([
+		['MKCOL', true],
+		['PUT', false],
+	])('should only treat a 405 as an If-None-Match rejection for non-MKCOL requests (%s)', async (method, shouldKeepHeader) => {
+		const requests: Record<string, string | number>[] = [];
+		shim.fetch = (async (_url: string, options: FetchOptions) => {
+			requests.push(options.headers as Record<string, string | number>);
+			// The server always rejects with 405, whether or not the header is present
+			return makeResponse(405);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test double only implements the subset of shim.fetch used here
+		}) as any;
+
+		const api = makeApi();
+
+		await expect(api.exec(method, 'dir/')).rejects.toThrow();
+
+		// A 405 on MKCOL means the collection already exists, so no retry should happen
+		expect(requests.length).toBe(shouldKeepHeader ? 1 : 2);
+
+		// Either way the header must be kept: the 405 was not caused by it, since it was
+		// also returned when the retry omitted the header
+		requests.length = 0;
+		await expect(api.exec('PROPFIND', 'dir/')).rejects.toThrow();
+		expect('If-None-Match' in requests[0]).toBe(true);
+	});
+
+	test('should keep sending If-None-Match when a retry without it fails too', async () => {
+		const requests: Record<string, string | number>[] = [];
+		shim.fetch = (async (_url: string, options: FetchOptions) => {
+			requests.push(options.headers as Record<string, string | number>);
+			// The header is not the cause of the failure - the server rejects either way
+			return makeResponse(400);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test double only implements the subset of shim.fetch used here
+		}) as any;
+
+		const api = makeApi();
+
+		await expect(api.exec('PUT', 'test.md', 'content')).rejects.toThrow();
+		expect(requests.length).toBe(2);
+
+		requests.length = 0;
+		await expect(api.exec('PUT', 'test2.md', 'content')).rejects.toThrow();
+		expect(requests.length).toBe(1);
+		expect('If-None-Match' in requests[0]).toBe(true);
+	});
+
+	test('should stop sending If-None-Match when the server rejects it with a 400', async () => {
+		const requests: Record<string, string | number>[] = [];
+		shim.fetch = (async (_url: string, options: FetchOptions) => {
+			const headers = options.headers as Record<string, string | number>;
+			requests.push(headers);
+			if ('If-None-Match' in headers) return makeResponse(400);
+			return makeResponse(200, '');
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test double only implements the subset of shim.fetch used here
+		}) as any;
+
+		const api = makeApi();
+
+		await api.exec('PUT', 'test.md', 'content');
+		expect(requests.length).toBe(2);
+
+		requests.length = 0;
+		await api.exec('PUT', 'test2.md', 'content');
+		expect(requests.length).toBe(1);
+		expect('If-None-Match' in requests[0]).toBe(false);
+	});
+
+});

--- a/packages/lib/WebDavApi.test.ts
+++ b/packages/lib/WebDavApi.test.ts
@@ -58,9 +58,10 @@ describe('WebDavApi', () => {
 	test('should keep sending If-None-Match when a retry without it fails too', async () => {
 		const requests: Record<string, string | number>[] = [];
 		shim.fetch = (async (_url: string, options: FetchOptions) => {
-			requests.push(options.headers as Record<string, string | number>);
+			const headers = options.headers as Record<string, string | number>;
+			requests.push(headers);
 			// The header is not the cause of the failure - the server rejects either way
-			return makeResponse(400);
+			return makeResponse('If-None-Match' in headers ? 400 : 500);
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test double only implements the subset of shim.fetch used here
 		}) as any;
 
@@ -69,9 +70,10 @@ describe('WebDavApi', () => {
 		await expect(api.exec('PUT', 'test.md', 'content')).rejects.toThrow();
 		expect(requests.length).toBe(2);
 
+		// The headerless retry failed with a non-terminal error, so nothing was learned about
+		// the server and the detection is run again, starting with the header
 		requests.length = 0;
 		await expect(api.exec('PUT', 'test2.md', 'content')).rejects.toThrow();
-		expect(requests.length).toBe(1);
 		expect('If-None-Match' in requests[0]).toBe(true);
 	});
 

--- a/packages/lib/WebDavApi.ts
+++ b/packages/lib/WebDavApi.ts
@@ -392,8 +392,12 @@ class WebDavApi {
 			response = await shim.fetch(url, fetchOptions);
 			// These are known error codes used for servers which reject when the If-None-Match header is sent. As these
 			// particular error codes are terminal, there should not be a risk of an intermittent failure selecting the
-			// wrong mode for the lifetime of the app
-			const terminalRejectionCodes = [400, 405];
+			// wrong mode for the lifetime of the app.
+			//
+			// 405 is excluded for MKCOL because per RFC 4918 that is the normal response when the collection already
+			// exists, and has nothing to do with If-None-Match. Treating it as a rejection made the retry succeed for
+			// the wrong reason and permanently disabled the header, which broke sync on servers that need it.
+			const terminalRejectionCodes = fetchOptions.method === 'MKCOL' ? [400] : [400, 405];
 			if (response.ok) {
 				this.excludeIfNoneMatch = ExcludeIfNoneMatch.No;
 			} else if (terminalRejectionCodes.includes(response.status)) {
@@ -404,7 +408,7 @@ class WebDavApi {
 				if (responseAlt.ok) {
 					this.excludeIfNoneMatch = ExcludeIfNoneMatch.Yes;
 					return responseAlt;
-				} else if (terminalRejectionCodes.includes(response.status)) {
+				} else if (terminalRejectionCodes.includes(responseAlt.status)) {
 					this.excludeIfNoneMatch = ExcludeIfNoneMatch.No;
 				}
 			}


### PR DESCRIPTION
Fixes #16422

#15983 added 405 to the statuses treated as "server rejects our `If-None-Match` header". But 405 is the normal `MKCOL` response when a directory already exists, which sync hits every run — so the header got disabled for the whole session, and later `PUT`s failed with 409.

Fix: don't count 405 as a rejection for `MKCOL`. Also fixes the retry branch checking `response.status` instead of `responseAlt.status`.