### PR TITLE
Desktop, Mobile: Resolves #16038: Add note history support for locked notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -602,6 +602,7 @@ packages/app-desktop/gui/utils/NoteListUtils.js
 packages/app-desktop/gui/utils/announceForAccessibility.js
 packages/app-desktop/gui/utils/convertToScreenCoordinates.js
 packages/app-desktop/gui/utils/dragAndDrop.js
+packages/app-desktop/gui/utils/hasNoteLockKey.js
 packages/app-desktop/gui/utils/loadScript.js
 packages/app-desktop/gulpfile.js
 packages/app-desktop/integration-tests/chatPanel.spec.js
@@ -1601,6 +1602,7 @@ packages/lib/services/ResourceEditWatcher/reducer.js
 packages/lib/services/ResourceFetcher.js
 packages/lib/services/ResourceService.test.js
 packages/lib/services/ResourceService.js
+packages/lib/services/RevisionService.noteLock.test.js
 packages/lib/services/RevisionService.test.js
 packages/lib/services/RevisionService.js
 packages/lib/services/SettingUtils.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -628,6 +628,7 @@ packages/app-desktop/gui/utils/NoteListUtils.js
 packages/app-desktop/gui/utils/announceForAccessibility.js
 packages/app-desktop/gui/utils/convertToScreenCoordinates.js
 packages/app-desktop/gui/utils/dragAndDrop.js
+packages/app-desktop/gui/utils/hasNoteLockKey.js
 packages/app-desktop/gui/utils/loadScript.js
 packages/app-desktop/gulpfile.js
 packages/app-desktop/integration-tests/chatPanel.spec.js
@@ -1627,6 +1628,7 @@ packages/lib/services/ResourceEditWatcher/reducer.js
 packages/lib/services/ResourceFetcher.js
 packages/lib/services/ResourceService.test.js
 packages/lib/services/ResourceService.js
+packages/lib/services/RevisionService.noteLock.test.js
 packages/lib/services/RevisionService.test.js
 packages/lib/services/RevisionService.js
 packages/lib/services/SettingUtils.js

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -30,7 +30,7 @@ import ExternalEditWatcher from '@joplin/lib/services/ExternalEditWatcher';
 import { itemIsReadOnly } from '@joplin/lib/models/utils/readOnly';
 import NoteLockSession from '@joplin/lib/services/noteLock/NoteLockSession';
 import isNoteLockEnabled from '@joplin/lib/services/noteLock/isNoteLockEnabled';
-import { SyncInfo } from '@joplin/lib/services/synchronizer/syncInfoUtils';
+import hasNoteLockKey from '../utils/hasNoteLockKey';
 import NoteLockPanel from './NoteLockPanel/NoteLockPanel';
 import { themeStyle } from '@joplin/lib/theme';
 import { substrWithEllipsis } from '@joplin/lib/string-utils';
@@ -634,7 +634,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 
 		return (
 			<div style={revStyle} ref={containerRef}>
-				<NoteRevisionViewer customCss={props.customCss} noteId={formNote.id} onBack={noteRevisionViewer_onBack} />
+				<NoteRevisionViewer customCss={props.customCss} noteId={isNoteLockEnabled() ? effectiveNoteId : formNote.id} onBack={noteRevisionViewer_onBack} />
 			</div>
 		);
 	}
