### PR TITLE
Desktop: Fixes #16539: Fix LMStudio compatibility

### DIFF
--- a/packages/lib/services/ai/tools/buildEditorTools.ts
+++ b/packages/lib/services/ai/tools/buildEditorTools.ts
@@ -210,6 +210,7 @@ const buildEditorTools = ({ note, commands }: EditorToolContext) => {
 				description: 'Get the current, up-to-date content of the note. This returns the full content of the note that\'s currently open in Joplin\'s editor.',
 				inputSchema: {
 					type: 'object',
+					properties: {},
 					required: [],
 					additionalProperties: false,
 				},


### PR DESCRIPTION
# Problem

LMStudio expects a `properties: {}` object within each `object` of the input schema. Joplin's `editor_readNoteBody` tool lacked this section, breaking LMStudio.

# Solution

Add the missing `properties: {}` block.

Fixes #16539.

# Testing

1. Connect Joplin to LMStudio with the `gemma4-e4b` model.
2. Send a short message (e.g. `Hi!`) in the chat. Verify that LMStudio responds successfully.
3. Repeat for Ollama and Joplin Cloud AI.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the area you are targeting, then add the issue you are addressing.

The format is:

    <Prefix>: <Fixes|Resolves> #<issue>: <description>

Use "Resolves #123" for new features or improvements, and "Fixes #123" for bug fixes.

Examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- Mobile, Desktop, Cli: Resolves #777: Improved note search performance

Valid prefixes:

- `Desktop` — the Windows/macOS/Linux app (Electron app)
- `Mobile` — the mobile app (both Android and iOS)
- `Android` — only the Android app
- `iOS` — only the iOS app
- `Web` — only the web app
- `Windows` — Windows-specific changes
- `Linux` — Linux-specific changes
- `macOS` — macOS-specific changes
- `Cli` — the command line app
- `Server` — the Joplin Server
- `Clipper` — the web clipper browser extension
- `Transcribe` — the Transcribe server
- `Plugins` — the plugin API or built-in plugins
- `Api` — the data API
- `Cloud` — Joplin Cloud
- `Tools` — internal scripts and build tools
- `CI` — continuous integration and GitHub workflows
- `Doc` — documentation, README, website content
- `Chore` — maintenance work that does not fit any of the above (dependency bumps, refactoring, cleanup)

If the change targets several areas, separate them with commas — for example "Mobile, Desktop, Cli: Resolves #777: Improved note search performance".

-->
