### PR TITLE
Chore: Disable mobile UI tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -46,7 +46,8 @@ jobs:
           path: packages/app-desktop/playwright-report/
           retention-days: 7
   Mobile:
-    if: github.repository == 'laurent22/joplin'
+    # Disabled temporarily due to compiler errors in CI
+    if: github.repository == 'laurent22/joplin' && false
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
# Problem

The mobile UI tests are failing in CI with compiler errors (perhaps due to an XCode upgrade). For example,
```
n file included from /Users/runner/work/joplin/joplin/packages/app-mobile/ios/Pods/fmt/src/format.cc:8:
/Users/runner/work/joplin/joplin/packages/app-mobile/ios/Pods/fmt/include/fmt/format-inl.h:59:24: error: call to consteval function 'fmt::basic_format_string<char, fmt::basic_string_view<char> &, const char (&)[3]>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression
   59 |     fmt::format_to(it, FMT_STRING("{}{}"), message, SEP);
      |                        ^
In file included from /Users/runner/work/joplin/joplin/packages/app-mobile/ios/Pods/fmt/src/format.cc:8:
In file included from /Users/runner/work/joplin/joplin/packages/app-mobile/ios/Pods/fmt/include/fmt/format-inl.h:27:
/Users/runner/work/joplin/joplin/packages/app-mobile/ios/Pods/fmt/include/fmt/format.h:1827:23: note: expanded from macro 'FMT_STRING'
 1827 | #define FMT_STRING(s) FMT_STRING_IMPL(s, fmt::detail::compile_string, )
      |                       ^

```

# Solution

For now, disable the mobile UI tests in CI.

This pull request targets `release-3.7`.


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Web` — only the web app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
