### PR TITLE
Server: Do not log invalid requests as errors

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -170,7 +170,11 @@ async function main() {
 		} catch (error) {
 			ctx.status = error.httpCode || 500;
 
-			appLogger().error(`Middleware error on ${ctx.path}:`, error);
+			if (ctx.status >= 500) {
+				appLogger().error(`Middleware error on ${ctx.path}:`, error);
+			} else {
+				appLogger().info(`Middleware error on ${ctx.path}:`, error);
+			}
 
 			const responseFormat = routeResponseFormat(ctx);
 


### PR DESCRIPTION
Requests that fail with a 4xx status were logged as server errors, even though they mean the request itself was invalid rather than that anything went wrong on the server. In practice most of these are bots probing for paths like /admin/.env, which fill the log with errors for requests that were correctly refused.

These are now logged at info level, with error reserved for 5xx. This matches what routeHandler already does for the routes it handles.