### PR TITLE
Desktop: Resolves #16427: Tag area broken with Japanese language

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/styles/editor-status-indicator.scss
+++ b/packages/app-desktop/gui/NoteEditor/styles/editor-status-indicator.scss
@@ -2,6 +2,7 @@
 .editor-status-indicator {
 	width: 0;
 	overflow: hidden;
+	white-space: nowrap;
 
 	&:has(> :focus-visible), &.-show {
 		width: unset;


### PR DESCRIPTION
Resolves #16427

The hidden “Tab indents” button uses `width: 0` and `overflow: hidden` but still takes up height because Japanese text can wrap between characters and move to new lines when there is no width

I added `white-space: nowrap` to `.editor-status-indicator` to keep the text on one line and fix the extra space.

Before:
<img width="1210" height="678" alt="05-before-fix-japanese" src="https://github.com/user-attachments/assets/6fe73bb1-5ebd-4574-af33-48a4635bbe15" />


After:
<img width="1210" height="678" alt="06-after-fix-japanese" src="https://github.com/user-attachments/assets/7efa1a29-3e1a-4d49-a7dd-76cd2b7c49e6" />


