### PR TITLE
Chore: Fixes #16494: Fix flaky note menu test and decryption warning

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
@@ -1,6 +1,6 @@
 import Note from '@joplin/lib/models/Note';
 import Setting from '@joplin/lib/models/Setting';
-import { setupDatabaseAndSynchronizer, supportDir, switchClient } from '@joplin/lib/testing/test-utils';
+import { setupDatabaseAndSynchronizer, supportDir, switchClient, withWarningSilenced } from '@joplin/lib/testing/test-utils';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import useFormNote, { HookDependencies } from './useFormNote';
 import shim from '@joplin/lib/shim';
@@ -114,9 +114,11 @@ describe('useFormNote', () => {
 			const render = renderHook(props => useFormNote(props), {
 				initialProps: { ...defaultFormNoteProps, noteId: testNote.id, noteLockSessionUnlocked: true, onDecryptFailedChange },
 			});
-			await waitFor(() => {
-				expect(render.result.current.decryptFailed).toBe(true);
-			});
+			await withWarningSilenced(/Could not decrypt locked note/, async () => {
+				await waitFor(() => {
+					expect(render.result.current.decryptFailed).toBe(true);
+				});
+			}, { requireWarning: true });
 			expect(render.result.current.formNote).toMatchObject({
 				id: '',
 				body: '',

--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -117,18 +117,18 @@ const openNoteActionsMenu = async () => {
 		cursor = cursor.parent;
 	}
 
-	// Wrap in act(...) -- this tells the test library that component state is intended to update (prevents
-	// warnings).
-	await waitFor(async () => {
+	// act() rather than waitFor(): waitFor rejects if the timer mode changes while it polls, and
+	// draining the fake timers updates the menu drawer's state.
+	await act(async () => {
 		await runWithFakeTimers(async () => {
 			await userEvent.press(actionMenuButton);
 		});
+	});
 
-		// State can update until the menu content is marked as open (part of the
-		// menu transition).
-		await waitFor(async () => {
-			expect(await screen.findByTestId('menu-content-open')).toBeVisible();
-		});
+	// State can update until the menu content is marked as open (part of the
+	// menu transition).
+	await waitFor(async () => {
+		expect(await screen.findByTestId('menu-content-open')).toBeVisible();
 	});
 };
 


### PR DESCRIPTION
Fixes #16494

The mobile note menu helper switched to fake timers inside `waitFor`, causing intermittent CI failures. This wraps the press and timer cleanup in `act`, then waits for the menu to appear. Keeping the cleanup inside `act` also prevents the drawer animation from producing a warning.

The desktop `useFormNote` test deliberately triggers a decryption failure. This silences the expected warning and checks that it was logged. The existing assertions are unchanged.

## Testing

- Mobile Note suite: 27 passed, no timer-mode errors or BottomDrawer act warnings.
- Desktop useFormNote suite: 8 passed, no warning output.