### PR TITLE
Server: Fixes sync errors when an upload is retried

### DIFF
--- a/packages/server/src/models/ItemModel.test.ts
+++ b/packages/server/src/models/ItemModel.test.ts
@@ -661,4 +661,28 @@ describe('ItemModel', () => {
 		expect(trashedNote.deleted_time).toBe(123);
 	});
 
+	test('should update the item when it was created by a concurrent request', async () => {
+		const { user: user1 } = await createUserAndSession(1);
+
+		// Simulates a client retrying an upload while the original request is still being
+		// processed: the item does not exist when the caller checks for it, but does by the
+		// time it is inserted.
+		await models().item().saveForUser(user1.id, {
+			name: 'test.txt',
+			content: Buffer.from('original'),
+		});
+
+		const savedItem = await models().item().saveForUser(user1.id, {
+			name: 'test.txt',
+			content: Buffer.from('retried'),
+		});
+
+		const allItems = await models().item().all();
+		expect(allItems.length).toBe(1);
+		expect(savedItem.id).toBe(allItems[0].id);
+
+		const content = await models().item().loadWithContent(savedItem.id);
+		expect(content.content.toString()).toBe('retried');
+	});
+
 });

--- a/packages/server/src/models/ItemModel.ts
+++ b/packages/server/src/models/ItemModel.ts
@@ -1186,15 +1186,20 @@ export default class ItemModel extends BaseModel<Item> {
 		}
 
 		return this.withTransaction(async () => {
+			// Savepoint needed because on Postgres a failed statement aborts the whole
+			// transaction, and we recover from the unique constraint error below.
+			const savePoint = await this.setSavePoint();
+
 			try {
 				item = await super.save(item, options);
+				await this.releaseSavePoint(savePoint);
 			} catch (error) {
+				await this.rollbackSavePoint(savePoint);
+
 				if (isUniqueConstraintError(error)) {
-					// The item was created by a concurrent request between the moment we
-					// checked whether it exists and the moment we inserted it. This happens
-					// when a client retries an upload that is in fact still being processed.
-					// Since (name, owner_id) already identifies the item, save it again as an
-					// update, so that retrying an upload is not treated as an error.
+					// The item was created by a concurrent request - typically a client
+					// retrying an upload that is still being processed. Save it as an update
+					// so that the retry is not treated as an error.
 					const existingItem = await this.loadByName(item.owner_id || userId, item.name, { fields: ['id'] });
 
 					if (!existingItem) {

--- a/packages/server/src/models/ItemModel.ts
+++ b/packages/server/src/models/ItemModel.ts
@@ -1163,7 +1163,7 @@ export default class ItemModel extends BaseModel<Item> {
 		if (!userId) throw new Error('userId is required');
 
 		item = { ... item };
-		const isNew = await this.isNew(item, options);
+		let isNew = await this.isNew(item, options);
 
 		let previousItem: ChangePreviousItem = null;
 		let previousName: string|null = null;
@@ -1190,8 +1190,22 @@ export default class ItemModel extends BaseModel<Item> {
 				item = await super.save(item, options);
 			} catch (error) {
 				if (isUniqueConstraintError(error)) {
-					modelLogger.error(`Unique constraint error on item: ${JSON.stringify({ id: item.id, name: item.name, jop_id: item.jop_id, owner_id: item.owner_id })}`, error);
-					throw new ErrorConflict(`This item is already present and cannot be added again: ${item.name}`);
+					// The item was created by a concurrent request between the moment we
+					// checked whether it exists and the moment we inserted it. This happens
+					// when a client retries an upload that is in fact still being processed.
+					// Since (name, owner_id) already identifies the item, save it again as an
+					// update, so that retrying an upload is not treated as an error.
+					const existingItem = await this.loadByName(item.owner_id || userId, item.name, { fields: ['id'] });
+
+					if (!existingItem) {
+						modelLogger.error(`Unique constraint error on item, but the item could not be found: ${JSON.stringify({ id: item.id, name: item.name, jop_id: item.jop_id, owner_id: item.owner_id })}`, error);
+						throw new ErrorConflict(`This item is already present and cannot be added again: ${item.name}`);
+					}
+
+					modelLogger.info(`Item was created by a concurrent request - updating it instead: ${JSON.stringify({ name: item.name, jop_id: item.jop_id, owner_id: item.owner_id })}`);
+
+					isNew = false;
+					item = await super.save({ ...item, id: existingItem.id }, { ...options, isNew: false });
 				} else {
 					throw error;
 				}


### PR DESCRIPTION
When a sync client uploads a note or attachment over a slow or dropped connection, it retries. If the original request was still being processed, the server rejected the retry as a duplicate, and the client marked the note as impossible to sync — even though the upload had succeeded. The server now completes the retried upload instead of rejecting it.

Also quietens the shared notebook maintenance task, which reported members as missing items when they weren't: it counted the notebook's items and each member's items separately, so a note added between the two counts looked like a gap. Both figures now come from a single count.
