### PR TITLE
Server: Fixes #16448: Add email (SMTP) setup to .env-sample and documentation

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -16,6 +16,23 @@
 # POSTGRES_HOST=localhost
 
 # =============================================================================
+# EMAIL (SMTP) CONFIG EXAMPLE
+# -----------------------------------------------------------------------------
+# This step is optional. Joplin Server can send emails (password reset links,
+# email change confirmations, etc.) through an SMTP server. To enable it, set
+# MAILER_ENABLED to true and provide the connection details below.
+# =============================================================================
+#
+# MAILER_ENABLED=true
+# MAILER_HOST=smtp.example.com
+# MAILER_PORT=465
+# MAILER_SECURITY=tls # Can be "tls", "starttls" or "none"
+# MAILER_AUTH_USER=username
+# MAILER_AUTH_PASSWORD=password
+# MAILER_NOREPLY_NAME=Joplin
+# MAILER_NOREPLY_EMAIL=noreply@example.com
+
+# =============================================================================
 # TRANSCRIBE CONFIG EXAMPLE
 # -----------------------------------------------------------------------------
 # This service is not required, and it will be ignored by using --profile server

--- a/.env-sample
+++ b/.env-sample
@@ -26,7 +26,8 @@
 # MAILER_ENABLED=true
 # MAILER_HOST=smtp.example.com
 # MAILER_PORT=465
-# MAILER_SECURITY=tls # Can be "tls", "starttls" or "none"
+# Can be "tls", "starttls" or "none"
+# MAILER_SECURITY=tls
 # MAILER_AUTH_USER=username
 # MAILER_AUTH_PASSWORD=password
 # MAILER_NOREPLY_NAME=Joplin

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -133,6 +133,31 @@ Besides the database and filesystem, it's also possible to use AWS S3 for storag
 
 	STORAGE_DRIVER=Type=S3; Region=YOUR_REGION_CODE; AccessKeyId=YOUR_ACCESS_KEY; SecretAccessKeyId=YOUR_SECRET_ACCESS_KEY; Bucket=YOUR_BUCKET
 
+## Setting up email (SMTP)
+
+This step is optional.
+
+By default, the server does not send any email. It can however be configured to send messages — for example password reset links, email change confirmations or payment failure notices — through an SMTP server, by setting the following variables in the `.env` file:
+
+```conf
+MAILER_ENABLED=true
+MAILER_HOST=smtp.example.com
+MAILER_PORT=465
+MAILER_SECURITY=tls
+MAILER_AUTH_USER=username
+MAILER_AUTH_PASSWORD=password
+MAILER_NOREPLY_NAME=Joplin
+MAILER_NOREPLY_EMAIL=noreply@example.com
+```
+
+- **MAILER_ENABLED** — set to `true` to enable sending emails. If it is `false` or if **MAILER_HOST** is not set, the email service is disabled.
+- **MAILER_HOST** and **MAILER_PORT** — the address and port of the SMTP server. Port 465 is typically used for TLS, and 587 for STARTTLS.
+- **MAILER_SECURITY** — how the connection is secured. Can be `tls` (the default), `starttls` or `none`.
+- **MAILER_AUTH_USER** and **MAILER_AUTH_PASSWORD** — credentials to login to the SMTP server. Leave them empty if the server does not require authentication.
+- **MAILER_NOREPLY_NAME** and **MAILER_NOREPLY_EMAIL** — the display name and email address used as the sender of all outgoing emails. **MAILER_NOREPLY_EMAIL** must be set for the email service to work.
+
+Restart the server for these variables to take effect.
+
 ## Verify access to the admin page
 
 Once Joplin Server is exposed to the internet, open the admin UI. For the following instructions, we'll assume that Joplin Server is running on `https://example.com/joplin`.

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -152,8 +152,8 @@ MAILER_NOREPLY_EMAIL=noreply@example.com
 
 - **MAILER_ENABLED** — set to `true` to enable sending emails. If it is `false` or if **MAILER_HOST** is not set, the email service is disabled.
 - **MAILER_HOST** and **MAILER_PORT** — the address and port of the SMTP server. Port 465 is typically used for TLS, and 587 for STARTTLS.
-- **MAILER_SECURITY** — how the connection is secured. Can be `tls` (the default), `starttls` or `none`.
-- **MAILER_AUTH_USER** and **MAILER_AUTH_PASSWORD** — credentials to login to the SMTP server. Leave them empty if the server does not require authentication.
+- **MAILER_SECURITY** — how the connection is secured. Valid values are `tls` (the default), `starttls` and `none`. Note that `none` disables encryption, so it should not be used together with **MAILER_AUTH_USER** / **MAILER_AUTH_PASSWORD**, as the credentials would then be sent to the SMTP server unencrypted.
+- **MAILER_AUTH_USER** and **MAILER_AUTH_PASSWORD** — credentials to log in to the SMTP server. Leave them empty if the server does not require authentication.
 - **MAILER_NOREPLY_NAME** and **MAILER_NOREPLY_EMAIL** — the display name and email address used as the sender of all outgoing emails. **MAILER_NOREPLY_EMAIL** must be set for the email service to work.
 
 Restart the server for these variables to take effect.

--- a/packages/tools/cspell/dictionary2.txt
+++ b/packages/tools/cspell/dictionary2.txt
@@ -277,6 +277,7 @@ noneditable
 nonlatin
 NONLATIN
 nonprofit
+noreply
 Noreg
 Norge
 nospecialcharacters


### PR DESCRIPTION
### Problem

Joplin Server already supports sending emails (password reset links, email-change confirmations, payment notices, etc.) via SMTP, reading a full set of `MAILER_*` environment variables (`packages/server/src/env.ts`, consumed by `EmailService.ts` / `config.ts`). However, none of these variables were present in the default `.env-sample` that self-hosters start from, and the server documentation did not mention email setup at all — so the feature was effectively undiscoverable. Fixes #16448.

### What this changes

Docs-only change, no runtime behavior:

1. **`.env-sample`** — added an "Email (SMTP) config example" section (commented out, matching the existing style of the file) listing all 8 variables: `MAILER_ENABLED`, `MAILER_HOST`, `MAILER_PORT`, `MAILER_SECURITY`, `MAILER_AUTH_USER`, `MAILER_AUTH_PASSWORD`, `MAILER_NOREPLY_NAME`, `MAILER_NOREPLY_EMAIL`.
2. **`packages/server/README.md`** — added a "Setting up email (SMTP)" section (between "Setup storage" and "Verify access to the admin page", following the same optional-step format as the neighbouring sections) with a `conf` example block and a description of each variable.

All defaults, valid values and behaviours documented were verified against `env.ts` (`MailerSecurity` enum = `tls`/`starttls`/`none`, defaults port 465 / security tls) and `EmailService.ts` (service disabled when `MAILER_HOST` is unset or `MAILER_ENABLED` is false; `MAILER_NOREPLY_EMAIL` required).

### Note on tests

The monorepo install repeatedly failed on my Windows machine (yarn cache/link EPERM-ENOENT races), so `packages/server/src/env.test.ts` could not be executed locally. Since this PR changes no code (only `.env-sample` and a Markdown file, neither of which is referenced by any test), this has no bearing on the change.

### How to test

Self-host the server using the updated `.env-sample` (uncomment the email block), run with a working SMTP server and confirm a password-reset email is delivered.