@@ -852,15 +852,6 @@ function NoteEditorContent(props: NoteEditorProps) {
 interface ConnectProps {
 	windowId: string;
 }
-
-// Memoized because mapStateToProps runs on every dispatch and SyncInfo parses the cached JSON.
-let hasNoteLockKeyCache: { syncInfoCache: string; value: boolean } = null;
-const hasNoteLockKey = (syncInfoCache: string) => {
-	if (!hasNoteLockKeyCache || hasNoteLockKeyCache.syncInfoCache !== syncInfoCache) {
-		hasNoteLockKeyCache = { syncInfoCache, value: !!new SyncInfo(syncInfoCache).noteLockKey };
-	}
-	return hasNoteLockKeyCache.value;
-};
 
 const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 	const whenClauseContext = stateToWhenClauseContext(state, { windowId: ownProps.windowId });

--- a/packages/app-desktop/gui/NoteRevisionViewer.tsx
+++ b/packages/app-desktop/gui/NoteRevisionViewer.tsx
@@ -27,6 +27,11 @@ import { focus } from '@joplin/lib/utils/focusHandler';
 import useDeleteHistoryClick from '@joplin/lib/components/shared/NoteRevisionViewer/useDeleteHistoryClick';
 import { getGlobalSettings } from '@joplin/renderer/types';
 import Setting from '@joplin/lib/models/Setting';
+import isNoteLockEnabled from '@joplin/lib/services/noteLock/isNoteLockEnabled';
+import NoteLockService from '@joplin/lib/services/noteLock/NoteLockService';
+import NoteLockPanel from './NoteEditor/NoteLockPanel/NoteLockPanel';
+import hasNoteLockKey from './utils/hasNoteLockKey';
+import { Dispatch } from 'redux';
 
 interface Props {
 	themeId: number;
@@ -36,6 +41,9 @@ interface Props {
 	scrollbarSize: ScrollbarSize;
 	fontFamily: string;
 	showNoteLinkIcon: boolean;
+	noteLockSessionUnlocked: boolean;
+	hasNoteLockKey: boolean;
+	dispatch: Dispatch;
 }
 
 const useNoteContent = (
@@ -47,8 +55,13 @@ const useNoteContent = (
 	scrollbarSize: ScrollbarSize,
 	fontFamily: string,
 	showNoteLinkIcon: boolean,
+	canDecrypt: boolean,
 ) => {
 	const [note, setNote] = useState<NoteEntity>(null);
+	// The revision note as merged from the diffs, with a locked body still encrypted. Restoring
+	// this keeps the restored copy a valid locked note, so it is never decrypted for restore.
+	const [restoreNote, setRestoreNote] = useState<NoteEntity>(null);
+	const [decryptFailed, setDecryptFailed] = useState(false);
 
 	const markupToHtml = useMarkupToHtml({
 		themeId,
@@ -62,13 +75,35 @@ const useNoteContent = (
 	useAsyncEffect(async (event) => {
 		if (!revisions.length || !currentRevId) {
 			setNote(null);
+			setRestoreNote(null);
+			setDecryptFailed(false);
 		} else {
 			const revIndex = BaseModel.modelIndexById(revisions, currentRevId);
 			const note = await RevisionService.instance().revisionNote(revisions, revIndex);
 			if (!note || event.cancelled) return;
-			setNote(note);
+			setRestoreNote(note);
+			if (isNoteLockEnabled() && revisions[revIndex].is_locked) {
+				// A revision is a JSON diff object, so a gated load is not possible: the diffs are
+				// merged first and the resulting body is decrypted manually here.
+				let displayBody = '';
+				let failed = false;
+				if (canDecrypt) {
+					try {
+						displayBody = await NoteLockService.instance().decryptString(note.body ?? '');
+					} catch (error) {
+						console.warn('Could not decrypt revision content:', error);
+						failed = true;
+					}
+					if (event.cancelled) return;
+				}
+				setDecryptFailed(failed);
+				setNote({ ...note, body: displayBody });
+			} else {
+				setDecryptFailed(false);
+				setNote(note);
+			}
 		}
-	}, [revisions, currentRevId, themeId, customCss, viewerRef]);
+	}, [revisions, currentRevId, themeId, customCss, viewerRef, canDecrypt]);
 
 	useQueuedAsyncEffect(async () => {
 		const noteBody = note?.body ?? _('This note has no history');
@@ -85,10 +120,10 @@ const useNoteContent = (
 		});
 	}, [note, viewerRef, markupToHtml, showNoteLinkIcon]);
 
-	return note;
+	return { note, restoreNote, decryptFailed };
 };
 
-const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack, customCss, scrollbarSize, fontFamily, showNoteLinkIcon }) => {
+const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack, customCss, scrollbarSize, fontFamily, showNoteLinkIcon, noteLockSessionUnlocked, hasNoteLockKey, dispatch }) => {
 	const helpButton_onClick = useCallback(() => {}, []);
 	const viewerRef = useRef<NoteViewerControl|null>(null);
 	const revisionListRef = useRef<HTMLSelectElement|null>(null);
@@ -98,8 +133,9 @@ const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack,
 	const [restoring, setRestoring] = useState(false);
 	const [deleting, setDeleting] = useState(false);
 
-	const note = useNoteContent(
-		viewerRef, currentRevId, revisions, themeId, customCss, scrollbarSize, fontFamily, showNoteLinkIcon,
+	const canDecrypt = noteLockSessionUnlocked && hasNoteLockKey;
+	const { note, restoreNote, decryptFailed } = useNoteContent(
+		viewerRef, currentRevId, revisions, themeId, customCss, scrollbarSize, fontFamily, showNoteLinkIcon, canDecrypt,
 	);
 
 	const viewer_domReady = useCallback(async () => {
@@ -112,12 +148,12 @@ const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack,
 	}, [noteId]);
 
 	const importButton_onClick = useCallback(async () => {
-		if (!note) return;
+		if (!restoreNote) return;
 		setRestoring(true);
-		await RevisionService.instance().importRevisionNote(note);
+		await RevisionService.instance().importRevisionNote(restoreNote);
 		setRestoring(false);
-		await shim.showMessageBox(RevisionService.instance().restoreSuccessMessage(note), { type: MessageBoxType.Info });
-	}, [note]);
+		await shim.showMessageBox(RevisionService.instance().restoreSuccessMessage(restoreNote), { type: MessageBoxType.Info });
+	}, [restoreNote]);
 
 	const resetScreenState = useCallback(() => {
 		setRevisions([]);
@@ -188,6 +224,9 @@ const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack,
 		);
 	}
 
+	const revisionLocked = isNoteLockEnabled() && revisions.some(r => r.id === currentRevId && !!r.is_locked);
+	const showLockPanel = revisionLocked && (!canDecrypt || decryptFailed);
+
 	const restoreButtonTitle = _('Restore');
 	const deleteHistoryButtonTitle = _('Delete history');
 	const helpMessage = getHelpMessage(restoreButtonTitle);
@@ -201,17 +240,18 @@ const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack,
 			<select disabled={!revisions.length} value={currentRevId} className='revisions' style={theme.dropdownList} onChange={revisionList_onChange} ref={revisionListRef}>
 				{revisionListItems}
 			</select>
-			<button disabled={!revisions.length || restoring} onClick={importButton_onClick} className='restore'style={{ ...theme.buttonStyle, marginLeft: 10, height: theme.inputStyle.height }}>
+			<button disabled={!revisions.length || restoring || showLockPanel} onClick={importButton_onClick} className='restore'style={{ ...theme.buttonStyle, marginLeft: 10, height: theme.inputStyle.height }}>
 				{restoreButtonTitle}
 			</button>
-			<button disabled={!revisions.length || deleting} onClick={deleteHistoryButton_onClick} className='deleteHistory'style={{ ...theme.buttonStyle, marginLeft: 10, height: theme.inputStyle.height }}>
+			<button disabled={!revisions.length || deleting || showLockPanel} onClick={deleteHistoryButton_onClick} className='deleteHistory'style={{ ...theme.buttonStyle, marginLeft: 10, height: theme.inputStyle.height }}>
 				{deleteHistoryButtonTitle}
 			</button>
 			<HelpButton tip={helpMessage} id="noteRevisionHelpButton" onClick={helpButton_onClick} />
 		</div>
 	);
 
