### PR TITLE
Desktop: Fixes #16414: Return 202 for MCP notification requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1868,6 +1868,7 @@ packages/lib/services/rest/routes/events.js
 packages/lib/services/rest/routes/folders.test.js
 packages/lib/services/rest/routes/folders.js
 packages/lib/services/rest/routes/master_keys.js
+packages/lib/services/rest/routes/mcp.test.js
 packages/lib/services/rest/routes/mcp.js
 packages/lib/services/rest/routes/notes.test.js
 packages/lib/services/rest/routes/notes.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -1894,6 +1894,7 @@ packages/lib/services/rest/routes/events.js
 packages/lib/services/rest/routes/folders.test.js
 packages/lib/services/rest/routes/folders.js
 packages/lib/services/rest/routes/master_keys.js
+packages/lib/services/rest/routes/mcp.test.js
 packages/lib/services/rest/routes/mcp.js
 packages/lib/services/rest/routes/notes.test.js
 packages/lib/services/rest/routes/notes.js

--- a/packages/lib/ClipperServer.ts
+++ b/packages/lib/ClipperServer.ts
@@ -195,14 +195,18 @@ export default class ClipperServer {
 						'Content-Length': body.length,
 					});
 					response.end(instance.body);
+				} else if (typeof instance.body === 'string' || instance.body === null || instance.body === undefined) {
+					writeCorsHeaders(code, instance.contentType ? instance.contentType : 'text/plain');
+					response.end(instance.body ? instance.body : '');
 				} else {
-					throw new Error('Not implemented');
+					writeCorsHeaders(code, instance.contentType ? instance.contentType : 'application/json');
+					response.end(JSON.stringify(instance.body));
 				}
 			};
 
 			const writeResponse = (code: number, response: unknown) => {
 				if (response instanceof ApiResponse) {
-					writeResponseInstance(code, response);
+					writeResponseInstance(response.status ? response.status : code, response);
 				} else if (typeof response === 'string') {
 					writeResponseText(code, response);
 				} else if (response === null || response === undefined) {

--- a/packages/lib/services/rest/ApiResponse.ts
+++ b/packages/lib/services/rest/ApiResponse.ts
@@ -4,5 +4,7 @@ export default class ApiResponse {
 	public body: unknown;
 	public contentType: string;
 	public attachmentFilename: string;
+	// When set, overrides the default status code the server would use.
+	public status: number = null;
 
 }

--- a/packages/lib/services/rest/routes/mcp.test.ts
+++ b/packages/lib/services/rest/routes/mcp.test.ts
@@ -1,0 +1,43 @@
+import Setting from '../../../models/Setting';
+import { setupDatabaseAndSynchronizer, switchClient } from '../../../testing/test-utils';
+import { Request, RequestMethod } from '../Api';
+import ApiResponse from '../ApiResponse';
+import route_mcp from './mcp';
+
+const makeRequest = (body: unknown) => {
+	return {
+		method: RequestMethod.POST,
+		body: JSON.stringify(body),
+	} as Request;
+};
+
+describe('routes/mcp', () => {
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+		Setting.setValue('mcp.enabled', true);
+	});
+
+	test.each([
+		['single notification', { jsonrpc: '2.0', method: 'notifications/initialized' }],
+		['batch of notifications', [{ jsonrpc: '2.0', method: 'notifications/initialized' }]],
+	])('should acknowledge %s with an empty 202', async (_description, payload) => {
+		const response = await route_mcp(makeRequest(payload));
+
+		// Strict MCP clients close the transport if this is a 200.
+		expect(response).toBeInstanceOf(ApiResponse);
+		expect((response as ApiResponse).status).toBe(202);
+		expect((response as ApiResponse).body).toBe('');
+	});
+
+	test('should return the response body for regular requests', async () => {
+		const response = await route_mcp(makeRequest({
+			jsonrpc: '2.0', id: 1, method: 'initialize', params: {},
+		}));
+
+		expect(response).not.toBeInstanceOf(ApiResponse);
+		expect((response as { id: number }).id).toBe(1);
+	});
+
+});

--- a/packages/lib/services/rest/routes/mcp.ts
+++ b/packages/lib/services/rest/routes/mcp.ts
@@ -3,6 +3,16 @@ import { ErrorBadRequest, ErrorForbidden, ErrorMethodNotAllowed } from '../utils
 import Setting from '../../../models/Setting';
 import McpServer from '../../mcp/McpServer';
 import { JsonRpcRequest, JsonRpcResponse } from '../../mcp/types';
+import ApiResponse from '../ApiResponse';
+
+// The MCP spec requires notifications to be acknowledged with an empty 202.
+// Strict clients such as Codex close the transport if they get a 200 instead.
+const acceptedResponse = () => {
+	const response = new ApiResponse();
+	response.status = 202;
+	response.body = '';
+	return response;
+};
 
 // Single-endpoint JSON-RPC transport. v1 only handles client-initiated
 // requests so plain POST/response is enough; streamable HTTP can come later
@@ -33,12 +43,12 @@ export default async function(request: Request) {
 			const r = await server.handleRequest(item as JsonRpcRequest);
 			if (r) responses.push(r);
 		}
-		if (!responses.length) return '';
+		if (!responses.length) return acceptedResponse();
 		return responses;
 	}
 
 	const response = await server.handleRequest(payload as JsonRpcRequest);
 	// Notifications get no body per JSON-RPC spec.
-	if (!response) return '';
+	if (!response) return acceptedResponse();
 	return response;
 }


### PR DESCRIPTION
MCP notifications must be acknowledged with an empty `202`, but Joplin returned `200`, causing strict clients like Codex to drop the connection during the handshake.

The route layer had no way to set a status code, so this adds an optional `status` to `ApiResponse` and uses it for MCP notifications. Verified with Codex.