### PR TITLE
Web: Fixes #16435: Define __DEV__ at build time so release builds don't load React Refresh on localhost

### DIFF
--- a/packages/app-mobile/index.web.ts
+++ b/packages/app-mobile/index.web.ts
@@ -29,6 +29,8 @@ interface ExtendedWindow extends Window {
 }
 declare const window: ExtendedWindow;
 if (__DEV__) {
+	document.title = 'Joplin DEV';
+
 	window.joplin = {
 		Setting,
 		Note,

--- a/packages/app-mobile/web/public/environment.js
+++ b/packages/app-mobile/web/public/environment.js
@@ -1,5 +1,6 @@
-// Change to enable or disable React Native dev mode.
-window.__DEV__ = window.location.origin.includes('localhost');
+// __DEV__ is defined at build time by webpack (see web/webpack.config.ts), so
+// that release builds never include the React Refresh runtime, regardless of
+// the hostname the app is served from. See https://github.com/laurent22/joplin/issues/16435
 
 // Silences errors related to generated code.
 window.exports = {};
@@ -10,7 +11,3 @@ window.process = {
 		EXPO_OS: 'web',
 	},
 };
-
-if (__DEV__) {
-	document.title = 'Joplin DEV';
-}

--- a/packages/app-mobile/web/webpack.config.ts
+++ b/packages/app-mobile/web/webpack.config.ts
@@ -10,7 +10,7 @@ const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin'
 const appDirectory = path.resolve(__dirname, '../');
 const babelConfig = require('../babel.config');
 
-const buildSharedConfig = (hotReload: boolean): webpack.Configuration => {
+const buildSharedConfig = (hotReload: boolean, isDev: boolean): webpack.Configuration => {
 	const babelLoaderConfiguration = {
 		test: /\.(tsx|jsx|ts|js|mjs)$/,
 		exclude: [
@@ -59,9 +59,16 @@ const buildSharedConfig = (hotReload: boolean): webpack.Configuration => {
 			],
 		},
 
-		plugins: hotReload ? [
-			new ReactRefreshWebpackPlugin(),
-		] : [],
+		plugins: [
+			// Like Metro, webpack defines __DEV__ at build time. It must reflect the
+			// build mode and not the hostname the app is served from, otherwise a
+			// release build served on localhost would load the React Refresh runtime
+			// and fail. See https://github.com/laurent22/joplin/issues/16435
+			new webpack.DefinePlugin({
+				__DEV__: JSON.stringify(isDev),
+			}),
+			...(hotReload ? [new ReactRefreshWebpackPlugin()] : []),
+		],
 
 		resolve: {
 			alias: {
@@ -117,8 +124,9 @@ const buildSharedConfig = (hotReload: boolean): webpack.Configuration => {
 	};
 };
 
-export default (env: Record<string, boolean>) => {
+export default (env: Record<string, boolean>, argv: { mode?: string }) => {
 	const hotReload = !!env.HOT_RELOAD;
+	const isDev = argv.mode !== 'production';
 	const appConfig: webpack.Configuration = {
 		target: 'web',
 
@@ -126,7 +134,7 @@ export default (env: Record<string, boolean>) => {
 			app: path.resolve(appDirectory, 'index.web.ts'),
 		},
 
-		...buildSharedConfig(hotReload),
+		...buildSharedConfig(hotReload, isDev),
 
 		devServer: {
 			// Required by @sqlite.org/sqlite-wasm
@@ -144,7 +152,7 @@ export default (env: Record<string, boolean>) => {
 		entry: {
 			serviceWorker: path.resolve(appDirectory, 'web/serviceWorker.ts'),
 		},
-		...buildSharedConfig(false),
+		...buildSharedConfig(false, isDev),
 	};
 
 	return [serviceWorkerConfig, appConfig];


### PR DESCRIPTION
Web: Fixes #16435: Define __DEV__ at build time so release builds don't load React Refresh on localhost

## Problem

#16435: In a release web build (`yarn web`), opening the app on `http://localhost:PORT` fails at startup with:

> Error: React Refresh runtime should not be included in the production bundle

while the same build served on `http://127.0.0.1:PORT` works.

## Cause

`web/public/environment.js` — a *static* file, identical in dev and release builds — set `window.__DEV__` based on the hostname:

```js
window.__DEV__ = window.location.origin.includes('localhost');
```

When a release bundle is loaded on `localhost`, `__DEV__` is `true`, so expo's `async-require/setup.ts` (which runs `if (__DEV__ && typeof window !== 'undefined') require('./setupFastRefresh')`) loads `react-refresh/runtime` at startup. Webpack has already replaced `process.env.NODE_ENV` with `"production"` in a `--mode production` build, and the React Refresh runtime's production entry point throws exactly this error. The `localhost` vs `127.0.0.1` difference is just the hostname test.

Credit to @personalizedrefrigerator for the precise diagnosis in #16435.

## Fix

`__DEV__` is a **build-mode** flag, not a **deployment-host** flag, so it should be decided at build time the way Metro does it for iOS/Android:

- `web/webpack.config.ts`: define `__DEV__` with `webpack.DefinePlugin`, set from the webpack mode (`--mode development` → `true`, `--mode production` → `false`).
- `web/public/environment.js`: remove the hostname-based assignment (and the `document.title` block that read it — `environment.js` is plain static JS, not processed by webpack, so it can no longer see the build-time constant).
- `index.web.ts`: set the `Joplin DEV` title inside the existing `if (__DEV__)` debug block, which *is* part of the bundle.

Because `__DEV__` is now a compile-time literal inside the bundle, release builds no longer reference the React Refresh runtime at all (expo's `setupFastRefresh`/`setupHMR` require calls sit behind `if (false)` and get dropped), which also makes them immune to the failure regardless of the host they are served from.

Behaviour is unchanged for development: `yarn serve-web` and `yarn serve-web-hot-reload` run webpack in development mode, so `__DEV__` stays `true` and HMR keeps working exactly as before. Nothing else needed touching — all other `__DEV__` consumers (`config.default.ts`, `buildStartupTasks.ts`, `lockToSingleInstance.ts`, expo/RNW) use the bare global identifier, which DefinePlugin replaces.

## Testing

Verified with full release builds (webpack 5.97.1, `yarn web`), served statically on `localhost` with the COOP/COEP headers matching the dev-server config, in Chrome:

1. **Unfixed build (control)** on `http://localhost:8092` — reproduces the issue exactly: the page reports the uncaught error `React Refresh runtime should not be included in the production bundle.` (its bundle still contains the React Refresh runtime + 15 `__DEV__` references, and `environment.js` sets `window.__DEV__` from the hostname).
2. **Fixed build** on `http://localhost:8090` / `:8091` — no error at all; the app boots normally on `localhost` (window title `Joplin`, app UI mounts, PWA manifest active). Its bundle contains 0 occurrences of `__DEV__`, `ReactRefresh` or the error string — the dev-only code is compile-time eliminated.
3. **Dev hot-reload** (`yarn serve-web-hot-reload`) — dev bundle still contains the React Refresh runtime (HMR wired), the page loads with the `Joplin DEV` title, and editing a source file triggers an incremental rebuild that completes ("webpack compiled successfully").
4. `yarn tsc` and the pre-commit lint checks (`eslint --fix`, spellcheck, `checkIgnoredFiles`) pass.

Fixes #16435