-	const viewer = <NoteTextViewer themeId={themeId} viewerStyle={{ display: 'flex', flex: 1, borderLeft: 'none' }} ref={viewerRef} onDomReady={viewer_domReady} onIpcMessage={webview_ipcMessage} />;
+	// The viewer stays mounted while the lock panel shows because its dom-ready event loads the revision list.
+	const viewer = <NoteTextViewer themeId={themeId} viewerStyle={{ display: showLockPanel ? 'none' : 'flex', flex: 1, borderLeft: 'none' }} ref={viewerRef} onDomReady={viewer_domReady} onIpcMessage={webview_ipcMessage} />;
 
 	useEffect(() => {
 		// We need to force focus here because otherwise the focus is lost and goes back
@@ -222,6 +262,12 @@ const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack,
 	return (
 		<div className='revision-viewer-root'>
 			{titleInput}
+			{showLockPanel ? <NoteLockPanel
+				noteTitle={restoreNote?.title ?? ''}
+				hasNoteLockKey={hasNoteLockKey}
+				dispatch={dispatch}
+				undecryptable={decryptFailed && noteLockSessionUnlocked}
+			/> : null}
 			{viewer}
 			<ReactTooltip place="bottom" delayShow={300} className="help-tooltip" />
 		</div>
@@ -234,6 +280,8 @@ const mapStateToProps = (state: AppState) => {
 		scrollbarSize: state.settings['style.scrollbarSize'],
 		fontFamily: state.settings['style.viewer.fontFamily'],
 		showNoteLinkIcon: state.settings['notes.showNoteLinkIcon'],
+		noteLockSessionUnlocked: state.noteLockSessionUnlocked,
+		hasNoteLockKey: hasNoteLockKey(state.settings['syncInfoCache']),
 	};
 };
 

--- a/packages/app-desktop/gui/NoteRevisionViewer.tsx
+++ b/packages/app-desktop/gui/NoteRevisionViewer.tsx
@@ -243,7 +243,7 @@ const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack,
 			<button disabled={!revisions.length || restoring || showLockPanel} onClick={importButton_onClick} className='restore'style={{ ...theme.buttonStyle, marginLeft: 10, height: theme.inputStyle.height }}>
 				{restoreButtonTitle}
 			</button>
-			<button disabled={!revisions.length || deleting || showLockPanel} onClick={deleteHistoryButton_onClick} className='deleteHistory'style={{ ...theme.buttonStyle, marginLeft: 10, height: theme.inputStyle.height }}>
+			<button disabled={!revisions.length || deleting} onClick={deleteHistoryButton_onClick} className='deleteHistory'style={{ ...theme.buttonStyle, marginLeft: 10, height: theme.inputStyle.height }}>
 				{deleteHistoryButtonTitle}
 			</button>
 			<HelpButton tip={helpMessage} id="noteRevisionHelpButton" onClick={helpButton_onClick} />

--- a/packages/app-desktop/gui/utils/hasNoteLockKey.ts
+++ b/packages/app-desktop/gui/utils/hasNoteLockKey.ts
@@ -1,0 +1,11 @@
+import { SyncInfo } from '@joplin/lib/services/synchronizer/syncInfoUtils';
+
+// Memoized because mapStateToProps runs on every dispatch and SyncInfo parses the cached JSON.
+let cache: { syncInfoCache: string; value: boolean } = null;
+
+export default (syncInfoCache: string) => {
+	if (!cache || cache.syncInfoCache !== syncInfoCache) {
+		cache = { syncInfoCache, value: !!new SyncInfo(syncInfoCache).noteLockKey };
+	}
+	return cache.value;
+};

--- a/packages/app-mobile/components/screens/NoteRevisionViewer.test.tsx
+++ b/packages/app-mobile/components/screens/NoteRevisionViewer.test.tsx
@@ -12,6 +12,9 @@ import { useMemo } from 'react';
 import Revision from '@joplin/lib/models/Revision';
 import { ModelType } from '@joplin/lib/BaseModel';
 import getWebViewDomById from '../../utils/testing/getWebViewDomById';
+import Setting from '@joplin/lib/models/Setting';
+import NoteLockKey from '@joplin/lib/services/noteLock/NoteLockKey';
+import NoteLockService from '@joplin/lib/services/noteLock/NoteLockService';
 
 interface WrapperProps {
 	noteId: string;
@@ -72,6 +75,7 @@ describe('screens/NoteRevisionViewer', () => {
 	});
 	afterEach(() => {
 		screen.unmount();
+		jest.restoreAllMocks();
 	});
 
 	test('should render "No revision selected" when no revisions are selected', async () => {
@@ -81,6 +85,46 @@ describe('screens/NoteRevisionViewer', () => {
 		expect(await getRevisionViewerText()).toBe('No revision selected');
 
 		unmount();
+	});
+
+	test('should gate an encrypted revision behind the unlock panel until the session is unlocked', async () => {
+		Setting.setValue('featureFlag.noteLock', true);
+		const note = await Note.save({ title: 'Note', body: 'enc(secret)', is_locked: 1, parent_id: '' });
+		await Revision.save({
+			item_type: ModelType.Note,
+			item_id: note.id,
+			item_updated_time: note.updated_time,
+			parent_id: '',
+			is_locked: 1,
+			title_diff: Revision.createTextPatch('', 'Note'),
+			body_diff: Revision.createTextPatch('', 'enc(secret)'),
+			metadata_diff: '{"new":{},"deleted":[]}',
+		});
+		jest.spyOn(NoteLockKey.instance(), 'load').mockReturnValue({ id: 'key-id' });
+		jest.spyOn(NoteLockService, 'instance').mockReturnValue({
+			decryptString: async (cipherText: string) => {
+				if (cipherText !== 'enc(secret)') throw new Error('Unexpected cipher text');
+				return 'secret';
+			},
+		} as ReturnType<typeof NoteLockService.instance>);
+
+		render(<WrappedRevisionViewerScreen noteId={note.id}/>);
+
+		const dropdown = screen.getByRole('button', { name: 'Select a revision...' });
+		fireEvent.press(dropdown);
+		await waitFor(() => {
+			fireEvent.press(screen.getAllByRole('menuitem')[0]);
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText('This note is encrypted. Enter the note lock password to unlock encrypted notes for this session.')).toBeVisible();
+		});
+
+		store.dispatch({ type: 'SET_NOTE_LOCK_SESSION_UNLOCKED', value: true });
+
+		await waitFor(async () => {
+			expect(await getRevisionViewerText()).toBe('secret');
+		});
 	});
 
 	test('selecting a revision should render its content', async () => {

--- a/packages/app-mobile/components/screens/NoteRevisionViewer.test.tsx
+++ b/packages/app-mobile/components/screens/NoteRevisionViewer.test.tsx
@@ -117,7 +117,7 @@ describe('screens/NoteRevisionViewer', () => {
 		});
 
 		await waitFor(() => {
-			expect(screen.getByText('This note is encrypted. Enter the note lock password to unlock encrypted notes for this session.')).toBeVisible();
+			expect(screen.getByText('This note is locked. Enter your password to unlock your notes for this session.')).toBeVisible();
 		});
 
 		store.dispatch({ type: 'SET_NOTE_LOCK_SESSION_UNLOCKED', value: true });

--- a/packages/app-mobile/components/screens/NoteRevisionViewer.tsx
+++ b/packages/app-mobile/components/screens/NoteRevisionViewer.tsx
@@ -226,7 +226,7 @@ const NoteRevisionViewer: React.FC<Props> = props => {
 		resetScreenState,
 	});
 
-	const disableDeleteHistory = deleting || !hasRevisions || showLockPanel;
+	const disableDeleteHistory = deleting || !hasRevisions;
 	const menuOptions = useMemo(() => {
 		const output: MenuOption[] = [{
 			title: _('Delete history'),

--- a/packages/app-mobile/components/screens/NoteRevisionViewer.tsx
+++ b/packages/app-mobile/components/screens/NoteRevisionViewer.tsx
@@ -25,10 +25,15 @@ import useDeleteHistoryClick from '@joplin/lib/components/shared/NoteRevisionVie
 import { OnScrollCallback } from '../NoteBodyViewer/types';
 import TextWrapCalculator from './Notes/TextWrapCalculator';
 import { MenuOptionStyle } from '../BottomDrawerMenu';
+import isNoteLockEnabled from '@joplin/lib/services/noteLock/isNoteLockEnabled';
+import NoteLockService from '@joplin/lib/services/noteLock/NoteLockService';
+import NoteLockKey from '@joplin/lib/services/noteLock/NoteLockKey';
+import NoteLockPanel from './Note/NoteLockPanel';
 
 interface Props {
 	themeId: number;
 	selectedNoteId: string;
+	noteLockSessionUnlocked: boolean;
 
 	// Properties passed by the navigation logic
 	navigation?: {
@@ -55,26 +60,51 @@ const useRevisions = (noteId: string) => {
 	return revisions;
 };
 
-const useRevisionNote = (revisions: RevisionEntity[], revisionId: string) => {
+const useRevisionNote = (revisions: RevisionEntity[], revisionId: string, canDecrypt: boolean) => {
 	const [note, setNote] = useState<NoteEntity|null>(null);
+	// The revision note as merged from the diffs, with a locked body still encrypted. Restoring
+	// this keeps the restored copy a valid locked note, so it is never decrypted for restore.
+	const [restoreNote, setRestoreNote] = useState<NoteEntity|null>(null);
+	const [decryptFailed, setDecryptFailed] = useState(false);
 	const [resources, setResources] = useState<AttachedResources>({});
 
 	useAsyncEffect(async event => {
 		const revisionIndex = BaseModel.modelIndexById(revisions, revisionId);
 		if (revisionIndex === -1) {
 			setNote(null);
+			setRestoreNote(null);
 			return;
 		}
-		const note = await RevisionService.instance().revisionNote(revisions, revisionIndex);
+		let note = await RevisionService.instance().revisionNote(revisions, revisionIndex);
 		if (event.cancelled) return;
+		setRestoreNote(note);
+		if (isNoteLockEnabled() && revisions[revisionIndex].is_locked) {
+			// Revisions are merged before decryption, so a gated load is not possible.
+			// Keep this in sync with app-desktop/gui/NoteRevisionViewer.tsx.
+			let displayBody = '';
+			let failed = false;
+			if (canDecrypt) {
+				try {
+					displayBody = await NoteLockService.instance().decryptString(note.body ?? '');
+				} catch (error) {
+					console.warn('Could not decrypt revision content:', error);
+					failed = true;
+				}
+				if (event.cancelled) return;
+			}
+			setDecryptFailed(failed);
+			note = { ...note, body: displayBody };
+		} else {
+			setDecryptFailed(false);
+		}
 		setNote(note);
 
 		const resources = await attachedResources(note?.body ?? '');
 		if (event.cancelled) return;
 		setResources(resources);
-	}, [revisions, revisionId]);
+	}, [revisions, revisionId, canDecrypt]);
 
-	return { note, resources };
+	return { note, restoreNote, decryptFailed, resources };
 };
 
 const useStyles = (themeId: number) => {
@@ -137,7 +167,11 @@ const NoteRevisionViewer: React.FC<Props> = props => {
 	const noteId = props.navigation?.state?.noteId ?? props.selectedNoteId;
 	const revisions = useRevisions(noteId);
 	const [currentRevisionId, setCurrentRevisionId] = useState<string>('');
-	const { note, resources } = useRevisionNote(revisions, currentRevisionId);
+	const hasNoteLockKey = isNoteLockEnabled() && !!NoteLockKey.instance().load();
+	const canDecrypt = props.noteLockSessionUnlocked && hasNoteLockKey;
+	const { note, restoreNote, decryptFailed, resources } = useRevisionNote(revisions, currentRevisionId, canDecrypt);
+	const revisionLocked = isNoteLockEnabled() && revisions.some(r => r.id === currentRevisionId && !!r.is_locked);
+	const showLockPanel = revisionLocked && (!canDecrypt || decryptFailed);
 	const [initialScroll, setInitialScroll] = useState(0);
 	const [hasRevisions, setHasRevisions] = useState(false);
 	const [multiline, setMultiline] = useState(false);
@@ -168,15 +202,15 @@ const NoteRevisionViewer: React.FC<Props> = props => {
 
 	const [restoring, setRestoring] = useState(false);
 	const onRestore = useCallback(async () => {
-		if (!note) return;
+		if (!restoreNote) return;
 		setRestoring(true);
 		try {
-			await RevisionService.instance().importRevisionNote(note);
-			await shim.showMessageBox(RevisionService.instance().restoreSuccessMessage(note), { type: MessageBoxType.Info });
+			await RevisionService.instance().importRevisionNote(restoreNote);
+			await shim.showMessageBox(RevisionService.instance().restoreSuccessMessage(restoreNote), { type: MessageBoxType.Info });
 		} finally {
 			setRestoring(false);
 		}
-	}, [note]);
+	}, [restoreNote]);
 
 	const resetScreenState = useCallback(() => {
 		setCurrentRevisionId(null);
@@ -192,7 +226,7 @@ const NoteRevisionViewer: React.FC<Props> = props => {
 		resetScreenState,
 	});
 
-	const disableDeleteHistory = deleting || !hasRevisions;
+	const disableDeleteHistory = deleting || !hasRevisions || showLockPanel;
 	const menuOptions = useMemo(() => {
 		const output: MenuOption[] = [{
 			title: _('Delete history'),
@@ -221,7 +255,7 @@ const NoteRevisionViewer: React.FC<Props> = props => {
 	const restoreButton = (
 		<PrimaryButton
 			onPress={onRestore}
-			disabled={restoring || !note}
+			disabled={restoring || !note || showLockPanel}
 		>{restoreButtonTitle}</PrimaryButton>
 	);
 
@@ -306,21 +340,29 @@ const NoteRevisionViewer: React.FC<Props> = props => {
 			/>
 		</View>
 		{note ? titleComponent : ''}
-		<NoteBodyViewer
-			style={styles.noteViewer}
-			noteBody={note?.body ?? _('No revision selected')}
-			noteMarkupLanguage={MarkupLanguage.Markdown}
-			noteResources={resources}
-			highlightedKeywords={emptyStringList}
-			paddingBottom={0}
-			initialScrollPercent={initialScroll}
-			onScroll={onScroll}
-			noteHash={''}
-		/>
+		{showLockPanel ?
+			<NoteLockPanel
+				themeId={props.themeId}
+				hasNoteLockKey={hasNoteLockKey}
+				undecryptable={decryptFailed && props.noteLockSessionUnlocked}
+			/> :
+			<NoteBodyViewer
+				style={styles.noteViewer}
+				noteBody={note?.body ?? _('No revision selected')}
+				noteMarkupLanguage={MarkupLanguage.Markdown}
+				noteResources={resources}
+				highlightedKeywords={emptyStringList}
+				paddingBottom={0}
+				initialScrollPercent={initialScroll}
+				onScroll={onScroll}
+				noteHash={''}
+			/>
+		}
 	</View>;
 };
 
 export default connect((state: AppState) => ({
 	themeId: state.settings.theme,
 	selectedNoteId: state.selectedNoteIds[0] ?? '',
+	noteLockSessionUnlocked: state.noteLockSessionUnlocked,
 }))(NoteRevisionViewer);

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -15,6 +15,9 @@ import MasterKey from './models/MasterKey';
 import BaseModel, { DeleteOptions, ModelType } from './BaseModel';
 import time from './time';
 import ResourceService from './services/ResourceService';
+import RevisionService from './services/RevisionService';
+import isNoteLockEnabled from './services/noteLock/isNoteLockEnabled';
+import NoteLockNote from './services/noteLock/NoteLockNote';
 import EncryptionService from './services/e2ee/EncryptionService';
 import JoplinError from './JoplinError';
 import ShareService from './services/share/ShareService';
@@ -1119,12 +1122,24 @@ export default class Synchronizer {
 									locals.push(saved);
 								}
 
+								// Dispatched before the revision cleanup below: the reload marker is what
+								// makes queued editor saves stale, so it must advance before any await here.
 								if (action === SyncAction.UpdateLocal && content.type_ === BaseModel.TYPE_NOTE && content.id) {
 									// Force the viewer / editor to reload on mobile, if a note is updated and it is currently open
 									this.dispatch({
 										type: 'EDITOR_NOTE_NEEDS_RELOAD',
 										noteId: content.id,
 									});
+								}
+
+								if (isNoteLockEnabled() && content.type_ === BaseModel.TYPE_NOTE && NoteLockNote.isLocking(content, local)) {
+									// A note that was locked on another device may still have plaintext
+									// revisions locally, so clear them when the lock state arrives through sync.
+									try {
+										await RevisionService.instance().deleteUnencryptedHistoryForNote(content.id, { sourceDescription: 'Synchronizer: note lock' });
+									} catch (error) {
+										logger.warn(`Could not delete unencrypted revisions for locked note ${content.id}`, error);
+									}
 								}
 							}
 

--- a/packages/lib/services/RevisionService.noteLock.test.ts
+++ b/packages/lib/services/RevisionService.noteLock.test.ts
@@ -1,0 +1,126 @@
+import { revisionService, setupDatabaseAndSynchronizer, switchClient, encryptionService, afterAllCleanUp } from '../testing/test-utils';
+import Setting from '../models/Setting';
+import Note from '../models/Note';
+import Revision from '../models/Revision';
+import BaseModel from '../BaseModel';
+import EncryptionService from './e2ee/EncryptionService';
+import NoteLockKey from './noteLock/NoteLockKey';
+import NoteLockService from './noteLock/NoteLockService';
+import NoteLockSession from './noteLock/NoteLockSession';
+
+// setNoteLockState only emits events now, so lock transitions are applied here the way the
+// note screen does, with a direct gated save.
+const enableNoteLock = async (noteId: string) => {
+	const toSave = { ...await Note.load(noteId), is_locked: 1 };
+	(toSave as Record<string, unknown>).isDecrypted = true;
+	await Note.save(toSave, { useNoteLock: true });
+};
+
+const disableNoteLock = async (noteId: string) => {
+	const note = await Note.load(noteId, { useNoteLock: true });
+	await Note.save({ ...note, is_locked: 0 }, { useNoteLock: true });
+};
+
+const setUpUnlockedSession = async (password = '123456') => {
+	await NoteLockKey.instance().create(password);
+	await NoteLockSession.instance().unlock(password);
+};
+
+// Two plaintext revisions, then the note is locked and a standalone revision is collected.
+const createLockedNoteWithHistory = async () => {
+	await setUpUnlockedSession();
+	const note = await Note.save({ title: 'note', body: 'secret v1' });
+	await Note.save({ id: note.id, body: 'secret v2' });
+	await revisionService().collectRevisions();
+	await enableNoteLock(note.id);
+	await revisionService().collectRevisions();
+	return note;
+};
+
+describe('RevisionService.noteLock', () => {
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+		NoteLockService.destroyInstance();
+		NoteLockSession.destroyInstance();
+		NoteLockKey.destroyInstance();
+		EncryptionService.instance_ = encryptionService();
+		Setting.setValue('featureFlag.noteLock', true);
+		Setting.setValue('revisionService.intervalBetweenRevisions', 0);
+	});
+
+	afterAll(async () => {
+		await afterAllCleanUp();
+	});
+
+	it('should create standalone revisions while the note is locked', async () => {
+		const note = await createLockedNoteWithHistory();
+
+		const decrypted = await Note.load(note.id, { useNoteLock: true });
+		await Note.save({ ...decrypted, body: 'secret v3' }, { useNoteLock: true });
+		await revisionService().collectRevisions();
+
+		const revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
+		expect(revisions.length).toBe(2);
+		for (const rev of revisions) {
+			expect(rev.is_locked).toBe(1);
+			expect(rev.parent_id).toBe('');
+			expect(rev.body_diff).not.toContain('secret');
+		}
+
+		const revNote = await revisionService().revisionNote(revisions, revisions.length - 1);
+		expect(revNote.is_locked).toBe(1);
+		expect(revNote.body).not.toContain('secret');
+	});
+
+	it('should create a locked standalone revision for the old-note copy too', async () => {
+		Setting.setValue('revisionService.oldNoteInterval', 0);
+		await setUpUnlockedSession();
+		const note = await Note.save({ title: 'note', body: 'secret v1' });
+		await enableNoteLock(note.id);
+		await revisionService().collectRevisions();
+
+		const decrypted = await Note.load(note.id, { useNoteLock: true });
+		await Note.save({ ...decrypted, body: 'secret v2' }, { useNoteLock: true });
+		await revisionService().collectRevisions();
+
+		const revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
+		expect(revisions.length).toBeGreaterThanOrEqual(2);
+		for (const rev of revisions) {
+			expect(rev.is_locked).toBe(1);
+			expect(rev.parent_id).toBe('');
+			expect(rev.body_diff).not.toContain('secret');
+		}
+	});
+
+	it('should start a fresh revision chain for the first unencrypted revision after disabling', async () => {
+		const note = await createLockedNoteWithHistory();
+
+		await disableNoteLock(note.id);
+		await revisionService().collectRevisions();
+
+		const revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
+		expect(revisions.length).toBe(2);
+		expect(revisions[0].is_locked).toBe(1);
+		expect(revisions[1].is_locked).toBe(0);
+		expect(revisions[1].parent_id).toBe('');
+
+		const revNote = await revisionService().revisionNote(revisions, 1);
+		expect(revNote.body).toBe('secret v2');
+	});
+
+	it('should restore an encrypted revision as a locked note', async () => {
+		const note = await createLockedNoteWithHistory();
+
+		const revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
+		const revNote = await revisionService().revisionNote(revisions, revisions.length - 1);
+		const restored = await revisionService().importRevisionNote(revNote);
+
+		const reloaded = await Note.load(restored.id);
+		expect(reloaded.is_locked).toBe(1);
+		expect(reloaded.body).not.toContain('secret');
+		expect((await Note.load(restored.id, { useNoteLock: true })).body).toBe('secret v2');
+	});
+
+});

--- a/packages/lib/services/RevisionService.noteLock.test.ts
+++ b/packages/lib/services/RevisionService.noteLock.test.ts
@@ -110,6 +110,18 @@ describe('RevisionService.noteLock', () => {
 		expect(revNote.body).toBe('secret v2');
 	});
 
+	it('should keep marking revisions of a locked note while the feature flag is off', async () => {
+		const note = await createLockedNoteWithHistory();
+
+		Setting.setValue('featureFlag.noteLock', false);
+		await Note.save({ id: note.id, title: 'renamed' });
+		await revisionService().collectRevisions();
+
+		const revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
+		expect(revisions.length).toBe(2);
+		expect(revisions[1].is_locked).toBe(1);
+	});
+
 	it('should restore an encrypted revision as a locked note', async () => {
 		const note = await createLockedNoteWithHistory();
 

--- a/packages/lib/services/RevisionService.ts
+++ b/packages/lib/services/RevisionService.ts
@@ -10,6 +10,8 @@ import BaseService from './BaseService';
 import { _ } from '../locale';
 import { ItemChangeEntity, NoteEntity, RevisionEntity } from './database/types';
 import Logger from '@joplin/utils/Logger';
+import isNoteLockEnabled from './noteLock/isNoteLockEnabled';
+import NoteLockNote from './noteLock/NoteLockNote';
 import { MarkupLanguage } from '../../renderer';
 import { substrWithEllipsis } from '../string-utils';
 const { sprintf } = require('sprintf-js');
@@ -90,7 +92,15 @@ export default class RevisionService extends BaseService {
 			const noteTitle = note.title ? note.title : '';
 			const noteBody = note.body ? note.body : '';
 
-			if (!parentRev) {
+			if (isNoteLockEnabled() && NoteLockNote.isLocked(note)) {
+				// A locked note body is ciphertext, so diffing it against other revisions would produce
+				// large meaningless patches. Each revision is standalone instead: no parent, full contents.
+				if (parentRev && !bypassInterval && Date.now() - parentRev.updated_time < Setting.value('revisionService.intervalBetweenRevisions')) return null;
+				output.is_locked = 1;
+				output.title_diff = Revision.createTextPatch('', noteTitle);
+				output.body_diff = Revision.createTextPatch('', noteBody);
+				output.metadata_diff = Revision.createObjectPatch({}, noteMd);
+			} else if (!parentRev || (!!parentRev.is_locked && !note.is_locked)) {
 				output.title_diff = Revision.createTextPatch('', noteTitle);
 				output.body_diff = Revision.createTextPatch('', noteBody);
 				output.metadata_diff = Revision.createObjectPatch({}, noteMd);

--- a/packages/lib/services/RevisionService.ts
+++ b/packages/lib/services/RevisionService.ts
@@ -86,6 +86,8 @@ export default class RevisionService extends BaseService {
 				item_type: BaseModel.TYPE_NOTE,
 				item_id: note.id,
 				item_updated_time: note.updated_time,
+				// Carried with the flag off too, so the revision still marks its body as ciphertext.
+				is_locked: note.is_locked ? 1 : 0,
 			};
 
 			const noteMd = this.noteMetadata_(note);
@@ -96,7 +98,6 @@ export default class RevisionService extends BaseService {
 				// A locked note body is ciphertext, so diffing it against other revisions would produce
 				// large meaningless patches. Each revision is standalone instead: no parent, full contents.
 				if (parentRev && !bypassInterval && Date.now() - parentRev.updated_time < Setting.value('revisionService.intervalBetweenRevisions')) return null;
-				output.is_locked = 1;
 				output.title_diff = Revision.createTextPatch('', noteTitle);
 				output.body_diff = Revision.createTextPatch('', noteBody);
 				output.metadata_diff = Revision.createObjectPatch({}, noteMd);

--- a/packages/lib/services/synchronizer/Synchronizer.revisions.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.revisions.test.ts
@@ -5,6 +5,12 @@ import Note from '../../models/Note';
 import Revision from '../../models/Revision';
 import { loadMasterKeysFromSettings, setupAndEnableEncryption } from '../e2ee/utils';
 import { onRevisionServiceSettingsChanged } from './syncInfoUtils';
+import EncryptionService from '../e2ee/EncryptionService';
+import NoteLockKey from '../noteLock/NoteLockKey';
+import NoteLockSession from '../noteLock/NoteLockSession';
+import ItemChange from '../../models/ItemChange';
+import { ModelType } from '../../BaseModel';
+import RevisionService from '../RevisionService';
 
 describe('Synchronizer.revisions', () => {
 
@@ -328,6 +334,84 @@ describe('Synchronizer.revisions', () => {
 		expect(Setting.value('revisionService.enabled')).toBe(false);
 		await synchronizerStart();
 		expect(Setting.value('revisionService.enabled')).toBe(true);
+	}));
+
+	it('should delete local plaintext revisions when a note arrives locked via sync', (async () => {
+		Setting.setValue('featureFlag.noteLock', true);
+		const note = await Note.save({ title: 'note', body: 'secret v1' });
+		await Note.save({ id: note.id, body: 'secret v2' });
+		await synchronizerStart();
+		// The plaintext revision only exists on this client: it is collected after the sync.
+		await revisionService().collectRevisions();
+		expect((await Revision.allByType(BaseModel.TYPE_NOTE, note.id)).some(r => !r.is_locked)).toBe(true);
+
+		await switchClient(2);
+
+		Setting.setValue('featureFlag.noteLock', true);
+		NoteLockSession.destroyInstance();
+		NoteLockKey.destroyInstance();
+		EncryptionService.instance_ = encryptionService();
+		await synchronizerStart();
+		await NoteLockKey.instance().create('123456');
+		await NoteLockSession.instance().unlock('123456');
+		// setNoteLockState only emits events now, so the lock transition is applied like the note screen does it.
+		const toSave = { ...await Note.load(note.id), is_locked: 1 };
+		(toSave as Record<string, unknown>).isDecrypted = true;
+		await Note.save(toSave, { useNoteLock: true });
+		await synchronizerStart();
+
+		await switchClient(1);
+
+		Setting.setValue('featureFlag.noteLock', true);
+		await synchronizerStart();
+
+		for (const rev of await Revision.allByType(BaseModel.TYPE_NOTE, note.id)) {
+			expect(rev.is_locked).toBe(1);
+		}
+		// The cached pre-change body is cleared too, otherwise the next collection would build a
+		// plaintext revision from it.
+		const itemChange = await ItemChange.itemChange(ModelType.Note, note.id);
+		expect(itemChange?.before_change_item ?? '').not.toContain('secret');
+	}));
+
+	it('should advance the editor reload marker before the incoming lock revision cleanup', (async () => {
+		Setting.setValue('featureFlag.noteLock', true);
+		const note = await Note.save({ title: 'note', body: 'secret v1' });
+		await synchronizerStart();
+
+		await switchClient(2);
+
+		Setting.setValue('featureFlag.noteLock', true);
+		NoteLockSession.destroyInstance();
+		NoteLockKey.destroyInstance();
+		EncryptionService.instance_ = encryptionService();
+		await synchronizerStart();
+		await NoteLockKey.instance().create('123456');
+		await NoteLockSession.instance().unlock('123456');
+		const toSave = { ...await Note.load(note.id), is_locked: 1 };
+		(toSave as Record<string, unknown>).isDecrypted = true;
+		await Note.save(toSave, { useNoteLock: true });
+		await synchronizerStart();
+
+		await switchClient(1);
+
+		Setting.setValue('featureFlag.noteLock', true);
+		// A queued editor save only becomes stale once the reload marker advances, so the
+		// dispatch must fire before the awaited revision cleanup opens a race window.
+		const dispatch = jest.fn();
+		synchronizer().dispatch = dispatch;
+		let dispatchedBeforeCleanup = false;
+		const cleanupSpy = jest.spyOn(RevisionService.instance(), 'deleteUnencryptedHistoryForNote').mockImplementation(async () => {
+			dispatchedBeforeCleanup = dispatch.mock.calls.some(([action]) => action.type === 'EDITOR_NOTE_NEEDS_RELOAD' && action.noteId === note.id);
+		});
+		try {
+			await synchronizerStart();
+			expect(cleanupSpy).toHaveBeenCalled();
+			expect(dispatchedBeforeCleanup).toBe(true);
+		} finally {
+			cleanupSpy.mockRestore();
+			synchronizer().dispatch = () => {};
+		}
 	}));
 
 	it('should not overwrite a customised local ttlDays with another client default', (async () => {


### PR DESCRIPTION
Resolves #16038
## Summary

Adds note history for locked notes, behind the feature flag. Reviewed early on the fork as keshav0479/joplin#5 while it was stacked on the mobile note lock UI, which is now on dev.

<img width="800"  alt="16476" src="https://github.com/user-attachments/assets/b6b97fbc-052a-4390-90ae-3e66077e05d9" />

Revisions of a locked note are stored standalone, no parent and full contents, since diffing a ciphertext body just produces meaningless patches. The revision viewer on desktop and mobile shows the note screen's unlock panel for an encrypted revision and decrypts it once the session is unlocked. Restoring keeps the body encrypted so the restored copy stays locked, and plaintext revisions are deleted when a note arrives locked through sync. A fresh revision chain starts whenever the lock state of a note changes, in either direction, so a locked revision never depends on plaintext history and the cleanup cannot orphan it. Restore stays disabled until the selected revision has loaded and been decrypted.

The revision viewer now takes the selected note id instead of the form note's, since a locked note has no form note while the session is locked and the history was coming up empty. `hasNoteLockKey` moved out of NoteEditor into its own module so both screens can use it.

Locked notes build up history faster than normal ones, since re-encryption changes the ciphertext on every save so a revision is never seen as unchanged.

The Data API side, blocking revision reads and writes for locked notes, landed with the guardrails in #16098; this PR does not touch it.

With the flag off, the only differences are that revisions of a locked note carry the lock flag and that a lock state change starts a fresh chain; everything else behaves as before.

## Testing

- `yarn tsc`
- `yarn workspace @joplin/lib test` (RevisionService, RevisionService.noteLock, noteLock, Synchronizer.revisions)
- `yarn workspace @joplin/app-mobile test NoteRevisionViewer`
- `yarn workspace @joplin/app-desktop test useFormNote`
- manually on desktop and the mobile web app: the panel with the session locked, unlocking to read a revision, restore keeping the note encrypted, and note history with the flag off behaving as before. Also the cannot-decrypt message after a password reset on desktop, and a revision with an attachment on mobile
- After syncing with dev: `@joplin/lib` RevisionService, RevisionService.noteLock, Synchronizer.revisions, the noteLock services, REST revisions routes and note-screen-shared suites; `@joplin/app-mobile` NoteRevisionViewer; desktop and lib builds.

## Screenshots

Taken before #16292 changed the panel wording; the panels now read "This note is locked. Enter your password to unlock your notes for this session." and "This note could not be unlocked. If it was locked prior to a password reset, the content is no longer recoverable." Layout is unchanged.

### Desktop

**Locked session**

<img alt="1-desktop-locked" src="https://github.com/user-attachments/assets/af8522c6-cec6-4c90-99fa-4d722d7febf5" />

**After unlocking**

<img alt="2-desktop-unlocked" src="https://github.com/user-attachments/assets/85738f96-86cd-421f-b75e-0d5e0ec1b044" />

**After a password reset**

<img alt="3-desktop-cannot-decrypt" src="https://github.com/user-attachments/assets/f9100bd2-a733-424f-8ea8-4cccdfd71867" />

### Mobile

| Locked session | Revision with an attachment |
| --- | --- |
| <img width="220" alt="4-mobile-locked" src="https://github.com/user-attachments/assets/0fe07eec-abfd-41fc-8bd1-b61df530c047" /> | <img width="220" alt="5-mobile-attachment" src="https://github.com/user-attachments/assets/105031ce-4d34-46be-866d-4a66be53976a" /> |

## AI Assistance Disclosure

I used AI tools while working on this PR for code suggestions and review, checking scope and tests, and drafting parts of this description, including the disclosure. I reviewed the final changes and reran the tests listed above myself.