### PR TITLE
Desktop, Mobile, Cli: Fixes #16486: Fix WebDAV sync error "Protocol https: not supported" on servers that redirect

### DIFF
--- a/packages/app-mobile/utils/shim-init-react/index.web.ts
+++ b/packages/app-mobile/utils/shim-init-react/index.web.ts
@@ -91,6 +91,10 @@ const shimInit = () => {
 		return null;
 	};
 
+	shim.httpAgents = () => {
+		return { http: null, https: null };
+	};
+
 	shim.waitForFrame = () => {
 		return new Promise<void>((resolve) => {
 			requestAnimationFrame(() => {

--- a/packages/app-mobile/utils/shim-init-react/shimInitShared.ts
+++ b/packages/app-mobile/utils/shim-init-react/shimInitShared.ts
@@ -20,6 +20,7 @@ const shimInitShared = () => {
 	};
 
 	shim.httpAgent = () => null;
+	shim.httpAgents = () => ({ http: null, https: null });
 
 	shim.fetch = async function(url, options = null) {
 		// The native fetch() throws an uncatchable error that crashes the

--- a/packages/lib/WebDavApi.ts
+++ b/packages/lib/WebDavApi.ts
@@ -483,8 +483,6 @@ class WebDavApi {
 		}
 		const url = `${this.baseUrl()}/${ltrimSlashes(path)}`;
 
-		if (shim.httpAgent(url)) fetchOptions.agent = shim.httpAgent(url);
-
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- shim.fetch/uploadBlob/fetchBlob return slightly different response shapes (node-fetch vs blob); narrowing forces per-branch typing
 		let response: any = null;
 

--- a/packages/lib/shim-init-node.test.ts
+++ b/packages/lib/shim-init-node.test.ts
@@ -2,6 +2,19 @@ import { shimInit } from './shim-init-node';
 import shim from './shim';
 import { createTempDir, setupDatabaseAndSynchronizer, supportDir } from './testing/test-utils';
 import { copyFile } from 'fs-extra';
+import * as http from 'http';
+import { AddressInfo } from 'net';
+
+const startServer = async (handler: http.RequestListener) => {
+	const server = http.createServer(handler);
+	await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+	const port = (server.address() as AddressInfo).port;
+	return { server, url: `http://127.0.0.1:${port}` };
+};
+
+const closeServer = async (server: http.Server) => {
+	await new Promise<void>(resolve => server.close(() => resolve()));
+};
 
 describe('shim-init-node', () => {
 
@@ -28,6 +41,43 @@ describe('shim-init-node', () => {
 		const resource = await shim.createResourceFromPath(fileWithDifferentExtension);
 
 		expect(resource.file_extension).toBe('mscz');
+	});
+
+	// https://github.com/laurent22/joplin/issues/16486 - the agent used to be bound once from the
+	// initial URL, which made the request fail with ERR_INVALID_PROTOCOL when a redirect switched
+	// between http: and https:. node-fetch calls the agent function for every hop, so passing a
+	// function is what allows the agent to follow the protocol change.
+	test('should pass an agent that resolves per protocol rather than a fixed one', async () => {
+		const server = await startServer((_req, res) => {
+			res.writeHead(200);
+			res.end('done');
+		});
+
+		// shim.fetch sets `agent` on the options object it is given, so it can be inspected afterwards
+		const options: { agent?: unknown } = {};
+
+		try {
+			const response = await shim.fetch(`${server.url}/`, options);
+			expect(response.status).toBe(200);
+
+			expect(typeof options.agent).toBe('function');
+
+			const agents = shim.httpAgents();
+			const resolve = options.agent as (url: { protocol: string })=> unknown;
+			expect(resolve({ protocol: 'https:' })).toBe(agents.https);
+			expect(resolve({ protocol: 'http:' })).toBe(agents.http);
+		} finally {
+			await closeServer(server.server);
+		}
+	});
+
+	test('should expose an agent per protocol', async () => {
+		const agents = shim.httpAgents();
+		expect(agents.http).toBeTruthy();
+		expect(agents.https).toBeTruthy();
+		expect(agents.http).not.toBe(agents.https);
+		expect(shim.httpAgent('http://example.com')).toBe(agents.http);
+		expect(shim.httpAgent('https://example.com')).toBe(agents.https);
 	});
 
 });

--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -552,7 +552,14 @@ function shimInit(options: ShimInitOptions = null) {
 			throw new Error(`Not a valid URL: ${url}`);
 		}
 		const resolvedProxyUrl = resolveProxyUrl(proxySettings.proxyUrl);
-		options.agent = (resolvedProxyUrl && proxySettings.proxyEnabled) ? shim.proxyAgent(url, resolvedProxyUrl) : shim.httpAgent(url);
+		if (resolvedProxyUrl && proxySettings.proxyEnabled) {
+			options.agent = shim.proxyAgent(url, resolvedProxyUrl);
+		} else {
+			// node-fetch calls this for every request, including each redirect hop, so the agent
+			// always matches the protocol actually being used.
+			const agents = shim.httpAgents();
+			options.agent = (parsedUrl: URL) => parsedUrl.protocol === 'https:' ? agents.https : agents.http;
+		}
 		return shim.fetchWithRetry(() => {
 			return nodeFetch(url, options);
 		}, options);
@@ -606,7 +613,13 @@ function shimInit(options: ShimInitOptions = null) {
 		};
 
 		const resolvedProxyUrl = resolveProxyUrl(proxySettings.proxyUrl);
-		requestOptions.agent = (resolvedProxyUrl && proxySettings.proxyEnabled) ? shim.proxyAgent(url.href, resolvedProxyUrl) : shim.httpAgent(url.href);
+		if (resolvedProxyUrl && proxySettings.proxyEnabled) {
+			requestOptions.agent = shim.proxyAgent(url.href, resolvedProxyUrl);
+		} else {
+			// follow-redirects re-picks from this map on each hop, so a redirect that switches
+			// protocol gets the matching agent.
+			requestOptions.agents = shim.httpAgents();
+		}
 
 		const doFetchOperation = async () => {
 			return new Promise((resolve, reject) => {
@@ -728,7 +741,7 @@ function shimInit(options: ShimInitOptions = null) {
 		tlsEcdhCurve = 'auto';
 	}
 
-	shim.httpAgent = url => {
+	shim.httpAgents = () => {
 		if (!shim.httpAgent_) {
 			const AgentSettings = {
 				keepAlive: true,
@@ -741,7 +754,12 @@ function shimInit(options: ShimInitOptions = null) {
 				https: new https.Agent(AgentSettings),
 			};
 		}
-		return url.startsWith('https') ? shim.httpAgent_.https : shim.httpAgent_.http;
+		return shim.httpAgent_;
+	};
+
+	shim.httpAgent = url => {
+		const agents = shim.httpAgents();
+		return url.startsWith('https') ? agents.https : agents.http;
 	};
 
 	shim.proxyAgent = (serverUrl: string, proxyUrl: string) => {

--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -435,6 +435,14 @@ const shim = {
 		throw new Error('Not implemented: httpAgent');
 	},
 
+	// Returns the agents for both protocols, so that callers which follow redirects can pick the
+	// right one for each hop. Binding a single agent up-front breaks when a redirect switches
+	// between http: and https: - see https://github.com/laurent22/joplin/issues/16486
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- See httpAgent_ above
+	httpAgents: (): { http: any; https: any } => {
+		throw new Error('Not implemented: httpAgents');
+	},
+
 	openOrCreateFile: (_path: string, _defaultContents: string): string => {
 		throw new Error('Not implemented: openOrCreateFile');
 	},


### PR DESCRIPTION
Fixes #16486

Sync to some WebDAV servers (e.g. magentacloud.de) failed in 3.7 with:

> Protocol "https:" not supported. Expected "http:" (Code ERR_INVALID_PROTOCOL)

This worked in 3.6 and broke in ae5ab0bf (PQS TLS support, #15055), which started passing an explicit HTTP agent chosen once from the initial URL. When a server redirects between `http:` and `https:`, that agent no longer matches the protocol being used and the request is rejected.

The agent is now selected per redirect hop instead of being fixed up front, so sync works again on these servers. Proxy behaviour is unchanged.