### PR TITLE
Mobile: Joplin Cloud login screen: Fix loading indicator is difficult to see in dark mode

### DIFF
--- a/packages/app-mobile/components/screens/JoplinCloudLoginScreen.tsx
+++ b/packages/app-mobile/components/screens/JoplinCloudLoginScreen.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { View, Text, StyleSheet, Linking, Animated, Easing } from 'react-native';
 import { connect } from 'react-redux';
 import { _ } from '@joplin/lib/locale';
-const { themeStyle } = require('../global-style.js');
+import { themeStyle } from '../global-style';
 import { AppState } from '../../utils/types';
 import { generateApplicationConfirmUrl, reducer, checkIfLoginWasSuccessful, saveApplicationAuthId, defaultState } from '@joplin/lib/services/joplinCloudUtils';
 import { uuidgen } from '@joplin/lib/uuid';
@@ -62,6 +62,7 @@ const useStyle = (themeId: number) => {
 				fontWeight: 'bold',
 			},
 			loadingIcon: {
+				color: theme.color,
 				marginVertical: theme.fontSize * 1.2,
 				fontSize: 38,
 				textAlign: 'center',


### PR DESCRIPTION
# Problem

The "loading" indicator is difficult to see in dark mode on the mobile app's Joplin Cloud login screen.

# Solution

Use the theme color as the font color for the icon. 

# Screenshots (iOS)

| Before | After |
|--------|--------|
| <img width="369" height="759" alt="dark loading indicator on dark background" src="https://github.com/user-attachments/assets/6bb102d6-b038-4969-9f1d-d1f01d148cd9" /> | <img width="369" height="759" alt="light loading indicator on dark background" src="https://github.com/user-attachments/assets/54ad1373-d47a-4182-9005-099bc32b2519" /> |

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Web` — only the web app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
