### PR TITLE
Server, Web: Applications tab: Fix web app is marked as "unknown"

### DIFF
--- a/packages/lib/services/joplinCloudUtils.ts
+++ b/packages/lib/services/joplinCloudUtils.ts
@@ -71,6 +71,8 @@ export const getApplicationInformation = async () => {
 		return { type: ApplicationType.Mobile, platform: ApplicationPlatform.Ios };
 	case 'android':
 		return { type: ApplicationType.Mobile, platform: ApplicationPlatform.Android };
+	case 'web':
+		return { type: ApplicationType.Mobile, platform: ApplicationPlatform.Web };
 	case 'darwin':
 		return { type: ApplicationType.Desktop, platform: ApplicationPlatform.MacOs };
 	case 'win32':

--- a/packages/lib/types.ts
+++ b/packages/lib/types.ts
@@ -7,6 +7,7 @@ export enum ApplicationPlatform {
 	MacOs = 3,
 	Android = 4,
 	Ios = 5,
+	Web = 6,
 }
 
 export enum ApplicationType {

--- a/packages/server/src/models/ApplicationModel.ts
+++ b/packages/server/src/models/ApplicationModel.ts
@@ -47,6 +47,7 @@ const getPlatform = (platform: string) => {
 	if (ApplicationPlatform.MacOs === platformAsInt) return ApplicationPlatform.MacOs;
 	if (ApplicationPlatform.Android === platformAsInt) return ApplicationPlatform.Android;
 	if (ApplicationPlatform.Ios === platformAsInt) return ApplicationPlatform.Ios;
+	if (ApplicationPlatform.Web === platformAsInt) return ApplicationPlatform.Web;
 	return ApplicationPlatform.Unknown;
 };
 
@@ -234,6 +235,7 @@ export default class ApplicationModel extends BaseModel<Application> {
 		if (ApplicationPlatform.MacOs === platform) return 'MacOS';
 		if (ApplicationPlatform.Android === platform) return 'Android';
 		if (ApplicationPlatform.Ios === platform) return 'iOS';
+		if (ApplicationPlatform.Web === platform) return 'Web';
 		return 'Unknown';
 	}
 


### PR DESCRIPTION
# Problem

The web app's type is listed as "Unknown" in the Joplin Server/Cloud "Applications" tab. (Note: Requires Joplin Server [with the new auth system](https://github.com/laurent22/joplin/issues/14372)).

# Solution

Add support for a "Web" application type in the apps list.

# Testing

1. Switch to the [branch with work-in-progress support for Joplin's new auth system on Joplin Server](https://github.com/personalizedrefrigerator/joplin/tree/pr/all/enable-joplin-server-new-auth-system) (see #14372).
2. Merge the changes from this pull request.
3. Start the server and web app.
4. Sign in to the server from the web app.
5. Sign in to the server from the desktop app.
6. Check the "Applications" tab. Verify that the web and desktop entries are displayed correctly (i.e. neither is labelled as "Unknown").

Screen recording (web):

https://github.com/user-attachments/assets/32062ac4-3873-42de-80db-3f3343678a3a

Screen recording (desktop):

https://github.com/user-attachments/assets/3d214bab-74d7-4136-81ba-5c7e3d1bfa32

