### PR TITLE
Desktop: Fixes #16215: Increase defaultAutoSelectFamilyAttemptTimeout to 500 ms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -681,6 +681,7 @@ packages/app-desktop/utils/customProtocols/registerCustomProtocols.js
 packages/app-desktop/utils/getAssetPath.js
 packages/app-desktop/utils/initReact.js
 packages/app-desktop/utils/initializeCommandService.js
+packages/app-desktop/utils/initializeNetworkConnectionAttemptTimeout.js
 packages/app-desktop/utils/isSafeToOpen.test.js
 packages/app-desktop/utils/isSafeToOpen.js
 packages/app-desktop/utils/layout/layoutKeyToLabel.js

--- a/.ignore.eslint
+++ b/.ignore.eslint
@@ -707,6 +707,7 @@ packages/app-desktop/utils/customProtocols/registerCustomProtocols.js
 packages/app-desktop/utils/getAssetPath.js
 packages/app-desktop/utils/initReact.js
 packages/app-desktop/utils/initializeCommandService.js
+packages/app-desktop/utils/initializeNetworkConnectionAttemptTimeout.js
 packages/app-desktop/utils/isSafeToOpen.test.js
 packages/app-desktop/utils/isSafeToOpen.js
 packages/app-desktop/utils/layout/layoutKeyToLabel.js

--- a/packages/app-desktop/main-html.ts
+++ b/packages/app-desktop/main-html.ts
@@ -37,7 +37,10 @@ import initLib from '@joplin/lib/initLib';
 import PerformanceLogger from '@joplin/lib/PerformanceLogger';
 import * as pdfJs from 'pdfjs-dist';
 import { isAppleSilicon } from 'is-apple-silicon';
+import initializeNetworkConnectionAttemptTimeout from './utils/initializeNetworkConnectionAttemptTimeout';
 require('@sentry/electron/renderer');
+
+initializeNetworkConnectionAttemptTimeout();
 
 // Allows components to use React as a global
 window.React = React;

--- a/packages/app-desktop/main.ts
+++ b/packages/app-desktop/main.ts
@@ -13,6 +13,9 @@ const packageInfo = require('./packageInfo.js');
 import { isCallbackUrl } from '@joplin/lib/callbackUrlUtils';
 import determineBaseAppDirs from '@joplin/lib/determineBaseAppDirs';
 import registerCustomProtocols from './utils/customProtocols/registerCustomProtocols';
+import initializeNetworkConnectionAttemptTimeout from './utils/initializeNetworkConnectionAttemptTimeout';
+
+initializeNetworkConnectionAttemptTimeout();
 
 // Electron takes the application name from package.json `name` and
 // displays this in the tray icon toolip and message box titles, however in

--- a/packages/app-desktop/utils/initializeNetworkConnectionAttemptTimeout.ts
+++ b/packages/app-desktop/utils/initializeNetworkConnectionAttemptTimeout.ts
@@ -1,0 +1,10 @@
+const net = require('net') as typeof import('net') & {
+	getDefaultAutoSelectFamilyAttemptTimeout: ()=> number;
+	setDefaultAutoSelectFamilyAttemptTimeout: (value: number)=> void;
+};
+
+export default () => {
+	// Prior to Node 26, the default value is 250 ms, which is too low in some situations. Increase the default to match the Node 26
+	// default of 500 ms, at least until the app is upgraded to Node 26
+	net.setDefaultAutoSelectFamilyAttemptTimeout(Math.max(net.getDefaultAutoSelectFamilyAttemptTimeout(), 500));
+};


### PR DESCRIPTION
Due to a low default timeout value in Node 24, which is currently used for the desktop app, in certain scenarios where the sync target server is geographically far away from the client's location, and where the server has a particular network setup, this can cause network requests to consistently timeout prematurely and prevent the sync from working. The OP of #16215 who was experiencing this issue with Koofr, confirmed that this does not necessarily result in the sync with Joplin being slow in this particular case, but it is just establishing the TCP connection which is slow.

This PR overrides the default timeout on the desktop app to be at least 500 ms instead of the current 250 ms (to match the new default in Node 26), but if the Node default is increased beyond 500 ms in future, a higher default set by Node will be used instead. The mobile app is not affected by this issue due to using a different network stack, and the cli does not require a code change, because it will use whatever version of Node the user has installed on their machine, so the user can just upgrade their version of Node if experiencing the issue.

This fixes https://github.com/laurent22/joplin/issues/16215

### Testing

As I am unable to reproduce the issue myself, I asked the OP to test the change, and they confirmed that it resolves the issue. See https://github.com/laurent22/joplin/issues/16215#issuecomment-5674387636