### PR TITLE
Server: Do not log failed image downloads as warnings

### DIFF
--- a/packages/lib/services/rest/routes/notes.ts
+++ b/packages/lib/services/rest/routes/notes.ts
@@ -289,7 +289,10 @@ export async function downloadMediaFile(url: string, fetchOptions?: FetchOptions
 		}
 		return newMediaPath ?? mediaPath;
 	} catch (error) {
-		logger.warn(`Cannot download image at ${url}`, error);
+		// Clipped pages regularly contain images that cannot be downloaded - dead tracking
+		// pixels, expired links, etc. There's nothing to be done about it, and the note is
+		// still created without them, so this is not logged as a warning.
+		logger.info(`Cannot download image at ${url}`, error);
 		return '';
 	}
 }


### PR DESCRIPTION
Clipped pages regularly contain images that cannot be downloaded — dead tracking pixels, expired links, hosts that no longer exist. There's nothing to be done about any of it, and the note is still created without those images, so logging each one as a warning is just noise in the server log.

These are now logged at info level instead.
