### PR TITLE
Chore: Fixes #16503: Fix mobile startup tests not running

### DIFF
--- a/packages/app-mobile/config/config.default.ts
+++ b/packages/app-mobile/config/config.default.ts
@@ -1,4 +1,4 @@
 
 export default {
-	runStartupTests: __DEV__,
+	runStartupTests: () => __DEV__,
 };

--- a/packages/app-mobile/config/config.testing.ts
+++ b/packages/app-mobile/config/config.testing.ts
@@ -1,4 +1,4 @@
 
 export default {
-	runStartupTests: true,
+	runStartupTests: () => true,
 };

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -98,7 +98,7 @@ import VoiceTyping from '../services/voiceTyping/VoiceTyping';
 import whisper from '../services/voiceTyping/whisper';
 import PerFolderSortOrderService from '@joplin/lib/services/sortOrder/PerFolderSortOrderService';
 import getConflictFolderId from '@joplin/lib/models/utils/getConflictFolderId';
-const { runStartupTests } = require('@joplin/mobile-config');
+const mobileConfig = require('@joplin/mobile-config').default;
 
 
 function resourceFetcher_downloadComplete(event: { id: string; encrypted: boolean }) {
@@ -526,7 +526,7 @@ const buildStartupTasks = (
 		// call will throw an error, alerting us of the issue. Otherwise it will
 		// just print some messages in the console.
 		// ----------------------------------------------------------------------------
-		if (runStartupTests) {
+		if (mobileConfig.runStartupTests()) {
 			await runRsaIntegrationTests();
 			await runCryptoIntegrationTests();
 			await runOnDeviceFsDriverTests();


### PR DESCRIPTION
# Problem

The mobile startup tests were not running in dev mode.

# Solution

Fix the import for `@joplin/mobile-config` so that the enabled/disabled `runStartupTests` flag is imported correctly.

Fixes #16503.