### PR TITLE
Cli: Fixes #16541: Downgrade nanoid to fix ERR_REQUIRE_ESM crash on startup

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -86,7 +86,7 @@
     "moment": "2.30.1",
     "multiparty": "4.2.3",
     "mustache": "4.2.0",
-    "nanoid": "5.1.11",
+    "nanoid": "3.3.11",
     "node-diff3": "3.2.0",
     "node-fetch": "2.6.7",
     "node-notifier": "10.0.1",

--- a/renovate.json5
+++ b/renovate.json5
@@ -163,6 +163,7 @@
 		"react-native-reanimated",
 
 		// Cannot upgrade further due to ESM support
+		"nanoid",
 		"node-fetch",
 		"execa",
 		"open",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12916,7 +12916,7 @@ __metadata:
     moment: "npm:2.30.1"
     multiparty: "npm:4.2.3"
     mustache: "npm:4.2.0"
-    nanoid: "npm:5.1.11"
+    nanoid: "npm:3.3.11"
     node-diff3: "npm:3.2.0"
     node-fetch: "npm:2.6.7"
     node-notifier: "npm:10.0.1"


### PR DESCRIPTION
The CLI crashed on every invocation with `ERR_REQUIRE_ESM`. `packages/lib` declared nanoid 5.x, which is ESM-only, but the package compiles to CommonJS, so the published `uuid.js` does `require("nanoid/non-secure")` — impossible on Node < 22.12.

Introduced by 679c299ea (3.3.11 → 5.1.6), first shipped in 3.7.1. Desktop and mobile are unaffected as their bundlers resolve it. Not reproducible from a checkout, since the root `resolutions` field pins nanoid to 3.x but isn't published to npm — hence the green CI.

Pins `packages/lib` back to `3.3.11` and adds nanoid to the `ignoreDeps` ESM group to prevent a regression.